### PR TITLE
feat(pagination): dynamic footnote area expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,9 +147,11 @@ All notable changes to this project will be documented in this file.
   - Pagination engine measures footnote space and includes it in page layout calculations
   - Footnotes render with separator line (`<hr>`) above them
   - **Footnote continuation**: Long footnotes that don't fit on a page are split at paragraph boundaries and continue on subsequent pages (matching Word/Office behavior)
+  - **Dynamic footnote area expansion**: Footnote area can expand upward into body content space (up to 60% of page height) to fit more footnote content before splitting, reducing wasted space
   - Endnotes remain at document end (not per-page) - traditional behavior preserved
   - New TypeScript methods: `parseFootnoteRegistry()`, `extractFootnoteRefs()`, `measureFootnotesHeight()`, `addPageFootnotes()`, `splitFootnoteToFit()`, `measureContinuationHeight()`
   - New TypeScript interfaces: `FootnoteContinuation`, `PartialFootnote`
+  - New TypeScript constants: `MAX_FOOTNOTE_AREA_RATIO` (0.6), `MIN_BODY_CONTENT_HEIGHT` (72pt)
   - New CSS classes: `.page-footnotes`, `.footnote-item`, `.footnote-number`, `.footnote-content`, `.footnote-continuation`
 - `SkiaSharpHelpers.cs` - Color utilities for SkiaSharp compatibility
 - `GetPackage()` extension method in `PtOpenXmlUtil.cs` for SDK 3.x Package access

--- a/docs/architecture/pagination.md
+++ b/docs/architecture/pagination.md
@@ -393,6 +393,28 @@ for (const block of blocks) {
 3. **Measurement caching**: Footnote heights measured once per unique combination
 4. **Endnotes unchanged**: Endnotes remain at document end (traditional behavior)
 5. **Footnote continuation**: Long footnotes split at paragraph boundaries and continue on subsequent pages
+6. **Dynamic footnote area**: Footnotes can expand upward to use more page space before splitting
+
+### Dynamic Footnote Area Expansion
+
+Unlike a fixed body/footnote split, the footnote area can dynamically expand upward to fit more content:
+
+```typescript
+// Maximum footnote area: 60% of content height
+const MAX_FOOTNOTE_AREA_RATIO = 0.6;
+
+// Minimum body content per page: 72pt (1 inch)
+const MIN_BODY_CONTENT_HEIGHT = 72;
+```
+
+**Algorithm:**
+1. Calculate space needed for body block + its footnotes
+2. If total exceeds remaining space, check if footnote area can expand
+3. Footnote area can grow up to `MAX_FOOTNOTE_AREA_RATIO * contentHeight`
+4. Body content area shrinks correspondingly (minimum `MIN_BODY_CONTENT_HEIGHT`)
+5. Only split footnotes when expanded area is still insufficient
+
+This matches Word/Office behavior where footnotes tactically expand to fill available space.
 
 ### Footnote Continuation
 


### PR DESCRIPTION
## Summary

Footnote area can now expand upward into body content space to fit more footnote content before splitting, matching Word/Office behavior.

**Before**: Footnotes got "leftover" space after body content, leading to wasted whitespace when footnotes didn't fit.

**After**: Footnotes can claim up to 60% of page height, reducing splits and filling available space.

## Changes

### New Constants
- `MAX_FOOTNOTE_AREA_RATIO = 0.6` - Maximum 60% of content height for footnotes
- `MIN_BODY_CONTENT_HEIGHT = 72` - Minimum 1 inch body content per page

### Algorithm Update
1. Calculate space needed for body block + footnotes
2. If total exceeds remaining space, check if footnote area can expand
3. Footnote area grows up to `MAX_FOOTNOTE_AREA_RATIO * contentHeight`
4. Body content area shrinks correspondingly
5. Only split footnotes when expanded area is still insufficient

## Test plan

- [ ] Test with documents containing long footnotes
- [ ] Verify footnotes expand to fill available page space
- [ ] Verify body content maintains minimum height (1 inch)
- [ ] Verify footnotes only split when necessary after expansion
- [ ] Compare output with Word/LibreOffice rendering