### PR TITLE
feat(comparer): detect and emit native Word format change markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,21 @@ All notable changes to this project will be documented in this file.
     - `isMove()`, `isMoveSource()`, `isMoveDestination()` type guards
     - `findMovePair()` function to find linked move revisions
     - `moveGroupId` and `isMoveSource` properties on `Revision` interface
+- **Format Change Detection in WmlComparer** - Detects and tracks formatting-only changes (`w:rPrChange`)
+  - When text content is identical but formatting changes (bold, italic, font size, etc.), produces native Word format change markup
+  - Compared documents now contain `w:rPrChange` elements that Microsoft Word recognizes in Track Changes
+  - New `FormatChanged` value in `WmlComparerRevisionType` enum
+  - New `FormatChange` property on `WmlComparerRevision` with:
+    - `OldProperties`: Dictionary of original formatting properties
+    - `NewProperties`: Dictionary of new formatting properties
+    - `ChangedPropertyNames`: List of what changed (e.g., "bold", "italic", "fontSize")
+  - New setting in `WmlComparerSettings`:
+    - `DetectFormatChanges`: Enable/disable format change detection (default: true)
+  - Full WASM/npm support with new TypeScript helpers:
+    - `RevisionType.FormatChanged` enum value
+    - `isFormatChange()` type guard
+    - `FormatChangeDetails` interface with `oldProperties`, `newProperties`, `changedPropertyNames`
+    - `formatChange` property on `Revision` interface
 - **Improved Revision API** - Better TypeScript support for the `getRevisions()` API
   - `RevisionType` enum with `Inserted`, `Deleted`, and `Moved` values for type-safe comparisons
   - `isInsertion()`, `isDeletion()`, `isMove()`, `isMoveSource()`, `isMoveDestination()` helper functions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ DocumentBuilder.BuildDocument(sources, outputPath);
 - `DetectMoves` - Enable move detection in `GetRevisions()` (default: true)
 - `MoveSimilarityThreshold` - Jaccard similarity threshold for moves (default: 0.8)
 - `MoveMinimumWordCount` - Minimum words for move detection (default: 3)
+- `DetectFormatChanges` - Enable format change detection (default: true)
 
 Move detection produces **native Word move markup** (`w:moveFrom`/`w:moveTo`) when `DetectMoves` is enabled:
 - The comparer analyzes deleted/inserted content blocks for similarity after LCS comparison
@@ -121,6 +122,13 @@ Move detection produces **native Word move markup** (`w:moveFrom`/`w:moveTo`) wh
 - `GetRevisions()` recognizes this native markup and returns `WmlComparerRevisionType.Moved` revisions
 - `WmlComparerRevision.MoveGroupId` links source and destination revisions
 - `WmlComparerRevision.IsMoveSource` - true = moved FROM here, false = moved TO here
+
+Format change detection produces **native Word format change markup** (`w:rPrChange`) when `DetectFormatChanges` is enabled:
+- The comparer analyzes Equal atoms (same text content) for run property differences after LCS comparison
+- When text is identical but formatting differs (bold, italic, font size, etc.), atoms are marked as FormatChanged
+- The output document contains `w:rPrChange` elements inside `w:rPr` with the old formatting properties
+- `GetRevisions()` recognizes this native markup and returns `WmlComparerRevisionType.FormatChanged` revisions
+- `WmlComparerRevision.FormatChange` contains details about what changed (old/new properties, changed property names)
 
 **WmlToHtmlConverter.cs / HtmlToWmlConverter.cs** - Bidirectional DOCX ↔ HTML conversion. Key settings in `WmlToHtmlConverterSettings`:
 - `RenderTrackedChanges` - Render insertions/deletions as `<ins>`/`<del>` instead of accepting them

