### PR TITLE
feat(converter): add theme color resolution and @page CSS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,21 @@ All notable changes to this project will be documented in this file.
     - Traditional Chinese (zh-hant): `'Noto Serif CJK TC', 'Microsoft JhengHei', 'PMingLiU', ...`
     - Korean (ko): `'Noto Serif CJK KR', 'Malgun Gothic', 'Batang', ...`
   - Addresses converter gaps #13 (Limited Font Fallback) and #14 (No CJK Font-Family Fallback Chain)
+- **Theme Color Resolution** - Document theme colors are now resolved to actual RGB values
+  - New `ResolveThemeColors` setting (default: true) enables theme color resolution
+  - Reads color scheme from `theme1.xml` (`a:clrScheme` element)
+  - Supports all 12 theme colors: dk1, lt1, dk2, lt2, accent1-6, hlink, folHlink
+  - Applies `w:themeTint` (lighten toward white) and `w:themeShade` (darken toward black) modifiers
+  - Resolves `w:themeColor` in run colors, paragraph shading, cell shading, and fills
+  - Falls back to explicit color value if theme color not found
+  - Addresses converter gap #6 (Theme Colors Not Resolved)
+- **@page CSS Rule** - Optional CSS `@page` rule generation for print stylesheets
+  - New `GeneratePageCss` setting (default: false) enables `@page` rule generation
+  - Reads page dimensions from `w:sectPr/w:pgSz` and margins from `w:sectPr/w:pgMar`
+  - Generates CSS `@page { size: Xin Yin; margin: ... }` rules
+  - Supports US Letter, A4, and custom page sizes with proper inch conversions
+  - Useful for print stylesheets and PDF generation
+  - Addresses converter gap #1 (No Page/Document Setup CSS)
 - **Unsupported Content Placeholders** - Visual indicators for content that cannot be fully converted to HTML
   - New `RenderUnsupportedContentPlaceholders` setting (default: false for backward compatibility)
   - Supports these unsupported content types:

--- a/docs/architecture/wml_to_html_converter_gaps.md
+++ b/docs/architecture/wml_to_html_converter_gaps.md
@@ -8,12 +8,12 @@ This document catalogs known gaps, limitations, and areas for improvement in the
 
 | Category | Gap | Severity |
 |----------|-----|----------|
-| **Layout** | No `@page` CSS rule for print/PDF | Medium |
+| ~~**Layout**~~ | ~~No `@page` CSS rule for print/PDF~~ | ~~Medium~~ ✅ |
 | ~~**Layout**~~ | ~~Table width calculation inconsistent~~ | ~~Medium~~ ✅ |
 | ~~**Layout**~~ | ~~Borderless table detection missing~~ | ~~Medium~~ ✅ |
 | **Layout** | Wrapper divs for simple borders | Low |
 | **Layout** | Empty paragraphs verbose | Low |
-| **Rendering** | Theme colors not resolved | Medium |
+| ~~**Rendering**~~ | ~~Theme colors not resolved~~ | ~~Medium~~ ✅ |
 | **Rendering** | Text box content lost | Medium |
 | **Rendering** | Tab leader count varies by platform | Low |
 | ~~**Accessibility**~~ | ~~No `lang` attribute on html/body~~ | ~~Medium~~ ✅ |
@@ -28,22 +28,16 @@ This document catalogs known gaps, limitations, and areas for improvement in the
 
 ## Layout Issues
 
-### 1. No Page/Document Setup CSS
+### ~~1. No Page/Document Setup CSS~~ ✅ RESOLVED
 
-**Severity:** Medium
+**Status:** Implemented in December 2025
 
-**Problem:** The converter does not generate `@page` CSS rules for print media or document-level settings.
-
-**LibreOffice generates:**
-```css
-@page { size: 8.5in 11in; margin: 1in }
-```
-
-**Ours:** Nothing.
-
-**Impact:** Print output and PDF generation lack proper page dimensions and margins.
-
-**Solution:** Read page size from `w:sectPr/w:pgSz` and margins from `w:sectPr/w:pgMar`, generate `@page` CSS rule.
+**Solution Implemented:**
+- New `GeneratePageCss` setting enables `@page` CSS rule generation
+- Reads page dimensions from `w:sectPr/w:pgSz` and margins from `w:sectPr/w:pgMar`
+- Generates proper `@page { size: Xin Yin; margin: ... }` CSS rules
+- Supports US Letter, A4, and custom page sizes
+- Disabled by default for backward compatibility
 
 ---
 
