### PR TITLE
feat(annotations): add external annotation system (Issue #57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ All notable changes to this project will be documented in this file.
 - **Graphics Library**: Replaced System.Drawing with SkiaSharp 2.88.9
 
 ### Added
+- **External Annotation System** (Issue #57) - Store annotations externally without modifying the DOCX file
+  - New `ExternalAnnotationSet` type extends `OpenContractDocExport` with document binding:
+    - `documentId`: Unique identifier for the source document
+    - `documentHash`: SHA256 hash for integrity validation
+    - `createdAt`, `updatedAt`: ISO 8601 timestamps
+    - `textLabels`, `docLabelDefinitions`: Label definitions keyed by ID
+  - `ExternalAnnotationManager` static class provides core functionality:
+    - `ComputeDocumentHash()`: SHA256 hash of document bytes
+    - `CreateAnnotationSet()`: Create annotation set from document (wraps OpenContractExporter)
+    - `CreateAnnotation()`: Create annotation from character offsets
+    - `CreateAnnotationFromSearch()`: Create annotation by text search with occurrence index
+    - `FindTextOccurrences()`: Find all occurrences of text in document
+    - `Validate()`: Validate annotations against document (hash check + text verification)
+    - `SerializeToJson()` / `DeserializeFromJson()`: JSON serialization
+  - `ExternalAnnotationProjector` for HTML projection:
+    - `ProjectAnnotations()`: Post-process HTML to wrap annotated text with styled spans
+    - `ConvertWithAnnotations()`: Combined conversion + projection
+    - Supports annotation labels (Above, Inline, Tooltip, None modes)
+    - CSS generation with customizable class prefix
+  - TypeScript/npm wrapper functions:
+    - `computeDocumentHash()`: Get document hash for validation
+    - `createExternalAnnotationSet()`: Create annotation set from DOCX
+    - `validateExternalAnnotations()`: Validate annotations against document
+    - `convertDocxToHtmlWithExternalAnnotations()`: Convert with annotations projected
+    - `searchTextOffsets()`: Search for text occurrences in document
+    - `createAnnotation()`, `createAnnotationFromSearch()`, `findTextOccurrences()`: Client-side helpers
+  - Full type definitions: `AnnotationLabel`, `ExternalAnnotationSet`, `ExternalAnnotationValidationResult`, etc.
+  - 21 unit tests covering hash computation, annotation creation, validation, serialization, and projection
 - **OpenContracts Export Format** (Issue #56) - Export documents to OpenContracts format for interoperability
   - New `OpenContractExporter.Export()` method for complete document export:
     - `title`: Document title from core properties

--- a/Docxodus.Tests/ExternalAnnotationTests.cs
+++ b/Docxodus.Tests/ExternalAnnotationTests.cs
@@ -1,0 +1,561 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Docxodus;
+using Xunit;
+
+#if !ELIDE_XUNIT_TESTS
+
+namespace OxPt
+{
+    /// <summary>
+    /// Tests for the External Annotation system (Issue #57).
+    /// Tests cover hash computation, annotation creation, validation, and projection.
+    /// </summary>
+    public class ExternalAnnotationTests
+    {
+        private static readonly DirectoryInfo TestFilesDir = new DirectoryInfo("../../../../TestFiles/");
+
+        #region Helper Methods
+
+        /// <summary>
+        /// Creates a properly structured test document with all required parts.
+        /// </summary>
+        private static WmlDocument CreateTestDocument(Action<Body> configureBody)
+        {
+            using var ms = new MemoryStream();
+            using (var wDoc = WordprocessingDocument.Create(ms, WordprocessingDocumentType.Document))
+            {
+                var mainPart = wDoc.AddMainDocumentPart();
+                mainPart.Document = new Document();
+                var body = new Body();
+                mainPart.Document.Body = body;
+
+                // Add StyleDefinitionsPart (required for many operations)
+                var stylesPart = mainPart.AddNewPart<StyleDefinitionsPart>();
+                stylesPart.Styles = new Styles();
+
+                // Add DocumentSettingsPart
+                var settingsPart = mainPart.AddNewPart<DocumentSettingsPart>();
+                settingsPart.Settings = new Settings();
+
+                // Configure body content
+                configureBody(body);
+
+                mainPart.Document.Save();
+            }
+
+            return new WmlDocument("test.docx", ms.ToArray());
+        }
+
+        private static WmlDocument CreateSimpleTestDocument(string text)
+        {
+            return CreateTestDocument(body =>
+            {
+                body.AppendChild(new Paragraph(new Run(new Text(text))));
+            });
+        }
+
+        #endregion
+
+        #region Document Hash Tests
+
+        [Fact]
+        public void EA001_ComputeDocumentHash_SameDocument_ReturnsSameHash()
+        {
+            // Arrange
+            var doc = CreateSimpleTestDocument("Hello, world!");
+
+            // Act
+            var hash1 = ExternalAnnotationManager.ComputeDocumentHash(doc);
+            var hash2 = ExternalAnnotationManager.ComputeDocumentHash(doc);
+
+            // Assert
+            Assert.NotNull(hash1);
+            Assert.NotEmpty(hash1);
+            Assert.Equal(hash1, hash2);
+            Assert.Equal(64, hash1.Length); // SHA256 produces 64 hex characters
+        }
+
+        [Fact]
+        public void EA002_ComputeDocumentHash_ModifiedDocument_ReturnsDifferentHash()
+        {
+            // Arrange
+            var doc1 = CreateSimpleTestDocument("Hello, world!");
+            var doc2 = CreateSimpleTestDocument("Hello, world!!");
+
+            // Act
+            var hash1 = ExternalAnnotationManager.ComputeDocumentHash(doc1);
+            var hash2 = ExternalAnnotationManager.ComputeDocumentHash(doc2);
+
+            // Assert
+            Assert.NotEqual(hash1, hash2);
+        }
+
+        [Fact]
+        public void EA003_ComputeDocumentHash_ByteArray_MatchesWmlDocument()
+        {
+            // Arrange
+            var doc = CreateSimpleTestDocument("Test content");
+
+            // Act
+            var hashFromDoc = ExternalAnnotationManager.ComputeDocumentHash(doc);
+            var hashFromBytes = ExternalAnnotationManager.ComputeDocumentHash(doc.DocumentByteArray);
+
+            // Assert
+            Assert.Equal(hashFromDoc, hashFromBytes);
+        }
+
+        #endregion
+
+        #region Annotation Set Creation Tests
+
+        [Fact]
+        public void EA010_CreateAnnotationSet_ReturnsValidSet()
+        {
+            // Arrange
+            var doc = CreateSimpleTestDocument("Hello, world!");
+            var documentId = "test-doc-001";
+
+            // Act
+            var set = ExternalAnnotationManager.CreateAnnotationSet(doc, documentId);
+
+            // Assert
+            Assert.NotNull(set);
+            Assert.Equal(documentId, set.DocumentId);
+            Assert.NotEmpty(set.DocumentHash);
+            Assert.NotEmpty(set.CreatedAt);
+            Assert.NotEmpty(set.UpdatedAt);
+            Assert.Equal("1.0", set.Version);
+            Assert.NotNull(set.Content);
+            Assert.Contains("Hello, world!", set.Content);
+        }
+
+        [Fact]
+        public void EA011_CreateAnnotationSet_InheritsFromOpenContractDocExport()
+        {
+            // Arrange
+            var doc = CreateTestDocument(body =>
+            {
+                body.AppendChild(new Paragraph(new Run(new Text("First paragraph"))));
+                body.AppendChild(new Paragraph(new Run(new Text("Second paragraph"))));
+            });
+
+            // Act
+            var set = ExternalAnnotationManager.CreateAnnotationSet(doc, "test");
+
+            // Assert
+            Assert.True(set.PageCount >= 1);
+            Assert.NotNull(set.PawlsFileContent);
+            Assert.NotNull(set.LabelledText);
+            Assert.NotNull(set.TextLabels);
+            Assert.NotNull(set.DocLabelDefinitions);
+        }
+
+        #endregion
+
+        #region Annotation Creation Tests
+
+        [Fact]
+        public void EA020_CreateAnnotation_ValidOffsets_CreatesAnnotation()
+        {
+            // Arrange
+            var documentText = "Hello, world! This is a test.";
+
+            // Act
+            var annotation = ExternalAnnotationManager.CreateAnnotation(
+                "ann-001", "IMPORTANT", documentText, 0, 5);
+
+            // Assert
+            Assert.NotNull(annotation);
+            Assert.Equal("ann-001", annotation.Id);
+            Assert.Equal("IMPORTANT", annotation.AnnotationLabel);
+            Assert.Equal("Hello", annotation.RawText);
+            Assert.False(annotation.Structural);
+
+            var span = annotation.AnnotationJson as TextSpan;
+            Assert.NotNull(span);
+            Assert.Equal(0, span.Start);
+            Assert.Equal(5, span.End);
+            Assert.Equal("Hello", span.Text);
+        }
+
+        [Fact]
+        public void EA021_CreateAnnotation_InvalidOffsets_ThrowsException()
+        {
+            // Arrange
+            var documentText = "Hello";
+
+            // Assert - Start > End
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                ExternalAnnotationManager.CreateAnnotation("ann", "label", documentText, 3, 1));
+
+            // Assert - Negative start
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                ExternalAnnotationManager.CreateAnnotation("ann", "label", documentText, -1, 3));
+
+            // Assert - End > Length
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                ExternalAnnotationManager.CreateAnnotation("ann", "label", documentText, 0, 10));
+        }
+
+        [Fact]
+        public void EA022_CreateAnnotationFromSearch_ExistingText_FindsOffsets()
+        {
+            // Arrange
+            var documentText = "Hello, world! This is a test.";
+
+            // Act
+            var annotation = ExternalAnnotationManager.CreateAnnotationFromSearch(
+                "ann-001", "GREETING", documentText, "world");
+
+            // Assert
+            Assert.NotNull(annotation);
+            Assert.Equal("world", annotation.RawText);
+
+            var span = annotation.AnnotationJson as TextSpan;
+            Assert.NotNull(span);
+            Assert.Equal(7, span.Start);
+            Assert.Equal(12, span.End);
+        }
+
+        [Fact]
+        public void EA023_CreateAnnotationFromSearch_MultipleOccurrences_FindsCorrectOne()
+        {
+            // Arrange - use lowercase consistently
+            var documentText = "hello world, hello world, hello world!";
+
+            // Act
+            var ann1 = ExternalAnnotationManager.CreateAnnotationFromSearch(
+                "ann-1", "WORD", documentText, "hello", 1);
+            var ann2 = ExternalAnnotationManager.CreateAnnotationFromSearch(
+                "ann-2", "WORD", documentText, "hello", 2);
+            var ann3 = ExternalAnnotationManager.CreateAnnotationFromSearch(
+                "ann-3", "WORD", documentText, "hello", 3);
+
+            // Assert
+            Assert.NotNull(ann1);
+            Assert.NotNull(ann2);
+            Assert.NotNull(ann3);
+
+            var span1 = ann1.AnnotationJson as TextSpan;
+            var span2 = ann2.AnnotationJson as TextSpan;
+            var span3 = ann3.AnnotationJson as TextSpan;
+
+            Assert.NotNull(span1);
+            Assert.NotNull(span2);
+            Assert.NotNull(span3);
+
+            // First occurrence at 0, second at 13, third at 26
+            Assert.Equal(0, span1.Start);
+            Assert.Equal(13, span2.Start);
+            Assert.Equal(26, span3.Start);
+        }
+
+        [Fact]
+        public void EA024_CreateAnnotationFromSearch_NotFound_ReturnsNull()
+        {
+            // Arrange
+            var documentText = "Hello, world!";
+
+            // Act
+            var annotation = ExternalAnnotationManager.CreateAnnotationFromSearch(
+                "ann-001", "LABEL", documentText, "goodbye");
+
+            // Assert
+            Assert.Null(annotation);
+        }
+
+        [Fact]
+        public void EA025_FindTextOccurrences_ReturnsAllOccurrences()
+        {
+            // Arrange
+            var documentText = "the quick brown fox jumps over the lazy dog";
+
+            // Act
+            var occurrences = ExternalAnnotationManager.FindTextOccurrences(documentText, "the");
+
+            // Assert
+            Assert.Equal(2, occurrences.Count);
+            Assert.Equal((0, 3), occurrences[0]);
+            Assert.Equal((31, 34), occurrences[1]);
+        }
+
+        #endregion
+
+        #region Validation Tests
+
+        [Fact]
+        public void EA030_Validate_MatchingHash_ReturnsValid()
+        {
+            // Arrange
+            var doc = CreateSimpleTestDocument("Hello, world!");
+            var set = ExternalAnnotationManager.CreateAnnotationSet(doc, "test");
+
+            // Act
+            var result = ExternalAnnotationManager.Validate(doc, set);
+
+            // Assert
+            Assert.True(result.IsValid);
+            Assert.False(result.HashMismatch);
+            Assert.Empty(result.Issues);
+        }
+
+        [Fact]
+        public void EA031_Validate_MismatchedHash_ReturnsHashMismatch()
+        {
+            // Arrange
+            var doc1 = CreateSimpleTestDocument("Hello, world!");
+            var doc2 = CreateSimpleTestDocument("Hello, world!!");
+            var set = ExternalAnnotationManager.CreateAnnotationSet(doc1, "test");
+
+            // Act
+            var result = ExternalAnnotationManager.Validate(doc2, set);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.True(result.HashMismatch);
+        }
+
+        [Fact]
+        public void EA032_Validate_StaleAnnotation_ReportsTextMismatch()
+        {
+            // Arrange
+            var doc = CreateSimpleTestDocument("Hello, world!");
+            var set = ExternalAnnotationManager.CreateAnnotationSet(doc, "test");
+
+            // Add an annotation with wrong text
+            var badAnnotation = new OpenContractsAnnotation
+            {
+                Id = "bad-ann",
+                AnnotationLabel = "TEST",
+                RawText = "wrong text",
+                Page = 0,
+                AnnotationJson = new TextSpan
+                {
+                    Id = "bad-ann",
+                    Start = 0,
+                    End = 5,
+                    Text = "wrong text" // Doesn't match "Hello"
+                },
+                Structural = false
+            };
+            set.LabelledText.Add(badAnnotation);
+
+            // Act
+            var result = ExternalAnnotationManager.Validate(doc, set);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Contains(result.Issues, i => i.IssueType == "TextMismatch");
+        }
+
+        [Fact]
+        public void EA033_Validate_OutOfBoundsAnnotation_ReportsOutOfBounds()
+        {
+            // Arrange
+            var doc = CreateSimpleTestDocument("Hello");
+            var set = ExternalAnnotationManager.CreateAnnotationSet(doc, "test");
+
+            // Add an annotation with invalid offsets
+            var badAnnotation = new OpenContractsAnnotation
+            {
+                Id = "bad-ann",
+                AnnotationLabel = "TEST",
+                RawText = "out of bounds",
+                Page = 0,
+                AnnotationJson = new TextSpan
+                {
+                    Id = "bad-ann",
+                    Start = 0,
+                    End = 1000, // Way beyond document length
+                    Text = "out of bounds"
+                },
+                Structural = false
+            };
+            set.LabelledText.Add(badAnnotation);
+
+            // Act
+            var result = ExternalAnnotationManager.Validate(doc, set);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Contains(result.Issues, i => i.IssueType == "OutOfBounds");
+        }
+
+        #endregion
+
+        #region Serialization Tests
+
+        [Fact]
+        public void EA040_SerializeDeserialize_RoundTrip_PreservesAllData()
+        {
+            // Arrange
+            var doc = CreateSimpleTestDocument("Hello, world!");
+            var set = ExternalAnnotationManager.CreateAnnotationSet(doc, "test-doc");
+
+            // Add some labels
+            set.TextLabels["IMPORTANT"] = new AnnotationLabel
+            {
+                Id = "IMPORTANT",
+                Text = "Important",
+                Color = "#FF0000",
+                Description = "Important text",
+                LabelType = "text"
+            };
+
+            // Add an annotation
+            var annotation = ExternalAnnotationManager.CreateAnnotation(
+                "ann-001", "IMPORTANT", set.Content, 0, 5);
+            set.LabelledText.Add(annotation);
+
+            // Act
+            var json = ExternalAnnotationManager.SerializeToJson(set);
+            var deserialized = ExternalAnnotationManager.DeserializeFromJson(json);
+
+            // Assert
+            Assert.NotNull(deserialized);
+            Assert.Equal(set.DocumentId, deserialized.DocumentId);
+            Assert.Equal(set.DocumentHash, deserialized.DocumentHash);
+            Assert.Equal(set.Version, deserialized.Version);
+            Assert.Contains("Hello, world!", deserialized.Content);
+            Assert.Single(deserialized.TextLabels);
+            Assert.True(deserialized.TextLabels.ContainsKey("IMPORTANT"));
+        }
+
+        [Fact]
+        public void EA041_DeserializeFromJson_InvalidJson_ReturnsNull()
+        {
+            // Act
+            var result = ExternalAnnotationManager.DeserializeFromJson("not valid json");
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void EA042_DeserializeFromJson_EmptyString_ReturnsNull()
+        {
+            // Act
+            var result = ExternalAnnotationManager.DeserializeFromJson("");
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        #endregion
+
+        #region Projection Tests
+
+        [Fact]
+        public void EA050_ProjectAnnotations_SingleAnnotation_AddsWrapperSpan()
+        {
+            // Arrange
+            var doc = CreateSimpleTestDocument("Hello, world!");
+            var set = ExternalAnnotationManager.CreateAnnotationSet(doc, "test");
+
+            // Add label
+            set.TextLabels["GREETING"] = new AnnotationLabel
+            {
+                Id = "GREETING",
+                Text = "Greeting",
+                Color = "#FFEB3B"
+            };
+
+            // Add annotation
+            var annotation = ExternalAnnotationManager.CreateAnnotation(
+                "ann-001", "GREETING", set.Content, 0, 5);
+            set.LabelledText.Add(annotation);
+
+            var settings = new WmlToHtmlConverterSettings { PageTitle = "Test" };
+            var html = WmlToHtmlConverter.ConvertToHtml(doc, settings);
+
+            var projectionSettings = new ExternalAnnotationProjectionSettings
+            {
+                CssClassPrefix = "ext-annot-",
+                LabelMode = AnnotationLabelMode.Inline
+            };
+
+            // Act
+            var result = ExternalAnnotationProjector.ProjectAnnotations(html, set, projectionSettings);
+
+            // Assert
+            var resultStr = result.ToString();
+            Assert.Contains("ext-annot-highlight", resultStr);
+            Assert.Contains("data-annotation-id", resultStr);
+            Assert.Contains("ann-001", resultStr);
+        }
+
+        [Fact]
+        public void EA051_ConvertWithAnnotations_IntegratedFlow()
+        {
+            // Arrange
+            var doc = CreateSimpleTestDocument("Hello, world!");
+            var set = ExternalAnnotationManager.CreateAnnotationSet(doc, "test");
+
+            set.TextLabels["TEST"] = new AnnotationLabel
+            {
+                Id = "TEST",
+                Text = "Test Label",
+                Color = "#00FF00"
+            };
+
+            var annotation = ExternalAnnotationManager.CreateAnnotation(
+                "ann-001", "TEST", set.Content, 0, 5);
+            set.LabelledText.Add(annotation);
+
+            var htmlSettings = new WmlToHtmlConverterSettings { PageTitle = "Test" };
+            var projectionSettings = new ExternalAnnotationProjectionSettings();
+
+            // Act
+            var html = ExternalAnnotationProjector.ConvertWithAnnotations(
+                doc, set, htmlSettings, projectionSettings);
+
+            // Assert
+            Assert.NotNull(html);
+            Assert.Contains("ext-annot-highlight", html);
+        }
+
+        #endregion
+
+        #region Integration Tests with Real Documents
+
+        [Fact]
+        public void EA060_Integration_RealDocument_CreatesAndValidatesSet()
+        {
+            // Arrange
+            var sourceDocx = new FileInfo(Path.Combine(TestFilesDir.FullName, "HC001-5DayTourPlanTemplate.docx"));
+            if (!sourceDocx.Exists)
+            {
+                // Skip if test file doesn't exist
+                return;
+            }
+
+            var wmlDoc = new WmlDocument(sourceDocx.FullName);
+
+            // Act
+            var set = ExternalAnnotationManager.CreateAnnotationSet(wmlDoc, "tour-template");
+
+            // Assert
+            Assert.NotEmpty(set.DocumentHash);
+            Assert.NotEmpty(set.Content);
+            Assert.True(set.PageCount >= 1);
+
+            // Validate should pass
+            var validation = ExternalAnnotationManager.Validate(wmlDoc, set);
+            Assert.True(validation.IsValid);
+            Assert.False(validation.HashMismatch);
+        }
+
+        #endregion
+    }
+}
+
+#endif

--- a/Docxodus/ExternalAnnotation.cs
+++ b/Docxodus/ExternalAnnotation.cs
@@ -1,0 +1,138 @@
+#nullable enable
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Docxodus;
+
+/// <summary>
+/// External annotation set that extends OpenContractDocExport with document binding.
+/// Uses the SAME annotation structure as OpenContracts for interoperability.
+///
+/// This enables storing annotations externally (in JSON/database) without modifying
+/// the source DOCX file. The documentHash allows validation that annotations
+/// still match the document content.
+/// </summary>
+public class ExternalAnnotationSet : OpenContractDocExport
+{
+    /// <summary>
+    /// Unique identifier for the source document (filename, UUID, or external reference).
+    /// </summary>
+    public string DocumentId { get; set; } = "";
+
+    /// <summary>
+    /// SHA256 hash of the source document for integrity validation.
+    /// Required - used to detect if annotations are stale.
+    /// </summary>
+    public string DocumentHash { get; set; } = "";
+
+    /// <summary>
+    /// ISO 8601 timestamp when this annotation set was created.
+    /// </summary>
+    public string CreatedAt { get; set; } = "";
+
+    /// <summary>
+    /// ISO 8601 timestamp when this annotation set was last modified.
+    /// </summary>
+    public string UpdatedAt { get; set; } = "";
+
+    /// <summary>
+    /// Version of the external annotation format (for future migrations).
+    /// </summary>
+    public string Version { get; set; } = "1.0";
+
+    /// <summary>
+    /// Text label definitions keyed by label ID.
+    /// These define the annotation categories available for text spans.
+    /// </summary>
+    public Dictionary<string, AnnotationLabel> TextLabels { get; set; } = new();
+
+    /// <summary>
+    /// Document label definitions keyed by label ID.
+    /// Note: DocLabels (List&lt;string&gt;) is inherited from OpenContractDocExport
+    /// and contains the applied document-level labels. This dictionary provides
+    /// the full label definitions.
+    /// </summary>
+    public Dictionary<string, AnnotationLabel> DocLabelDefinitions { get; set; } = new();
+}
+
+/// <summary>
+/// Result of validating an external annotation set against a document.
+/// </summary>
+public class ExternalAnnotationValidationResult
+{
+    /// <summary>
+    /// True if the annotation set is valid for the document.
+    /// False if there are any errors (hash mismatch or annotation issues).
+    /// </summary>
+    public bool IsValid { get; set; }
+
+    /// <summary>
+    /// True if the document hash doesn't match, indicating the document
+    /// may have been modified since the annotations were created.
+    /// </summary>
+    public bool HashMismatch { get; set; }
+
+    /// <summary>
+    /// List of specific issues found during validation.
+    /// </summary>
+    public List<ExternalAnnotationValidationIssue> Issues { get; set; } = new();
+}
+
+/// <summary>
+/// A single validation issue found when validating an external annotation set.
+/// </summary>
+public class ExternalAnnotationValidationIssue
+{
+    /// <summary>
+    /// ID of the annotation with the issue.
+    /// </summary>
+    public string AnnotationId { get; set; } = "";
+
+    /// <summary>
+    /// Type of issue: "TextMismatch", "OutOfBounds", or "MissingLabel".
+    /// </summary>
+    public string IssueType { get; set; } = "";
+
+    /// <summary>
+    /// Human-readable description of the issue.
+    /// </summary>
+    public string Description { get; set; } = "";
+
+    /// <summary>
+    /// For TextMismatch: the text that was expected (stored in annotation).
+    /// </summary>
+    public string? ExpectedText { get; set; }
+
+    /// <summary>
+    /// For TextMismatch: the actual text found at the annotation's offsets.
+    /// </summary>
+    public string? ActualText { get; set; }
+}
+
+/// <summary>
+/// Settings for projecting external annotations onto HTML.
+/// </summary>
+public class ExternalAnnotationProjectionSettings
+{
+    /// <summary>
+    /// CSS class prefix for annotation elements (default: "ext-annot-").
+    /// </summary>
+    public string CssClassPrefix { get; set; } = "ext-annot-";
+
+    /// <summary>
+    /// How to display annotation labels.
+    /// </summary>
+    public AnnotationLabelMode LabelMode { get; set; } = AnnotationLabelMode.Above;
+
+    /// <summary>
+    /// Whether to include annotation metadata as data attributes.
+    /// </summary>
+    public bool IncludeMetadata { get; set; } = true;
+
+    /// <summary>
+    /// Whether to validate annotations before projection.
+    /// If true, invalid annotations will be skipped.
+    /// </summary>
+    public bool ValidateBeforeProjection { get; set; } = true;
+}

--- a/Docxodus/ExternalAnnotationManager.cs
+++ b/Docxodus/ExternalAnnotationManager.cs
@@ -1,0 +1,364 @@
+#nullable enable
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace Docxodus;
+
+/// <summary>
+/// Manages external annotations that don't modify the source document.
+/// Provides hash computation, validation, and serialization.
+/// </summary>
+public static class ExternalAnnotationManager
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    #region Document Hash
+
+    /// <summary>
+    /// Compute the SHA256 hash of a document for integrity validation.
+    /// </summary>
+    /// <param name="doc">The document to hash.</param>
+    /// <returns>Lowercase hex string of the SHA256 hash.</returns>
+    public static string ComputeDocumentHash(WmlDocument doc)
+    {
+        if (doc == null) throw new ArgumentNullException(nameof(doc));
+        return ComputeDocumentHash(doc.DocumentByteArray);
+    }
+
+    /// <summary>
+    /// Compute the SHA256 hash of document bytes for integrity validation.
+    /// </summary>
+    /// <param name="documentBytes">The document bytes to hash.</param>
+    /// <returns>Lowercase hex string of the SHA256 hash.</returns>
+    public static string ComputeDocumentHash(byte[] documentBytes)
+    {
+        if (documentBytes == null) throw new ArgumentNullException(nameof(documentBytes));
+
+        var hashBytes = SHA256.HashData(documentBytes);
+        return Convert.ToHexString(hashBytes).ToLowerInvariant();
+    }
+
+    #endregion
+
+    #region Annotation Set Creation
+
+    /// <summary>
+    /// Create an ExternalAnnotationSet from a document.
+    /// This extracts the document structure and computes the hash.
+    /// </summary>
+    /// <param name="doc">The source document.</param>
+    /// <param name="documentId">Identifier for the document (filename, UUID, etc.).</param>
+    /// <returns>A new ExternalAnnotationSet with document content and hash.</returns>
+    public static ExternalAnnotationSet CreateAnnotationSet(WmlDocument doc, string documentId)
+    {
+        if (doc == null) throw new ArgumentNullException(nameof(doc));
+        if (string.IsNullOrEmpty(documentId)) throw new ArgumentException("Document ID is required", nameof(documentId));
+
+        // Use OpenContractExporter to get the document structure
+        var export = OpenContractExporter.Export(doc);
+
+        var now = DateTime.UtcNow.ToString("o");
+        var hash = ComputeDocumentHash(doc);
+
+        // Create the external annotation set by copying export data
+        return new ExternalAnnotationSet
+        {
+            // Document binding
+            DocumentId = documentId,
+            DocumentHash = hash,
+            CreatedAt = now,
+            UpdatedAt = now,
+            Version = "1.0",
+
+            // Inherited from OpenContractDocExport
+            Title = export.Title,
+            Content = export.Content,
+            Description = export.Description,
+            PageCount = export.PageCount,
+            PawlsFileContent = export.PawlsFileContent,
+            DocLabels = export.DocLabels,
+            LabelledText = export.LabelledText,
+            Relationships = export.Relationships,
+
+            // New fields for external annotations
+            TextLabels = new Dictionary<string, AnnotationLabel>(),
+            DocLabelDefinitions = new Dictionary<string, AnnotationLabel>()
+        };
+    }
+
+    #endregion
+
+    #region Annotation Creation Helpers
+
+    /// <summary>
+    /// Create an annotation from character offsets.
+    /// </summary>
+    /// <param name="id">Unique identifier for the annotation.</param>
+    /// <param name="labelId">Label/category ID for the annotation.</param>
+    /// <param name="documentText">Full document text (for extracting rawText).</param>
+    /// <param name="startOffset">Start character offset (0-indexed, inclusive).</param>
+    /// <param name="endOffset">End character offset (exclusive).</param>
+    /// <returns>A new OpenContractsAnnotation with TextSpan targeting.</returns>
+    public static OpenContractsAnnotation CreateAnnotation(
+        string id,
+        string labelId,
+        string documentText,
+        int startOffset,
+        int endOffset)
+    {
+        if (string.IsNullOrEmpty(id)) throw new ArgumentException("ID is required", nameof(id));
+        if (string.IsNullOrEmpty(labelId)) throw new ArgumentException("Label ID is required", nameof(labelId));
+        if (documentText == null) throw new ArgumentNullException(nameof(documentText));
+        if (startOffset < 0) throw new ArgumentOutOfRangeException(nameof(startOffset), "Start offset must be non-negative");
+        if (endOffset < startOffset) throw new ArgumentOutOfRangeException(nameof(endOffset), "End offset must be >= start offset");
+        if (endOffset > documentText.Length) throw new ArgumentOutOfRangeException(nameof(endOffset), "End offset exceeds document length");
+
+        var rawText = documentText.Substring(startOffset, endOffset - startOffset);
+
+        return new OpenContractsAnnotation
+        {
+            Id = id,
+            AnnotationLabel = labelId,
+            RawText = rawText,
+            Page = 0, // Page will be computed during projection if needed
+            AnnotationJson = new TextSpan
+            {
+                Id = id,
+                Start = startOffset,
+                End = endOffset,
+                Text = rawText
+            },
+            AnnotationType = "text",
+            Structural = false
+        };
+    }
+
+    /// <summary>
+    /// Create an annotation by searching for text in the document.
+    /// </summary>
+    /// <param name="id">Unique identifier for the annotation.</param>
+    /// <param name="labelId">Label/category ID for the annotation.</param>
+    /// <param name="documentText">Full document text to search in.</param>
+    /// <param name="searchText">Text to search for.</param>
+    /// <param name="occurrence">Which occurrence to use (1-based, default: 1).</param>
+    /// <returns>A new OpenContractsAnnotation, or null if text not found.</returns>
+    public static OpenContractsAnnotation? CreateAnnotationFromSearch(
+        string id,
+        string labelId,
+        string documentText,
+        string searchText,
+        int occurrence = 1)
+    {
+        if (string.IsNullOrEmpty(id)) throw new ArgumentException("ID is required", nameof(id));
+        if (string.IsNullOrEmpty(labelId)) throw new ArgumentException("Label ID is required", nameof(labelId));
+        if (documentText == null) throw new ArgumentNullException(nameof(documentText));
+        if (string.IsNullOrEmpty(searchText)) throw new ArgumentException("Search text is required", nameof(searchText));
+        if (occurrence < 1) throw new ArgumentOutOfRangeException(nameof(occurrence), "Occurrence must be >= 1");
+
+        var offsets = FindTextOccurrences(documentText, searchText);
+
+        if (occurrence > offsets.Count)
+        {
+            return null; // Occurrence not found
+        }
+
+        var (start, end) = offsets[occurrence - 1];
+        return CreateAnnotation(id, labelId, documentText, start, end);
+    }
+
+    /// <summary>
+    /// Find all occurrences of a text string in the document.
+    /// </summary>
+    /// <param name="documentText">Full document text to search in.</param>
+    /// <param name="searchText">Text to search for.</param>
+    /// <param name="maxResults">Maximum number of results (default: 100).</param>
+    /// <returns>List of (startOffset, endOffset) tuples.</returns>
+    public static List<(int start, int end)> FindTextOccurrences(
+        string documentText,
+        string searchText,
+        int maxResults = 100)
+    {
+        if (documentText == null) throw new ArgumentNullException(nameof(documentText));
+        if (string.IsNullOrEmpty(searchText)) return new List<(int, int)>();
+
+        var results = new List<(int start, int end)>();
+        var index = 0;
+
+        while (results.Count < maxResults)
+        {
+            index = documentText.IndexOf(searchText, index, StringComparison.Ordinal);
+            if (index < 0) break;
+
+            results.Add((index, index + searchText.Length));
+            index += 1; // Move past start of this match to find overlapping matches
+        }
+
+        return results;
+    }
+
+    #endregion
+
+    #region Validation
+
+    /// <summary>
+    /// Validate an external annotation set against a document.
+    /// Checks hash match and verifies each annotation's text still matches.
+    /// </summary>
+    /// <param name="doc">The document to validate against.</param>
+    /// <param name="annotationSet">The annotation set to validate.</param>
+    /// <returns>Validation result with any issues found.</returns>
+    public static ExternalAnnotationValidationResult Validate(
+        WmlDocument doc,
+        ExternalAnnotationSet annotationSet)
+    {
+        if (doc == null) throw new ArgumentNullException(nameof(doc));
+        if (annotationSet == null) throw new ArgumentNullException(nameof(annotationSet));
+
+        var result = new ExternalAnnotationValidationResult
+        {
+            IsValid = true,
+            HashMismatch = false,
+            Issues = new List<ExternalAnnotationValidationIssue>()
+        };
+
+        // Check document hash
+        var currentHash = ComputeDocumentHash(doc);
+        if (!string.Equals(currentHash, annotationSet.DocumentHash, StringComparison.OrdinalIgnoreCase))
+        {
+            result.HashMismatch = true;
+            result.IsValid = false;
+        }
+
+        // Get current document text
+        var export = OpenContractExporter.Export(doc);
+        var documentText = export.Content;
+
+        // Validate each annotation
+        foreach (var annotation in annotationSet.LabelledText)
+        {
+            // Skip structural annotations (they don't have user-specified text)
+            if (annotation.Structural) continue;
+
+            var issue = ValidateAnnotation(annotation, documentText, annotationSet.TextLabels);
+            if (issue != null)
+            {
+                result.Issues.Add(issue);
+                result.IsValid = false;
+            }
+        }
+
+        return result;
+    }
+
+    private static ExternalAnnotationValidationIssue? ValidateAnnotation(
+        OpenContractsAnnotation annotation,
+        string documentText,
+        Dictionary<string, AnnotationLabel> labels)
+    {
+        var annotationId = annotation.Id ?? "(unnamed)";
+
+        // Check if label exists
+        if (!string.IsNullOrEmpty(annotation.AnnotationLabel) &&
+            labels.Count > 0 &&
+            !labels.ContainsKey(annotation.AnnotationLabel))
+        {
+            return new ExternalAnnotationValidationIssue
+            {
+                AnnotationId = annotationId,
+                IssueType = "MissingLabel",
+                Description = $"Label '{annotation.AnnotationLabel}' is not defined in TextLabels"
+            };
+        }
+
+        // Check text span targeting
+        if (annotation.AnnotationJson is TextSpan textSpan)
+        {
+            // Check bounds
+            if (textSpan.Start < 0 || textSpan.End < textSpan.Start)
+            {
+                return new ExternalAnnotationValidationIssue
+                {
+                    AnnotationId = annotationId,
+                    IssueType = "OutOfBounds",
+                    Description = $"Invalid offsets: start={textSpan.Start}, end={textSpan.End}"
+                };
+            }
+
+            if (textSpan.End > documentText.Length)
+            {
+                return new ExternalAnnotationValidationIssue
+                {
+                    AnnotationId = annotationId,
+                    IssueType = "OutOfBounds",
+                    Description = $"End offset {textSpan.End} exceeds document length {documentText.Length}"
+                };
+            }
+
+            // Check text match
+            var actualText = documentText.Substring(textSpan.Start, textSpan.End - textSpan.Start);
+            var expectedText = textSpan.Text ?? annotation.RawText;
+
+            if (!string.Equals(actualText, expectedText, StringComparison.Ordinal))
+            {
+                return new ExternalAnnotationValidationIssue
+                {
+                    AnnotationId = annotationId,
+                    IssueType = "TextMismatch",
+                    Description = "Text at annotation offsets does not match expected text",
+                    ExpectedText = expectedText,
+                    ActualText = actualText
+                };
+            }
+        }
+
+        return null;
+    }
+
+    #endregion
+
+    #region Serialization
+
+    /// <summary>
+    /// Serialize an annotation set to JSON.
+    /// </summary>
+    /// <param name="set">The annotation set to serialize.</param>
+    /// <returns>JSON string representation.</returns>
+    public static string SerializeToJson(ExternalAnnotationSet set)
+    {
+        if (set == null) throw new ArgumentNullException(nameof(set));
+        return JsonSerializer.Serialize(set, s_jsonOptions);
+    }
+
+    /// <summary>
+    /// Deserialize an annotation set from JSON.
+    /// </summary>
+    /// <param name="json">JSON string to deserialize.</param>
+    /// <returns>The deserialized annotation set, or null if invalid.</returns>
+    public static ExternalAnnotationSet? DeserializeFromJson(string json)
+    {
+        if (string.IsNullOrEmpty(json)) return null;
+
+        try
+        {
+            return JsonSerializer.Deserialize<ExternalAnnotationSet>(json, s_jsonOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    #endregion
+}

--- a/Docxodus/ExternalAnnotationProjector.cs
+++ b/Docxodus/ExternalAnnotationProjector.cs
@@ -1,0 +1,438 @@
+#nullable enable
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+using System.Xml.Linq;
+
+namespace Docxodus;
+
+/// <summary>
+/// Projects external annotations onto HTML content.
+/// Wraps annotated text ranges with styled spans.
+/// </summary>
+public static class ExternalAnnotationProjector
+{
+    private static readonly XNamespace Xhtml = "http://www.w3.org/1999/xhtml";
+
+    /// <summary>
+    /// Project external annotations onto an HTML document.
+    /// This post-processes the HTML to wrap annotated text with styled spans.
+    /// </summary>
+    /// <param name="htmlDocument">The HTML document (as XElement).</param>
+    /// <param name="annotationSet">The external annotation set to project.</param>
+    /// <param name="settings">Projection settings.</param>
+    /// <returns>Modified HTML with annotations projected.</returns>
+    public static XElement ProjectAnnotations(
+        XElement htmlDocument,
+        ExternalAnnotationSet annotationSet,
+        ExternalAnnotationProjectionSettings settings)
+    {
+        if (htmlDocument == null) throw new ArgumentNullException(nameof(htmlDocument));
+        if (annotationSet == null) throw new ArgumentNullException(nameof(annotationSet));
+        settings ??= new ExternalAnnotationProjectionSettings();
+
+        // Clone the document to avoid modifying the original
+        var result = new XElement(htmlDocument);
+
+        // Build the text-to-element mapping
+        var textMap = BuildTextMap(result);
+        var htmlText = GetHtmlText(textMap);
+
+        // Track which offsets we've used (for handling multiple occurrences)
+        var usedOffsets = new HashSet<int>();
+
+        // Sort annotations by start offset for correct nesting
+        var sortedAnnotations = annotationSet.LabelledText
+            .Where(a => !a.Structural && a.AnnotationJson is TextSpan)
+            .Select(a => (Annotation: a, Span: (TextSpan)a.AnnotationJson!))
+            .OrderBy(x => x.Span.Start)
+            .ThenByDescending(x => x.Span.End) // Longer spans first for nesting
+            .ToList();
+
+        // Project each annotation using text search (not offsets)
+        foreach (var (annotation, span) in sortedAnnotations)
+        {
+            var label = annotationSet.TextLabels.TryGetValue(annotation.AnnotationLabel, out var l)
+                ? l : null;
+
+            // Use the annotation's raw text to find it in the HTML
+            var searchText = span.Text ?? annotation.RawText;
+            if (string.IsNullOrEmpty(searchText)) continue;
+
+            // Find this text in the HTML
+            var htmlLocation = FindTextInHtml(htmlText, searchText, usedOffsets);
+            if (htmlLocation == null) continue;
+
+            // Create a synthetic span with HTML-space offsets
+            var htmlSpan = new TextSpan
+            {
+                Id = span.Id,
+                Start = htmlLocation.Value.start,
+                End = htmlLocation.Value.end,
+                Text = searchText
+            };
+
+            // Rebuild text map since we may have modified it in previous iteration
+            textMap = BuildTextMap(result);
+
+            ProjectSingleAnnotation(result, textMap, annotation, htmlSpan, label, settings);
+        }
+
+        // Add CSS for annotations
+        AddAnnotationCss(result, annotationSet.TextLabels, settings);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Convert a document to HTML with external annotations projected.
+    /// This combines WmlToHtmlConverter with annotation projection.
+    /// </summary>
+    /// <param name="doc">The source document.</param>
+    /// <param name="annotationSet">The external annotation set to project.</param>
+    /// <param name="htmlSettings">HTML conversion settings.</param>
+    /// <param name="projectionSettings">Annotation projection settings.</param>
+    /// <returns>HTML string with annotations projected.</returns>
+    public static string ConvertWithAnnotations(
+        WmlDocument doc,
+        ExternalAnnotationSet annotationSet,
+        WmlToHtmlConverterSettings? htmlSettings = null,
+        ExternalAnnotationProjectionSettings? projectionSettings = null)
+    {
+        if (doc == null) throw new ArgumentNullException(nameof(doc));
+        if (annotationSet == null) throw new ArgumentNullException(nameof(annotationSet));
+
+        htmlSettings ??= new WmlToHtmlConverterSettings();
+        projectionSettings ??= new ExternalAnnotationProjectionSettings();
+
+        // Convert document to HTML
+        var html = WmlToHtmlConverter.ConvertToHtml(doc, htmlSettings);
+
+        // Project annotations
+        var annotatedHtml = ProjectAnnotations(html, annotationSet, projectionSettings);
+
+        return annotatedHtml.ToString();
+    }
+
+    #region Text Mapping
+
+    private class TextMapEntry
+    {
+        public XText TextNode { get; set; } = null!;
+        public int StartOffset { get; set; }
+        public int EndOffset { get; set; }
+    }
+
+    private static List<TextMapEntry> BuildTextMap(XElement html)
+    {
+        var entries = new List<TextMapEntry>();
+        var offset = 0;
+
+        // Find body element
+        var body = html.Descendants()
+            .FirstOrDefault(e => e.Name.LocalName.Equals("body", StringComparison.OrdinalIgnoreCase));
+
+        if (body == null)
+        {
+            body = html;
+        }
+
+        // Collect all text nodes with their offsets
+        foreach (var textNode in GetTextNodes(body))
+        {
+            var text = textNode.Value;
+            entries.Add(new TextMapEntry
+            {
+                TextNode = textNode,
+                StartOffset = offset,
+                EndOffset = offset + text.Length
+            });
+            offset += text.Length;
+        }
+
+        return entries;
+    }
+
+    /// <summary>
+    /// Get the concatenated text from all text nodes in the HTML body.
+    /// This represents the "HTML text" which may differ from document source text.
+    /// </summary>
+    private static string GetHtmlText(List<TextMapEntry> textMap)
+    {
+        var sb = new StringBuilder();
+        foreach (var entry in textMap)
+        {
+            sb.Append(entry.TextNode.Value);
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Find the text in HTML by searching for the annotation's raw text.
+    /// Returns (htmlStart, htmlEnd) offsets in HTML text space, or null if not found.
+    /// </summary>
+    private static (int start, int end)? FindTextInHtml(
+        string htmlText,
+        string searchText,
+        HashSet<int> usedOffsets)
+    {
+        if (string.IsNullOrEmpty(searchText)) return null;
+
+        // Find all occurrences and pick the first unused one
+        var index = 0;
+        while (index < htmlText.Length)
+        {
+            index = htmlText.IndexOf(searchText, index, StringComparison.Ordinal);
+            if (index < 0) break;
+
+            if (!usedOffsets.Contains(index))
+            {
+                usedOffsets.Add(index);
+                return (index, index + searchText.Length);
+            }
+            index++;
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<XText> GetTextNodes(XElement element)
+    {
+        foreach (var node in element.Nodes())
+        {
+            if (node is XText text)
+            {
+                yield return text;
+            }
+            else if (node is XElement child)
+            {
+                // Skip script and style elements
+                var name = child.Name.LocalName.ToLowerInvariant();
+                if (name != "script" && name != "style")
+                {
+                    foreach (var childText in GetTextNodes(child))
+                    {
+                        yield return childText;
+                    }
+                }
+            }
+        }
+    }
+
+    #endregion
+
+    #region Annotation Projection
+
+    private static void ProjectSingleAnnotation(
+        XElement html,
+        List<TextMapEntry> textMap,
+        OpenContractsAnnotation annotation,
+        TextSpan span,
+        AnnotationLabel? label,
+        ExternalAnnotationProjectionSettings settings)
+    {
+        // Find text nodes that overlap with this annotation
+        var overlappingEntries = textMap
+            .Where(e => e.EndOffset > span.Start && e.StartOffset < span.End)
+            .ToList();
+
+        if (overlappingEntries.Count == 0) return;
+
+        var isFirst = true;
+        var isLast = false;
+
+        for (int i = 0; i < overlappingEntries.Count; i++)
+        {
+            isLast = (i == overlappingEntries.Count - 1);
+            var entry = overlappingEntries[i];
+
+            WrapTextNode(entry, span, annotation, label, settings, isFirst, isLast);
+            isFirst = false;
+        }
+    }
+
+    private static void WrapTextNode(
+        TextMapEntry entry,
+        TextSpan span,
+        OpenContractsAnnotation annotation,
+        AnnotationLabel? label,
+        ExternalAnnotationProjectionSettings settings,
+        bool isFirst,
+        bool isLast)
+    {
+        var textNode = entry.TextNode;
+        var text = textNode.Value;
+        var parent = textNode.Parent;
+        if (parent == null) return;
+
+        // Calculate the portion of text to wrap
+        var textStart = Math.Max(0, span.Start - entry.StartOffset);
+        var textEnd = Math.Min(text.Length, span.End - entry.StartOffset);
+
+        if (textStart >= textEnd) return;
+
+        // Split the text into before/annotated/after parts
+        var beforeText = text.Substring(0, textStart);
+        var annotatedText = text.Substring(textStart, textEnd - textStart);
+        var afterText = text.Substring(textEnd);
+
+        // Create the wrapper span
+        var wrapper = CreateAnnotationWrapper(annotation, label, settings, isFirst, isLast);
+        wrapper.Add(new XText(annotatedText));
+
+        // Build the replacement nodes
+        var replacements = new List<XNode>();
+        if (beforeText.Length > 0)
+        {
+            replacements.Add(new XText(beforeText));
+        }
+        replacements.Add(wrapper);
+        if (afterText.Length > 0)
+        {
+            replacements.Add(new XText(afterText));
+        }
+
+        // Replace the text node
+        textNode.ReplaceWith(replacements.ToArray());
+    }
+
+    private static XElement CreateAnnotationWrapper(
+        OpenContractsAnnotation annotation,
+        AnnotationLabel? label,
+        ExternalAnnotationProjectionSettings settings,
+        bool isFirst,
+        bool isLast)
+    {
+        var prefix = settings.CssClassPrefix;
+        var cssClasses = new List<string> { $"{prefix}highlight" };
+
+        if (isFirst && isLast)
+        {
+            cssClasses.Add($"{prefix}single");
+        }
+        else if (isFirst)
+        {
+            cssClasses.Add($"{prefix}start");
+        }
+        else if (isLast)
+        {
+            cssClasses.Add($"{prefix}end");
+        }
+        else
+        {
+            cssClasses.Add($"{prefix}continuation");
+        }
+
+        var wrapper = new XElement("span",
+            new XAttribute("class", string.Join(" ", cssClasses)));
+
+        // Add data attributes
+        if (settings.IncludeMetadata)
+        {
+            wrapper.Add(new XAttribute("data-annotation-id", annotation.Id ?? ""));
+            wrapper.Add(new XAttribute("data-label-id", annotation.AnnotationLabel ?? ""));
+
+            if (label != null)
+            {
+                wrapper.Add(new XAttribute("data-label", label.Text));
+                wrapper.Add(new XAttribute("style", $"--annot-color: {label.Color};"));
+            }
+        }
+
+        // Add label element if this is the first segment
+        if (isFirst && settings.LabelMode != AnnotationLabelMode.None && label != null)
+        {
+            var labelText = label.Text;
+            if (!string.IsNullOrEmpty(labelText))
+            {
+                switch (settings.LabelMode)
+                {
+                    case AnnotationLabelMode.Above:
+                    case AnnotationLabelMode.Inline:
+                        var labelSpan = new XElement("span",
+                            new XAttribute("class", $"{prefix}label"),
+                            new XText(labelText));
+                        wrapper.AddFirst(labelSpan);
+                        break;
+                    case AnnotationLabelMode.Tooltip:
+                        wrapper.Add(new XAttribute("title", labelText));
+                        break;
+                }
+            }
+        }
+
+        return wrapper;
+    }
+
+    #endregion
+
+    #region CSS Generation
+
+    private static void AddAnnotationCss(
+        XElement html,
+        Dictionary<string, AnnotationLabel> labels,
+        ExternalAnnotationProjectionSettings settings)
+    {
+        var prefix = settings.CssClassPrefix;
+
+        var css = new StringBuilder();
+        css.AppendLine();
+        css.AppendLine("/* External Annotation Styles */");
+        css.AppendLine($".{prefix}highlight {{");
+        css.AppendLine("  background-color: color-mix(in srgb, var(--annot-color, #FFEB3B) 30%, transparent);");
+        css.AppendLine("  border-bottom: 2px solid var(--annot-color, #FFEB3B);");
+        css.AppendLine("  display: inline;");
+        css.AppendLine("  padding: 0.1em 0;");
+        css.AppendLine("}");
+
+        // Both Above and Inline use inline display - Above just has a superscript style
+        if (settings.LabelMode == AnnotationLabelMode.Above)
+        {
+            css.AppendLine($".{prefix}label {{");
+            css.AppendLine("  font-size: 0.65em;");
+            css.AppendLine("  background-color: var(--annot-color, #FFEB3B);");
+            css.AppendLine("  color: white;");
+            css.AppendLine("  padding: 0.1em 0.3em;");
+            css.AppendLine("  border-radius: 3px;");
+            css.AppendLine("  vertical-align: super;");
+            css.AppendLine("  margin-right: 0.2em;");
+            css.AppendLine("}");
+        }
+        else if (settings.LabelMode == AnnotationLabelMode.Inline)
+        {
+            css.AppendLine($".{prefix}label {{");
+            css.AppendLine("  font-size: 0.65em;");
+            css.AppendLine("  background-color: var(--annot-color, #FFEB3B);");
+            css.AppendLine("  color: white;");
+            css.AppendLine("  padding: 0.1em 0.3em;");
+            css.AppendLine("  border-radius: 3px;");
+            css.AppendLine("  margin-right: 0.2em;");
+            css.AppendLine("}");
+        }
+
+        // Add per-label color classes
+        foreach (var (id, label) in labels)
+        {
+            var safeId = id.Replace(" ", "-").Replace(".", "-");
+            css.AppendLine($".{prefix}label-{safeId} {{");
+            css.AppendLine($"  --annot-color: {label.Color};");
+            css.AppendLine("}");
+        }
+
+        // Find or create head element
+        var head = html.Descendants()
+            .FirstOrDefault(e => e.Name.LocalName.Equals("head", StringComparison.OrdinalIgnoreCase));
+
+        if (head != null)
+        {
+            var style = new XElement("style",
+                new XAttribute("type", "text/css"),
+                new XText(css.ToString()));
+            head.Add(style);
+        }
+    }
+
+    #endregion
+}

--- a/Docxodus/OpenContractExporter.cs
+++ b/Docxodus/OpenContractExporter.cs
@@ -294,6 +294,43 @@ public class OpenContractsRelationship
     public bool Structural { get; set; }
 }
 
+/// <summary>
+/// Label definition matching OpenContracts AnnotationLabelPythonType.
+/// Used to define annotation categories with styling and metadata.
+/// </summary>
+public class AnnotationLabel
+{
+    /// <summary>
+    /// Unique identifier for this label.
+    /// </summary>
+    public string Id { get; set; } = "";
+
+    /// <summary>
+    /// Color for this label (hex format, e.g., "#FFEB3B").
+    /// </summary>
+    public string Color { get; set; } = "#FFEB3B";
+
+    /// <summary>
+    /// Human-readable description of this label.
+    /// </summary>
+    public string Description { get; set; } = "";
+
+    /// <summary>
+    /// Icon name or identifier for UI display.
+    /// </summary>
+    public string Icon { get; set; } = "";
+
+    /// <summary>
+    /// Display text/name for this label.
+    /// </summary>
+    public string Text { get; set; } = "";
+
+    /// <summary>
+    /// Type of label: "text" for text annotations, "doc" for document-level, "metadata" for metadata.
+    /// </summary>
+    public string LabelType { get; set; } = "text";
+}
+
 #endregion
 
 #region Internal Structure Classes

--- a/npm/examples/external-annotations-demo.html
+++ b/npm/examples/external-annotations-demo.html
@@ -1,0 +1,464 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>External Annotations Demo</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      margin: 0;
+      padding: 20px;
+      background: #f5f5f5;
+    }
+    h1 {
+      margin-top: 0;
+    }
+    .container {
+      display: flex;
+      gap: 20px;
+      height: calc(100vh - 100px);
+    }
+    .panel {
+      background: white;
+      border-radius: 8px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+    }
+    .panel-header {
+      padding: 12px 16px;
+      background: #f8f9fa;
+      border-bottom: 1px solid #e9ecef;
+      font-weight: 600;
+    }
+    .panel-content {
+      flex: 1;
+      overflow: auto;
+      padding: 16px;
+    }
+    .left-panel {
+      width: 350px;
+      flex-shrink: 0;
+    }
+    .right-panel {
+      flex: 1;
+    }
+
+    /* File input */
+    .file-input-wrapper {
+      margin-bottom: 16px;
+    }
+    .file-input-wrapper input {
+      width: 100%;
+    }
+
+    /* Status */
+    .status {
+      padding: 8px 12px;
+      border-radius: 4px;
+      margin-bottom: 16px;
+      font-size: 14px;
+    }
+    .status.loading {
+      background: #fff3cd;
+      color: #856404;
+    }
+    .status.success {
+      background: #d4edda;
+      color: #155724;
+    }
+    .status.error {
+      background: #f8d7da;
+      color: #721c24;
+    }
+
+    /* Annotation list */
+    .annotation-list {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .annotation-item {
+      border: 1px solid #dee2e6;
+      border-radius: 6px;
+      overflow: hidden;
+      font-size: 13px;
+    }
+    .annotation-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      background: #f8f9fa;
+      cursor: pointer;
+    }
+    .annotation-header:hover {
+      background: #e9ecef;
+    }
+    .annotation-color {
+      width: 16px;
+      height: 16px;
+      border-radius: 3px;
+      flex-shrink: 0;
+    }
+    .annotation-label {
+      font-weight: 500;
+      flex: 1;
+    }
+    .annotation-text {
+      color: #6c757d;
+      font-size: 12px;
+      max-width: 150px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .annotation-json {
+      padding: 8px 12px;
+      background: #f8f9fa;
+      border-top: 1px solid #dee2e6;
+      font-family: 'Monaco', 'Menlo', monospace;
+      font-size: 11px;
+      white-space: pre-wrap;
+      word-break: break-all;
+      max-height: 150px;
+      overflow: auto;
+      display: none;
+    }
+    .annotation-item.expanded .annotation-json {
+      display: block;
+    }
+
+    /* Add annotation form */
+    .add-form {
+      margin-top: 16px;
+      padding-top: 16px;
+      border-top: 1px solid #dee2e6;
+    }
+    .add-form h4 {
+      margin: 0 0 12px 0;
+      font-size: 14px;
+    }
+    .form-group {
+      margin-bottom: 12px;
+    }
+    .form-group label {
+      display: block;
+      font-size: 12px;
+      color: #6c757d;
+      margin-bottom: 4px;
+    }
+    .form-group input, .form-group select {
+      width: 100%;
+      padding: 6px 10px;
+      border: 1px solid #ced4da;
+      border-radius: 4px;
+      font-size: 13px;
+    }
+    .btn {
+      padding: 8px 16px;
+      border: none;
+      border-radius: 4px;
+      font-size: 13px;
+      cursor: pointer;
+    }
+    .btn-primary {
+      background: #007bff;
+      color: white;
+    }
+    .btn-primary:hover {
+      background: #0056b3;
+    }
+    .btn-primary:disabled {
+      background: #6c757d;
+      cursor: not-allowed;
+    }
+
+    /* Document view */
+    .document-frame {
+      border: 1px solid #dee2e6;
+      border-radius: 4px;
+      background: white;
+      height: 100%;
+      overflow: auto;
+    }
+    .document-frame iframe {
+      width: 100%;
+      height: 100%;
+      border: none;
+    }
+
+    /* Hash display */
+    .hash-display {
+      font-family: monospace;
+      font-size: 11px;
+      color: #6c757d;
+      word-break: break-all;
+      margin-bottom: 16px;
+      padding: 8px;
+      background: #f8f9fa;
+      border-radius: 4px;
+    }
+  </style>
+</head>
+<body>
+  <h1>External Annotations Demo</h1>
+
+  <div class="container">
+    <!-- Left Panel: Annotations -->
+    <div class="panel left-panel">
+      <div class="panel-header">Annotations</div>
+      <div class="panel-content">
+        <div class="file-input-wrapper">
+          <input type="file" id="fileInput" accept=".docx" />
+        </div>
+
+        <div id="status" class="status" style="display: none;"></div>
+
+        <div id="hashDisplay" class="hash-display" style="display: none;"></div>
+
+        <div id="annotationList" class="annotation-list"></div>
+
+        <div id="addForm" class="add-form" style="display: none;">
+          <h4>Add Annotation</h4>
+          <div class="form-group">
+            <label>Search Text</label>
+            <input type="text" id="searchText" placeholder="Text to annotate..." />
+          </div>
+          <div class="form-group">
+            <label>Label</label>
+            <select id="labelSelect">
+              <option value="IMPORTANT" data-color="#FF5722">Important</option>
+              <option value="DEFINITION" data-color="#2196F3">Definition</option>
+              <option value="CLAUSE" data-color="#4CAF50">Clause</option>
+              <option value="DATE" data-color="#9C27B0">Date</option>
+              <option value="PARTY" data-color="#FF9800">Party</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label>Occurrence (1 = first)</label>
+            <input type="number" id="occurrence" value="1" min="1" />
+          </div>
+          <button class="btn btn-primary" id="addBtn" disabled>Add Annotation</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Right Panel: Document View -->
+    <div class="panel right-panel">
+      <div class="panel-header">Document View</div>
+      <div class="panel-content">
+        <div class="document-frame">
+          <iframe id="documentFrame"></iframe>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script type="module">
+    // Import from the built library
+    // In production, use: import { ... } from 'docxodus';
+    import {
+      initialize,
+      createExternalAnnotationSet,
+      convertDocxToHtmlWithExternalAnnotations,
+      createAnnotationFromSearch,
+      validateExternalAnnotations,
+      AnnotationLabelMode
+    } from '../dist/index.js';
+
+    // State
+    let currentFile = null;
+    let currentFileBytes = null;
+    let annotationSet = null;
+    let annotationCounter = 0;
+
+    // Label definitions
+    const labelDefinitions = {
+      IMPORTANT: { id: 'IMPORTANT', text: 'Important', color: '#FF5722', description: 'Important text', icon: '', labelType: 'text' },
+      DEFINITION: { id: 'DEFINITION', text: 'Definition', color: '#2196F3', description: 'Term definition', icon: '', labelType: 'text' },
+      CLAUSE: { id: 'CLAUSE', text: 'Clause', color: '#4CAF50', description: 'Contract clause', icon: '', labelType: 'text' },
+      DATE: { id: 'DATE', text: 'Date', color: '#9C27B0', description: 'Date reference', icon: '', labelType: 'text' },
+      PARTY: { id: 'PARTY', text: 'Party', color: '#FF9800', description: 'Party name', icon: '', labelType: 'text' },
+    };
+
+    // DOM elements
+    const fileInput = document.getElementById('fileInput');
+    const status = document.getElementById('status');
+    const hashDisplay = document.getElementById('hashDisplay');
+    const annotationList = document.getElementById('annotationList');
+    const addForm = document.getElementById('addForm');
+    const searchText = document.getElementById('searchText');
+    const labelSelect = document.getElementById('labelSelect');
+    const occurrence = document.getElementById('occurrence');
+    const addBtn = document.getElementById('addBtn');
+    const documentFrame = document.getElementById('documentFrame');
+
+    // Show status
+    function showStatus(message, type = 'loading') {
+      status.textContent = message;
+      status.className = `status ${type}`;
+      status.style.display = 'block';
+    }
+
+    function hideStatus() {
+      status.style.display = 'none';
+    }
+
+    // Render annotation list
+    function renderAnnotations() {
+      if (!annotationSet) {
+        annotationList.innerHTML = '<p style="color: #6c757d; font-size: 13px;">Load a document to see annotations</p>';
+        return;
+      }
+
+      // Filter to only show non-structural (user) annotations
+      const userAnnotations = annotationSet.labelledText.filter(a => !a.structural);
+
+      if (userAnnotations.length === 0) {
+        annotationList.innerHTML = '<p style="color: #6c757d; font-size: 13px;">No annotations yet. Add one below!</p>';
+        return;
+      }
+
+      annotationList.innerHTML = userAnnotations.map((ann, idx) => {
+        const label = annotationSet.textLabels[ann.annotationLabel] || { text: ann.annotationLabel, color: '#FFEB3B' };
+        const span = ann.annotationJson;
+        return `
+          <div class="annotation-item" data-idx="${idx}">
+            <div class="annotation-header" onclick="toggleAnnotation(${idx})">
+              <div class="annotation-color" style="background: ${label.color}"></div>
+              <span class="annotation-label">${label.text}</span>
+              <span class="annotation-text">"${ann.rawText.substring(0, 30)}${ann.rawText.length > 30 ? '...' : ''}"</span>
+            </div>
+            <div class="annotation-json">${JSON.stringify(ann, null, 2)}</div>
+          </div>
+        `;
+      }).join('');
+    }
+
+    // Toggle annotation JSON visibility
+    window.toggleAnnotation = function(idx) {
+      const item = document.querySelector(`.annotation-item[data-idx="${idx}"]`);
+      if (item) {
+        item.classList.toggle('expanded');
+      }
+    };
+
+    // Render document with annotations
+    async function renderDocument() {
+      if (!currentFileBytes || !annotationSet) return;
+
+      try {
+        const html = await convertDocxToHtmlWithExternalAnnotations(
+          currentFileBytes,
+          annotationSet,
+          { pageTitle: 'Annotated Document' },
+          { labelMode: AnnotationLabelMode.Inline, cssClassPrefix: 'ext-annot-' }
+        );
+
+        // Write to iframe
+        const doc = documentFrame.contentDocument;
+        doc.open();
+        doc.write(html);
+        doc.close();
+      } catch (err) {
+        console.error('Render error:', err);
+        showStatus(`Render error: ${err.message}`, 'error');
+      }
+    }
+
+    // Handle file selection
+    fileInput.addEventListener('change', async (e) => {
+      const file = e.target.files[0];
+      if (!file) return;
+
+      currentFile = file;
+      showStatus('Initializing WASM...');
+
+      try {
+        // Initialize WASM (auto-detects path)
+        await initialize();
+
+        showStatus('Processing document...');
+
+        // Read file bytes
+        const buffer = await file.arrayBuffer();
+        currentFileBytes = new Uint8Array(buffer);
+
+        // Create annotation set
+        annotationSet = await createExternalAnnotationSet(currentFileBytes, file.name);
+
+        // Add label definitions
+        for (const [id, label] of Object.entries(labelDefinitions)) {
+          annotationSet.textLabels[id] = label;
+        }
+
+        // Show hash
+        hashDisplay.innerHTML = `<strong>Document Hash:</strong><br>${annotationSet.documentHash}`;
+        hashDisplay.style.display = 'block';
+
+        // Show form
+        addForm.style.display = 'block';
+        addBtn.disabled = false;
+
+        // Render
+        renderAnnotations();
+        await renderDocument();
+
+        hideStatus();
+      } catch (err) {
+        console.error('Load error:', err);
+        showStatus(`Error: ${err.message}`, 'error');
+      }
+    });
+
+    // Handle add annotation
+    addBtn.addEventListener('click', async () => {
+      const text = searchText.value.trim();
+      if (!text) {
+        alert('Please enter text to search for');
+        return;
+      }
+
+      const labelId = labelSelect.value;
+      const occ = parseInt(occurrence.value) || 1;
+
+      // Create annotation using client-side helper
+      const ann = createAnnotationFromSearch(
+        `ann-${++annotationCounter}`,
+        labelId,
+        annotationSet.content,
+        text,
+        occ
+      );
+
+      if (!ann) {
+        alert(`Text "${text}" not found in document (occurrence ${occ})`);
+        return;
+      }
+
+      // Add to annotation set
+      annotationSet.labelledText.push(ann);
+      annotationSet.updatedAt = new Date().toISOString();
+
+      // Clear form
+      searchText.value = '';
+      occurrence.value = '1';
+
+      // Re-render
+      renderAnnotations();
+      await renderDocument();
+
+      console.log('Added annotation:', ann);
+    });
+
+    // Initial render
+    renderAnnotations();
+  </script>
+</body>
+</html>

--- a/npm/tests/test-harness.html
+++ b/npm/tests/test-harness.html
@@ -404,6 +404,157 @@
                 } catch (e) {
                     return { error: { message: e.message } };
                 }
+            },
+
+            // ===== External Annotation API (Issue #57) =====
+
+            /**
+             * Compute SHA256 hash of document for integrity validation.
+             */
+            computeDocumentHash: function(bytes) {
+                try {
+                    const result = window.Docxodus.DocumentConverter.ComputeDocumentHash(bytes);
+                    if (result.startsWith('{') && result.includes('"Error"')) {
+                        return { error: JSON.parse(result) };
+                    }
+                    const parsed = JSON.parse(result);
+                    return { hash: parsed.Hash || parsed.hash };
+                } catch (e) {
+                    return { error: { message: e.message } };
+                }
+            },
+
+            /**
+             * Create external annotation set from document.
+             */
+            createExternalAnnotationSet: function(bytes, documentId) {
+                try {
+                    const result = window.Docxodus.DocumentConverter.CreateExternalAnnotationSet(bytes, documentId);
+                    if (result.startsWith('{') && result.includes('"Error"')) {
+                        return { error: JSON.parse(result) };
+                    }
+                    return { annotationSet: JSON.parse(result) };
+                } catch (e) {
+                    return { error: { message: e.message } };
+                }
+            },
+
+            /**
+             * Validate external annotations against document.
+             */
+            validateExternalAnnotations: function(bytes, annotationSet) {
+                try {
+                    const annotationSetJson = JSON.stringify(annotationSet);
+                    const result = window.Docxodus.DocumentConverter.ValidateExternalAnnotations(bytes, annotationSetJson);
+                    if (result.startsWith('{') && result.includes('"Error"')) {
+                        return { error: JSON.parse(result) };
+                    }
+                    const parsed = JSON.parse(result);
+                    return {
+                        isValid: parsed.IsValid ?? parsed.isValid,
+                        hashMismatch: parsed.HashMismatch ?? parsed.hashMismatch,
+                        issues: parsed.Issues || parsed.issues || []
+                    };
+                } catch (e) {
+                    return { error: { message: e.message } };
+                }
+            },
+
+            /**
+             * Convert DOCX to HTML with external annotations projected.
+             */
+            convertToHtmlWithExternalAnnotations: function(bytes, annotationSet, labelMode = 1) {
+                try {
+                    const annotationSetJson = JSON.stringify(annotationSet);
+                    const result = window.Docxodus.DocumentConverter.ConvertDocxToHtmlWithExternalAnnotations(
+                        bytes,
+                        annotationSetJson,
+                        'Document',       // pageTitle
+                        'docx-',          // cssPrefix
+                        true,             // fabricateClasses
+                        '',               // additionalCss
+                        'ext-annot-',     // extAnnotCssClassPrefix
+                        labelMode         // 0=Above, 1=Inline, 2=Tooltip, 3=None
+                    );
+                    if (result.startsWith('{') && result.includes('"Error"')) {
+                        return { error: JSON.parse(result) };
+                    }
+                    const parsed = JSON.parse(result);
+                    return { html: parsed.Html || parsed.html };
+                } catch (e) {
+                    return { error: { message: e.message } };
+                }
+            },
+
+            /**
+             * Search for text occurrences in document.
+             */
+            searchTextOffsets: function(bytes, searchText, maxResults = 100) {
+                try {
+                    const result = window.Docxodus.DocumentConverter.SearchTextOffsets(bytes, searchText, maxResults);
+                    if (result.startsWith('{') && result.includes('"Error"')) {
+                        return { error: JSON.parse(result) };
+                    }
+                    const parsed = JSON.parse(result);
+                    return {
+                        results: (parsed.Results || parsed.results || []).map(r => ({
+                            id: r.Id ?? r.id,
+                            start: r.Start ?? r.start,
+                            end: r.End ?? r.end,
+                            text: r.Text ?? r.text
+                        }))
+                    };
+                } catch (e) {
+                    return { error: { message: e.message } };
+                }
+            },
+
+            /**
+             * Client-side helper: Create annotation from offsets.
+             */
+            createAnnotationFromOffsets: function(id, labelId, documentText, startOffset, endOffset) {
+                if (startOffset < 0 || endOffset < startOffset || endOffset > documentText.length) {
+                    return { error: { message: 'Invalid offsets' } };
+                }
+                const rawText = documentText.substring(startOffset, endOffset);
+                return {
+                    annotation: {
+                        id: id,
+                        annotationLabel: labelId,
+                        rawText: rawText,
+                        page: 0,
+                        annotationJson: { id: id, start: startOffset, end: endOffset, text: rawText },
+                        annotationType: 'text',
+                        structural: false
+                    }
+                };
+            },
+
+            /**
+             * Client-side helper: Find all occurrences of text.
+             */
+            findTextOccurrences: function(documentText, searchText, maxResults = 100) {
+                const results = [];
+                let index = 0;
+                while (results.length < maxResults) {
+                    index = documentText.indexOf(searchText, index);
+                    if (index < 0) break;
+                    results.push({ start: index, end: index + searchText.length });
+                    index += 1;
+                }
+                return results;
+            },
+
+            /**
+             * Client-side helper: Create annotation by searching for text.
+             */
+            createAnnotationFromSearch: function(id, labelId, documentText, searchText, occurrence = 1) {
+                const offsets = this.findTextOccurrences(documentText, searchText);
+                if (occurrence > offsets.length) {
+                    return { annotation: null };
+                }
+                const { start, end } = offsets[occurrence - 1];
+                return this.createAnnotationFromOffsets(id, labelId, documentText, start, end);
             }
         };
 

--- a/wasm/DocxodusWasm/JsonContext.cs
+++ b/wasm/DocxodusWasm/JsonContext.cs
@@ -5,7 +5,9 @@ namespace DocxodusWasm;
 /// <summary>
 /// JSON serialization context for AOT/trimming-safe serialization.
 /// Uses source generators to avoid reflection.
+/// PropertyNameCaseInsensitive enables flexible deserialization (both PascalCase and camelCase).
 /// </summary>
+[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
 [JsonSerializable(typeof(ErrorResponse))]
 [JsonSerializable(typeof(VersionInfo))]
 [JsonSerializable(typeof(RevisionsResponse))]
@@ -52,6 +54,16 @@ namespace DocxodusWasm;
 [JsonSerializable(typeof(TokenIdDto[]))]
 [JsonSerializable(typeof(OpenContractsSinglePageAnnotationDto))]
 [JsonSerializable(typeof(Dictionary<string, OpenContractsSinglePageAnnotationDto>))]
+// External annotation types
+[JsonSerializable(typeof(DocumentHashResponse))]
+[JsonSerializable(typeof(ExternalAnnotationSetDto))]
+[JsonSerializable(typeof(ExternalAnnotationValidationResultDto))]
+[JsonSerializable(typeof(ExternalAnnotationValidationIssueDto))]
+[JsonSerializable(typeof(ExternalAnnotationValidationIssueDto[]))]
+[JsonSerializable(typeof(AnnotationLabelDto))]
+[JsonSerializable(typeof(Dictionary<string, AnnotationLabelDto>))]
+[JsonSerializable(typeof(TextSearchResponse))]
+[JsonSerializable(typeof(HtmlConversionResponse))]
 internal partial class DocxodusJsonContext : JsonSerializerContext
 {
 }
@@ -958,6 +970,105 @@ public class OpenContractsRelationshipDto
     /// Whether this is a structural relationship.
     /// </summary>
     public bool Structural { get; set; }
+}
+
+#endregion
+
+#region External Annotation Types
+
+/// <summary>
+/// Response containing document hash.
+/// </summary>
+public class DocumentHashResponse
+{
+    /// <summary>
+    /// SHA256 hash of the document (lowercase hex).
+    /// </summary>
+    public string Hash { get; set; } = "";
+}
+
+/// <summary>
+/// Response containing HTML conversion result.
+/// </summary>
+public class HtmlConversionResponse
+{
+    /// <summary>
+    /// The generated HTML content.
+    /// </summary>
+    public string Html { get; set; } = "";
+}
+
+/// <summary>
+/// Response containing text search results.
+/// </summary>
+public class TextSearchResponse
+{
+    /// <summary>
+    /// Array of text spans with character offsets.
+    /// </summary>
+    public TextSpanDto[] Results { get; set; } = Array.Empty<TextSpanDto>();
+}
+
+/// <summary>
+/// External annotation set DTO extending OpenContractExportResponse.
+/// </summary>
+public class ExternalAnnotationSetDto
+{
+    // Document binding fields
+    public string DocumentId { get; set; } = "";
+    public string DocumentHash { get; set; } = "";
+    public string CreatedAt { get; set; } = "";
+    public string UpdatedAt { get; set; } = "";
+    public string Version { get; set; } = "1.0";
+
+    // Inherited from OpenContractExportResponse
+    public string Title { get; set; } = "";
+    public string Content { get; set; } = "";
+    public string? Description { get; set; }
+    public int PageCount { get; set; }
+    public PawlsPageDto[] PawlsFileContent { get; set; } = Array.Empty<PawlsPageDto>();
+    public string[] DocLabels { get; set; } = Array.Empty<string>();
+    public OpenContractsAnnotationDto[] LabelledText { get; set; } = Array.Empty<OpenContractsAnnotationDto>();
+    public OpenContractsRelationshipDto[]? Relationships { get; set; }
+
+    // Label definitions
+    public Dictionary<string, AnnotationLabelDto> TextLabels { get; set; } = new();
+    public Dictionary<string, AnnotationLabelDto> DocLabelDefinitions { get; set; } = new();
+}
+
+/// <summary>
+/// Annotation label definition DTO.
+/// </summary>
+public class AnnotationLabelDto
+{
+    public string Id { get; set; } = "";
+    public string Color { get; set; } = "#FFEB3B";
+    public string Description { get; set; } = "";
+    public string Icon { get; set; } = "";
+    public string Text { get; set; } = "";
+    public string LabelType { get; set; } = "text";
+}
+
+/// <summary>
+/// External annotation validation result DTO.
+/// </summary>
+public class ExternalAnnotationValidationResultDto
+{
+    public bool IsValid { get; set; }
+    public bool HashMismatch { get; set; }
+    public ExternalAnnotationValidationIssueDto[] Issues { get; set; } = Array.Empty<ExternalAnnotationValidationIssueDto>();
+}
+
+/// <summary>
+/// External annotation validation issue DTO.
+/// </summary>
+public class ExternalAnnotationValidationIssueDto
+{
+    public string AnnotationId { get; set; } = "";
+    public string IssueType { get; set; } = "";
+    public string Description { get; set; } = "";
+    public string? ExpectedText { get; set; }
+    public string? ActualText { get; set; }
 }
 
 #endregion


### PR DESCRIPTION
## Summary

Implements **External Annotation Storage and Projection System** - a parallel annotation system that stores annotations externally as JSON without modifying the source DOCX file.

- **External storage**: Annotations stored as JSON, not embedded in DOCX
- **Document binding**: SHA256 hash validates annotations against source document
- **Character offset targeting**: Precise text targeting with search fallback
- **HTML projection**: Annotations rendered as styled spans on converted HTML
- **OpenContracts compatible**: Extends existing `OpenContractDocExport` format

### Key Components

| Component | Purpose |
|-----------|---------|
| `ExternalAnnotationSet` | Extends OpenContractDocExport with document binding |
| `ExternalAnnotationManager` | Hash, validation, annotation creation, serialization |
| `ExternalAnnotationProjector` | Projects annotations onto HTML as styled spans |

### API Additions

**C# / .NET:**
- `ExternalAnnotationManager.ComputeDocumentHash()`
- `ExternalAnnotationManager.CreateAnnotationSet()`
- `ExternalAnnotationManager.CreateAnnotation()` / `CreateAnnotationFromSearch()`
- `ExternalAnnotationManager.Validate()`
- `ExternalAnnotationProjector.ProjectAnnotations()` / `ConvertWithAnnotations()`

**TypeScript/npm:**
- `computeDocumentHash()`
- `createExternalAnnotationSet()`
- `validateExternalAnnotations()`
- `convertDocxToHtmlWithExternalAnnotations()`
- `searchTextOffsets()`

### Label Display Modes

| Mode | Description |
|------|-------------|
| Above | Superscript label before highlight |
| Inline | Label inline before highlight |
| Tooltip | Label shown on hover |
| None | Highlight only, no label |

## Test plan

- [x] 21 C# unit tests for core functionality (hash, create, validate, serialize, project)
- [x] 11 Playwright browser tests for WASM integration
- [x] Visual demo test shows annotations + JSON panel with hover interactions
- [x] Full test suite passes (`dotnet test` + `npx playwright test`)

## Screenshots

The visual demo shows:
- Document with colored annotation highlights
- Side panel with raw annotation JSON
- Tooltips on hover
- JSON highlighting on annotation hover

Closes #57