### PR TITLE
docs: Move tracked changes design doc and add pagination compatibility

### DIFF
--- a/npm/tests/test-harness.html
+++ b/npm/tests/test-harness.html
@@ -313,6 +313,38 @@
                 }
             },
 
+            // Convert DOCX to HTML with pagination AND tracked changes
+            convertToHtmlWithPaginationAndTrackedChanges: function(bytes, paginationMode = 1, paginationScale = 1.0, renderTrackedChanges = true) {
+                try {
+                    const result = window.Docxodus.DocumentConverter.ConvertDocxToHtmlComplete(
+                        bytes,
+                        'Document',           // pageTitle
+                        'docx-',              // cssPrefix
+                        true,                 // fabricateClasses
+                        '',                   // additionalCss
+                        -1,                   // commentRenderMode (disabled)
+                        'comment-',           // commentCssClassPrefix
+                        paginationMode,       // 0=None, 1=Paginated
+                        paginationScale,      // scale factor
+                        'page-',              // paginationCssClassPrefix
+                        false,                // renderAnnotations
+                        0,                    // annotationLabelMode
+                        'annot-',             // annotationCssClassPrefix
+                        true,                 // renderFootnotesAndEndnotes
+                        true,                 // renderHeadersAndFooters
+                        renderTrackedChanges, // renderTrackedChanges
+                        true,                 // showDeletedContent
+                        true                  // renderMoveOperations
+                    );
+                    if (result.startsWith('{') && result.includes('"Error"')) {
+                        return { error: JSON.parse(result) };
+                    }
+                    return { html: result };
+                } catch (e) {
+                    return { error: { message: e.message } };
+                }
+            },
+
             // Add annotation with flexible targeting
             addAnnotationWithTarget: function(bytes, request) {
                 try {


### PR DESCRIPTION
## Summary

- Move `TRACKED_CHANGES_HTML_DESIGN.md` from `Docxodus/` to `docs/architecture/tracked_changes.md`
- Add **Pagination Compatibility** section documenting how tracked changes work with the pagination system
- Add combined test verifying `<ins>`/`<del>` elements are preserved during pagination
- Add `convertToHtmlWithPaginationAndTrackedChanges` helper to test harness

## Background

Analysis confirmed that tracked changes and pagination are fully compatible features:
- C# generates HTML with both pagination metadata AND tracked change markup
- TypeScript pagination engine treats tracked changes as normal DOM content
- `cloneNode(true)` preserves all elements, CSS classes, and `data-*` attributes

## Test Plan

- [x] New test: "tracked changes are preserved when paginating a compared document"
  - Compares two documents to create tracked changes
  - Converts to HTML with pagination + tracked changes enabled  
  - Runs PaginationEngine
  - Verifies `ins.rev-ins` and `del.rev-del` elements in `.page-content` containers
- [x] Existing pagination tests still pass
- [x] Build succeeds