@@ -117,16 +111,17 @@ This document catalogs known gaps, limitations, and areas for improvement in the
 
 ## Rendering Issues
 
-### 6. Theme Colors Not Resolved
+### ~~6. Theme Colors Not Resolved~~ ✅ RESOLVED
 
-**Severity:** Medium
-**Location:** Lines 3468-3472
+**Status:** Implemented in December 2025
 
-While `w:themeColor` and `w:themeTint` are copied during border overrides, **theme colors are never resolved to actual RGB values** from the document's theme (`theme1.xml`).
-
-**Impact:** Colors appear wrong when documents use theme colors instead of explicit RGB.
-
-**Solution:** Read theme from `/word/theme/theme1.xml`, resolve `w:themeColor` values like `accent1`, `dark1`, etc. to RGB.
+**Solution Implemented:**
+- New `ResolveThemeColors` setting enables theme color resolution (default: true)
+- Reads color scheme from `theme1.xml` (`a:clrScheme` element)
+- Supports all 12 theme colors: dk1, lt1, dk2, lt2, accent1-6, hlink, folHlink
+- Applies `w:themeTint` (lighten) and `w:themeShade` (darken) modifiers
+- Resolves `w:themeColor` in run colors, paragraph/cell shading, and fills
+- Falls back to explicit color value if theme color not found
 
 ---
 
@@ -356,13 +351,13 @@ Missing: highlight, caps, smallCaps, spacing, position, etc.
 
 1. ~~**Table width calculation** - Fix twips→points conversion accuracy~~ ✅ Done
 2. ~~**Borderless table detection** - For signature blocks and layout tables~~ ✅ Done
-3. **Theme color resolution** - Colors appear wrong with theme colors
+3. ~~**Theme color resolution** - Colors appear wrong with theme colors~~ ✅ Done
 4. ~~**Add `lang` attribute** to `<html>` from document settings~~ ✅ Done
 
 ### Medium Priority (Accessibility/Standards)
 
 5. ~~**Add `lang` attributes** to foreign language spans~~ ✅ Done
-6. **Add `@page` CSS rule** for print media
+6. ~~**Add `@page` CSS rule** for print media~~ ✅ Done
 7. ~~**CJK font-family fallback** chain~~ ✅ Done
 8. ~~**Improve generic font fallback** - unknown fonts need serif/sans-serif fallback~~ ✅ Done
 


### PR DESCRIPTION
## Summary

- **Theme Color Resolution**: Resolves `w:themeColor` attributes to actual RGB values from document theme
- **@page CSS Rule**: Optional CSS `@page` rule generation for print stylesheets and PDF generation

## Changes

### Theme Color Resolution
- New `ResolveThemeColors` setting (default: true) enables theme color resolution
- Reads color scheme from `theme1.xml` (`a:clrScheme` element)
- Supports all 12 theme colors: dk1, lt1, dk2, lt2, accent1-6, hlink, folHlink
- Applies `w:themeTint` (lighten toward white) and `w:themeShade` (darken toward black) modifiers
- Resolves `w:themeColor` in run colors, paragraph shading, cell shading, and fills
- Falls back to explicit color value if theme color not found

### @page CSS Rule
- New `GeneratePageCss` setting (default: false) enables `@page` rule generation
- Reads page dimensions from `w:sectPr/w:pgSz` and margins from `w:sectPr/w:pgMar`
- Generates CSS `@page { size: Xin Yin; margin: ... }` rules
- Supports US Letter, A4, and custom page sizes with proper inch conversions
- Useful for print stylesheets and PDF generation

## Test plan

- [x] Added 7 new unit tests for theme color and @page CSS functionality
- [x] All 1159 existing tests pass
- [x] Build succeeds with no new errors

## Documentation

- Updated `docs/architecture/wml_to_html_converter_gaps.md` to mark issues #1 and #6 as resolved
- Updated `CHANGELOG.md` with new features