### PR TITLE
feat: implement CommentRenderMode.Margin for HTML converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
   - `CommentRenderMode` enum with three rendering modes:
     - `EndnoteStyle` (default): Comments rendered at end of document with bidirectional anchor links
     - `Inline`: Comments rendered as tooltips with `title` and `data-comment` attributes
-    - `Margin`: Comments positioned in margin column via CSS
+    - `Margin`: Comments positioned in a flexbox-based margin column alongside content, with author/date headers and back-reference links
   - New settings in `WmlToHtmlConverterSettings`:
     - `RenderComments`: Enable/disable comment rendering
     - `CommentRenderMode`: Select rendering mode
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
     - `IncludeCommentMetadata`: Include author/date in HTML output
   - Comment highlighting with configurable CSS classes
   - Full comment metadata support (author, date, initials)
+  - Margin mode includes print-friendly CSS media queries
   - WASM/npm support via `commentRenderMode` parameter and TypeScript `CommentRenderMode` enum
 - **WebAssembly NPM Package** (`docxodus`) - Browser-based document comparison and HTML conversion
   - `wasm/DocxodusWasm/` - .NET 8 WASM project with JSExport methods

--- a/docs/architecture/comment_rendering.md
+++ b/docs/architecture/comment_rendering.md
@@ -10,7 +10,7 @@ Word documents store comments as annotations linked to text ranges. The converte
 
 1. **EndnoteStyle** (default): Comments appear at the end of the document with bidirectional anchor links, similar to footnotes
 2. **Inline**: Comments are embedded as `title` attributes and `data-*` attributes for tooltip display
-3. **Margin**: Comments are positioned in a side margin using CSS (requires additional styling)
+3. **Margin**: Comments are positioned in a side column using CSS flexbox layout
 
 ## OOXML Comment Structure
 
@@ -369,56 +369,177 @@ Each comment item includes:
 
 ### Margin Mode
 
+In margin mode, the entire document body is wrapped in a flexbox container with the main content on the left and a comment column on the right:
+
 ```html
-<span class="comment-highlight comment-margin-anchor" data-comment-id="0">
-  <span>This text has a comment</span>
-</span>
-<aside class="comment-margin" data-for="0">
-  <span class="comment-author">John Doe</span>
-  <p>This is the comment text.</p>
-</aside>
+<div class="comment-margin-container">
+  <!-- Main content area -->
+  <div class="comment-margin-content">
+    <p>
+      <span class="comment-highlight" data-comment-id="0">
+        This text has a comment
+      </span>
+      <sup><a href="#comment-0" class="comment-marker" id="comment-ref-0">[0]</a></sup>
+    </p>
+  </div>
+
+  <!-- Margin column with comments -->
+  <aside class="comment-margin-column">
+    <div class="comment-margin-note" id="comment-0" data-comment-id="0">
+      <div class="comment-margin-note-header">
+        <span class="comment-margin-author">John Doe</span>
+        <span class="comment-margin-date">Jan 15</span>
+        <a href="#comment-ref-0" class="comment-margin-backref">↩</a>
+      </div>
+      <div class="comment-margin-note-body">
+        <p>This is the comment text.</p>
+      </div>
+    </div>
+  </aside>
+</div>
 ```
 
 ## Generated CSS
 
