### PR TITLE
fix(html): use min-width for tab-preceding spans to prevent text overflow

### DIFF
--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -3090,11 +3090,15 @@ namespace Docxodus
             if (txElementsPrecedingTab.Count > 1)
             {
                 var span = new XElement(Xhtml.span, txElementsPrecedingTab);
+                // Use min-width instead of width so the container expands to fit content
+                // when text is wider than the calculated tab position. This fixes issues
+                // where list numbers (e.g., "2.3") overlap with heading text because the
+                // TabWidth for text elements is 0 (due to font measurement limitations).
                 var spanStyle = new Dictionary<string, string>
                 {
                     { "display", "inline-block" },
                     { "text-indent", "0" },
-                    { "width", string.Format(NumberFormatInfo.InvariantInfo, "{0:0.000}in", totalWidth) }
+                    { "min-width", string.Format(NumberFormatInfo.InvariantInfo, "{0:0.000}in", totalWidth) }
                 };
                 span.AddAnnotation(spanStyle);
             }
@@ -3106,7 +3110,8 @@ namespace Docxodus
                     var spanStyle = element.Annotation<Dictionary<string, string>>();
                     spanStyle.AddIfMissing("display", "inline-block");
                     spanStyle.AddIfMissing("text-indent", "0");
-                    spanStyle.AddIfMissing("width", string.Format(NumberFormatInfo.InvariantInfo, "{0:0.000}in", totalWidth));
+                    // Use min-width instead of width to allow content to expand naturally
+                    spanStyle.AddIfMissing("min-width", string.Format(NumberFormatInfo.InvariantInfo, "{0:0.000}in", totalWidth));
                 }
             }
             return txElementsPrecedingTab;


### PR DESCRIPTION
## Summary

- Changed `TransformElementsPrecedingTab` to use `min-width` instead of `width` for spans containing text that precedes tabs (like list numbers "2.3")
- Added test `HC015_TabPrecedingText_UsesMinWidth` to verify the fix

## Problem

Section numbers like "2.3" were overlapping with heading text ("Deemed Liquidation Events") in the HTML output. The spans containing tab-preceding text had a tiny fixed `width` (e.g., `width: 0.063in`) that was much smaller than the actual text content.

## Root Cause

The `TabWidth` for text elements (`W.t`) is hardcoded to 0 in `CalculateSpanWidthForTabs` (line 4287) due to font measurement limitations on some platforms. This meant the total width calculation in `TransformElementsPrecedingTab` only accounted for the tab gap, not the actual text width.

## Solution

Changed from `width` to `min-width` in the CSS styles. This allows the container to:
1. Expand naturally to fit the text content when text is wider than the calculated position
2. Still respect the minimum tab stop position when the text is shorter

## Test plan

- [x] Added test `HC015_TabPrecedingText_UsesMinWidth` that verifies `min-width` is used
- [x] All existing HTML converter tests pass (75 tests)
- [x] Full test suite passes (1030 tests)