### PR TITLE
fix(converter): handle null rPr in DefineRunStyle and GetLangAttribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -307,7 +307,8 @@ All notable changes to this project will be documented in this file.
   - Copies `abstractNum` and `num` elements from revised document when missing in original
   - Reuses existing definitions when content matches (regardless of ID)
   - Remaps IDs when conflicts occur to avoid duplicates
-  - Null-safe attribute extraction for robustness with malformed documents
+
+- **WmlToHtmlConverter null rPr crash** - Fixed `InvalidOperationException` crash in `DefineRunStyle` and `GetLangAttribute` when converting runs without `w:rPr` elements. Changed `.First()` to `.FirstOrDefault()` with null checks to handle runs that have no explicit run properties gracefully.
 
 ### Changed
 - Replaced `FontPartType`/`ImagePartType` with `PartTypeInfo` pattern for SDK 3.x compatibility
@@ -315,6 +316,9 @@ All notable changes to this project will be documented in this file.
 - Migrated all color handling from `System.Drawing.Color` to `SKColor`
 - Migrated font handling from `FontFamily`/`FontStyle` to `SKFontManager`/`SKTypeface`
 - Migrated image handling from `Bitmap`/`ImageFormat` to `SKBitmap`/`SKEncodedImageFormat`
+
+### Documentation
+- Updated `docs/architecture/wml_to_html_converter_gaps.md` with comprehensive gap analysis including pagination mode limitations, DrawingML text handling, and prioritized fix recommendations
 
 ### Test Status
 - 1051 passed, 0 failed, 1 skipped out of 1052 tests (~99.9% pass rate)

--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -4824,7 +4824,9 @@ namespace Docxodus
         {
             var style = new Dictionary<string, string>();
 
-            var rPr = run.Elements(W.rPr).First();
+            var rPr = run.Elements(W.rPr).FirstOrDefault();
+            if (rPr == null)
+                return style;
 
             var styleName = (string) run.Attribute(PtOpenXml.StyleName);
             if (styleName != null)
@@ -4976,7 +4978,9 @@ namespace Docxodus
         {
             const string defaultLanguage = "en-US"; // todo need to get defaultLanguage
 
-            var rPr = run.Elements(W.rPr).First();
+            var rPr = run.Elements(W.rPr).FirstOrDefault();
+            if (rPr == null)
+                return null;
             var languageType = (string)run.Attribute(PtOpenXml.LanguageType);
 
             string lang = null;


### PR DESCRIPTION
## Summary

- Fixed `InvalidOperationException` crash in `DefineRunStyle` and `GetLangAttribute` when converting runs without `w:rPr` elements
- Changed `.First()` to `.FirstOrDefault()` with null checks to handle runs that have no explicit run properties gracefully

## Problem

Previously, two methods in `WmlToHtmlConverter.cs` used `.First()` on `run.Elements(W.rPr)`:
- `DefineRunStyle` (line 4827)
- `GetLangAttribute` (line 4979)

This would crash with `InvalidOperationException: Sequence contains no elements` if a run had no `w:rPr` element.

## Solution

- Changed `.First()` to `.FirstOrDefault()` with null checks
- `DefineRunStyle` returns empty style dictionary when `rPr` is null
- `GetLangAttribute` returns null when `rPr` is null

## Test plan

- [x] Added test `HC016_RunWithoutRPr_DoesNotCrash` that creates a document with runs lacking `w:rPr` elements and verifies conversion succeeds
- [x] All 75 HTML converter tests pass
- [x] Updated documentation in `wml_to_html_converter_gaps.md` to mark issue as resolved
- [x] Added changelog entry