--- a/Docxodus.Tests/WmlComparerFormatChangeTests.cs
+++ b/Docxodus.Tests/WmlComparerFormatChangeTests.cs
@@ -1,0 +1,573 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Docxodus;
+using Xunit;
+using static Docxodus.WmlComparer;
+
+namespace OxPt
+{
+    /// <summary>
+    /// Tests for format change detection in WmlComparer.
+    /// Tests verify that when text content is identical but formatting changes,
+    /// the comparison produces native w:rPrChange markup.
+    /// </summary>
+    public class WmlComparerFormatChangeTests
+    {
+        #region Helper Methods
+
+        /// <summary>
+        /// Creates a minimal valid DOCX document with the specified paragraphs.
+        /// </summary>
+        private static WmlDocument CreateDocumentWithParagraphs(params string[] paragraphs)
+        {
+            using var stream = new MemoryStream();
+            using (var doc = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document))
+            {
+                var mainPart = doc.AddMainDocumentPart();
+                mainPart.Document = new Document(
+                    new Body(
+                        paragraphs.Select(text =>
+                            new Paragraph(
+                                new Run(
+                                    new Text(text)
+                                )
+                            )
+                        )
+                    )
+                );
+
+                // Add required styles part
+                var stylesPart = mainPart.AddNewPart<StyleDefinitionsPart>();
+                stylesPart.Styles = new Styles(
+                    new DocDefaults(
+                        new RunPropertiesDefault(
+                            new RunPropertiesBaseStyle(
+                                new RunFonts { Ascii = "Calibri" },
+                                new FontSize { Val = "22" }
+                            )
+                        ),
+                        new ParagraphPropertiesDefault()
+                    )
+                );
+
+                // Add required settings part
+                var settingsPart = mainPart.AddNewPart<DocumentSettingsPart>();
+                settingsPart.Settings = new Settings();
+
+                doc.Save();
+            }
+
+            stream.Position = 0;
+            return new WmlDocument("test.docx", stream.ToArray());
+        }
+
+        /// <summary>
+        /// Creates a DOCX document with a paragraph that has bold text.
+        /// </summary>
+        private static WmlDocument CreateDocumentWithBoldParagraph(string text)
+        {
+            using var stream = new MemoryStream();
+            using (var doc = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document))
+            {
+                var mainPart = doc.AddMainDocumentPart();
+                mainPart.Document = new Document(
+                    new Body(
+                        new Paragraph(
+                            new Run(
+                                new RunProperties(new Bold()),
+                                new Text(text)
+                            )
+                        )
+                    )
+                );
+
+                // Add required styles part
+                var stylesPart = mainPart.AddNewPart<StyleDefinitionsPart>();
+                stylesPart.Styles = new Styles(
+                    new DocDefaults(
+                        new RunPropertiesDefault(
+                            new RunPropertiesBaseStyle(
+                                new RunFonts { Ascii = "Calibri" },
+                                new FontSize { Val = "22" }
+                            )
+                        ),
+                        new ParagraphPropertiesDefault()
+                    )
+                );
+
+                // Add required settings part
+                var settingsPart = mainPart.AddNewPart<DocumentSettingsPart>();
+                settingsPart.Settings = new Settings();
+
+                doc.Save();
+            }
+
+            stream.Position = 0;
+            return new WmlDocument("test.docx", stream.ToArray());
+        }
+
+        /// <summary>
+        /// Creates a DOCX document with a paragraph that has italic text.
+        /// </summary>
+        private static WmlDocument CreateDocumentWithItalicParagraph(string text)
+        {
+            using var stream = new MemoryStream();
+            using (var doc = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document))
+            {
+                var mainPart = doc.AddMainDocumentPart();
+                mainPart.Document = new Document(
+                    new Body(
+                        new Paragraph(
+                            new Run(
+                                new RunProperties(new Italic()),
+                                new Text(text)
+                            )
+                        )
+                    )
+                );
+
+                // Add required styles part
+                var stylesPart = mainPart.AddNewPart<StyleDefinitionsPart>();
+                stylesPart.Styles = new Styles(
+                    new DocDefaults(
+                        new RunPropertiesDefault(
+                            new RunPropertiesBaseStyle(
+                                new RunFonts { Ascii = "Calibri" },
+                                new FontSize { Val = "22" }
+                            )
+                        ),
+                        new ParagraphPropertiesDefault()
+                    )
+                );
+
+                // Add required settings part
+                var settingsPart = mainPart.AddNewPart<DocumentSettingsPart>();
+                settingsPart.Settings = new Settings();
+
+                doc.Save();
+            }
+
+            stream.Position = 0;
+            return new WmlDocument("test.docx", stream.ToArray());
+        }
+
+        /// <summary>
+        /// Creates a DOCX document with a paragraph that has both bold and italic text.
+        /// </summary>
+        private static WmlDocument CreateDocumentWithBoldItalicParagraph(string text)
+        {
+            using var stream = new MemoryStream();
+            using (var doc = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document))
+            {
+                var mainPart = doc.AddMainDocumentPart();
+                mainPart.Document = new Document(
+                    new Body(
+                        new Paragraph(
+                            new Run(
+                                new RunProperties(new Bold(), new Italic()),
+                                new Text(text)
+                            )
+                        )
+                    )
+                );
+
+                // Add required styles part
+                var stylesPart = mainPart.AddNewPart<StyleDefinitionsPart>();
+                stylesPart.Styles = new Styles(
+                    new DocDefaults(
+                        new RunPropertiesDefault(
+                            new RunPropertiesBaseStyle(
+                                new RunFonts { Ascii = "Calibri" },
+                                new FontSize { Val = "22" }
+                            )
+                        ),
+                        new ParagraphPropertiesDefault()
+                    )
+                );
+
+                // Add required settings part
+                var settingsPart = mainPart.AddNewPart<DocumentSettingsPart>();
+                settingsPart.Settings = new Settings();
+
+                doc.Save();
+            }
+
+            stream.Position = 0;
+            return new WmlDocument("test.docx", stream.ToArray());
+        }
+
+        private static XNamespace W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+
+        #endregion
+
+        #region Basic Format Change Detection Tests
+
+        [Fact]
+        public void FormatChange_AddBold_ShouldContainRPrChangeElement()
+        {
+            // Arrange: Create two documents - same text, doc2 has bold
+            var doc1 = CreateDocumentWithParagraphs("This is some sample text.");
+            var doc2 = CreateDocumentWithBoldParagraph("This is some sample text.");
+
+            var settings = new WmlComparerSettings
+            {
+                DetectFormatChanges = true
+            };
+
+            // Act
+            var compared = WmlComparer.Compare(doc1, doc2, settings);
+
+            // Assert: Check that the compared document contains w:rPrChange
+            using var ms = new MemoryStream(compared.DocumentByteArray);
+            using var wDoc = WordprocessingDocument.Open(ms, false);
+            var mainDoc = wDoc.MainDocumentPart.GetXDocument();
+            var rPrChanges = mainDoc.Descendants(W + "rPrChange").ToList();
+
+            Assert.NotEmpty(rPrChanges);
+        }
+
+        [Fact]
+        public void FormatChange_RemoveBold_ShouldContainRPrChangeElement()
+        {
+            // Arrange: Create two documents - doc1 has bold, doc2 doesn't
+            var doc1 = CreateDocumentWithBoldParagraph("This is some sample text.");
+            var doc2 = CreateDocumentWithParagraphs("This is some sample text.");
+
+            var settings = new WmlComparerSettings
+            {
+                DetectFormatChanges = true
+            };
+
+            // Act
+            var compared = WmlComparer.Compare(doc1, doc2, settings);
+
+            // Assert: Check that the compared document contains w:rPrChange
+            using var ms = new MemoryStream(compared.DocumentByteArray);
+            using var wDoc = WordprocessingDocument.Open(ms, false);
+            var mainDoc = wDoc.MainDocumentPart.GetXDocument();
+            var rPrChanges = mainDoc.Descendants(W + "rPrChange").ToList();
+
+            Assert.NotEmpty(rPrChanges);
+        }
+
+        [Fact]
+        public void FormatChange_BoldToItalic_ShouldContainRPrChangeElement()
+        {
+            // Arrange: Create two documents - doc1 has bold, doc2 has italic
+            var doc1 = CreateDocumentWithBoldParagraph("This is some sample text.");
+            var doc2 = CreateDocumentWithItalicParagraph("This is some sample text.");
+
+            var settings = new WmlComparerSettings
+            {
+                DetectFormatChanges = true
+            };
+
+            // Act
+            var compared = WmlComparer.Compare(doc1, doc2, settings);
+
+            // Assert: Check that the compared document contains w:rPrChange
+            using var ms = new MemoryStream(compared.DocumentByteArray);
+            using var wDoc = WordprocessingDocument.Open(ms, false);
+            var mainDoc = wDoc.MainDocumentPart.GetXDocument();
+            var rPrChanges = mainDoc.Descendants(W + "rPrChange").ToList();
+
+            Assert.NotEmpty(rPrChanges);
+        }
+
+        [Fact]
+        public void FormatChange_AddMultipleFormats_ShouldContainRPrChangeElement()
+        {
+            // Arrange: Create two documents - plain to bold+italic
+            var doc1 = CreateDocumentWithParagraphs("This is some sample text.");
+            var doc2 = CreateDocumentWithBoldItalicParagraph("This is some sample text.");
+
+            var settings = new WmlComparerSettings
+            {
+                DetectFormatChanges = true
+            };
+
+            // Act
+            var compared = WmlComparer.Compare(doc1, doc2, settings);
+
+            // Assert: Check that the compared document contains w:rPrChange
+            using var ms = new MemoryStream(compared.DocumentByteArray);
+            using var wDoc = WordprocessingDocument.Open(ms, false);
+            var mainDoc = wDoc.MainDocumentPart.GetXDocument();
+            var rPrChanges = mainDoc.Descendants(W + "rPrChange").ToList();
+
+            Assert.NotEmpty(rPrChanges);
+        }
+
+        #endregion
+
+        #region RprChange Attributes Tests
+
+        [Fact]
+        public void FormatChange_ShouldHaveRequiredAttributes()
+        {
+            // Arrange
+            var doc1 = CreateDocumentWithParagraphs("This is some sample text.");
+            var doc2 = CreateDocumentWithBoldParagraph("This is some sample text.");
+
+            var settings = new WmlComparerSettings
+            {
+                DetectFormatChanges = true,
+                AuthorForRevisions = "Test Author"
+            };
+
+            // Act
+            var compared = WmlComparer.Compare(doc1, doc2, settings);
+
+            // Assert: Check that rPrChange has required attributes
+            using var ms = new MemoryStream(compared.DocumentByteArray);
+            using var wDoc = WordprocessingDocument.Open(ms, false);
+            var mainDoc = wDoc.MainDocumentPart.GetXDocument();
+            var rPrChanges = mainDoc.Descendants(W + "rPrChange").ToList();
+
+            Assert.NotEmpty(rPrChanges);
+            foreach (var rPrChange in rPrChanges)
+            {
+                Assert.NotNull(rPrChange.Attribute(W + "id"));
+                Assert.NotNull(rPrChange.Attribute(W + "author"));
+                Assert.NotNull(rPrChange.Attribute(W + "date"));
+                Assert.Equal("Test Author", (string)rPrChange.Attribute(W + "author"));
+            }
+        }
+
+        [Fact]
+        public void FormatChange_ShouldContainOldProperties()
+        {
+            // Arrange: bold to plain - the old properties should be bold
+            var doc1 = CreateDocumentWithBoldParagraph("This is some sample text.");
+            var doc2 = CreateDocumentWithParagraphs("This is some sample text.");
+
+            var settings = new WmlComparerSettings
+            {
+                DetectFormatChanges = true
+            };
+
+            // Act
+            var compared = WmlComparer.Compare(doc1, doc2, settings);
+
+            // Assert: Check that rPrChange contains rPr with the old properties
+            using var ms = new MemoryStream(compared.DocumentByteArray);
+            using var wDoc = WordprocessingDocument.Open(ms, false);
+            var mainDoc = wDoc.MainDocumentPart.GetXDocument();
+            var rPrChanges = mainDoc.Descendants(W + "rPrChange").ToList();
+
+            Assert.NotEmpty(rPrChanges);
+            var rPrChange = rPrChanges.First();
+            var oldRPr = rPrChange.Element(W + "rPr");
+            Assert.NotNull(oldRPr);
+            // The old properties should contain bold
+            Assert.NotNull(oldRPr.Element(W + "b"));
+        }
+
+        #endregion
+
+        #region Settings Tests
+
+        [Fact]
+        public void FormatChange_WhenDisabled_ShouldNotContainRPrChangeElement()
+        {
+            // Arrange
+            var doc1 = CreateDocumentWithParagraphs("This is some sample text.");
+            var doc2 = CreateDocumentWithBoldParagraph("This is some sample text.");
+
+            var settings = new WmlComparerSettings
+            {
+                DetectFormatChanges = false  // Disabled
+            };
+
+            // Act
+            var compared = WmlComparer.Compare(doc1, doc2, settings);
+
+            // Assert: Should NOT contain rPrChange
+            using var ms = new MemoryStream(compared.DocumentByteArray);
+            using var wDoc = WordprocessingDocument.Open(ms, false);
+            var mainDoc = wDoc.MainDocumentPart.GetXDocument();
+            var rPrChanges = mainDoc.Descendants(W + "rPrChange").ToList();
+
+            Assert.Empty(rPrChanges);
+        }
+
+        [Fact]
+        public void FormatChange_NoFormattingChange_ShouldNotContainRPrChangeElement()
+        {
+            // Arrange: Same text, same formatting
+            var doc1 = CreateDocumentWithBoldParagraph("This is some sample text.");
+            var doc2 = CreateDocumentWithBoldParagraph("This is some sample text.");
+
+            var settings = new WmlComparerSettings
+            {
+                DetectFormatChanges = true
+            };
+
+            // Act
+            var compared = WmlComparer.Compare(doc1, doc2, settings);
+
+            // Assert: Should NOT contain rPrChange since formatting is the same
+            using var ms = new MemoryStream(compared.DocumentByteArray);
+            using var wDoc = WordprocessingDocument.Open(ms, false);
+            var mainDoc = wDoc.MainDocumentPart.GetXDocument();
+            var rPrChanges = mainDoc.Descendants(W + "rPrChange").ToList();
+
+            Assert.Empty(rPrChanges);
+        }
+
+        #endregion
+
+        #region GetRevisions Tests
+
+        [Fact]
+        public void GetRevisions_FormatChange_ShouldReturnFormatChangedType()
+        {
+            // Arrange
+            var doc1 = CreateDocumentWithParagraphs("This is some sample text.");
+            var doc2 = CreateDocumentWithBoldParagraph("This is some sample text.");
+
+            var settings = new WmlComparerSettings
+            {
+                DetectFormatChanges = true
+            };
+
+            // Act
+            var compared = WmlComparer.Compare(doc1, doc2, settings);
+            var revisions = WmlComparer.GetRevisions(compared, settings);
+
+            // Assert
+            var formatChangedRevisions = revisions.Where(r => r.RevisionType == WmlComparerRevisionType.FormatChanged).ToList();
+            Assert.NotEmpty(formatChangedRevisions);
+        }
+
+        [Fact]
+        public void GetRevisions_FormatChange_ShouldHaveFormatChangeDetails()
+        {
+            // Arrange
+            var doc1 = CreateDocumentWithParagraphs("This is some sample text.");
+            var doc2 = CreateDocumentWithBoldParagraph("This is some sample text.");
+
+            var settings = new WmlComparerSettings
+            {
+                DetectFormatChanges = true
+            };
+
+            // Act
+            var compared = WmlComparer.Compare(doc1, doc2, settings);
+            var revisions = WmlComparer.GetRevisions(compared, settings);
+
+            // Assert
+            var formatChangedRevisions = revisions.Where(r => r.RevisionType == WmlComparerRevisionType.FormatChanged).ToList();
+            Assert.NotEmpty(formatChangedRevisions);
+
+            var revision = formatChangedRevisions.First();
+            Assert.NotNull(revision.FormatChange);
+            Assert.NotNull(revision.FormatChange.ChangedPropertyNames);
+            Assert.Contains("bold", revision.FormatChange.ChangedPropertyNames);
+        }
+
+        [Fact]
+        public void GetRevisions_FormatChange_ShouldHaveCorrectText()
+        {
+            // Arrange
+            var doc1 = CreateDocumentWithParagraphs("This is some sample text.");
+            var doc2 = CreateDocumentWithBoldParagraph("This is some sample text.");
+
+            var settings = new WmlComparerSettings
+            {
+                DetectFormatChanges = true
+            };
+
+            // Act
+            var compared = WmlComparer.Compare(doc1, doc2, settings);
+            var revisions = WmlComparer.GetRevisions(compared, settings);
+
+            // Assert
+            var formatChangedRevisions = revisions.Where(r => r.RevisionType == WmlComparerRevisionType.FormatChanged).ToList();
+            Assert.NotEmpty(formatChangedRevisions);
+
+            var revision = formatChangedRevisions.First();
+            Assert.NotNull(revision.Text);
+            Assert.Contains("sample", revision.Text);
+        }
+
+        #endregion
+
+        #region Integration with Text Changes Tests
+
+        [Fact]
+        public void FormatChange_WithTextChange_ShouldTrackBoth()
+        {
+            // Arrange: Both text and format change
+            // Doc1: plain "Hello world"
+            // Doc2: bold "Hello there" (both text and format change)
+            var doc1 = CreateDocumentWithParagraphs("Hello world");
+
+            using var stream = new MemoryStream();
+            using (var doc = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document))
+            {
+                var mainPart = doc.AddMainDocumentPart();
+                mainPart.Document = new Document(
+                    new Body(
+                        new Paragraph(
+                            new Run(
+                                new RunProperties(new Bold()),
+                                new Text("Hello there")
+                            )
+                        )
+                    )
+                );
+
+                var stylesPart = mainPart.AddNewPart<StyleDefinitionsPart>();
+                stylesPart.Styles = new Styles(
+                    new DocDefaults(
+                        new RunPropertiesDefault(
+                            new RunPropertiesBaseStyle(
+                                new RunFonts { Ascii = "Calibri" },
+                                new FontSize { Val = "22" }
+                            )
+                        ),
+                        new ParagraphPropertiesDefault()
+                    )
+                );
+
+                var settingsPart = mainPart.AddNewPart<DocumentSettingsPart>();
+                settingsPart.Settings = new Settings();
+
+                doc.Save();
+            }
+
+            stream.Position = 0;
+            var doc2 = new WmlDocument("test.docx", stream.ToArray());
+
+            var settings = new WmlComparerSettings
+            {
+                DetectFormatChanges = true
+            };
+
+            // Act
+            var compared = WmlComparer.Compare(doc1, doc2, settings);
+            var revisions = WmlComparer.GetRevisions(compared, settings);
+
+            // Assert: Should have both text changes and potentially format changes
+            Assert.True(revisions.Count > 0, "Should have revisions");
+
+            // Text changes should result in ins/del
+            var textRevisions = revisions.Where(r =>
+                r.RevisionType == WmlComparerRevisionType.Inserted ||
+                r.RevisionType == WmlComparerRevisionType.Deleted).ToList();
+            Assert.NotEmpty(textRevisions);
+        }
+
+        #endregion
+    }
+}

