### PR TITLE
feat(pagination): implement dynamic header/footer heights for lazy loading

### DIFF
--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -969,10 +969,12 @@ namespace Docxodus
             sb.AppendLine("    line-height: 1.4;");
             sb.AppendLine("}");
 
-            // Separator line above footnotes - subtle horizontal rule
+            // Separator line above footnotes - using background instead of border
+            // to avoid subpixel rendering issues that can cause the line to disappear during scrolling
             sb.AppendLine($".{prefix}footnotes hr {{");
             sb.AppendLine("    border: none;");
-            sb.AppendLine("    border-top: 1px solid #999;");
+            sb.AppendLine("    height: 1px;");
+            sb.AppendLine("    background-color: #999;");
             sb.AppendLine("    width: 33%;");
             sb.AppendLine("    margin: 0 0 6pt 0;");
             sb.AppendLine("    opacity: 0.6;");
@@ -998,12 +1000,14 @@ namespace Docxodus
             sb.AppendLine("}");
 
             // Make first paragraph in footnote content inline to flow with number
-            sb.AppendLine(".footnote-content > p:first-child {");
+            // Use :first-of-type instead of :first-child because XML serialization adds
+            // whitespace text nodes that would prevent :first-child from matching
+            sb.AppendLine(".footnote-content > p:first-of-type {");
             sb.AppendLine("    display: inline;");
             sb.AppendLine("}");
 
             // Subsequent paragraphs in footnote get normal block display with indent
-            sb.AppendLine(".footnote-content > p:not(:first-child) {");
+            sb.AppendLine(".footnote-content > p:not(:first-of-type) {");
             sb.AppendLine("    display: block;");
             sb.AppendLine("    margin-top: 2pt;");
             sb.AppendLine("    margin-left: 12pt;");


### PR DESCRIPTION
## Summary

- **Dynamic header/footer heights**: Headers and footers can now expand beyond their margin areas when content requires more space (e.g., large first-page legal disclaimers)
- **Pre-measured heights**: All header/footer heights are measured once during initialization for consistency and performance
- **Lazy loading compatible**: Architecture designed for future streaming/on-demand pagination

## Changes

### Pagination Engine (`npm/src/pagination.ts`)
- Extended `SectionHeaderFooter` interface with pre-measured height fields
- Added `measureHeaderFooterHeight()` during registry parsing
- Added `getEffectiveHeights()` - deterministic method for computing available space at any page position
- Updated `flowToPages()` to use dynamic content heights per page position
- Simplified `createPage()` to use cached heights instead of re-measuring

### CSS Fixes (`Docxodus/WmlToHtmlConverter.cs`)
- Fixed footnote number/content line break by using `:first-of-type` instead of `:first-child` (XML serialization adds whitespace text nodes)
- Fixed footnote separator disappearing on scroll by using `background-color` instead of `border-top`

### Documentation (`docs/architecture/paginated_headers_footers.md`)
- Added "Dynamic Header/Footer Heights" section explaining the architecture and lazy loading compatibility

## Architecture Diagram

```
┌─────────────────────────────────────────────────────────────┐
│                    PAGINATION PHASES                         │
├─────────────────────────────────────────────────────────────┤
│  1. INITIALIZATION (one-time)                                │
│     └─ Parse and measure all headers/footers                │
│                                                              │
│  2. CONTENT FLOW (streamable)                                │
│     └─ Use pre-computed heights for page break decisions    │
│                                                              │
│  3. PAGE RENDERING (on-demand)                               │
│     └─ Look up cached heights, no re-measurement needed     │
└─────────────────────────────────────────────────────────────┘
```

## Test plan

- [x] TypeScript builds successfully
- [x] All 1051 .NET tests pass
- [ ] Manual test: Document with large first-page header renders correctly
- [ ] Manual test: Footnote numbers appear inline with content (no line break)
- [ ] Manual test: Footnote separator remains visible during scrolling