### PR TITLE
feat(wasm): expose footnotes, headers/footers, and tracked changes rendering options

### DIFF
--- a/docs/npm-package.md
+++ b/docs/npm-package.md
@@ -14,6 +14,9 @@ npm install docxodus
 - **Move Detection**: Automatically identify when content is relocated (not just deleted/inserted)
 - **HTML Conversion**: Convert DOCX documents to HTML for display in the browser
 - **Comment Rendering**: Render Word document comments in three different styles
+- **Footnotes & Endnotes**: Render footnotes and endnotes with bidirectional links
+- **Headers & Footers**: Render document headers and footers in HTML output
+- **Tracked Changes Rendering**: Render insertions, deletions, and move operations in HTML
 - **Custom Annotations**: Add, remove, and render custom highlights with labels on document content
 - **Document Structure API**: Analyze documents and get navigable element trees for precise targeting
 - **Revision Extraction**: Get structured data about all revisions in a compared document
@@ -106,6 +109,35 @@ const html = await convertDocxToHtml(docxFile, {
 | `additionalCss` | `string` | `""` | Additional CSS to include |
 | `commentRenderMode` | `CommentRenderMode` | `Disabled` | How to render comments |
 | `commentCssClassPrefix` | `string` | `"comment-"` | CSS prefix for comment elements |
+| `renderFootnotesAndEndnotes` | `boolean` | `false` | Render footnotes/endnotes sections |
+| `renderHeadersAndFooters` | `boolean` | `false` | Render document headers/footers |
+| `renderTrackedChanges` | `boolean` | `false` | Render tracked changes (redlines) |
+| `showDeletedContent` | `boolean` | `true` | Show deleted content with strikethrough |
+| `renderMoveOperations` | `boolean` | `true` | Distinguish moves from insert/delete |
+| `renderAnnotations` | `boolean` | `false` | Render custom annotations |
+| `annotationLabelMode` | `AnnotationLabelMode` | `Above` | How to display annotation labels |
+| `annotationCssClassPrefix` | `string` | `"annot-"` | CSS prefix for annotations |
+| `paginationMode` | `PaginationMode` | `None` | Pagination mode for PDF-style view |
+| `paginationScale` | `number` | `1.0` | Scale factor for paginated view |
+| `paginationCssClassPrefix` | `string` | `"page-"` | CSS prefix for pagination |
+
+**Examples:**
+
+```typescript
+// Render with footnotes and tracked changes
+const html = await convertDocxToHtml(docxFile, {
+  renderFootnotesAndEndnotes: true,
+  renderHeadersAndFooters: true,
+  renderTrackedChanges: true,
+  showDeletedContent: true
+});
+
+// Render with annotations
+const html = await convertDocxToHtml(docxFile, {
+  renderAnnotations: true,
+  annotationLabelMode: AnnotationLabelMode.Above
+});
+```
 
 #### `compareDocuments(original, modified, options?): Promise<Uint8Array>`
 

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -297,6 +297,23 @@ async function toBytes(input: File | Uint8Array): Promise<Uint8Array> {
  *   renderAnnotations: true,
  *   annotationLabelMode: AnnotationLabelMode.Above
  * });
+ *
+ * // With footnotes and endnotes
+ * const html = await convertDocxToHtml(docxFile, {
+ *   renderFootnotesAndEndnotes: true
+ * });
+ *
+ * // With headers and footers
+ * const html = await convertDocxToHtml(docxFile, {
+ *   renderHeadersAndFooters: true
+ * });
+ *
+ * // With tracked changes (redlines visible)
+ * const html = await convertDocxToHtml(docxFile, {
+ *   renderTrackedChanges: true,
+ *   showDeletedContent: true,
+ *   renderMoveOperations: true
+ * });
  * ```
  */
 export async function convertDocxToHtml(
@@ -308,22 +325,34 @@ export async function convertDocxToHtml(
 
   let result: string;
 
-  // Use full method when annotations are requested
-  if (options?.renderAnnotations) {
-    result = exports.DocumentConverter.ConvertDocxToHtmlFull(
+  // Check if any of the new complete options are specified
+  const needsCompleteMethod = options?.renderFootnotesAndEndnotes !== undefined ||
+    options?.renderHeadersAndFooters !== undefined ||
+    options?.renderTrackedChanges !== undefined ||
+    options?.showDeletedContent !== undefined ||
+    options?.renderMoveOperations !== undefined;
+
+  // Use complete method when any new options are specified (most comprehensive)
+  if (needsCompleteMethod || options?.renderAnnotations) {
+    result = exports.DocumentConverter.ConvertDocxToHtmlComplete(
       bytes,
-      options.pageTitle ?? "Document",
-      options.cssPrefix ?? "docx-",
-      options.fabricateClasses ?? true,
-      options.additionalCss ?? "",
-      options.commentRenderMode ?? CommentRenderMode.Disabled,
-      options.commentCssClassPrefix ?? "comment-",
-      options.paginationMode ?? PaginationMode.None,
-      options.paginationScale ?? 1.0,
-      options.paginationCssClassPrefix ?? "page-",
-      options.renderAnnotations,
-      options.annotationLabelMode ?? AnnotationLabelMode.Above,
-      options.annotationCssClassPrefix ?? "annot-"
+      options?.pageTitle ?? "Document",
+      options?.cssPrefix ?? "docx-",
+      options?.fabricateClasses ?? true,
+      options?.additionalCss ?? "",
+      options?.commentRenderMode ?? CommentRenderMode.Disabled,
+      options?.commentCssClassPrefix ?? "comment-",
+      options?.paginationMode ?? PaginationMode.None,
+      options?.paginationScale ?? 1.0,
+      options?.paginationCssClassPrefix ?? "page-",
+      options?.renderAnnotations ?? false,
+      options?.annotationLabelMode ?? AnnotationLabelMode.Above,
+      options?.annotationCssClassPrefix ?? "annot-",
+      options?.renderFootnotesAndEndnotes ?? false,
+      options?.renderHeadersAndFooters ?? false,
+      options?.renderTrackedChanges ?? false,
+      options?.showDeletedContent ?? true,
+      options?.renderMoveOperations ?? true
     );
   }
   // Use pagination-aware method when pagination is requested

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -83,6 +83,16 @@ export interface ConversionOptions {
   annotationLabelMode?: AnnotationLabelMode;
   /** CSS class prefix for annotation elements (default: "annot-") */
   annotationCssClassPrefix?: string;
+  /** Whether to render footnotes and endnotes sections at the end of the document (default: false) */
+  renderFootnotesAndEndnotes?: boolean;
+  /** Whether to render document headers and footers (default: false) */
+  renderHeadersAndFooters?: boolean;
+  /** Whether to render tracked changes visually (insertions/deletions) (default: false) */
+  renderTrackedChanges?: boolean;
+  /** Whether to show deleted content with strikethrough (only when renderTrackedChanges=true, default: true) */
+  showDeletedContent?: boolean;
+  /** Whether to distinguish move operations from regular insert/delete (only when renderTrackedChanges=true, default: true) */
+  renderMoveOperations?: boolean;
 }
 
 /**
@@ -371,6 +381,26 @@ export interface DocxodusWasmExports {
       renderAnnotations: boolean,
       annotationLabelMode: number,
       annotationCssClassPrefix: string
+    ) => string;
+    ConvertDocxToHtmlComplete: (
+      bytes: Uint8Array,
+      pageTitle: string,
+      cssPrefix: string,
+      fabricateClasses: boolean,
+      additionalCss: string,
+      commentRenderMode: number,
+      commentCssClassPrefix: string,
+      paginationMode: number,
+      paginationScale: number,
+      paginationCssClassPrefix: string,
+      renderAnnotations: boolean,
+      annotationLabelMode: number,
+      annotationCssClassPrefix: string,
+      renderFootnotesAndEndnotes: boolean,
+      renderHeadersAndFooters: boolean,
+      renderTrackedChanges: boolean,
+      showDeletedContent: boolean,
+      renderMoveOperations: boolean
     ) => string;
     GetAnnotations: (bytes: Uint8Array) => string;
     AddAnnotation: (bytes: Uint8Array, requestJson: string) => string;

--- a/wasm/DocxodusWasm/DocumentConverter.cs
+++ b/wasm/DocxodusWasm/DocumentConverter.cs
@@ -147,6 +147,72 @@ public partial class DocumentConverter
         int annotationLabelMode,
         string annotationCssClassPrefix)
     {
+        // Delegate to complete version with new options disabled for backward compatibility
+        return ConvertDocxToHtmlComplete(
+            docxBytes,
+            pageTitle,
+            cssPrefix,
+            fabricateClasses,
+            additionalCss,
+            commentRenderMode,
+            commentCssClassPrefix,
+            paginationMode,
+            paginationScale,
+            paginationCssClassPrefix,
+            renderAnnotations,
+            annotationLabelMode,
+            annotationCssClassPrefix,
+            renderFootnotesAndEndnotes: false,
+            renderHeadersAndFooters: false,
+            renderTrackedChanges: false,
+            showDeletedContent: true,
+            renderMoveOperations: true
+        );
+    }
+
+    /// <summary>
+    /// Convert a DOCX file to HTML with all available options.
+    /// </summary>
+    /// <param name="docxBytes">The DOCX file as a byte array</param>
+    /// <param name="pageTitle">Title for the HTML document</param>
+    /// <param name="cssPrefix">Prefix for generated CSS class names</param>
+    /// <param name="fabricateClasses">Whether to generate CSS classes</param>
+    /// <param name="additionalCss">Additional CSS to include</param>
+    /// <param name="commentRenderMode">Comment render mode: -1=disabled, 0=EndnoteStyle, 1=Inline, 2=Margin</param>
+    /// <param name="commentCssClassPrefix">CSS class prefix for comments (default: "comment-")</param>
+    /// <param name="paginationMode">Pagination mode: 0=None, 1=Paginated</param>
+    /// <param name="paginationScale">Scale factor for page rendering (1.0 = 100%)</param>
+    /// <param name="paginationCssClassPrefix">CSS class prefix for pagination elements (default: "page-")</param>
+    /// <param name="renderAnnotations">Whether to render custom annotations</param>
+    /// <param name="annotationLabelMode">Annotation label mode: 0=Above, 1=Inline, 2=Tooltip, 3=None</param>
+    /// <param name="annotationCssClassPrefix">CSS class prefix for annotations (default: "annot-")</param>
+    /// <param name="renderFootnotesAndEndnotes">Whether to render footnotes and endnotes sections</param>
+    /// <param name="renderHeadersAndFooters">Whether to render document headers and footers</param>
+    /// <param name="renderTrackedChanges">Whether to render tracked changes (insertions/deletions)</param>
+    /// <param name="showDeletedContent">Whether to show deleted content with strikethrough (only when renderTrackedChanges=true)</param>
+    /// <param name="renderMoveOperations">Whether to distinguish move operations from insert/delete (only when renderTrackedChanges=true)</param>
+    /// <returns>HTML string or JSON error object</returns>
+    [JSExport]
+    public static string ConvertDocxToHtmlComplete(
+        byte[] docxBytes,
+        string pageTitle,
+        string cssPrefix,
+        bool fabricateClasses,
+        string additionalCss,
+        int commentRenderMode,
+        string commentCssClassPrefix,
+        int paginationMode,
+        double paginationScale,
+        string paginationCssClassPrefix,
+        bool renderAnnotations,
+        int annotationLabelMode,
+        string annotationCssClassPrefix,
+        bool renderFootnotesAndEndnotes,
+        bool renderHeadersAndFooters,
+        bool renderTrackedChanges,
+        bool showDeletedContent,
+        bool renderMoveOperations)
+    {
         if (docxBytes == null || docxBytes.Length == 0)
         {
             return SerializeError("No document data provided");
@@ -180,7 +246,13 @@ public partial class DocumentConverter
                 RenderAnnotations = renderAnnotations,
                 AnnotationLabelMode = (AnnotationLabelMode)annotationLabelMode,
                 AnnotationCssClassPrefix = annotationCssClassPrefix ?? "annot-",
-                IncludeAnnotationMetadata = true
+                IncludeAnnotationMetadata = true,
+                RenderFootnotesAndEndnotes = renderFootnotesAndEndnotes,
+                RenderHeadersAndFooters = renderHeadersAndFooters,
+                RenderTrackedChanges = renderTrackedChanges,
+                ShowDeletedContent = showDeletedContent,
+                RenderMoveOperations = renderMoveOperations,
+                IncludeRevisionMetadata = true
             };
 
             var htmlElement = WmlToHtmlConverter.ConvertToHtml(wordDoc, settings);


### PR DESCRIPTION
## Summary

Exposes the existing C# rendering options for footnotes/endnotes, headers/footers, and tracked changes to the WASM/JavaScript API.

### New `ConversionOptions` properties:

| Option | Type | Default | Description |
|--------|------|---------|-------------|
| `renderFootnotesAndEndnotes` | `boolean` | `false` | Render footnotes and endnotes sections at end of document |
| `renderHeadersAndFooters` | `boolean` | `false` | Render document headers and footers |
| `renderTrackedChanges` | `boolean` | `false` | Render tracked changes (insertions, deletions, moves) |
| `showDeletedContent` | `boolean` | `true` | Show deleted content with strikethrough (when renderTrackedChanges=true) |
| `renderMoveOperations` | `boolean` | `true` | Distinguish move operations from insert/delete (when renderTrackedChanges=true) |

### Changes

- **wasm/DocxodusWasm/DocumentConverter.cs**: Add new `ConvertDocxToHtmlComplete` method with all rendering options
- **npm/src/types.ts**: Add new options to `ConversionOptions` interface and `DocxodusWasmExports`
- **npm/src/index.ts**: Update `convertDocxToHtml` to use `ConvertDocxToHtmlComplete` when new options are specified
- **docs/npm-package.md**: Update documentation with new options and examples

### Example Usage

```typescript
// Render with footnotes and tracked changes
const html = await convertDocxToHtml(docxFile, {
  renderFootnotesAndEndnotes: true,
  renderHeadersAndFooters: true,
  renderTrackedChanges: true,
  showDeletedContent: true
});
```

## Test plan

- [x] Build WASM and TypeScript (`npm run build`)
- [x] All 62 Playwright tests pass (`npm test`)
- [x] Backward compatible - existing API continues to work