### PR TITLE
feat(pagination): add footnote continuation across pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,9 +146,11 @@ All notable changes to this project will be documented in this file.
   - Single-pass, forward-only pagination algorithm (lazy-loading compatible)
   - Pagination engine measures footnote space and includes it in page layout calculations
   - Footnotes render with separator line (`<hr>`) above them
+  - **Footnote continuation**: Long footnotes that don't fit on a page are split at paragraph boundaries and continue on subsequent pages (matching Word/Office behavior)
   - Endnotes remain at document end (not per-page) - traditional behavior preserved
-  - New TypeScript methods: `parseFootnoteRegistry()`, `extractFootnoteRefs()`, `measureFootnotesHeight()`, `addPageFootnotes()`
-  - New CSS classes: `.page-footnotes`, `.footnote-item`, `.footnote-number`, `.footnote-content`
+  - New TypeScript methods: `parseFootnoteRegistry()`, `extractFootnoteRefs()`, `measureFootnotesHeight()`, `addPageFootnotes()`, `splitFootnoteToFit()`, `measureContinuationHeight()`
+  - New TypeScript interfaces: `FootnoteContinuation`, `PartialFootnote`
+  - New CSS classes: `.page-footnotes`, `.footnote-item`, `.footnote-number`, `.footnote-content`, `.footnote-continuation`
 - `SkiaSharpHelpers.cs` - Color utilities for SkiaSharp compatibility
 - `GetPackage()` extension method in `PtOpenXmlUtil.cs` for SDK 3.x Package access
 - `SkiaSharp.NativeAssets.Linux.NoDependencies` package for Linux runtime support

--- a/docs/architecture/pagination.md
+++ b/docs/architecture/pagination.md
@@ -392,6 +392,28 @@ for (const block of blocks) {
 2. **Footnote registry**: Small upfront data, cloned per-page as needed
 3. **Measurement caching**: Footnote heights measured once per unique combination
 4. **Endnotes unchanged**: Endnotes remain at document end (traditional behavior)
+5. **Footnote continuation**: Long footnotes split at paragraph boundaries and continue on subsequent pages
+
+### Footnote Continuation
+
+When a footnote is too long to fit in the remaining space on a page, the pagination engine splits it:
+
+1. **Split at paragraph boundaries**: The `splitFootnoteToFit()` method finds paragraph-level break points within the footnote content
+2. **Partial rendering**: The fitting portion renders on the current page with the footnote number
+3. **Continuation storage**: Remaining content stored in `FootnoteContinuation` interface for next page
+4. **Continuation rendering**: On subsequent pages, continuation content renders first (before new footnotes), without the footnote number
+
+```typescript
+interface FootnoteContinuation {
+  footnoteId: string;           // ID of the footnote being continued
+  remainingElements: HTMLElement[];  // Paragraphs that didn't fit
+}
+
+interface PartialFootnote {
+  footnoteId: string;           // ID of the split footnote
+  fittingElements: HTMLElement[];    // Paragraphs that fit on this page
+}
+```
 
 ### CSS Classes
 
@@ -415,6 +437,11 @@ for (const block of blocks) {
 .footnote-item {
   margin-bottom: 2pt;
 }
+
+/* Continued footnote content from previous page */
+.footnote-continuation {
+  margin-bottom: 4pt;
+}
 ```
 
 ## Related Documentation
@@ -428,4 +455,4 @@ for (const block of blocks) {
 3. **Column support**: Handle multi-column sections
 4. **Virtual scrolling**: Only render visible pages for large documents
 5. **Server-side rendering**: Pre-compute pagination for static documents
-6. **Footnote continuation**: Split long footnotes across pages
+6. **Line-level footnote splitting**: Split within paragraphs for even better fit


### PR DESCRIPTION
## Summary

- Long footnotes that don't fit on a page are now split at paragraph boundaries and continue on subsequent pages
- Matches Word/Office behavior for handling oversized footnotes
- Algorithm remains forward-only and lazy-loading compatible

## Changes

### TypeScript (npm/src/pagination.ts)
- Add `FootnoteContinuation` interface for tracking content that continues to next page
- Add `PartialFootnote` interface for tracking split footnotes on current page
- Add `splitFootnoteToFit()` method for paragraph-level splitting
- Add `measureContinuationHeight()` method for continuation measurement
- Update `flowToPages()` to detect and handle footnote overflow
- Update `addPageFootnotes()` to render partial and continuation content
- Track `pendingFootnoteContinuation` across pages and sections

### Documentation
- Update `docs/architecture/pagination.md` with Footnote Continuation section
- Update `CHANGELOG.md` with new feature details

## Test plan

- [ ] Test with documents containing long footnotes (multiple paragraphs)
- [ ] Verify footnote starts on page where referenced
- [ ] Verify continuation appears on subsequent page(s)
- [ ] Verify footnote number only appears on first part
- [ ] Verify endnotes remain at document end (unchanged)