--- a/Docxodus.Tests/WmlComparerTests.cs
+++ b/Docxodus.Tests/WmlComparerTests.cs
@@ -585,7 +585,7 @@ namespace OxPt
         [InlineData("WC-2010", "WC/WC059-Footnote.docx", "WC/WC059-Footnote-Mod.docx", 5)]
         [InlineData("WC-2020", "WC/WC060-Endnote.docx", "WC/WC060-Endnote-Mod.docx", 3)]
         [InlineData("WC-2030", "WC/WC061-Style-Added.docx", "WC/WC061-Style-Added-Mod.docx", 1)]
-        [InlineData("WC-2040", "WC/WC062-New-Char-Style-Added.docx", "WC/WC062-New-Char-Style-Added-Mod.docx", 2)]
+        [InlineData("WC-2040", "WC/WC062-New-Char-Style-Added.docx", "WC/WC062-New-Char-Style-Added-Mod.docx", 3)] // +1 from format change detection
         [InlineData("WC-2050", "WC/WC063-Footnote.docx", "WC/WC063-Footnote-Mod.docx", 1)]
         [InlineData("WC-2060", "WC/WC063-Footnote-Mod.docx", "WC/WC063-Footnote.docx", 1)]
         [InlineData("WC-2070", "WC/WC064-Footnote.docx", "WC/WC064-Footnote-Mod.docx", 0)]

