### PR TITLE
feat(npm): add Web Worker support for non-blocking WASM operations (Issue #44 Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,18 @@ All notable changes to this project will be documented in this file.
 - **Graphics Library**: Replaced System.Drawing with SkiaSharp 2.88.9
 
 ### Added
-- **Frame Yielding for UI Responsiveness** (Issue #44) - WASM operations now yield to the browser before heavy work begins
+- **Frame Yielding for UI Responsiveness** (Issue #44 Phase 1) - WASM operations now yield to the browser before heavy work begins
   - All async functions in the npm wrapper (`convertDocxToHtml`, `compareDocuments`, `compareDocumentsToHtml`, `getRevisions`, `addAnnotation`, `addAnnotationWithTarget`, `getDocumentStructure`) automatically yield using double-`requestAnimationFrame` pattern
   - This allows React state updates (loading spinners, progress indicators) to paint before blocking WASM execution
   - Transparent to consumers - no API changes required
   - Gracefully skipped in non-browser environments (Node.js, SSR)
-  - Phase 1 of 3: Future phases will add Web Worker support and lazy loading
+- **Web Worker Support for Non-blocking Operations** (Issue #44 Phase 2) - Fully non-blocking WASM execution via Web Workers
+  - New `docxodus/worker` export provides worker-based API: `import { createWorkerDocxodus } from 'docxodus/worker'`
+  - Worker API mirrors main API: `convertDocxToHtml`, `compareDocuments`, `compareDocumentsToHtml`, `getRevisions`, `getVersion`
+  - Main thread remains fully responsive during WASM execution - animations continue, user interactions work
+  - Zero-copy transfer of document bytes via Transferable for optimal performance
+  - Worker can be terminated when no longer needed
+  - Phase 3 (lazy loading) will build on this foundation
 - **Custom Annotations** - Full support for adding, removing, and rendering custom annotations on DOCX documents
   - `AnnotationManager` class for programmatic annotation CRUD operations:
     - `AddAnnotation()`: Add annotation by text search or paragraph range

--- a/npm/package.json
+++ b/npm/package.json
@@ -14,6 +14,10 @@
     "./react": {
       "import": "./dist/react.js",
       "types": "./dist/react.d.ts"
+    },
+    "./worker": {
+      "import": "./dist/worker-proxy.js",
+      "types": "./dist/worker-proxy.d.ts"
     }
   },
   "files": [
@@ -23,8 +27,9 @@
     "build:wasm": "../scripts/build-wasm.sh",
     "build:ts": "tsc",
     "build:pagination-bundle": "esbuild src/pagination.ts --bundle --format=iife --global-name=DocxodusPagination --outfile=dist/pagination.bundle.js",
-    "build": "npm run build:wasm && npm run build:ts && npm run build:pagination-bundle",
-    "pretest": "cp tests/test-harness.html dist/wasm/ && cp dist/pagination.bundle.js dist/wasm/",
+    "build:worker-bundle": "esbuild src/docxodus.worker.ts --bundle --format=esm --outfile=dist/docxodus.worker.js && esbuild src/worker-proxy.ts --bundle --format=esm --outfile=dist/worker-proxy.bundle.js",
+    "build": "npm run build:wasm && npm run build:ts && npm run build:pagination-bundle && npm run build:worker-bundle",
+    "pretest": "cp tests/test-harness.html dist/wasm/ && cp tests/worker-test-harness.html dist/wasm/ && cp dist/pagination.bundle.js dist/wasm/ && cp dist/docxodus.worker.js dist/wasm/ && cp dist/worker-proxy.bundle.js dist/wasm/worker-proxy.js",
     "test": "playwright test",
     "test:ui": "playwright test --ui",
     "prepublishOnly": "npm run build"

--- a/npm/src/docxodus.worker.ts
+++ b/npm/src/docxodus.worker.ts
@@ -1,0 +1,462 @@
+/**
+ * Docxodus Web Worker
+ *
+ * This worker runs the WASM runtime in a separate thread, keeping the main
+ * thread free for UI updates and user interactions.
+ *
+ * Communication is via postMessage with structured request/response types.
+ * Document bytes are transferred (not copied) for efficiency.
+ */
+
+import type {
+  WorkerRequest,
+  WorkerResponse,
+  WorkerInitRequest,
+  WorkerConvertRequest,
+  WorkerCompareRequest,
+  WorkerCompareToHtmlRequest,
+  WorkerGetRevisionsRequest,
+  DocxodusWasmExports,
+  ConversionOptions,
+  CompareOptions,
+  GetRevisionsOptions,
+  Revision,
+  RevisionType,
+} from "./types.js";
+
+// Worker-local state
+let wasmExports: DocxodusWasmExports | null = null;
+let initPromise: Promise<void> | null = null;
+
+/**
+ * Initialize the WASM runtime in the worker.
+ */
+async function initializeWasm(basePath: string): Promise<void> {
+  if (wasmExports) {
+    return; // Already initialized
+  }
+
+  if (initPromise) {
+    return initPromise; // Initialization in progress
+  }
+
+  initPromise = (async () => {
+    try {
+      // Normalize base path
+      const normalizedPath = basePath.endsWith("/") ? basePath : basePath + "/";
+
+      // Import dotnet.js from the WASM directory
+      // In a worker, we need to use importScripts or dynamic import
+      const dotnetModule = await import(
+        /* webpackIgnore: true */ `${normalizedPath}_framework/dotnet.js`
+      );
+
+      const { getAssemblyExports, getConfig } = await dotnetModule.dotnet
+        .withDiagnosticTracing(false)
+        .create();
+
+      const config = getConfig();
+      const exports = await getAssemblyExports(config.mainAssemblyName);
+
+      // Map exports to the expected structure (same as index.ts)
+      wasmExports = {
+        DocumentConverter: (exports as any).DocxodusWasm.DocumentConverter,
+        DocumentComparer: (exports as any).DocxodusWasm.DocumentComparer,
+      };
+    } catch (error) {
+      initPromise = null;
+      throw error;
+    }
+  })();
+
+  return initPromise;
+}
+
+/**
+ * Ensure WASM is initialized, throwing if not.
+ */
+function ensureInitialized(): DocxodusWasmExports {
+  if (!wasmExports) {
+    throw new Error("Worker not initialized. Call init first.");
+  }
+  return wasmExports;
+}
+
+/**
+ * Check if a result string is an error response.
+ */
+function isErrorResponse(result: string): boolean {
+  return result.startsWith("{") && result.includes('"Error"');
+}
+
+/**
+ * Parse an error response.
+ */
+function parseError(result: string): { error: string } {
+  try {
+    const parsed = JSON.parse(result);
+    return { error: parsed.Error || parsed.error || "Unknown error" };
+  } catch {
+    return { error: result };
+  }
+}
+
+/**
+ * Handle convertDocxToHtml request.
+ */
+function handleConvert(
+  request: WorkerConvertRequest
+): { html?: string; error?: string } {
+  const exports = ensureInitialized();
+  const options = request.options;
+
+  try {
+    let result: string;
+
+    // Check if any of the complete options are specified
+    const needsCompleteMethod =
+      options?.renderFootnotesAndEndnotes !== undefined ||
+      options?.renderHeadersAndFooters !== undefined ||
+      options?.renderTrackedChanges !== undefined ||
+      options?.showDeletedContent !== undefined ||
+      options?.renderMoveOperations !== undefined;
+
+    if (needsCompleteMethod || options?.renderAnnotations) {
+      result = exports.DocumentConverter.ConvertDocxToHtmlComplete(
+        request.documentBytes,
+        options?.pageTitle ?? "Document",
+        options?.cssPrefix ?? "docx-",
+        options?.fabricateClasses ?? true,
+        options?.additionalCss ?? "",
+        options?.commentRenderMode ?? -1,
+        options?.commentCssClassPrefix ?? "comment-",
+        options?.paginationMode ?? 0,
+        options?.paginationScale ?? 1.0,
+        options?.paginationCssClassPrefix ?? "page-",
+        options?.renderAnnotations ?? false,
+        options?.annotationLabelMode ?? 0,
+        options?.annotationCssClassPrefix ?? "annot-",
+        options?.renderFootnotesAndEndnotes ?? false,
+        options?.renderHeadersAndFooters ?? false,
+        options?.renderTrackedChanges ?? false,
+        options?.showDeletedContent ?? true,
+        options?.renderMoveOperations ?? true
+      );
+    } else if (
+      options?.paginationMode !== undefined &&
+      options.paginationMode !== 0
+    ) {
+      result = exports.DocumentConverter.ConvertDocxToHtmlWithPagination(
+        request.documentBytes,
+        options.pageTitle ?? "Document",
+        options.cssPrefix ?? "docx-",
+        options.fabricateClasses ?? true,
+        options.additionalCss ?? "",
+        options.commentRenderMode ?? -1,
+        options.commentCssClassPrefix ?? "comment-",
+        options.paginationMode,
+        options.paginationScale ?? 1.0,
+        options.paginationCssClassPrefix ?? "page-"
+      );
+    } else if (options) {
+      result = exports.DocumentConverter.ConvertDocxToHtmlWithOptions(
+        request.documentBytes,
+        options.pageTitle ?? "Document",
+        options.cssPrefix ?? "docx-",
+        options.fabricateClasses ?? true,
+        options.additionalCss ?? "",
+        options.commentRenderMode ?? -1,
+        options.commentCssClassPrefix ?? "comment-"
+      );
+    } else {
+      result = exports.DocumentConverter.ConvertDocxToHtml(
+        request.documentBytes
+      );
+    }
+
+    if (isErrorResponse(result)) {
+      return parseError(result);
+    }
+
+    return { html: result };
+  } catch (error) {
+    return { error: String(error) };
+  }
+}
+
+/**
+ * Handle compareDocuments request.
+ */
+function handleCompare(
+  request: WorkerCompareRequest
+): { documentBytes?: Uint8Array; error?: string } {
+  const exports = ensureInitialized();
+  const options = request.options;
+
+  try {
+    let result: Uint8Array;
+
+    if (options?.detailThreshold !== undefined || options?.caseInsensitive) {
+      result = exports.DocumentComparer.CompareDocumentsWithOptions(
+        request.originalBytes,
+        request.modifiedBytes,
+        options?.authorName ?? "Docxodus",
+        options?.detailThreshold ?? 0.15,
+        options?.caseInsensitive ?? false
+      );
+    } else {
+      result = exports.DocumentComparer.CompareDocuments(
+        request.originalBytes,
+        request.modifiedBytes,
+        options?.authorName ?? "Docxodus"
+      );
+    }
+
+    if (result.length === 0) {
+      return { error: "Comparison returned empty result" };
+    }
+
+    return { documentBytes: result };
+  } catch (error) {
+    return { error: String(error) };
+  }
+}
+
+/**
+ * Handle compareDocumentsToHtml request.
+ */
+function handleCompareToHtml(
+  request: WorkerCompareToHtmlRequest
+): { html?: string; error?: string } {
+  const exports = ensureInitialized();
+  const options = request.options;
+
+  try {
+    const renderTrackedChanges = options?.renderTrackedChanges ?? true;
+
+    const result = exports.DocumentComparer.CompareDocumentsToHtmlWithOptions(
+      request.originalBytes,
+      request.modifiedBytes,
+      options?.authorName ?? "Docxodus",
+      renderTrackedChanges
+    );
+
+    if (isErrorResponse(result)) {
+      return parseError(result);
+    }
+
+    return { html: result };
+  } catch (error) {
+    return { error: String(error) };
+  }
+}
+
+/**
+ * Handle getRevisions request.
+ */
+function handleGetRevisions(
+  request: WorkerGetRevisionsRequest
+): { revisions?: Revision[]; error?: string } {
+  const exports = ensureInitialized();
+  const options = request.options;
+
+  try {
+    const detectMoves = options?.detectMoves ?? true;
+    const moveSimilarityThreshold = options?.moveSimilarityThreshold ?? 0.8;
+    const moveMinimumWordCount = options?.moveMinimumWordCount ?? 3;
+    const caseInsensitive = options?.caseInsensitive ?? false;
+
+    const result = exports.DocumentComparer.GetRevisionsJsonWithOptions(
+      request.documentBytes,
+      detectMoves,
+      moveSimilarityThreshold,
+      moveMinimumWordCount,
+      caseInsensitive
+    );
+
+    if (isErrorResponse(result)) {
+      return parseError(result);
+    }
+
+    const parsed = JSON.parse(result);
+    const revisions = (parsed.Revisions || parsed.revisions || []).map(
+      (r: any): Revision => ({
+        author: r.Author || r.author,
+        date: r.Date || r.date,
+        revisionType: r.RevisionType || r.revisionType,
+        text: r.Text || r.text,
+        moveGroupId: r.MoveGroupId ?? r.moveGroupId,
+        isMoveSource: r.IsMoveSource ?? r.isMoveSource,
+        formatChange: r.FormatChange || r.formatChange
+          ? {
+              oldProperties:
+                r.FormatChange?.OldProperties ||
+                r.formatChange?.oldProperties,
+              newProperties:
+                r.FormatChange?.NewProperties ||
+                r.formatChange?.newProperties,
+              changedPropertyNames:
+                r.FormatChange?.ChangedPropertyNames ||
+                r.formatChange?.changedPropertyNames,
+            }
+          : undefined,
+      })
+    );
+
+    return { revisions };
+  } catch (error) {
+    return { error: String(error) };
+  }
+}
+
+/**
+ * Handle getVersion request.
+ */
+function handleGetVersion(): {
+  version?: { library: string; dotnetVersion: string; platform: string };
+  error?: string;
+} {
+  const exports = ensureInitialized();
+
+  try {
+    const result = exports.DocumentConverter.GetVersion();
+    const parsed = JSON.parse(result);
+
+    return {
+      version: {
+        library: parsed.Library || parsed.library,
+        dotnetVersion: parsed.DotnetVersion || parsed.dotnetVersion,
+        platform: parsed.Platform || parsed.platform,
+      },
+    };
+  } catch (error) {
+    return { error: String(error) };
+  }
+}
+
+/**
+ * Main message handler.
+ */
+self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
+  const request = event.data;
+
+  try {
+    let response: WorkerResponse;
+
+    switch (request.type) {
+      case "init": {
+        const initRequest = request as WorkerInitRequest;
+        try {
+          await initializeWasm(initRequest.wasmBasePath);
+          response = {
+            id: request.id,
+            type: "init",
+            success: true,
+          };
+        } catch (error) {
+          response = {
+            id: request.id,
+            type: "init",
+            success: false,
+            error: String(error),
+          };
+        }
+        break;
+      }
+
+      case "convertDocxToHtml": {
+        const convertRequest = request as WorkerConvertRequest;
+        const result = handleConvert(convertRequest);
+        response = {
+          id: request.id,
+          type: "convertDocxToHtml",
+          success: !result.error,
+          html: result.html,
+          error: result.error,
+        };
+        break;
+      }
+
+      case "compareDocuments": {
+        const compareRequest = request as WorkerCompareRequest;
+        const result = handleCompare(compareRequest);
+        response = {
+          id: request.id,
+          type: "compareDocuments",
+          success: !result.error,
+          documentBytes: result.documentBytes,
+          error: result.error,
+        };
+        // Transfer the bytes back (zero-copy)
+        if (result.documentBytes) {
+          self.postMessage(response, { transfer: [result.documentBytes.buffer as ArrayBuffer] });
+          return;
+        }
+        break;
+      }
+
+      case "compareDocumentsToHtml": {
+        const compareToHtmlRequest = request as WorkerCompareToHtmlRequest;
+        const result = handleCompareToHtml(compareToHtmlRequest);
+        response = {
+          id: request.id,
+          type: "compareDocumentsToHtml",
+          success: !result.error,
+          html: result.html,
+          error: result.error,
+        };
+        break;
+      }
+
+      case "getRevisions": {
+        const getRevisionsRequest = request as WorkerGetRevisionsRequest;
+        const result = handleGetRevisions(getRevisionsRequest);
+        response = {
+          id: request.id,
+          type: "getRevisions",
+          success: !result.error,
+          revisions: result.revisions,
+          error: result.error,
+        };
+        break;
+      }
+
+      case "getVersion": {
+        const result = handleGetVersion();
+        response = {
+          id: request.id,
+          type: "getVersion",
+          success: !result.error,
+          version: result.version,
+          error: result.error,
+        };
+        break;
+      }
+
+      default: {
+        // This should never happen due to type narrowing, but handle gracefully
+        const unknownRequest = request as { id: string; type: string };
+        self.postMessage({
+          id: unknownRequest.id,
+          type: unknownRequest.type,
+          success: false,
+          error: `Unknown request type: ${unknownRequest.type}`,
+        });
+        return;
+      }
+    }
+
+    self.postMessage(response);
+  } catch (error) {
+    // Catch-all for unexpected errors
+    self.postMessage({
+      id: request.id,
+      type: request.type,
+      success: false,
+      error: String(error),
+    } as WorkerResponse);
+  }
+};
+
+// Signal that the worker is ready
+self.postMessage({ type: "ready" });

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -907,3 +907,189 @@ export function targetSearchInElement(
 ): AnnotationTarget {
   return { elementId, searchText, occurrence };
 }
+
+// ============================================================================
+// Web Worker Types (Phase 2: Non-blocking WASM operations)
+// ============================================================================
+
+/**
+ * Message types sent from main thread to worker.
+ */
+export type WorkerRequestType =
+  | "init"
+  | "convertDocxToHtml"
+  | "compareDocuments"
+  | "compareDocumentsToHtml"
+  | "getRevisions"
+  | "getVersion";
+
+/**
+ * Base structure for worker requests.
+ */
+export interface WorkerRequestBase {
+  /** Unique request ID for correlating responses */
+  id: string;
+  /** The operation type */
+  type: WorkerRequestType;
+}
+
+/**
+ * Initialize the worker with WASM base path.
+ */
+export interface WorkerInitRequest extends WorkerRequestBase {
+  type: "init";
+  /** Base URL for loading WASM files (e.g., "/wasm/") */
+  wasmBasePath: string;
+}
+
+/**
+ * Convert DOCX to HTML request.
+ */
+export interface WorkerConvertRequest extends WorkerRequestBase {
+  type: "convertDocxToHtml";
+  /** Document bytes (transferred, not copied) */
+  documentBytes: Uint8Array;
+  /** Conversion options */
+  options?: ConversionOptions;
+}
+
+/**
+ * Compare two documents request.
+ */
+export interface WorkerCompareRequest extends WorkerRequestBase {
+  type: "compareDocuments";
+  /** Original document bytes */
+  originalBytes: Uint8Array;
+  /** Modified document bytes */
+  modifiedBytes: Uint8Array;
+  /** Comparison options */
+  options?: CompareOptions;
+}
+
+/**
+ * Compare documents and return HTML request.
+ */
+export interface WorkerCompareToHtmlRequest extends WorkerRequestBase {
+  type: "compareDocumentsToHtml";
+  /** Original document bytes */
+  originalBytes: Uint8Array;
+  /** Modified document bytes */
+  modifiedBytes: Uint8Array;
+  /** Comparison options */
+  options?: CompareOptions;
+}
+
+/**
+ * Get revisions from a document request.
+ */
+export interface WorkerGetRevisionsRequest extends WorkerRequestBase {
+  type: "getRevisions";
+  /** Document bytes */
+  documentBytes: Uint8Array;
+  /** Revision extraction options */
+  options?: GetRevisionsOptions;
+}
+
+/**
+ * Get library version request.
+ */
+export interface WorkerGetVersionRequest extends WorkerRequestBase {
+  type: "getVersion";
+}
+
+/**
+ * Union type of all possible worker requests.
+ */
+export type WorkerRequest =
+  | WorkerInitRequest
+  | WorkerConvertRequest
+  | WorkerCompareRequest
+  | WorkerCompareToHtmlRequest
+  | WorkerGetRevisionsRequest
+  | WorkerGetVersionRequest;
+
+/**
+ * Base structure for worker responses.
+ */
+export interface WorkerResponseBase {
+  /** Request ID this response corresponds to */
+  id: string;
+  /** Whether the operation succeeded */
+  success: boolean;
+  /** Error message if success is false */
+  error?: string;
+}
+
+/**
+ * Response from init request.
+ */
+export interface WorkerInitResponse extends WorkerResponseBase {
+  type: "init";
+}
+
+/**
+ * Response from convertDocxToHtml request.
+ */
+export interface WorkerConvertResponse extends WorkerResponseBase {
+  type: "convertDocxToHtml";
+  /** The converted HTML string */
+  html?: string;
+}
+
+/**
+ * Response from compareDocuments request.
+ */
+export interface WorkerCompareResponse extends WorkerResponseBase {
+  type: "compareDocuments";
+  /** The redlined document bytes */
+  documentBytes?: Uint8Array;
+}
+
+/**
+ * Response from compareDocumentsToHtml request.
+ */
+export interface WorkerCompareToHtmlResponse extends WorkerResponseBase {
+  type: "compareDocumentsToHtml";
+  /** The HTML string with redlines */
+  html?: string;
+}
+
+/**
+ * Response from getRevisions request.
+ */
+export interface WorkerGetRevisionsResponse extends WorkerResponseBase {
+  type: "getRevisions";
+  /** Array of revisions */
+  revisions?: Revision[];
+}
+
+/**
+ * Response from getVersion request.
+ */
+export interface WorkerGetVersionResponse extends WorkerResponseBase {
+  type: "getVersion";
+  /** Version information */
+  version?: VersionInfo;
+}
+
+/**
+ * Union type of all possible worker responses.
+ */
+export type WorkerResponse =
+  | WorkerInitResponse
+  | WorkerConvertResponse
+  | WorkerCompareResponse
+  | WorkerCompareToHtmlResponse
+  | WorkerGetRevisionsResponse
+  | WorkerGetVersionResponse;
+
+/**
+ * Options for creating a worker-based Docxodus instance.
+ */
+export interface WorkerDocxodusOptions {
+  /**
+   * Base URL for loading WASM files.
+   * Defaults to auto-detection from module URL.
+   */
+  wasmBasePath?: string;
+}

--- a/npm/src/worker-proxy.ts
+++ b/npm/src/worker-proxy.ts
@@ -1,0 +1,372 @@
+/**
+ * Worker Proxy - Main thread interface for the Docxodus Web Worker
+ *
+ * This module provides a Promise-based API that mirrors the main API but
+ * executes all WASM operations in a Web Worker, keeping the main thread free.
+ *
+ * @example
+ * ```typescript
+ * import { createWorkerDocxodus } from 'docxodus/worker';
+ *
+ * // Create worker instance
+ * const docxodus = await createWorkerDocxodus();
+ *
+ * // Use the same API as the main module, but non-blocking!
+ * const html = await docxodus.convertDocxToHtml(docxFile);
+ *
+ * // Clean up when done
+ * docxodus.terminate();
+ * ```
+ */
+
+import type {
+  WorkerRequest,
+  WorkerResponse,
+  WorkerConvertResponse,
+  WorkerCompareResponse,
+  WorkerCompareToHtmlResponse,
+  WorkerGetRevisionsResponse,
+  WorkerGetVersionResponse,
+  WorkerDocxodusOptions,
+  ConversionOptions,
+  CompareOptions,
+  GetRevisionsOptions,
+  Revision,
+  VersionInfo,
+} from "./types.js";
+
+/**
+ * Generate a unique request ID.
+ */
+function generateId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+}
+
+/**
+ * Convert a File or Uint8Array to Uint8Array.
+ */
+async function toBytes(document: File | Uint8Array): Promise<Uint8Array> {
+  if (document instanceof Uint8Array) {
+    return document;
+  }
+  const buffer = await document.arrayBuffer();
+  return new Uint8Array(buffer);
+}
+
+/**
+ * Derive the WASM base path from the current module URL.
+ */
+function deriveWasmBasePath(): string {
+  // Try to get the base path from the current script URL
+  if (typeof document !== "undefined") {
+    // Browser: look for docxodus script tag or use current location
+    const scripts = document.querySelectorAll('script[src*="docxodus"]');
+    if (scripts.length > 0) {
+      const src = (scripts[0] as HTMLScriptElement).src;
+      const base = src.substring(0, src.lastIndexOf("/") + 1);
+      return base + "wasm/";
+    }
+  }
+
+  // Default fallback
+  return "/wasm/";
+}
+
+/**
+ * A worker-based Docxodus instance.
+ *
+ * Provides the same API as the main module but executes all operations
+ * in a Web Worker for non-blocking UI.
+ */
+export interface WorkerDocxodus {
+  /**
+   * Convert a DOCX document to HTML.
+   * @param document - DOCX file as File object or Uint8Array
+   * @param options - Conversion options
+   * @returns HTML string
+   */
+  convertDocxToHtml(
+    document: File | Uint8Array,
+    options?: ConversionOptions
+  ): Promise<string>;
+
+  /**
+   * Compare two DOCX documents and return the redlined result.
+   * @param original - Original DOCX document
+   * @param modified - Modified DOCX document
+   * @param options - Comparison options
+   * @returns Redlined DOCX as Uint8Array
+   */
+  compareDocuments(
+    original: File | Uint8Array,
+    modified: File | Uint8Array,
+    options?: CompareOptions
+  ): Promise<Uint8Array>;
+
+  /**
+   * Compare two DOCX documents and return the result as HTML.
+   * @param original - Original DOCX document
+   * @param modified - Modified DOCX document
+   * @param options - Comparison options
+   * @returns HTML string with redlined content
+   */
+  compareDocumentsToHtml(
+    original: File | Uint8Array,
+    modified: File | Uint8Array,
+    options?: CompareOptions
+  ): Promise<string>;
+
+  /**
+   * Get revisions from a compared document.
+   * @param document - A document that has tracked changes
+   * @param options - Revision extraction options
+   * @returns Array of revisions
+   */
+  getRevisions(
+    document: File | Uint8Array,
+    options?: GetRevisionsOptions
+  ): Promise<Revision[]>;
+
+  /**
+   * Get version information about the library.
+   * @returns Version information
+   */
+  getVersion(): Promise<VersionInfo>;
+
+  /**
+   * Terminate the worker.
+   * After calling this, the instance cannot be used anymore.
+   */
+  terminate(): void;
+
+  /**
+   * Check if the worker is still active.
+   */
+  isActive(): boolean;
+}
+
+/**
+ * Create a worker-based Docxodus instance.
+ *
+ * This function spawns a Web Worker that loads the WASM runtime independently.
+ * All operations are executed in the worker, keeping the main thread responsive.
+ *
+ * @param options - Configuration options
+ * @returns A Promise that resolves to a WorkerDocxodus instance
+ *
+ * @example
+ * ```typescript
+ * // Basic usage
+ * const docxodus = await createWorkerDocxodus();
+ * const html = await docxodus.convertDocxToHtml(docxFile);
+ *
+ * // With custom WASM path
+ * const docxodus = await createWorkerDocxodus({
+ *   wasmBasePath: '/assets/wasm/'
+ * });
+ * ```
+ */
+export async function createWorkerDocxodus(
+  options?: WorkerDocxodusOptions
+): Promise<WorkerDocxodus> {
+  // Determine WASM base path
+  const wasmBasePath = options?.wasmBasePath ?? deriveWasmBasePath();
+
+  // Determine worker script path
+  // The worker bundle should be in the same directory as this module
+  let workerUrl: string;
+
+  // Try to create worker from bundled script or blob
+  // For now, we'll use a blob URL to inline the worker path
+  const workerScriptPath = new URL("./docxodus.worker.js", import.meta.url)
+    .href;
+
+  // Create the worker
+  const worker = new Worker(workerScriptPath, { type: "module" });
+
+  // Track pending requests
+  const pendingRequests = new Map<
+    string,
+    {
+      resolve: (value: any) => void;
+      reject: (error: Error) => void;
+    }
+  >();
+
+  // Track if worker is active
+  let isWorkerActive = true;
+
+  // Handle worker messages
+  worker.onmessage = (event: MessageEvent<WorkerResponse | { type: "ready" }>) => {
+    const response = event.data;
+
+    // Handle ready signal
+    if (response.type === "ready") {
+      return;
+    }
+
+    // Handle normal responses
+    const pending = pendingRequests.get(response.id);
+    if (pending) {
+      pendingRequests.delete(response.id);
+
+      if (response.success) {
+        pending.resolve(response);
+      } else {
+        pending.reject(new Error(response.error || "Unknown error"));
+      }
+    }
+  };
+
+  // Handle worker errors
+  worker.onerror = (error) => {
+    // Reject all pending requests
+    for (const pending of pendingRequests.values()) {
+      pending.reject(new Error(`Worker error: ${error.message}`));
+    }
+    pendingRequests.clear();
+    isWorkerActive = false;
+  };
+
+  /**
+   * Send a request to the worker and wait for response.
+   */
+  function sendRequest<T extends WorkerResponse>(
+    request: WorkerRequest,
+    transfer?: Transferable[]
+  ): Promise<T> {
+    return new Promise((resolve, reject) => {
+      if (!isWorkerActive) {
+        reject(new Error("Worker has been terminated"));
+        return;
+      }
+
+      pendingRequests.set(request.id, { resolve, reject });
+
+      if (transfer && transfer.length > 0) {
+        worker.postMessage(request, transfer);
+      } else {
+        worker.postMessage(request);
+      }
+    });
+  }
+
+  // Initialize the worker
+  const initResponse = await sendRequest({
+    id: generateId(),
+    type: "init",
+    wasmBasePath,
+  });
+
+  if (!initResponse.success) {
+    worker.terminate();
+    throw new Error(`Failed to initialize worker: ${initResponse.error}`);
+  }
+
+  // Return the WorkerDocxodus instance
+  return {
+    async convertDocxToHtml(
+      document: File | Uint8Array,
+      options?: ConversionOptions
+    ): Promise<string> {
+      const bytes = await toBytes(document);
+      const response = await sendRequest<WorkerConvertResponse>(
+        {
+          id: generateId(),
+          type: "convertDocxToHtml",
+          documentBytes: bytes,
+          options,
+        },
+        [bytes.buffer]
+      );
+      return response.html!;
+    },
+
+    async compareDocuments(
+      original: File | Uint8Array,
+      modified: File | Uint8Array,
+      options?: CompareOptions
+    ): Promise<Uint8Array> {
+      const originalBytes = await toBytes(original);
+      const modifiedBytes = await toBytes(modified);
+      const response = await sendRequest<WorkerCompareResponse>(
+        {
+          id: generateId(),
+          type: "compareDocuments",
+          originalBytes,
+          modifiedBytes,
+          options,
+        },
+        [originalBytes.buffer, modifiedBytes.buffer]
+      );
+      return response.documentBytes!;
+    },
+
+    async compareDocumentsToHtml(
+      original: File | Uint8Array,
+      modified: File | Uint8Array,
+      options?: CompareOptions
+    ): Promise<string> {
+      const originalBytes = await toBytes(original);
+      const modifiedBytes = await toBytes(modified);
+      const response = await sendRequest<WorkerCompareToHtmlResponse>(
+        {
+          id: generateId(),
+          type: "compareDocumentsToHtml",
+          originalBytes,
+          modifiedBytes,
+          options,
+        },
+        [originalBytes.buffer, modifiedBytes.buffer]
+      );
+      return response.html!;
+    },
+
+    async getRevisions(
+      document: File | Uint8Array,
+      options?: GetRevisionsOptions
+    ): Promise<Revision[]> {
+      const bytes = await toBytes(document);
+      const response = await sendRequest<WorkerGetRevisionsResponse>(
+        {
+          id: generateId(),
+          type: "getRevisions",
+          documentBytes: bytes,
+          options,
+        },
+        [bytes.buffer]
+      );
+      return response.revisions!;
+    },
+
+    async getVersion(): Promise<VersionInfo> {
+      const response = await sendRequest<WorkerGetVersionResponse>({
+        id: generateId(),
+        type: "getVersion",
+      });
+      return response.version!;
+    },
+
+    terminate(): void {
+      isWorkerActive = false;
+      worker.terminate();
+
+      // Reject any pending requests
+      for (const pending of pendingRequests.values()) {
+        pending.reject(new Error("Worker terminated"));
+      }
+      pendingRequests.clear();
+    },
+
+    isActive(): boolean {
+      return isWorkerActive;
+    },
+  };
+}
+
+/**
+ * Check if Web Workers are supported in the current environment.
+ */
+export function isWorkerSupported(): boolean {
+  return typeof Worker !== "undefined";
+}

--- a/npm/tests/worker-test-harness.html
+++ b/npm/tests/worker-test-harness.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Docxodus Worker Test Harness</title>
+</head>
+<body>
+    <h1>Docxodus Worker Test Harness</h1>
+    <div id="status">Loading...</div>
+    <pre id="output"></pre>
+
+    <script type="module">
+        // Import the worker proxy
+        import { createWorkerDocxodus, isWorkerSupported } from './worker-proxy.js';
+
+        // Store the worker instance globally for testing
+        window.DocxodusWorker = null;
+        window.DocxodusWorkerReady = false;
+        window.DocxodusWorkerError = null;
+
+        // Test helper to create worker
+        window.createDocxodusWorker = async function() {
+            try {
+                // The WASM files are in the same directory (test harness is served from dist/wasm)
+                window.DocxodusWorker = await createWorkerDocxodus({
+                    wasmBasePath: './'
+                });
+                window.DocxodusWorkerReady = true;
+                document.getElementById('status').textContent = 'Worker Ready';
+                console.log('Docxodus Worker Ready');
+                return window.DocxodusWorker;
+            } catch (error) {
+                window.DocxodusWorkerError = error;
+                document.getElementById('status').textContent = 'Worker Error: ' + error.message;
+                console.error('Failed to create worker:', error);
+                throw error;
+            }
+        };
+
+        // Test helpers
+        window.DocxodusWorkerTests = {
+            isSupported: function() {
+                return isWorkerSupported();
+            },
+
+            // Convert DOCX to HTML using worker
+            convertToHtml: async function(bytes) {
+                if (!window.DocxodusWorker) {
+                    return { error: { message: 'Worker not initialized' } };
+                }
+                try {
+                    const html = await window.DocxodusWorker.convertDocxToHtml(new Uint8Array(bytes));
+                    return { html };
+                } catch (error) {
+                    return { error: { message: error.message } };
+                }
+            },
+
+            // Compare documents using worker
+            compareDocuments: async function(originalBytes, modifiedBytes, authorName = 'Test') {
+                if (!window.DocxodusWorker) {
+                    return { error: { message: 'Worker not initialized' } };
+                }
+                try {
+                    const docxBytes = await window.DocxodusWorker.compareDocuments(
+                        new Uint8Array(originalBytes),
+                        new Uint8Array(modifiedBytes),
+                        { authorName }
+                    );
+                    return { docxBytes: Array.from(docxBytes) };
+                } catch (error) {
+                    return { error: { message: error.message } };
+                }
+            },
+
+            // Compare and get HTML using worker
+            compareToHtml: async function(originalBytes, modifiedBytes, authorName = 'Test') {
+                if (!window.DocxodusWorker) {
+                    return { error: { message: 'Worker not initialized' } };
+                }
+                try {
+                    const html = await window.DocxodusWorker.compareDocumentsToHtml(
+                        new Uint8Array(originalBytes),
+                        new Uint8Array(modifiedBytes),
+                        { authorName }
+                    );
+                    return { html };
+                } catch (error) {
+                    return { error: { message: error.message } };
+                }
+            },
+
+            // Get revisions using worker
+            getRevisions: async function(docxBytes) {
+                if (!window.DocxodusWorker) {
+                    return { error: { message: 'Worker not initialized' } };
+                }
+                try {
+                    const revisions = await window.DocxodusWorker.getRevisions(new Uint8Array(docxBytes));
+                    return { revisions };
+                } catch (error) {
+                    return { error: { message: error.message } };
+                }
+            },
+
+            // Get version using worker
+            getVersion: async function() {
+                if (!window.DocxodusWorker) {
+                    return { error: { message: 'Worker not initialized' } };
+                }
+                try {
+                    const version = await window.DocxodusWorker.getVersion();
+                    return version;
+                } catch (error) {
+                    return { error: { message: error.message } };
+                }
+            },
+
+            // Check if worker is active
+            isActive: function() {
+                return window.DocxodusWorker?.isActive() ?? false;
+            },
+
+            // Terminate worker
+            terminate: function() {
+                if (window.DocxodusWorker) {
+                    window.DocxodusWorker.terminate();
+                    window.DocxodusWorkerReady = false;
+                }
+            }
+        };
+
+        document.getElementById('status').textContent = 'Test harness loaded, call createDocxodusWorker() to initialize';
+    </script>
+</body>
+</html>

--- a/npm/tests/worker.spec.ts
+++ b/npm/tests/worker.spec.ts
@@ -1,0 +1,302 @@
+/**
+ * Web Worker Tests for Docxodus
+ *
+ * These tests verify that the Web Worker implementation provides
+ * non-blocking WASM operations while maintaining functional correctness.
+ */
+
+import { test, expect } from "@playwright/test";
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+// ESM compatibility: derive __dirname equivalent
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Read test files from the TestFiles directory
+const testFilesDir = path.join(__dirname, "../../TestFiles");
+
+function readTestFile(relativePath: string): Uint8Array {
+  const fullPath = path.join(testFilesDir, relativePath);
+  return new Uint8Array(fs.readFileSync(fullPath));
+}
+
+test.describe("Docxodus Web Worker Tests", () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to worker test harness
+    await page.goto("/worker-test-harness.html");
+
+    // Wait for test harness to load
+    await page.waitForFunction(() => (window as any).DocxodusWorkerTests !== undefined, {
+      timeout: 10000,
+    });
+  });
+
+  test.describe("Worker Initialization", () => {
+    test("isWorkerSupported returns true in browser", async ({ page }) => {
+      const isSupported = await page.evaluate(() => {
+        return (window as any).DocxodusWorkerTests.isSupported();
+      });
+      expect(isSupported).toBe(true);
+    });
+
+    test("worker can be created and initialized", async ({ page }) => {
+      // Create worker - this may take a while as it loads WASM
+      const result = await page.evaluate(async () => {
+        try {
+          await (window as any).createDocxodusWorker();
+          return {
+            ready: (window as any).DocxodusWorkerReady,
+            active: (window as any).DocxodusWorkerTests.isActive(),
+          };
+        } catch (error: any) {
+          return { error: error.message };
+        }
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.ready).toBe(true);
+      expect(result.active).toBe(true);
+
+      console.log("Worker initialized successfully");
+    }, { timeout: 60000 });
+
+    test("worker can be terminated", async ({ page }) => {
+      // Create and then terminate worker
+      const result = await page.evaluate(async () => {
+        await (window as any).createDocxodusWorker();
+        const activeBefore = (window as any).DocxodusWorkerTests.isActive();
+        (window as any).DocxodusWorkerTests.terminate();
+        const activeAfter = (window as any).DocxodusWorkerTests.isActive();
+        return { activeBefore, activeAfter };
+      });
+
+      expect(result.activeBefore).toBe(true);
+      expect(result.activeAfter).toBe(false);
+
+      console.log("Worker terminated successfully");
+    }, { timeout: 60000 });
+  });
+
+  test.describe("Non-blocking Behavior", () => {
+    test("UI remains responsive during conversion", async ({ page }) => {
+      const bytes = readTestFile("HC006-Test-01.docx");
+
+      // This test verifies that the main thread is not blocked during worker operations
+      const result = await page.evaluate(async (bytesArray) => {
+        // Create worker
+        await (window as any).createDocxodusWorker();
+
+        // Track UI responsiveness
+        let animationFrameCount = 0;
+        let conversionComplete = false;
+
+        // Start counting animation frames
+        const countFrames = () => {
+          if (!conversionComplete) {
+            animationFrameCount++;
+            requestAnimationFrame(countFrames);
+          }
+        };
+        requestAnimationFrame(countFrames);
+
+        // Start conversion in worker
+        const startTime = performance.now();
+        const conversionPromise = (window as any).DocxodusWorkerTests.convertToHtml(bytesArray);
+
+        // Wait for conversion
+        const result = await conversionPromise;
+        conversionComplete = true;
+
+        const endTime = performance.now();
+        const duration = endTime - startTime;
+
+        return {
+          success: !result.error,
+          htmlLength: result.html?.length || 0,
+          duration,
+          animationFrameCount,
+          // If frames were counted, the main thread wasn't blocked
+          mainThreadResponsive: animationFrameCount > 0,
+        };
+      }, Array.from(bytes));
+
+      expect(result.success).toBe(true);
+      expect(result.htmlLength).toBeGreaterThan(100);
+      expect(result.mainThreadResponsive).toBe(true);
+
+      console.log(
+        `Conversion took ${result.duration.toFixed(0)}ms, ` +
+        `${result.animationFrameCount} animation frames fired (main thread responsive)`
+      );
+    }, { timeout: 60000 });
+
+    test("multiple operations can be queued", async ({ page }) => {
+      const bytes = readTestFile("HC006-Test-01.docx");
+
+      const result = await page.evaluate(async (bytesArray) => {
+        await (window as any).createDocxodusWorker();
+
+        const startTime = performance.now();
+
+        // Queue multiple operations
+        const promises = [
+          (window as any).DocxodusWorkerTests.convertToHtml(bytesArray),
+          (window as any).DocxodusWorkerTests.getVersion(),
+        ];
+
+        const results = await Promise.all(promises);
+        const endTime = performance.now();
+
+        return {
+          conversionSuccess: !results[0].error,
+          htmlLength: results[0].html?.length || 0,
+          versionSuccess: !!results[1].library,
+          duration: endTime - startTime,
+        };
+      }, Array.from(bytes));
+
+      expect(result.conversionSuccess).toBe(true);
+      expect(result.htmlLength).toBeGreaterThan(100);
+      expect(result.versionSuccess).toBe(true);
+
+      console.log(`Multiple operations completed in ${result.duration.toFixed(0)}ms`);
+    }, { timeout: 60000 });
+  });
+
+  test.describe("Conversion Operations", () => {
+    test("convertDocxToHtml produces valid HTML", async ({ page }) => {
+      const bytes = readTestFile("HC006-Test-01.docx");
+
+      const result = await page.evaluate(async (bytesArray) => {
+        await (window as any).createDocxodusWorker();
+        return await (window as any).DocxodusWorkerTests.convertToHtml(bytesArray);
+      }, Array.from(bytes));
+
+      expect(result.error).toBeUndefined();
+      expect(result.html).toBeDefined();
+      expect(result.html.length).toBeGreaterThan(100);
+      expect(result.html).toContain("<html");
+      expect(result.html).toContain("</html>");
+
+      console.log(`Converted document to ${result.html.length} bytes of HTML`);
+    }, { timeout: 60000 });
+
+    test("getVersion returns library info", async ({ page }) => {
+      const result = await page.evaluate(async () => {
+        await (window as any).createDocxodusWorker();
+        return await (window as any).DocxodusWorkerTests.getVersion();
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.library).toBeDefined();
+      expect(result.dotnetVersion).toBeDefined();
+      expect(result.platform).toBeDefined();
+
+      console.log(`Worker version: ${result.library}`);
+    }, { timeout: 60000 });
+  });
+
+  test.describe("Comparison Operations", () => {
+    test("compareDocuments produces valid redlined document", async ({ page }) => {
+      const originalBytes = readTestFile("WC/WC001-Digits.docx");
+      const modifiedBytes = readTestFile("WC/WC001-Digits-Mod.docx");
+
+      const result = await page.evaluate(async ([original, modified]) => {
+        await (window as any).createDocxodusWorker();
+        return await (window as any).DocxodusWorkerTests.compareDocuments(original, modified);
+      }, [Array.from(originalBytes), Array.from(modifiedBytes)]);
+
+      expect(result.error).toBeUndefined();
+      expect(result.docxBytes).toBeDefined();
+      expect(result.docxBytes.length).toBeGreaterThan(0);
+
+      // Verify it's a valid DOCX (starts with PK zip signature)
+      expect(result.docxBytes[0]).toBe(0x50); // P
+      expect(result.docxBytes[1]).toBe(0x4B); // K
+
+      console.log(`Comparison produced ${result.docxBytes.length} byte redlined document`);
+    }, { timeout: 60000 });
+
+    test("compareDocumentsToHtml produces HTML with tracked changes", async ({ page }) => {
+      const originalBytes = readTestFile("WC/WC001-Digits.docx");
+      const modifiedBytes = readTestFile("WC/WC001-Digits-Mod.docx");
+
+      const result = await page.evaluate(async ([original, modified]) => {
+        await (window as any).createDocxodusWorker();
+        return await (window as any).DocxodusWorkerTests.compareToHtml(original, modified);
+      }, [Array.from(originalBytes), Array.from(modifiedBytes)]);
+
+      expect(result.error).toBeUndefined();
+      expect(result.html).toBeDefined();
+      expect(result.html.length).toBeGreaterThan(100);
+
+      // Should contain tracked changes markup
+      expect(result.html).toMatch(/<(ins|del)/);
+
+      console.log(`Comparison HTML with tracked changes: ${result.html.length} bytes`);
+    }, { timeout: 60000 });
+
+    test("getRevisions extracts revisions from compared document", async ({ page }) => {
+      const originalBytes = readTestFile("WC/WC001-Digits.docx");
+      const modifiedBytes = readTestFile("WC/WC001-Digits-Mod.docx");
+
+      // First compare to get a document with tracked changes
+      const compareResult = await page.evaluate(async ([original, modified]) => {
+        await (window as any).createDocxodusWorker();
+        return await (window as any).DocxodusWorkerTests.compareDocuments(original, modified);
+      }, [Array.from(originalBytes), Array.from(modifiedBytes)]);
+
+      expect(compareResult.error).toBeUndefined();
+
+      // Then extract revisions
+      const result = await page.evaluate(async (docxBytes) => {
+        return await (window as any).DocxodusWorkerTests.getRevisions(docxBytes);
+      }, compareResult.docxBytes);
+
+      expect(result.error).toBeUndefined();
+      expect(result.revisions).toBeDefined();
+      expect(result.revisions.length).toBeGreaterThan(0);
+
+      // Check revision structure
+      const firstRevision = result.revisions[0];
+      expect(firstRevision.author).toBeDefined();
+      expect(firstRevision.revisionType).toBeDefined();
+
+      console.log(`Extracted ${result.revisions.length} revisions`);
+    }, { timeout: 60000 });
+  });
+
+  test.describe("Error Handling", () => {
+    test("handles invalid document gracefully", async ({ page }) => {
+      const invalidBytes = new Uint8Array([0, 1, 2, 3, 4, 5]); // Not a valid DOCX
+
+      const result = await page.evaluate(async (bytesArray) => {
+        await (window as any).createDocxodusWorker();
+        return await (window as any).DocxodusWorkerTests.convertToHtml(bytesArray);
+      }, Array.from(invalidBytes));
+
+      expect(result.error).toBeDefined();
+      expect(result.error.message).toBeTruthy();
+
+      console.log(`Error handling works: ${result.error.message}`);
+    }, { timeout: 60000 });
+
+    test("rejects requests after termination", async ({ page }) => {
+      const bytes = readTestFile("HC006-Test-01.docx");
+
+      const result = await page.evaluate(async (bytesArray) => {
+        await (window as any).createDocxodusWorker();
+        (window as any).DocxodusWorkerTests.terminate();
+
+        // Try to convert after termination
+        return await (window as any).DocxodusWorkerTests.convertToHtml(bytesArray);
+      }, Array.from(bytes));
+
+      expect(result.error).toBeDefined();
+
+      console.log("Correctly rejects requests after termination");
+    }, { timeout: 60000 });
+  });
+});


### PR DESCRIPTION
## Summary

This PR implements Phase 2 of the solution for Issue #44 - Web Worker support for fully non-blocking WASM execution.

**Builds on:** PR #47 (Phase 1: Frame Yielding)

### Key Changes

- New `docxodus/worker` export provides worker-based API
- WASM runs in a separate thread - main UI thread stays fully responsive
- Same API as main module for easy migration
- Zero-copy transfer of document bytes via Transferable

### New Files

| File | Description |
|------|-------------|
| `npm/src/docxodus.worker.ts` | Worker script that loads WASM and handles messages |
| `npm/src/worker-proxy.ts` | Main thread interface for worker communication |
| `npm/tests/worker.spec.ts` | 12 comprehensive tests for worker functionality |
| `npm/tests/worker-test-harness.html` | Test harness for worker tests |

### Usage

```typescript
import { createWorkerDocxodus, isWorkerSupported } from 'docxodus/worker';

if (isWorkerSupported()) {
  const docxodus = await createWorkerDocxodus();

  // These don't block the main thread!
  const html = await docxodus.convertDocxToHtml(docxFile);
  const redlined = await docxodus.compareDocuments(original, modified);
  const revisions = await docxodus.getRevisions(comparedDoc);

  // Clean up when done
  docxodus.terminate();
}
```

### Test Results

- 12 new worker tests added
- All 79 tests pass (67 existing + 12 new)
- Tests verify UI responsiveness during conversion (animation frames continue firing)

## Test plan

- [x] Worker can be created and initialized
- [x] Worker can be terminated
- [x] UI remains responsive during conversion (animation frames counted)
- [x] All conversion operations work (convertDocxToHtml, compareDocuments, etc.)
- [x] Error handling works across worker boundary
- [x] Request rejection after termination

## Documentation

- Updated `docs/architecture/ui_responsiveness.md` with Phase 2 implementation details
- Updated `CHANGELOG.md` with feature description

## Future Work

Phase 3 (lazy loading) will build on this worker foundation to enable page-by-page rendering.

Relates to #44