-When comments are enabled, the following CSS is generated:
+When comments are enabled, base CSS is generated for all modes. Additional CSS is generated for margin mode.
+
+### Base CSS (All Modes)
 
 ```css
-/* Comment CSS */
+/* Comments CSS */
 span.comment-highlight {
-  background-color: #fff8dc;
-  border-bottom: 1px dotted #daa520;
+  background-color: #fff9c4;
+  border-bottom: 2px solid #fbc02d;
 }
-sup.comment-marker a {
-  color: #0066cc;
+a.comment-marker {
+  color: #1976d2;
   text-decoration: none;
-  font-size: 0.75em;
+  margin-left: 2px;
 }
+a.comment-marker:hover {
+  text-decoration: underline;
+}
+```
+
+### EndnoteStyle Mode CSS
+
+```css
 aside.comments-section {
   margin-top: 2em;
   padding-top: 1em;
-  border-top: 1px solid #ccc;
+  border-top: 2px solid #ccc;
 }
-.comment-item {
+aside.comments-section h2 {
+  font-size: 1.2em;
+  margin-bottom: 0.5em;
+}
+ol.comments-list {
+  list-style: none;
+  padding: 0;
+}
+li.comment {
   margin-bottom: 1em;
-  padding: 0.5em;
-  background-color: #f9f9f9;
-  border-left: 3px solid #daa520;
+  padding: 0.75em;
+  background-color: #f5f5f5;
+  border-left: 3px solid #1976d2;
+  border-radius: 0 4px 4px 0;
 }
-.comment-author {
+div.comment-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  margin-bottom: 0.5em;
+  font-size: 0.85em;
+}
+span.comment-author {
   font-weight: bold;
-  margin-right: 0.5em;
+  color: #1976d2;
 }
-.comment-date {
+span.comment-date {
   color: #666;
+}
+a.comment-backref {
+  margin-left: auto;
+  text-decoration: none;
+  color: #1976d2;
+}
+div.comment-body p {
+  margin: 0;
+}
+```
+
+### Margin Mode CSS
+
+When `CommentRenderMode.Margin` is selected, additional flexbox layout CSS is generated:
+
+```css
+/* Margin Mode Comments */
+div.comment-margin-container {
+  display: flex;
+  flex-direction: row;
+  gap: 1em;
+}
+div.comment-margin-content {
+  flex: 1;
+  min-width: 0;
+}
+aside.comment-margin-column {
+  width: 250px;
+  flex-shrink: 0;
+  position: relative;
+}
+div.comment-margin-note {
+  position: relative;
+  margin-bottom: 0.5em;
+  padding: 0.5em;
+  background-color: #fff9c4;
+  border-left: 3px solid #fbc02d;
+  border-radius: 0 4px 4px 0;
+  font-size: 0.85em;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+div.comment-margin-note-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.25em;
   font-size: 0.9em;
 }
-.comment-content {
-  margin-top: 0.25em;
+span.comment-margin-author {
+  font-weight: bold;
+  color: #f57f17;
 }
-.comment-backref {
-  float: right;
+span.comment-margin-date {
+  color: #666;
+  font-size: 0.85em;
+}
+div.comment-margin-note-body {
+  color: #333;
+}
+div.comment-margin-note-body p {
+  margin: 0;
+}
+a.comment-margin-backref {
+  color: #1976d2;
   text-decoration: none;
+  font-size: 0.85em;
+}
+a.comment-margin-backref:hover {
+  text-decoration: underline;
+}
+span.comment-highlight[data-comment-id] {
+  cursor: pointer;
+}
+
+/* Print styles for margin mode */
+@media print {
+  div.comment-margin-container {
+    display: block;
+  }
+  aside.comment-margin-column {
+    width: auto;
+    page-break-inside: avoid;
+  }
 }
 ```
 
@@ -457,12 +578,12 @@ The `CommentRenderMode` enum values:
 1. **Reply threads**: Word supports threaded comment replies, but these are flattened in the current implementation
 2. **Resolved comments**: The resolved/done state of comments is not currently rendered
 3. **Comment highlighting colors**: Word allows different highlight colors per comment; currently all use the same CSS
-4. **Overlapping comments**: When multiple comments cover the same text, only the first comment's metadata is shown on the highlight span
-5. **Margin mode**: Requires custom CSS for proper positioning; no default layout provided
+4. **Overlapping comments**: When multiple comments cover the same text, they are nested; only the innermost comment's metadata is most visible
+5. **Margin mode positioning**: Comments in margin mode are rendered in document order, not positioned adjacent to their anchor text (would require JavaScript for dynamic positioning)
 
 ## Future Enhancements
 
 - Support for comment reply threads
 - Per-author highlight colors (similar to revision author colors)
 - Resolved/active comment state indication