--- a/docs/architecture/format_change_detection.md
+++ b/docs/architecture/format_change_detection.md
@@ -1,0 +1,513 @@
+# Format Change Detection Architecture
+
+> **Status: IMPLEMENTED** (November 2025)
+
+## Overview
+
+This document describes the architecture for detecting and emitting native Word format change markup (`w:rPrChange`/`w:pPrChange`) in `WmlComparer.Compare()`. When enabled, formatting-only changes (bold, italic, font size, etc.) are tracked as distinct revisions, separate from text insertions and deletions.
+
+## Problem Statement
+
+Currently, when comparing documents:
+- Text changes are tracked via `w:ins` and `w:del`
+- Move operations are tracked via `w:moveFrom` and `w:moveTo`
+- **Formatting-only changes are NOT tracked**
+
+If text remains the same but formatting changes (e.g., making text bold), the current implementation treats this as "equal" content and doesn't emit any revision markup.
+
+## Solution: Following the Move Detection Pattern
+
+The move detection architecture established a successful pattern:
+1. **Post-LCS Detection**: Analyze atoms AFTER LCS comparison, BEFORE markup emission
+2. **Status Extension**: Add new `CorrelationStatus` values
+3. **Native Markup**: Emit Word-native revision elements
+
+Format change detection follows this same pattern.
+
+## Algorithm
+
+### Key Insight: We Already Have Both Document's Data
+
+When atoms are marked as `Equal`, the `FlattenToComparisonUnitAtomList` method already stores:
+- `ContentElement` - from the modified document (doc2)
+- `ContentElementBefore` - from the original document (doc1)
+- `ComparisonUnitAtomBefore` - full atom from original, including `AncestorElements`
+
+The `AncestorElements` array includes the `w:r` (run) element, which contains `w:rPr` (run properties).
+
+### Pipeline
+
+```
+Compare(doc1, doc2, settings)
+    │
+    ├─► Lcs() ─────────────────────────────► Deleted, Inserted, Equal
+    │
+    ├─► FlattenToComparisonUnitAtomList()
+    │       Equal atoms have: ContentElement, ContentElementBefore,
+    │                         ComparisonUnitAtomBefore (with AncestorElements)
+    │
+    │   ╔═══════════════════════════════════════════════════════════╗
+    │   ║  DetectMovesInAtomList()                                  ║
+    │   ║  Deleted + Inserted → MovedSource/MovedDestination        ║
+    │   ╠═══════════════════════════════════════════════════════════╣
+    │   ║  DetectFormatChangesInAtomList()    ← NEW                 ║
+    │   ║  Equal atoms with different rPr → FormatChanged           ║
+    │   ║  - Extract rPr from AncestorElements (w:r element)        ║
+    │   ║  - Compare before vs after rPr                            ║
+    │   ║  - Store FormatChangeInfo with old/new properties         ║
+    │   ╚═══════════════════════════════════════════════════════════╝
+    │
+    ├─► CoalesceRecurse()
+    │       Propagates FormatChanged status and FormatChangeInfo
+    │
+    ├─► MarkContentAsDeletedOrInsertedTransform()
+    │       - MovedSource → w:moveFrom
+    │       - MovedDestination → w:moveTo
+    │       - FormatChanged → content with w:rPrChange    ← NEW
+    │
+    └─► WmlDocument with tracked revisions
+```
+
+## OpenXML Format Change Markup
+
+### Run Property Change (w:rPrChange)
+
+When text formatting changes (bold, italic, font, etc.):
+
+```xml
+<w:r>
+  <w:rPr>
+    <w:b/>                    <!-- New: bold -->
+    <w:i/>                    <!-- New: italic -->
+    <w:rPrChange w:id="1" w:author="Author" w:date="2025-01-15T10:30:00Z">
+      <w:rPr>
+        <!-- Old: no bold, no italic (empty or different properties) -->
+      </w:rPr>
+    </w:rPrChange>
+  </w:rPr>
+  <w:t>formatted text</w:t>
+</w:r>
+```
+
+### Paragraph Property Change (w:pPrChange)
+
+When paragraph formatting changes (alignment, spacing, etc.):
+
+```xml
+<w:p>
+  <w:pPr>
+    <w:jc w:val="center"/>    <!-- New: centered -->
+    <w:pPrChange w:id="2" w:author="Author" w:date="2025-01-15T10:30:00Z">
+      <w:pPr>
+        <w:jc w:val="left"/>  <!-- Old: left aligned -->
+      </w:pPr>
+    </w:pPrChange>
+  </w:pPr>
+  <w:r><w:t>text</w:t></w:r>
+</w:p>
+```
+
+## Implementation Steps
+
+### Step 1: Extend CorrelationStatus Enum
+
+```csharp
+public enum CorrelationStatus
+{
+    Nil,
+    Normal,
+    Unknown,
+    Inserted,
+    Deleted,
+    Equal,
+    Group,
+    MovedSource,
+    MovedDestination,
+    FormatChanged,      // NEW: Text equal, run formatting differs
+}
+```
+
+### Step 2: Add FormatChangeInfo Class
+
+```csharp
+/// <summary>
+/// Stores information about formatting changes between original and modified content.
+/// </summary>
+public class FormatChangeInfo
+{
+    /// <summary>
+    /// Run properties from the original document (before changes).
+    /// </summary>
+    public XElement OldRunProperties { get; set; }
+
+    /// <summary>
+    /// Run properties from the modified document (after changes).
+    /// </summary>
+    public XElement NewRunProperties { get; set; }
+
+    /// <summary>
+    /// List of property names that changed (e.g., "bold", "italic", "fontSize").
+    /// </summary>
+    public List<string> ChangedProperties { get; set; } = new List<string>();
+}
+```
+
+### Step 3: Add FormatChangeInfo to ComparisonUnitAtom
+
+```csharp
+public class ComparisonUnitAtom : ComparisonUnit
+{
+    // ... existing properties ...
+
+    public int? MoveGroupId;
+    public string MoveName;
+
+    /// <summary>
+    /// For format-changed content: stores old and new formatting properties.
+    /// </summary>
+    public FormatChangeInfo FormatChange;  // NEW
+}
+```
+
+### Step 4: Implement DetectFormatChangesInAtomList()
+
+```csharp
+/// <summary>
+/// Analyzes Equal atoms for formatting differences.
+/// Converts atoms with different rPr to FormatChanged status.
+/// </summary>
+private static void DetectFormatChangesInAtomList(
+    List<ComparisonUnitAtom> atoms,
+    WmlComparerSettings settings)
+{
+    if (!settings.DetectFormatChanges)
+        return;
+
+    foreach (var atom in atoms)
+    {
+        // Only check Equal atoms that have a "before" reference
+        if (atom.CorrelationStatus != CorrelationStatus.Equal)
+            continue;
+        if (atom.ComparisonUnitAtomBefore == null)
+            continue;
+
+        // Extract rPr from both documents
+        var oldRPr = GetRunPropertiesFromAtom(atom.ComparisonUnitAtomBefore);
+        var newRPr = GetRunPropertiesFromAtom(atom);
+
+        // Compare run properties
+        if (!AreRunPropertiesEqual(oldRPr, newRPr, settings))
+        {
+            atom.CorrelationStatus = CorrelationStatus.FormatChanged;
+            atom.FormatChange = new FormatChangeInfo
+            {
+                OldRunProperties = oldRPr,
+                NewRunProperties = newRPr,
+                ChangedProperties = GetChangedPropertyNames(oldRPr, newRPr)
+            };
+        }
+    }
+}
+
+/// <summary>
+/// Extracts the w:rPr element from an atom's ancestor w:r element.
+/// </summary>
+private static XElement GetRunPropertiesFromAtom(ComparisonUnitAtom atom)
+{
+    // Find the w:r ancestor element
+    var runElement = atom.AncestorElements?.FirstOrDefault(a => a.Name == W.r);
+    if (runElement == null)
+        return null;
+
+    // Get the rPr child element
+    return runElement.Element(W.rPr);
+}
+
+/// <summary>
+/// Compares two rPr elements for equality, ignoring revision tracking elements.
+/// </summary>
+private static bool AreRunPropertiesEqual(XElement rPr1, XElement rPr2, WmlComparerSettings settings)
+{
+    // Normalize: treat null as empty rPr
+    var normalized1 = NormalizeRunProperties(rPr1);
+    var normalized2 = NormalizeRunProperties(rPr2);
+
+    // Compare the normalized XML
+    return XNode.DeepEquals(normalized1, normalized2);
+}
+
+/// <summary>
+/// Normalizes rPr for comparison by removing revision tracking elements
+/// and sorting children consistently.
+/// </summary>
+private static XElement NormalizeRunProperties(XElement rPr)
+{
+    if (rPr == null)
+        return new XElement(W.rPr);
+
+    // Clone and remove revision tracking elements (rPrChange, etc.)
+    var normalized = new XElement(W.rPr,
+        rPr.Elements()
+           .Where(e => e.Name != W.rPrChange)
+           .OrderBy(e => e.Name.LocalName)
+           .Select(e => new XElement(e.Name, e.Attributes().OrderBy(a => a.Name.LocalName))));
+
+    return normalized;
+}
+
+/// <summary>
+/// Returns a list of property names that differ between two rPr elements.
+/// </summary>
+private static List<string> GetChangedPropertyNames(XElement oldRPr, XElement newRPr)
+{
+    var changed = new List<string>();
+
+    var oldProps = (oldRPr?.Elements() ?? Enumerable.Empty<XElement>())
+        .Where(e => e.Name != W.rPrChange)
+        .ToDictionary(e => e.Name, e => e);
+    var newProps = (newRPr?.Elements() ?? Enumerable.Empty<XElement>())
+        .Where(e => e.Name != W.rPrChange)
+        .ToDictionary(e => e.Name, e => e);
+
+    // Find properties that were added, removed, or changed
+    var allPropertyNames = oldProps.Keys.Union(newProps.Keys);
+
+    foreach (var propName in allPropertyNames)
+    {
+        var hasOld = oldProps.TryGetValue(propName, out var oldProp);
+        var hasNew = newProps.TryGetValue(propName, out var newProp);
+
+        if (hasOld != hasNew || (hasOld && hasNew && !XNode.DeepEquals(oldProp, newProp)))
+        {
+            changed.Add(GetFriendlyPropertyName(propName));
+        }
+    }
+
+    return changed;
+}
+
+private static string GetFriendlyPropertyName(XName propName)
+{
+    return propName.LocalName switch
+    {
+        "b" => "bold",
+        "i" => "italic",
+        "u" => "underline",
+        "strike" => "strikethrough",
+        "sz" => "fontSize",
+        "szCs" => "fontSizeComplex",
+        "rFonts" => "font",
+        "color" => "color",
+        "highlight" => "highlight",
+        "vertAlign" => "verticalAlign",
+        _ => propName.LocalName
+    };
+}
+```
+
+### Step 5: Inject Detection in Pipeline
+
+After `DetectMovesInAtomList`, add:
+
+```csharp
+// Detect moves BEFORE markup is written
+DetectMovesInAtomList(listOfComparisonUnitAtoms, settings);
+
+// Detect format changes in Equal atoms
+DetectFormatChangesInAtomList(listOfComparisonUnitAtoms, settings);
+```
+
+### Step 6: Update CoalesceRecurse for FormatChanged Status
+
+Add handling to propagate format change status:
+
+```csharp
+if (atom.CorrelationStatus == CorrelationStatus.FormatChanged)
+{
+    element.Add(new XAttribute("Status", "FormatChanged"));
+    if (atom.FormatChange != null)
+    {
+        // Store old rPr as a child element for later use in markup emission
+        if (atom.FormatChange.OldRunProperties != null)
+        {
+            element.Add(new XAttribute(PtOpenXml.pt + "OldRPr",
+                atom.FormatChange.OldRunProperties.ToString(SaveOptions.DisableFormatting)));
+        }
+    }
+}
+```
+
+### Step 7: Emit Format Change Markup
+
+In `MarkContentAsDeletedOrInsertedTransform()`:
+
+```csharp
+else if (status == "FormatChanged")
+{
+    // Get the old rPr from the attribute
+    var oldRPrString = (string)element.Attribute(PtOpenXml.pt + "OldRPr");
+    var oldRPr = oldRPrString != null ? XElement.Parse(oldRPrString) : new XElement(W.rPr);
+
+    // Find or create the new rPr in the run
+    var run = element.Name == W.r ? element : element.AncestorsAndSelf(W.r).FirstOrDefault();
+    if (run != null)
+    {
+        var newRPr = run.Element(W.rPr) ?? new XElement(W.rPr);
+
+        // Add rPrChange to track the format change
+        newRPr.Add(new XElement(W.rPrChange,
+            new XAttribute(W.id, s_MaxId++),
+            new XAttribute(W.author, settings.AuthorForRevisions),
+            new XAttribute(W.date, settings.DateTimeForRevisions),
+            oldRPr));
+
+        // Ensure rPr is in the run
+        if (run.Element(W.rPr) == null)
+            run.AddFirst(newRPr);
+    }
+
+    // Return the element with its content (not wrapped like ins/del)
+    return element;
+}
+```
+
+### Step 8: Add WmlComparerSettings
+
+```csharp
+public class WmlComparerSettings
+{
+    // ... existing settings ...
+
+    /// <summary>
+    /// Enable detection of formatting-only changes (bold, italic, font size, etc.).
+    /// Default: true
+    /// </summary>
+    public bool DetectFormatChanges { get; set; } = true;
+}
+```
+
+### Step 9: Update GetRevisions() for Format Changes
+
+Add a new revision type and detection:
+
+```csharp
+public enum WmlComparerRevisionType
+{
+    Inserted,
+    Deleted,
+    Moved,
+    FormatChanged,  // NEW
+}
+
+public class WmlComparerRevision
+{
+    // ... existing properties ...
+
+    /// <summary>
+    /// For FormatChanged revisions: details about what formatting changed.
+    /// </summary>
+    public FormatChangeDetails FormatChange { get; set; }
+}
+
+public class FormatChangeDetails
+{
+    public Dictionary<string, string> OldProperties { get; set; }
+    public Dictionary<string, string> NewProperties { get; set; }
+    public List<string> ChangedPropertyNames { get; set; }
+}
+```
+
+In `GetRevisions()`, detect `w:rPrChange` elements:
+
+```csharp
+// Look for rPrChange elements
+var rPrChanges = mainXDoc.Descendants(W.rPrChange);
+foreach (var rPrChange in rPrChanges)
+{
+    var revision = new WmlComparerRevision
+    {
+        RevisionType = WmlComparerRevisionType.FormatChanged,
+        Author = (string)rPrChange.Attribute(W.author) ?? "",
+        Date = (string)rPrChange.Attribute(W.date) ?? "",
+        Text = GetTextFromAncestorRun(rPrChange),
+        FormatChange = ExtractFormatChangeDetails(rPrChange)
+    };
+    revisions.Add(revision);
+}
+```
+
+## Configuration
+
+### WmlComparerSettings
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `DetectFormatChanges` | `true` | Enable/disable format change detection |
+
+### Disabling Format Detection
+
+When `DetectFormatChanges = false`:
+- `DetectFormatChangesInAtomList()` returns immediately
+- No `w:rPrChange` markup is generated
+- Format-only changes are treated as equal content
+
+## Test Plan
+
+### Unit Tests
+
+1. **Simple bold change** - Text becomes bold
+2. **Multiple property changes** - Bold + italic + font size
+3. **Property removal** - Bold removed
+4. **No format change** - Same formatting, verify no FormatChanged status
+5. **Format + text change** - Text changed AND formatted (should be ins/del, not format change)
+6. **Paragraph property change** - Alignment change (future enhancement)
+
+### Integration Tests
+
+1. **Word compatibility** - Open result in Word, verify format changes in Track Changes
+2. **Round-trip** - Compare → GetRevisions → verify FormatChange populated
+3. **Accept revisions** - Verify format changes can be accepted/rejected
+
+## Future Enhancements
+
+### Paragraph Property Changes (Phase 2)
+
+Detect `w:pPr` differences and emit `w:pPrChange`:
+- Alignment changes
+- Indentation changes
+- Spacing changes
+- List formatting changes
+
+### Section Property Changes (Phase 3)
+
+Detect `w:sectPr` differences and emit `w:sectPrChange`:
+- Page size/orientation
+- Margins
+- Headers/footers
+
+### Table Property Changes (Phase 4)
+
+Detect `w:tblPr` differences and emit `w:tblPrChange`:
+- Table borders
+- Cell spacing
+- Table width
+
+## Complexity Analysis
+
+| Step | Risk | Complexity | Impact |
+|------|------|------------|--------|
+| Extend CorrelationStatus | Low | Low | Foundation for format tracking |
+| FormatChangeInfo class | Low | Low | Data structure |
+| DetectFormatChangesInAtomList | Medium | Medium | rPr comparison logic |
+| CoalesceRecurse changes | Low | Low | Status propagation |
+| Markup emission | Medium | Medium | Correct w:rPrChange placement |
+| GetRevisions() changes | Low | Low | Element detection |
+
+## Summary
+
+This architecture:
+1. **Follows the proven move detection pattern** - Same injection point, similar logic flow
+2. **Leverages existing infrastructure** - Uses `ContentElementBefore` and `ComparisonUnitAtomBefore`
+3. **Produces native Word markup** - Documents show format changes in Word's Track Changes
+4. **Is incrementally implementable** - Start with run properties, extend to paragraph/section/table
+5. **Maintains backward compatibility** - `DetectFormatChanges = false` preserves existing behavior

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -7,6 +7,7 @@ import type {
   CompareResult,
   DocxodusWasmExports,
   GetRevisionsOptions,
+  FormatChangeDetails,
 } from "./types.js";
 
 import {
@@ -18,6 +19,7 @@ import {
   isMoveSource,
   isMoveDestination,
   findMovePair,
+  isFormatChange,
 } from "./types.js";
 
 export type {
@@ -28,6 +30,7 @@ export type {
   ErrorResponse,
   CompareResult,
   GetRevisionsOptions,
+  FormatChangeDetails,
 };
 
 export {
@@ -39,6 +42,7 @@ export {
   isMoveSource,
   isMoveDestination,
   findMovePair,
+  isFormatChange,
 };
 
 let wasmExports: DocxodusWasmExports | null = null;
@@ -373,6 +377,11 @@ export async function getRevisions(
     text: r.Text || r.text,
     moveGroupId: r.MoveGroupId ?? r.moveGroupId,
     isMoveSource: r.IsMoveSource ?? r.isMoveSource,
+    formatChange: (r.FormatChange || r.formatChange) ? {
+      oldProperties: r.FormatChange?.OldProperties || r.formatChange?.oldProperties,
+      newProperties: r.FormatChange?.NewProperties || r.formatChange?.newProperties,
+      changedPropertyNames: r.FormatChange?.ChangedPropertyNames || r.formatChange?.changedPropertyNames,
+    } : undefined,
   }));
 }
 

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -8,6 +8,8 @@ export enum RevisionType {
   Deleted = "Deleted",
   /** Text or content that was relocated within the document */
   Moved = "Moved",
+  /** Text content unchanged but formatting (bold, italic, etc.) changed */
+  FormatChanged = "FormatChanged",
 }
 
 /**
@@ -112,6 +114,30 @@ export interface Revision {
    * Undefined for non-move revisions.
    */
   isMoveSource?: boolean;
