### PR TITLE
fix(pagination): improve footnote formatting and separator styling

### DIFF
--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -969,27 +969,44 @@ namespace Docxodus
             sb.AppendLine("    line-height: 1.4;");
             sb.AppendLine("}");
 
-            // Separator line above footnotes
+            // Separator line above footnotes - subtle horizontal rule
             sb.AppendLine($".{prefix}footnotes hr {{");
             sb.AppendLine("    border: none;");
-            sb.AppendLine("    border-top: 1px solid #666;");
-            sb.AppendLine("    width: 30%;");
-            sb.AppendLine("    margin: 0 0 4pt 0;");
+            sb.AppendLine("    border-top: 1px solid #999;");
+            sb.AppendLine("    width: 33%;");
+            sb.AppendLine("    margin: 0 0 6pt 0;");
+            sb.AppendLine("    opacity: 0.6;");
             sb.AppendLine("}");
 
             // Individual footnote item (in registry and on page)
             sb.AppendLine(".footnote-item {");
-            sb.AppendLine("    margin-bottom: 2pt;");
+            sb.AppendLine("    margin-bottom: 4pt;");
             sb.AppendLine("}");
 
-            // Footnote number
+            // Footnote number - inline with superscript styling
             sb.AppendLine(".footnote-number {");
             sb.AppendLine("    font-weight: normal;");
+            sb.AppendLine("    display: inline;");
+            sb.AppendLine("    vertical-align: super;");
+            sb.AppendLine("    font-size: 0.85em;");
+            sb.AppendLine("    margin-right: 2pt;");
             sb.AppendLine("}");
 
             // Footnote content (inline with number)
             sb.AppendLine(".footnote-content {");
             sb.AppendLine("    display: inline;");
+            sb.AppendLine("}");
+
+            // Make first paragraph in footnote content inline to flow with number
+            sb.AppendLine(".footnote-content > p:first-child {");
+            sb.AppendLine("    display: inline;");
+            sb.AppendLine("}");
+
+            // Subsequent paragraphs in footnote get normal block display with indent
+            sb.AppendLine(".footnote-content > p:not(:first-child) {");
+            sb.AppendLine("    display: block;");
+            sb.AppendLine("    margin-top: 2pt;");
+            sb.AppendLine("    margin-left: 12pt;");
             sb.AppendLine("}");
 
             return sb.ToString();


### PR DESCRIPTION
## Summary

Two formatting improvements for paginated footnotes:

### 1. Fix newline between footnote number and text

**Before:** Footnote number appeared on its own line, separate from the text
**After:** Number and first paragraph flow inline together

**CSS changes:**
- `.footnote-number`: Added `display: inline`, `vertical-align: super`, smaller font size
- `.footnote-content > p:first-child`: Set to `display: inline` to flow with number
- `.footnote-content > p:not(:first-child)`: Block display with left indent for continuation

### 2. Subtle separator line

Updated the horizontal rule above footnotes:
- Lighter color (`#999` instead of `#666`)
- Slightly wider (33% instead of 30%)
- Added opacity (60%) for subtlety
- More bottom margin (6pt instead of 4pt)

## Test plan

- [ ] Verify footnote numbers appear inline with text
- [ ] Verify multi-paragraph footnotes have proper indentation
- [ ] Verify separator line is visible but subtle