### PR TITLE
feat(npm): improve getRevisions() API with TypeScript enum and helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ All notable changes to this project will be documented in this file.
   - DOCX to HTML conversion
   - React hooks: `useDocxodus`, `useConversion`, `useComparison`
   - Build script: `scripts/build-wasm.sh`
+- **Improved Revision API** - Better TypeScript support for the `getRevisions()` API
+  - `RevisionType` enum with `Inserted` and `Deleted` values for type-safe comparisons
+  - `isInsertion()` and `isDeletion()` helper functions for filtering revisions
+  - Comprehensive JSDoc documentation on the `Revision` interface
+  - All types are properly exported from the package (`import { RevisionType, isInsertion, isDeletion } from 'docxodus'`)
 - `SkiaSharpHelpers.cs` - Color utilities for SkiaSharp compatibility
 - `GetPackage()` extension method in `PtOpenXmlUtil.cs` for SDK 3.x Package access
 - `SkiaSharp.NativeAssets.Linux.NoDependencies` package for Linux runtime support

--- a/docs/architecture/wml_comparer_gaps.md
+++ b/docs/architecture/wml_comparer_gaps.md
@@ -1,0 +1,136 @@
+# WmlComparer.cs - Gaps and Deficiencies
+
+This document catalogs known gaps, limitations, and areas for improvement in the WmlComparer (document comparison engine).
+
+## 1. Limited Revision Types Exposed
+
+**Location:** `WmlComparer.cs` lines 3317-3321
+
+The `WmlComparerRevisionType` enum only exposes two revision types:
+
+```csharp
+public enum WmlComparerRevisionType
+{
+    Inserted,
+    Deleted,
+}
+```
+
+However, the **HTML renderer** (`WmlToHtmlConverter`) supports rendering additional tracked change types from Word documents:
+- `w:ins` - Insertions (rendered as `<ins>`)
+- `w:del` - Deletions (rendered as `<del>`)
+- `w:moveFrom` / `w:moveTo` - Move operations (when `RenderMoveOperations` is enabled)
+- `w:rPrChange` / `w:pPrChange` - Format changes (described via `DescribeFormatChange`)
+
+### Impact
+
+When comparing two documents, the `GetRevisions()` API cannot distinguish between:
+- Content that was moved vs. deleted and re-inserted elsewhere
+- Pure text changes vs. formatting-only changes
+
+### Internal State Not Exposed
+
+The internal `CorrelationStatus` enum has more granular states that are not exposed to consumers:
+- `Nil`, `Normal`, `Unknown`, `Inserted`, `Deleted`, `Equal`, `Group`
+
+### Recommendation
+
+Extend `WmlComparerRevisionType` to include:
+- `Moved` - For content detected as moved (currently shows as deletion + insertion pair)
+- `FormatChange` - For formatting-only modifications
+
+This would bring the comparison API in line with what the HTML renderer already supports for documents with existing tracked changes.
+
+## 2. Move Detection Not Implemented
+
+**Status:** Gap
+
+The comparison algorithm does not attempt to detect when content has been moved from one location to another. Instead, moved content appears as:
+1. A deletion at the original location
+2. An insertion at the new location
+
+Word's native comparison feature can detect moves and mark them with `w:moveFrom` / `w:moveTo` elements, which the HTML renderer can then display distinctly from regular insertions/deletions.
+
+### Recommendation
+
+Implement move detection by:
+1. After identifying deletions and insertions, compare their text content
+2. If a deletion's text closely matches an insertion's text (above a similarity threshold), mark them as a move pair
+3. Add `Moved` to `WmlComparerRevisionType` and track source/destination locations
+
+## 3. Format Change Detection Not Exposed
+
+**Status:** Gap
+
+When formatting changes occur without text changes, the comparison engine may not surface these as distinct revisions. Word documents can track formatting changes via:
+- `w:rPrChange` - Run property changes (font, size, bold, etc.)
+- `w:pPrChange` - Paragraph property changes (alignment, spacing, etc.)
+- `w:sectPrChange` - Section property changes
+- `w:tblPrChange` - Table property changes
+
+### Recommendation
+
+Add a `FormatChange` revision type that captures:
+- The element affected
+- The old formatting properties
+- The new formatting properties
+
+## 4. Revision Metadata Limitations
+
+**Location:** `WmlComparerRevision` class
+
+The current revision class exposes:
+```csharp
+public class WmlComparerRevision
+{
+    public WmlComparerRevisionType RevisionType;
+    public string Text;
+    public string Author;
+    public string Date;
+    public XElement ContentXElement;
+    public XElement RevisionXElement;
+    public Uri PartUri;
+    public string PartContentType;
+}
+```
+
+### Missing Information
+
+- **Move pair linking** - If moves were detected, there's no way to link the "from" and "to" revisions
+- **Paragraph context** - The surrounding paragraph or heading for context
+- **Position information** - Character offset or paragraph number in the document
+
+## 5. npm/TypeScript API Reflects .NET Limitations
+
+The TypeScript `RevisionType` enum mirrors the .NET limitation:
+
+```typescript
+export enum RevisionType {
+  Inserted = "Inserted",
+  Deleted = "Deleted",
+}
+```
+
+When the .NET comparison engine is enhanced, the TypeScript types should be updated accordingly:
+- `npm/src/types.ts` - Add new enum values
+- `npm/src/index.ts` - Update exports
+- `wasm/DocxodusWasm/DocumentComparer.cs` - Update WASM bridge
+
+---
+
+## Summary of Priority Improvements
+
+### High Priority
+
+1. **Add move detection** - Distinguish moved content from delete+insert pairs
+2. **Expose format changes** - Add `FormatChange` revision type for formatting-only modifications
+
+### Medium Priority
+
+3. **Add revision context** - Include paragraph number or surrounding text for better UX
+4. **Link related revisions** - Connect move pairs and other related changes
+
+### Low Priority
+
+5. **Position information** - Add character/word offsets for precise location
+6. **Granular format change details** - Specify exactly which properties changed

