### PR TITLE
fix(converter): skip footnoteRef/endnoteRef runs to prevent empty spans

### DIFF
--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -4981,6 +4981,19 @@ namespace Docxodus
         private static object ConvertRun(WordprocessingDocument wordDoc, WmlToHtmlConverterSettings settings, XElement run)
         {
             var rPr = run.Element(W.rPr);
+
+            // Skip runs that only contain w:footnoteRef or w:endnoteRef.
+            // These are placeholder elements in footnote/endnote text that Word uses to display
+            // the note number. Since we add the note number separately (via footnote-number span
+            // in paginated mode, or via <ol> value attribute in non-paginated mode), we skip
+            // these runs to avoid creating empty styled spans.
+            var contentElements = run.Elements().Where(e => e.Name != W.rPr).ToList();
+            if (contentElements.Count == 1 &&
+                (contentElements[0].Name == W.footnoteRef || contentElements[0].Name == W.endnoteRef))
+            {
+                return null;
+            }
+
             if (rPr == null)
                 return run.Elements().Select(e => ConvertToHtmlTransform(wordDoc, settings, e, false, 0m));
 


### PR DESCRIPTION
## Summary

- Fix empty spans being generated in footnote/endnote HTML output
- Runs containing only `w:footnoteRef` or `w:endnoteRef` are now skipped in `ConvertRun()`
- Prevents whitespace issues caused by styled empty spans from footnote lead placeholders

## Problem

When rendering footnotes/endnotes to HTML, Word documents contain runs with `w:footnoteRef` or `w:endnoteRef` elements that Word uses to display the note number inside the note text. Since we add note numbers separately (via `footnote-number` span in paginated mode or `<ol>` value attribute in non-paginated mode), these runs produced empty styled spans causing:

1. Unexpected whitespace in the output
2. Empty spans with `xml:space="preserve"` affecting layout

## Solution

Added detection in `ConvertRun()` to identify runs that only contain `w:footnoteRef` or `w:endnoteRef` (plus optional `w:rPr`) and return `null` for them, preventing empty span generation.

## Test plan

- [x] Added `HC008b_FootnoteContent_NoEmptySpansFromFootnoteRef` test for non-paginated mode
- [x] Added `HC008c_FootnoteContent_PaginatedMode_NoEmptySpansFromFootnoteRef` test for paginated mode
- [x] All 1176 existing tests pass