### PR TITLE
fix(converter): remove default 108% line-height to match LibreOffice output

### DIFF
--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -5114,13 +5114,11 @@ namespace Docxodus
 
         private static void DefineLineHeight(Dictionary<string, string> style, XElement paragraph)
         {
-            var allRunsAreUniDirectional = paragraph
-                .DescendantsTrimmed(W.txbxContent)
-                .Where(e => e.Name == W.r)
-                .Select(run => (string)run.Attribute(PtOpenXml.LanguageType))
-                .All(lt => lt != "bidi");
-            if (allRunsAreUniDirectional)
-                style.AddIfMissing("line-height", "108%");
+            // Don't set a default line-height. LibreOffice doesn't set explicit line-height,
+            // and browser defaults (~1.2) provide reasonable spacing. The previous 108% default
+            // made text too tight compared to LibreOffice's HTML output.
+            // Line-height is only set explicitly when w:lineRule is specified in the document
+            // (handled by CreateStyleFromSpacing).
         }
 
         /*


### PR DESCRIPTION
## Summary
- Remove hardcoded 108% line-height default from `DefineLineHeight()` in `WmlToHtmlConverter.cs`
- Line-height is now only set when explicitly specified via `w:lineRule` in the document
- Improves visual alignment with LibreOffice's HTML rendering for paragraph and line spacing

## Background
Previously, `DefineLineHeight()` unconditionally added `line-height: 108%` to all unidirectional paragraphs. This made text appear more compressed than LibreOffice's HTML output, which doesn't set any explicit line-height and lets browsers use their default (~120%).

## Test plan
- [x] All 1176 existing tests pass
- [x] Manual visual comparison shows improved spacing alignment with LibreOffice