--- a/npm/README.md
+++ b/npm/README.md
@@ -174,12 +174,40 @@ Compare documents and return the result as HTML.
 Extract revision information from a compared document.
 
 ```typescript
+import { getRevisions, RevisionType, isInsertion, isDeletion } from 'docxodus';
+import type { Revision } from 'docxodus';
+
+// RevisionType enum - the only two types returned by the comparison engine
+enum RevisionType {
+  Inserted = "Inserted",  // Text or content that was added
+  Deleted = "Deleted",    // Text or content that was removed
+}
+
+// Revision interface with full documentation
 interface Revision {
+  /** Author who made the revision (may be empty string if not specified) */
   author: string;
+  /** ISO 8601 date string (e.g., "2024-01-15T10:30:00Z"), may be empty */
   date: string;
-  revisionType: string; // "Insertion", "Deletion", etc.
+  /** Type of revision - "Inserted" or "Deleted" */
+  revisionType: RevisionType | string;
+  /** Text content (newline for paragraph breaks, empty for images/equations) */
   text: string;
 }
+
+// Helper functions for type-safe filtering
+const revisions = await getRevisions(comparedDoc);
+const insertions = revisions.filter(isInsertion);
+const deletions = revisions.filter(isDeletion);
+
+// Or use the enum directly
+revisions.forEach(rev => {
+  if (rev.revisionType === RevisionType.Inserted) {
+    console.log(`${rev.author} added: "${rev.text}"`);
+  } else if (rev.revisionType === RevisionType.Deleted) {
+    console.log(`${rev.author} removed: "${rev.text}"`);
+  }
+});
 ```
 
 ### React Hooks

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -8,7 +8,12 @@ import type {
   DocxodusWasmExports,
 } from "./types.js";
 
