### PR TITLE
fix(react): add frame yielding to hooks for UI responsiveness (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,12 @@ All notable changes to this project will be documented in this file.
 - `SkiaSharp.NativeAssets.Linux.NoDependencies` package for Linux runtime support
 
 ### Fixed
+- **React hooks loading state not rendering before WASM blocks** (Issue #45) - Fixed `isConverting`/`isComparing`/`isLoading` states in React hooks not painting before WASM execution blocks the main thread. Added `requestAnimationFrame` yielding after state updates in:
+  - `useConversion`: `convert()` function
+  - `useComparison`: `compare()` and `compareToHtml()` functions
+  - `useAnnotations`: `reload()`, `add()`, and `remove()` functions
+  - `useDocumentStructure`: `reload()` function
+
 - **Header/footer positioning in paginated mode** - Fixed headers and footers overlapping with body content. Headers now properly constrain to the top margin area (`height: marginTop`) and footers constrain to the bottom margin area (`height: marginBottom`). Uses flexbox layout for proper content alignment within constrained areas.
 
 - **DocumentBuilder relationship copying** - Fixed bug where relationship IDs from source documents could incorrectly match existing IDs in target header/footer parts when using InsertId functionality. This caused validation errors like "The relationship 'rIdX' referenced by attribute 'r:embed' does not exist."

--- a/npm/src/react.ts
+++ b/npm/src/react.ts
@@ -389,6 +389,9 @@ export function useConversion(wasmBasePath?: string): UseConversionResult {
       setIsConverting(true);
       setError(null);
 
+      // Yield to allow React to render the loading state before WASM blocks
+      await new Promise(resolve => requestAnimationFrame(resolve));
+
       try {
         const result = await convertToHtml(document, options);
         setHtml(result);
@@ -491,6 +494,9 @@ export function useComparison(wasmBasePath?: string): UseComparisonResult {
       setIsComparing(true);
       setError(null);
 
+      // Yield to allow React to render the loading state before WASM blocks
+      await new Promise(resolve => requestAnimationFrame(resolve));
+
       try {
         const docResult = await docxodus.compare(original, modified, options);
         setResult(docResult);
@@ -521,6 +527,9 @@ export function useComparison(wasmBasePath?: string): UseComparisonResult {
 
       setIsComparing(true);
       setError(null);
+
+      // Yield to allow React to render the loading state before WASM blocks
+      await new Promise(resolve => requestAnimationFrame(resolve));
 
       try {
         const htmlResult = await docxodus.compareToHtml(original, modified, options);
@@ -939,6 +948,9 @@ export function useAnnotations(
     setIsLoading(true);
     setError(null);
 
+    // Yield to allow React to render the loading state before WASM blocks
+    await new Promise(resolve => requestAnimationFrame(resolve));
+
     try {
       const annots = await docxodus.getAnnotations(documentBytes);
       setAnnotations(annots);
@@ -963,6 +975,9 @@ export function useAnnotations(
 
       setIsLoading(true);
       setError(null);
+
+      // Yield to allow React to render the loading state before WASM blocks
+      await new Promise(resolve => requestAnimationFrame(resolve));
 
       try {
         const response = await docxodus.addAnnotation(documentBytes, request);
@@ -996,6 +1011,9 @@ export function useAnnotations(
 
       setIsLoading(true);
       setError(null);
+
+      // Yield to allow React to render the loading state before WASM blocks
+      await new Promise(resolve => requestAnimationFrame(resolve));
 
       try {
         const response = await docxodus.removeAnnotation(documentBytes, annotationId);
@@ -1271,6 +1289,9 @@ export function useDocumentStructure(
 
     setIsLoading(true);
     setError(null);
+
+    // Yield to allow React to render the loading state before WASM blocks
+    await new Promise(resolve => requestAnimationFrame(resolve));
 
     try {
       const struct = await docxodus.getDocumentStructure(document);


### PR DESCRIPTION
## Summary

- Fixes React hooks' loading states (`isConverting`, `isComparing`, `isLoading`) not rendering before WASM execution blocks the main thread
- Adds `requestAnimationFrame` yielding after state updates in all affected hooks

## Affected Hooks

| Hook | Functions Fixed |
|------|----------------|
| `useConversion` | `convert()` |
| `useComparison` | `compare()`, `compareToHtml()` |
| `useAnnotations` | `reload()`, `add()`, `remove()` |
| `useDocumentStructure` | `reload()` |

## Problem

The WASM execution blocks immediately after `setIsConverting(true)` is called, preventing React from painting the loading state before the operation begins. Users see no feedback that processing has started.

## Solution

```typescript
setIsConverting(true);
setError(null);

// Yield to allow React to render the loading state before WASM blocks
await new Promise(resolve => requestAnimationFrame(resolve));

try {
  const result = await convertToHtml(document, options);
```

## Test plan

- [x] TypeScript builds successfully (`npm run build:ts`)
- [x] All 95 Playwright tests pass (`npm test`)

Closes #45