### PR TITLE
fix: resolve WASM CDN loading CORS issues

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -209,34 +209,20 @@ jobs:
             echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build WASM
-        run: |
-          cd wasm/DocxodusWasm
-          dotnet publish -c Release
-
       - name: Install npm dependencies
         run: |
           cd npm
           npm ci
 
-      - name: Build TypeScript
-        run: |
-          cd npm
-          npm run build:ts
-
-      - name: Copy WASM to dist
-        run: |
-          mkdir -p npm/dist/wasm
-          cp -r wasm/DocxodusWasm/bin/Release/net8.0/browser-wasm/AppBundle/_framework npm/dist/wasm/
-          cp wasm/DocxodusWasm/main.js npm/dist/wasm/
-
       - name: Update package version
         run: |
           cd npm
           npm version ${{ steps.version.outputs.VERSION }} --no-git-tag-version
-          # Update CDN version in index.ts to match
-          sed -i "s/const PACKAGE_VERSION = \".*\"/const PACKAGE_VERSION = \"${{ steps.version.outputs.VERSION }}\"/" src/index.ts
-          npm run build:ts
+
+      - name: Build npm package (WASM + TypeScript)
+        run: |
+          cd npm
+          npm run build
 
       - name: Publish to npm
         run: |

--- a/npm/src/react.ts
+++ b/npm/src/react.ts
@@ -47,16 +47,16 @@ export interface UseDocxodusResult {
  * React hook for using Docxodus WASM functionality.
  * Automatically initializes the WASM runtime on mount.
  *
- * By default, WASM files are loaded from CDN (jsDelivr/unpkg).
- * Pass a custom path only if you need to host files locally.
+ * WASM files are auto-detected from the module's location (works with CDN, npm, or local hosting).
+ * Pass a custom path only if you need to host files at a different location.
  *
- * @param wasmBasePath - Optional custom path to WASM files. Leave empty for CDN (recommended).
+ * @param wasmBasePath - Optional custom path to WASM files. Leave empty for auto-detection.
  * @returns Object with ready state and document functions
  *
  * @example
  * ```tsx
  * function App() {
- *   // Uses CDN by default - no configuration needed!
+ *   // Auto-detects WASM location - no configuration needed!
  *   const { isReady, isLoading, error, convertToHtml } = useDocxodus();
  *
  *   const handleFile = async (file: File) => {
@@ -186,14 +186,14 @@ export interface UseConversionResult {
 
 /**
  * React hook for DOCX to HTML conversion with state management.
- * WASM files are loaded from CDN by default.
+ * WASM files are auto-detected from the module's location.
  *
- * @param wasmBasePath - Optional custom path to WASM files. Leave empty for CDN (recommended).
+ * @param wasmBasePath - Optional custom path to WASM files. Leave empty for auto-detection.
  *
  * @example
  * ```tsx
  * function Converter() {
- *   // Uses CDN by default - no configuration needed!
+ *   // Auto-detects WASM location - no configuration needed!
  *   const { html, isConverting, error, convert } = useConversion();
  *
  *   return (
@@ -279,14 +279,14 @@ export interface UseComparisonResult {
 
 /**
  * React hook for document comparison with state management.
- * WASM files are loaded from CDN by default.
+ * WASM files are auto-detected from the module's location.
  *
- * @param wasmBasePath - Optional custom path to WASM files. Leave empty for CDN (recommended).
+ * @param wasmBasePath - Optional custom path to WASM files. Leave empty for auto-detection.
  *
  * @example
  * ```tsx
  * function Comparer() {
- *   // Uses CDN by default - no configuration needed!
+ *   // Auto-detects WASM location - no configuration needed!
  *   const { html, isComparing, error, compareToHtml, downloadResult } = useComparison();
  *   const [original, setOriginal] = useState<File | null>(null);
  *   const [modified, setModified] = useState<File | null>(null);


### PR DESCRIPTION
## Summary

- Patches both `dotnet.js` AND `dotnet.native.js` for `credentials:"omit"` (previously only `dotnet.js` was patched)
- Replaces hardcoded `PACKAGE_VERSION` with `import.meta.url` auto-detection for reliable CDN/npm loading
- Fixes publish workflow to use `npm run build` instead of manual file copy (ensures CORS patches are applied)

## Problem

Users were seeing CORS errors when loading from CDN:
```
Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource 
at 'https://cdn.jsdelivr.net/npm/docxodus@3.1.1/dist/wasm/_framework/blazor.boot.json'. 
(Reason: Credential is not supported if the CORS header 'Access-Control-Allow-Origin' is '*').
```

**Root causes:**
1. `dotnet.native.js` still had `credentials:"same-origin"` (only `dotnet.js` was patched)
2. `PACKAGE_VERSION` was hardcoded as `"0.0.0"` but published version was `3.1.1`
3. CI workflow bypassed the build script, so CORS patches weren't applied

## Test plan

- [x] Local tests pass (36/36)