+  /**
+   * For FormatChanged revisions: details about what formatting changed.
+   * Undefined for non-format-change revisions.
+   */
+  formatChange?: FormatChangeDetails;
+}
+
+/**
+ * Details about formatting changes for FormatChanged revisions.
+ */
+export interface FormatChangeDetails {
+  /**
+   * Dictionary of old property names and values.
+   * Keys are friendly property names like "bold", "italic", "fontSize".
+   */
+  oldProperties?: Record<string, string>;
+  /**
+   * Dictionary of new property names and values.
+   */
+  newProperties?: Record<string, string>;
+  /**
+   * List of property names that changed (e.g., "bold", "italic", "fontSize").
+   */
+  changedPropertyNames?: string[];
 }
 
 /**
@@ -157,6 +183,24 @@ export function isDeletion(revision: Revision): boolean {
  */
 export function isMove(revision: Revision): boolean {
   return revision.revisionType === RevisionType.Moved;
+}
+
+/**
+ * Type guard to check if a revision is a format change.
+ * @param revision - The revision to check
+ * @returns true if the revision is a format change
+ *
+ * @example
+ * ```typescript
+ * const revisions = await getRevisions(doc);
+ * const formatChanges = revisions.filter(isFormatChange);
+ * for (const rev of formatChanges) {
+ *   console.log(`Format changed: ${rev.formatChange?.changedPropertyNames?.join(", ")}`);
+ * }
+ * ```
+ */
+export function isFormatChange(revision: Revision): boolean {
+  return revision.revisionType === RevisionType.FormatChanged;
 }
 
 /**

--- a/wasm/DocxodusWasm/DocumentComparer.cs
+++ b/wasm/DocxodusWasm/DocumentComparer.cs
@@ -200,7 +200,13 @@ public partial class DocumentComparer
                     RevisionType = r.RevisionType.ToString(),
                     Text = r.Text ?? "",
                     MoveGroupId = r.MoveGroupId,
-                    IsMoveSource = r.IsMoveSource
+                    IsMoveSource = r.IsMoveSource,
+                    FormatChange = r.FormatChange != null ? new FormatChangeInfo
+                    {
+                        OldProperties = r.FormatChange.OldProperties,
+                        NewProperties = r.FormatChange.NewProperties,
+                        ChangedPropertyNames = r.FormatChange.ChangedPropertyNames
+                    } : null
                 }).ToArray()
             };
 

--- a/wasm/DocxodusWasm/JsonContext.cs
+++ b/wasm/DocxodusWasm/JsonContext.cs
@@ -11,6 +11,7 @@ namespace DocxodusWasm;
 [JsonSerializable(typeof(RevisionsResponse))]
 [JsonSerializable(typeof(RevisionInfo))]
 [JsonSerializable(typeof(RevisionInfo[]))]
+[JsonSerializable(typeof(FormatChangeInfo))]
 internal partial class DocxodusJsonContext : JsonSerializerContext
 {
 }
@@ -54,4 +55,31 @@ public class RevisionInfo
     /// Null for non-move revisions.
     /// </summary>
     public bool? IsMoveSource { get; set; }
+
+    /// <summary>
+    /// For FormatChanged revisions: details about what formatting changed.
+    /// Null for non-format-change revisions.
+    /// </summary>
+    public FormatChangeInfo? FormatChange { get; set; }
+}
+
+/// <summary>
+/// Details about formatting changes for FormatChanged revisions.
+/// </summary>
+public class FormatChangeInfo
+{
+    /// <summary>
+    /// Dictionary of old property names and values.
+    /// </summary>
+    public Dictionary<string, string>? OldProperties { get; set; }
+
+    /// <summary>
+    /// Dictionary of new property names and values.
+    /// </summary>
+    public Dictionary<string, string>? NewProperties { get; set; }
+
+    /// <summary>
+    /// List of property names that changed (e.g., "bold", "italic", "fontSize").
+    /// </summary>
+    public List<string>? ChangedPropertyNames { get; set; }
 }


### PR DESCRIPTION
## Summary

- Implements format change detection in WmlComparer that produces Word-native `w:rPrChange` markup
- When text content is identical but formatting differs (bold, italic, font size, etc.), the comparison now tracks these as distinct format change revisions
- Microsoft Word recognizes and displays these format changes in its Track Changes panel

## Key Changes

**Core Implementation:**
- Extended `CorrelationStatus` enum with `FormatChanged` value
- Added `FormatChangeInfo` class to store old/new run properties
- Added `DetectFormatChanges` setting (default: `true`) to `WmlComparerSettings`
- Implemented `DetectFormatChangesInAtomList()` following the same pattern as move detection
- Updated markup emission to produce native `w:rPrChange` elements
- Updated `GetRevisions()` to recognize and return `FormatChanged` revisions

**API Additions:**
- `WmlComparerRevisionType.FormatChanged` enum value
- `WmlComparerRevision.FormatChange` property with `OldProperties`, `NewProperties`, `ChangedPropertyNames`

**WASM/npm Support:**
- `RevisionType.FormatChanged` enum value
- `isFormatChange()` type guard function
- `FormatChangeDetails` interface
- `formatChange` property on `Revision` interface

## Test Plan

- [x] 12 new tests in `WmlComparerFormatChangeTests.cs` covering:
  - Adding bold formatting
  - Removing bold formatting
  - Changing bold to italic
  - Multiple format changes
  - Required attributes on `w:rPrChange`
  - Old properties storage
  - Detection disabled behavior
  - No change when formatting is identical
  - GetRevisions returns FormatChanged type
  - Format change details populated correctly
  - Text content in format change revisions
  - Combined text + format changes
- [x] All 1030 existing tests pass
- [x] Updated WC-2040 test expectation (+1 revision from format detection)

Closes #21