### PR TITLE
fix: resolve WASM CDN loading CORS issue and Vite compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ All notable changes to this project will be documented in this file.
 
 - **WmlComparer table row comparison** (1 test: WC-1500) - Added LCS-based row matching (`ApplyLcsToTableRows`) for large tables (7+ rows) when content differs significantly, preventing cascading false differences from insertions/deletions in the middle of tables.
 
+- **WASM CDN loading CORS issue** - Fixed cross-origin loading failures when WASM files are served from CDNs (jsDelivr, unpkg). The .NET WASM runtime uses `credentials:"same-origin"` for fetch requests, which conflicts with CDN's `Access-Control-Allow-Origin: *` wildcard header. Build script now patches `dotnet.js` to use `credentials:"omit"` for CDN compatibility.
+
+- **Vite bundler compatibility** - Added `@vite-ignore` comment to dynamic import in `npm/src/index.ts` to prevent Vite from trying to analyze/resolve the WASM loader path during development builds.
+
 ### Changed
 - Replaced `FontPartType`/`ImagePartType` with `PartTypeInfo` pattern for SDK 3.x compatibility
 - Replaced `.Close()` calls with `Dispose()` pattern

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -84,7 +84,7 @@ export async function initialize(basePath?: string): Promise<void> {
 async function tryLoadFromPath(basePath: string): Promise<boolean> {
   try {
     const dotnetPath = basePath + "_framework/dotnet.js";
-    const { dotnet } = await import(/* webpackIgnore: true */ dotnetPath);
+    const { dotnet } = await import(/* webpackIgnore: true */ /* @vite-ignore */ dotnetPath);
 
     const { getAssemblyExports, getConfig } = await dotnet
       .withDiagnosticTracing(false)

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -51,6 +51,17 @@ cp "$WASM_PROJECT/main.js" "$WASM_DIST/"
 # Copy index.html for testing
 cp "$WASM_PROJECT/index.html" "$WASM_DIST/"
 
+# Patch dotnet.js for cross-origin CDN compatibility
+# The .NET WASM runtime uses credentials:"same-origin" which conflicts with CDN's CORS wildcard
+# (Access-Control-Allow-Origin: * cannot be used with credentials)
+echo "Patching dotnet.js for CDN compatibility..."
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS sed requires empty string for -i
+    sed -i '' 's/credentials:"same-origin"/credentials:"omit"/g' "$WASM_DIST/_framework/dotnet.js"
+else
+    sed -i 's/credentials:"same-origin"/credentials:"omit"/g' "$WASM_DIST/_framework/dotnet.js"
+fi
+
 # Report sizes
 echo ""
 echo "Build complete! File sizes:"


### PR DESCRIPTION
## Summary

- Patch `dotnet.js` at build time to use `credentials:"omit"` instead of `"same-origin"`, fixing CORS errors when loading WASM files from CDNs (jsDelivr, unpkg) that return `Access-Control-Allow-Origin: *` wildcard headers
- Add `@vite-ignore` comment to dynamic import in `npm/src/index.ts` to prevent Vite from analyzing the WASM loader path during development builds

## Test plan

- Verified `dotnet.js` patch applied correctly (2 instances of `credentials:"omit"` replacing `same-origin`)
- Verified TypeScript compiles without errors
- Verified `@vite-ignore` comment present in compiled `dist/index.js`
- Verified WASM rebuild successful (20MB bundle, 48 files)