-- Improved margin mode with automatic positioning
+- JavaScript-based dynamic positioning for margin mode comments

--- a/docs/architecture/wml_to_html_converter_gaps.md
+++ b/docs/architecture/wml_to_html_converter_gaps.md
@@ -1,0 +1,184 @@
+# WmlToHtmlConverter.cs - Gaps and Deficiencies
+
+This document catalogs known gaps, limitations, and areas for improvement in the WmlToHtmlConverter.
+
+## 1. Missing Element Handling
+
+Several Word elements are not handled in `ConvertToHtmlTransform`:
+
+| Element | Purpose | Impact |
+|---------|---------|--------|
+| `W.softHyphen` | Soft hyphen | Silently ignored, loses word-wrap hints |
+| `W.yearLong`, `W.yearShort`, `W.monthLong`, `W.monthShort`, `W.dayLong`, `W.dayShort` | Date/time fields | No output |
+| `W.pgNum`, `W.fldChar`, `W.fldSimple` (partially) | Page numbers, field codes | Incomplete field support |
+| `W.ruby` | Ruby annotations (CJK) | No support for East Asian text annotations |
+| `W.separator`, `W.continuationSeparator` | Footnote separators | Ignored |
+
+## 2. ~~Comment Rendering Mode Incomplete~~ (FIXED)
+
+**Status:** Resolved
+
+`CommentRenderMode.Margin` is now fully implemented with:
+- Flexbox-based layout with main content and margin column
+- CSS styling for margin notes with author, date, and back-reference links
+- Print media query for responsive behavior
+
+See `docs/architecture/comment_rendering.md` for full documentation.
+
+## 3. Text Box Content Not Fully Rendered
+
+**Location:** Line 2041
+
+Text boxes (`w:txbxContent`) are explicitly trimmed in multiple places:
+- `DescendantsTrimmed(W.txbxContent)` is used throughout
+- Text box content is preserved but not transformed to proper HTML `<div>` or `<aside>` elements
+
+## 4. Limited Drawing/Image Support
+
+**Location:** Lines 4617-4856
+
+- Only handles these content types: `png`, `gif`, `tiff`, `jpeg`
+- **WMF and EMF files are explicitly excluded** (line 4619 comment)
+- SVG images not supported
+- **No fallback or placeholder** for unsupported image types - they just disappear
+
+## 5. Incomplete Run Properties
+
+**Location:** Lines 2835-2865
+
+The code documents unsupported properties:
+```csharp
+// Don't handle:
+// - em (emphasis mark)
+// - emboss
+// - fitText
+// - imprint
+// - kern (kerning)
+// - outline
+// - shadow
+// - w (character width expansion)
+```
+
+## 6. Paragraph Properties Not Handled
+
+**Location:** Lines 2508-2555
+
+Many documented but unimplemented:
+- `contextualSpacing` - partially handled
+- `framePr` (frames)
+- `keepLines`, `keepNext` (pagination control)
+- `mirrorIndents`
+- `pageBreakBefore`
+- `suppressAutoHyphens`
+- `tabs` - only partially implemented
+- `textDirection`
+- `widowControl`
+
+## 7. Tab Width Calculation Disabled
+
+**Location:** Lines 3803-3823
+
+```csharp
+// TODO: Revisit. This is a quick fix because it doesn't work on Azure.
+// ...
+const int widthOfText = 0;  // <-- Always zero!
+```
+
+Tab width calculation for text content is completely disabled.
+
+## 8. Hard-coded Default Language
+
+**Location:** Line 3211
+
+```csharp
+const string defaultLanguage = "en-US"; // todo need to get defaultLanguage
+```
+
+Should read from document settings (`w:settings/w:themeFontLang`).
+
+## 9. Theme Colors Not Resolved
+
+**Location:** Lines 3468-3472
+
+While `w:themeColor` and `w:themeTint` are copied during border overrides, **theme colors are never resolved to actual RGB values** from the document's theme.
+
+## 10. No Math Equation Support
+
+OMML (`<m:oMath>`) elements are not handled at all - equations silently disappear from output.
+
+## 11. Section Break Handling
+
+**Location:** Lines 2461-2500
+
+- Section breaks are conflated if formatting is identical
+- No visual separation or page-break CSS added
+- Headers/footers for different sections not differentiated
+
+## 12. Tracked Changes - Partial Property Support
+
+**Location:** Lines 3003-3054
+
+`DescribeFormatChange` only checks 7 properties:
+- Bold, Italic, Underline, Strikethrough, Font size, Font name, Color
+
+Missing: highlight, caps, smallCaps, spacing, position, etc.
+
+## 13. Potential Null Reference Issues
+
+Several places access `.First()` without null checks:
+- Line 3061: `var rPr = run.Elements(W.rPr).First();` - crashes if no `rPr`
+- Line 3213: `var rPr = run.Elements(W.rPr).First();`
+
+## 14. Font Fallback Limited
+
+**Location:** Lines 4514-4547
+
+Only 28 fonts have fallback definitions. Unknown fonts get no CSS `font-family` fallback to serif/sans-serif.
+
+## 15. Static Mutable State
+
+**Location:** Lines 3883, 4410
+
+```csharp
+private static readonly HashSet<string> UnknownFonts = new HashSet<string>();
+private static readonly Dictionary<string, string> ShadeCache = new Dictionary<string, string>();
+```
+
+These are not thread-safe and will grow unbounded across multiple document conversions.
+
+## 16. Complex Script (BiDi) Handling Incomplete
+
+- RTL marks added but complex script font sizing (`w:szCs`) is only used when `languageType == "bidi"`
+- No proper handling of mixed LTR/RTL content in tables
+
+## 17. No Accessibility Attributes
+
+- Images get `alt` text from `descr` attribute
+- No ARIA roles on semantic elements
+- No `lang` attribute on the `<html>` element itself
+
+## 18. Form Fields Not Supported
+
+`w:ffData`, `w:checkBox`, `w:textInput`, `w:ddList` are not converted to HTML form elements.
+
+---
+
+## Summary of Priority Fixes
+
+### High Priority
+
+1. ~~**Implement `CommentRenderMode.Margin`**~~ - FIXED
+2. **Handle null `rPr`** in `DefineRunStyle` and `GetLangAttribute` to prevent crashes
+3. **Add thread-safety** to static caches or make them instance-based
+
+### Medium Priority
+
+4. **Add SVG image support** - increasingly common in modern documents
+5. **Implement theme color resolution** for accurate color rendering
+6. **Fix tab width calculation** - currently disabled entirely
+
+### Low Priority (Feature Additions)
+
+7. **Consider OMML to MathML conversion** for equation support
+8. **Add form field support** for interactive documents
+9. **Improve accessibility** with ARIA roles and proper `lang` attributes


