### PR TITLE
feat(converter): align whitespace handling with LibreOffice HTML output

### DIFF
--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -2673,7 +2673,7 @@ namespace Docxodus
         }
 
         /// <summary>
-        /// Converts text content to use &amp;nbsp; entities for significant whitespace.
+        /// Converts text content to use non-breaking space characters for significant whitespace.
         /// This matches LibreOffice's approach and allows HTML to be formatted without
         /// affecting the rendered output.
         /// </summary>
@@ -2722,13 +2722,14 @@ namespace Docxodus
                 }
                 else
                 {
-                    // Multiple spaces, or space at boundary - use nbsp
+                    // Multiple spaces, or space at boundary - use non-breaking space
+                    // Use Unicode character \u00A0 instead of &nbsp; entity for XML compatibility
                     for (int j = 0; j < spaceCount; j++)
                     {
                         // Alternate between nbsp and regular space for runs of spaces
                         // This preserves the spacing while allowing some flexibility
                         if (j % 2 == 0 || spaceCount == 1)
-                            result.Add(new XEntity("nbsp"));
+                            result.Add(new XText("\u00A0"));
                         else
                             result.Add(new XText(" "));
                     }


### PR DESCRIPTION
## Summary
- Remove `white-space: pre-wrap` from default CSS to match LibreOffice behavior
- Add `ConvertTextWithNbsp()` to convert significant whitespace to `&nbsp;` entities
- Add `NormalizeInlineWhitespace()` to remove whitespace text nodes between inline elements
- Add `ToHtmlString()` helper method for proper HTML serialization

## Problem
HTML whitespace between inline elements was rendering as visible spaces, causing output like "FIRST : The name..." instead of "FIRST: The name...". This was due to standard HTML whitespace handling where newlines/indentation between inline elements render as visible space.

## Solution
Multi-pronged approach aligned with LibreOffice's HTML output:
1. Removed `white-space: pre-wrap` CSS that was preserving all whitespace
2. Added `&nbsp;` conversion for significant whitespace (leading/trailing/multiple spaces)
3. Added inline whitespace normalization to remove whitespace text nodes between inline elements
4. Added `ToHtmlString()` post-processor to strip formatting whitespace from serialized output

## Test plan
- [x] Build passes
- [x] Manual conversion of NVCA-Model-COI-10-1-2025.docx shows correct whitespace rendering
- [ ] Verify existing HTML converter tests pass