-import { CommentRenderMode } from "./types.js";
+import {
+  CommentRenderMode,
+  RevisionType,
+  isInsertion,
+  isDeletion,
+} from "./types.js";
 
 export type {
   ConversionOptions,
@@ -19,7 +24,7 @@ export type {
   CompareResult,
 };
 
-export { CommentRenderMode };
+export { CommentRenderMode, RevisionType, isInsertion, isDeletion };
 
 let wasmExports: DocxodusWasmExports | null = null;
 let initPromise: Promise<void> | null = null;

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -1,4 +1,15 @@
 /**
+ * Revision type enum matching the .NET WmlComparerRevisionType
+ * These are the only two revision types returned by the comparison engine
+ */
+export enum RevisionType {
+  /** Text or content that was added/inserted */
+  Inserted = "Inserted",
+  /** Text or content that was removed/deleted */
+  Deleted = "Deleted",
+}
+
+/**
  * Comment render mode
  * Use -1 (Disabled) to not render comments, or a positive value to enable with that mode
  */
@@ -50,17 +61,74 @@ export interface CompareOptions {
 }
 
 /**
- * Information about a document revision
+ * Information about a document revision extracted from a compared document.
+ *
+ * @example
+ * ```typescript
+ * const revisions = await getRevisions(comparedDoc);
+ * for (const rev of revisions) {
+ *   if (rev.revisionType === RevisionType.Inserted) {
+ *     console.log(`${rev.author} added: "${rev.text}"`);
+ *   } else if (rev.revisionType === RevisionType.Deleted) {
+ *     console.log(`${rev.author} removed: "${rev.text}"`);
+ *   }
+ * }
+ * ```
  */
 export interface Revision {
-  /** Author who made the revision */
+  /**
+   * Author who made the revision.
+   * This comes from the Word document's tracked changes author attribute.
+   * May be empty string if the document doesn't specify an author.
+   */
   author: string;
-  /** ISO date string of the revision */
+  /**
+   * ISO 8601 date string when the revision was made.
+   * Format: "YYYY-MM-DDTHH:mm:ssZ" (e.g., "2024-01-15T10:30:00Z")
+   * May be empty string if the document doesn't specify a date.
+   */
   date: string;
-  /** Type of revision: "Insertion", "Deletion", etc. */
-  revisionType: string;
-  /** Text content of the revision */
+  /**
+   * Type of revision - either "Inserted" or "Deleted".
+   * Use the RevisionType enum for type-safe comparisons.
+   */
+  revisionType: RevisionType | string;
+  /**
+   * Text content of the revision.
+   * For paragraph breaks, this will be a newline character.
+   * May be empty string for non-text elements (e.g., images, math equations).
+   */
   text: string;
+}
+
+/**
+ * Type guard to check if a revision is an insertion.
+ * @param revision - The revision to check
+ * @returns true if the revision is an insertion
+ *
+ * @example
+ * ```typescript
+ * const revisions = await getRevisions(doc);
+ * const insertions = revisions.filter(isInsertion);
+ * ```
+ */
+export function isInsertion(revision: Revision): boolean {
+  return revision.revisionType === RevisionType.Inserted;
+}
+
+/**
+ * Type guard to check if a revision is a deletion.
+ * @param revision - The revision to check
+ * @returns true if the revision is a deletion
+ *
+ * @example
+ * ```typescript
+ * const revisions = await getRevisions(doc);
+ * const deletions = revisions.filter(isDeletion);
+ * ```
+ */
+export function isDeletion(revision: Revision): boolean {
+  return revision.revisionType === RevisionType.Deleted;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `RevisionType` enum with `Inserted` and `Deleted` values for type-safe comparisons
- Add `isInsertion()` and `isDeletion()` helper functions for filtering revisions  
- Update `Revision` interface with comprehensive JSDoc documentation
- Document edge cases: empty author/date strings, newlines for paragraph breaks
- Export all new types and functions from package entry point
- Update npm README with detailed usage examples
- Add `docs/architecture/wml_comparer_gaps.md` documenting comparison engine limitations and future improvements

## Usage

```typescript
import { getRevisions, RevisionType, isInsertion, isDeletion } from 'docxodus';
import type { Revision } from 'docxodus';

const revisions = await getRevisions(comparedDoc);

// Option A: Use helper functions
const insertions = revisions.filter(isInsertion);
const deletions = revisions.filter(isDeletion);

// Option B: Use enum directly
revisions.forEach(rev => {
  if (rev.revisionType === RevisionType.Inserted) {
    console.log(`${rev.author} added: "${rev.text}"`);
  }
});
```

## Test plan

- [x] TypeScript builds successfully (`npm run build:ts`)
- [x] .NET tests pass (`dotnet test`)