### PR DESCRIPTION
## Summary

- Implements the previously-unimplemented `CommentRenderMode.Margin` for comment rendering in `WmlToHtmlConverter`
- Displays comments in a side column alongside document content using CSS flexbox layout
- Adds comprehensive documentation of known gaps in the HTML converter

## Changes

### WmlToHtmlConverter.cs
- Added flexbox-based margin layout CSS with print media query support
- Modified body rendering to wrap content in margin container when margin mode is enabled
- Added `RenderMarginCommentsColumn()` method to create the aside element containing all margin comments
- Added `RenderMarginCommentNote()` method to render individual comment notes with header (author, date, back-link) and body

### Tests
- `HC020_Comments_MarginMode`: Tests margin mode with a real document containing comments
- `HC021_Comments_MarginMode_MultipleComments`: Tests multiple comments ordering in margin mode

### Documentation
- Updated `docs/architecture/comment_rendering.md` with margin mode HTML structure and CSS
- Added `docs/architecture/wml_to_html_converter_gaps.md` documenting known limitations and areas for improvement

## Test plan

- [x] Run `HC020_Comments_MarginMode` test
- [x] Run `HC021_Comments_MarginMode_MultipleComments` test
- [x] Run all comment-related tests (8 passed)
- [x] Run full test suite (997 passed, 1 skipped)