### PR TITLE
feat(converter): add lang attribute to HTML output for accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ All notable changes to this project will be documented in this file.
 - **Graphics Library**: Replaced System.Drawing with SkiaSharp 2.88.9
 
 ### Added
+- **Document Language Attribute** - HTML output now includes `lang` attribute for improved accessibility
+  - New `DocumentLanguage` setting to manually override the language (default: auto-detect)
+  - `<html>` element now includes `lang` attribute (e.g., `<html lang="en-US">`)
+  - Language is auto-detected from:
+    1. `w:themeFontLang` in document settings
+    2. Default paragraph style's `w:rPr/w:lang`
+    3. Falls back to "en-US"
+  - Foreign text spans get `lang` attribute when different from document default
+  - Improves screen reader pronunciation and browser font selection
+  - Addresses converter gaps #10 (Document Language Attribute) and #11 (Foreign Text Spans)
 - **Unsupported Content Placeholders** - Visual indicators for content that cannot be fully converted to HTML
   - New `RenderUnsupportedContentPlaceholders` setting (default: false for backward compatibility)
   - Supports these unsupported content types:

--- a/docs/architecture/wml_to_html_converter_gaps.md
+++ b/docs/architecture/wml_to_html_converter_gaps.md
@@ -15,8 +15,8 @@ This document catalogs known gaps, limitations, and areas for improvement in the
 | **Rendering** | Theme colors not resolved | Medium |
 | **Rendering** | Text box content lost | Medium |
 | **Rendering** | Tab leader count varies by platform | Low |
-| **Accessibility** | No `lang` attribute on html/body | Medium |
-| **Accessibility** | No `lang` attribute on foreign text spans | Medium |
+| ~~**Accessibility**~~ | ~~No `lang` attribute on html/body~~ | ~~Medium~~ ✅ |
+| ~~**Accessibility**~~ | ~~No `lang` attribute on foreign text spans~~ | ~~Medium~~ ✅ |
 | **Accessibility** | No ARIA roles | Low |
 | **Fonts** | Limited font fallback (28 fonts) | Medium |
 | **Fonts** | No CJK font-family fallback chain | Medium |
@@ -184,41 +184,26 @@ The tab span width is correct; only the dot count filling that width varies.
 
 ## Accessibility Issues
 
-### 10. No Document Language Attribute
+### ~~10. No Document Language Attribute~~ ✅ RESOLVED
 
-**Severity:** Medium
+**Status:** Implemented in December 2025
 
-**Problem:** No `lang` attribute on `<html>` or `<body>` element.
-
-**LibreOffice:**
-```html
-<body lang="en-US">
-```
-
-**Ours:** No language attribute.
-
-**Impact:** Screen readers cannot determine document language; browsers cannot apply correct hyphenation.
-
-**Solution:** Read from `w:settings/w:themeFontLang` or `w:lang` on document default styles.
+**Solution Implemented:**
+- `<html>` element now includes `lang` attribute (e.g., `<html lang="en-US">`)
+- Language auto-detected from `w:themeFontLang` in document settings
+- Falls back to default paragraph style's language, then "en-US"
+- New `DocumentLanguage` setting allows manual override
 
 ---
 
-### 11. No Language Attributes on Foreign Text
+### ~~11. No Language Attributes on Foreign Text~~ ✅ RESOLVED
 
-**Severity:** Medium
+**Status:** Implemented in December 2025
 
-**Problem:** Text in different languages (CJK, etc.) lacks `lang` attribute.
-
-**LibreOffice:**
-```html
-<span lang="zh-CN">株式会社</span>
-```
-
-**Ours:** No `lang` attribute on runs with different language.
-
-**Impact:** Screen readers mispronounce foreign text; browsers use wrong fonts.
-
-**Solution:** Read `w:rPr/w:lang` attributes and add `lang` to corresponding `<span>` elements.
+**Solution Implemented:**
+- `GetLangAttribute()` now uses actual document default language (not hardcoded "en-US")
+- Foreign text spans get `lang` attribute when different from document default
+- Supports western, bidi (Arabic/Hebrew), and east Asian language detection
 
 ---
 
@@ -385,11 +370,11 @@ Missing: highlight, caps, smallCaps, spacing, position, etc.
 1. **Table width calculation** - Fix twips→points conversion accuracy
 2. **Borderless table detection** - For signature blocks and layout tables
 3. **Theme color resolution** - Colors appear wrong with theme colors
-4. **Add `lang` attribute** to `<html>` from document settings
+4. ~~**Add `lang` attribute** to `<html>` from document settings~~ ✅ Done
 
 ### Medium Priority (Accessibility/Standards)
 
-5. **Add `lang` attributes** to foreign language spans
+5. ~~**Add `lang` attributes** to foreign language spans~~ ✅ Done
 6. **Add `@page` CSS rule** for print media
 7. **CJK font-family fallback** chain
 8. **Improve generic font fallback** - unknown fonts need serif/sans-serif fallback

--- a/npm/src/docxodus.worker.ts
+++ b/npm/src/docxodus.worker.ts
@@ -124,7 +124,8 @@ function handleConvert(
       options?.renderTrackedChanges !== undefined ||
       options?.showDeletedContent !== undefined ||
       options?.renderMoveOperations !== undefined ||
-      options?.renderUnsupportedContentPlaceholders !== undefined;
+      options?.renderUnsupportedContentPlaceholders !== undefined ||
+      options?.documentLanguage !== undefined;
 
     if (needsCompleteMethod || options?.renderAnnotations) {
       result = exports.DocumentConverter.ConvertDocxToHtmlComplete(
@@ -146,7 +147,8 @@ function handleConvert(
         options?.renderTrackedChanges ?? false,
         options?.showDeletedContent ?? true,
         options?.renderMoveOperations ?? true,
-        options?.renderUnsupportedContentPlaceholders ?? false
+        options?.renderUnsupportedContentPlaceholders ?? false,
+        options?.documentLanguage ?? null
       );
     } else if (
       options?.paginationMode !== undefined &&

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -401,7 +401,8 @@ export async function convertDocxToHtml(
     options?.renderTrackedChanges !== undefined ||
     options?.showDeletedContent !== undefined ||
     options?.renderMoveOperations !== undefined ||
-    options?.renderUnsupportedContentPlaceholders !== undefined;
+    options?.renderUnsupportedContentPlaceholders !== undefined ||
+    options?.documentLanguage !== undefined;
 
   // Use complete method when any new options are specified (most comprehensive)
   if (needsCompleteMethod || options?.renderAnnotations) {
@@ -424,7 +425,8 @@ export async function convertDocxToHtml(
       options?.renderTrackedChanges ?? false,
       options?.showDeletedContent ?? true,
       options?.renderMoveOperations ?? true,
-      options?.renderUnsupportedContentPlaceholders ?? false
+      options?.renderUnsupportedContentPlaceholders ?? false,
+      options?.documentLanguage ?? null
     );
   }
   // Use pagination-aware method when pagination is requested

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -122,6 +122,13 @@ export interface ConversionOptions {
    * will display as styled placeholder spans instead of being silently dropped.
    */
   renderUnsupportedContentPlaceholders?: boolean;
+  /**
+   * Override the document's default language for the HTML lang attribute.
+   * If not specified, the language is auto-detected from document settings
+   * (w:themeFontLang or default paragraph style), falling back to "en-US".
+   * Examples: "en-US", "fr-FR", "de-DE", "ja-JP"
+   */
+  documentLanguage?: string;
 }
 
 /**
@@ -430,7 +437,8 @@ export interface DocxodusWasmExports {
       renderTrackedChanges: boolean,
       showDeletedContent: boolean,
       renderMoveOperations: boolean,
-      renderUnsupportedContentPlaceholders: boolean
+      renderUnsupportedContentPlaceholders: boolean,
+      documentLanguage: string | null
     ) => string;
     GetAnnotations: (bytes: Uint8Array) => string;
     AddAnnotation: (bytes: Uint8Array, requestJson: string) => string;

--- a/wasm/DocxodusWasm/DocumentConverter.cs
+++ b/wasm/DocxodusWasm/DocumentConverter.cs
@@ -223,6 +223,7 @@ public partial class DocumentConverter
     /// <param name="showDeletedContent">Whether to show deleted content with strikethrough (only when renderTrackedChanges=true)</param>
     /// <param name="renderMoveOperations">Whether to distinguish move operations from insert/delete (only when renderTrackedChanges=true)</param>
     /// <param name="renderUnsupportedContentPlaceholders">Whether to render placeholders for unsupported content (math, forms, WMF/EMF images)</param>
+    /// <param name="documentLanguage">Override the document's default language for the HTML lang attribute (null = auto-detect from document)</param>
     /// <returns>HTML string or JSON error object</returns>
     [JSExport]
     public static string ConvertDocxToHtmlComplete(
@@ -244,7 +245,8 @@ public partial class DocumentConverter
         bool renderTrackedChanges,
         bool showDeletedContent,
         bool renderMoveOperations,
-        bool renderUnsupportedContentPlaceholders = false)
+        bool renderUnsupportedContentPlaceholders = false,
+        string? documentLanguage = null)
     {
         if (docxBytes == null || docxBytes.Length == 0)
         {
@@ -289,6 +291,7 @@ public partial class DocumentConverter
                 RenderUnsupportedContentPlaceholders = renderUnsupportedContentPlaceholders,
                 UnsupportedContentCssClassPrefix = "unsupported-",
                 IncludeUnsupportedContentMetadata = true,
+                DocumentLanguage = documentLanguage,
                 // Embed images as base64 data URIs - no SkiaSharp needed
                 ImageHandler = CreateBase64ImageHandler()
             };


### PR DESCRIPTION
## Summary

- Adds `lang` attribute to `<html>` element for improved accessibility (screen readers, browser hyphenation)
- Adds `lang` attribute to foreign text spans when language differs from document default
- Adds `DocumentLanguage` setting to manually override document language

## Changes

**Core Implementation:**
- `DocumentLanguage` setting added to `WmlToHtmlConverterSettings` and `HtmlConverterSettings`
- `GetDocumentDefaultLanguage()` helper extracts language from document settings
- Language priority: `w:themeFontLang` → default paragraph style → "en-US" fallback
- `GetLangAttribute()` now uses actual document default instead of hardcoded "en-US"

**Full Stack:**
- WASM: Added `documentLanguage` parameter to `ConvertDocxToHtmlComplete()`
- npm: Added `documentLanguage?: string` to `ConversionOptions` interface

**Tests:**
- HC033: `<html>` gets `lang` from themeFontLang
- HC034: `DocumentLanguage` setting overrides document
- HC035: Fallback to "en-US" when not specified
- HC036: `HtmlConverterSettings.DocumentLanguage` works

## Test plan

- [x] All 1140 tests pass
- [x] WASM builds successfully
- [x] TypeScript compiles

Addresses converter gaps #10 and #11 from `docs/architecture/wml_to_html_converter_gaps.md`