### PR TITLE
fix(converter): use sequential display numbers for footnotes/endnotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased] - .NET 8 / Open XML SDK 3.x Migration
 
 ### Fixed
+- **Footnote/endnote numbering** - Fixed footnotes and endnotes displaying raw XML IDs instead of sequential display numbers
+  - Per ECMA-376, `w:id` is a reference identifier, not the display number
+  - Added `FootnoteNumberingTracker` class to scan document and build XML ID → display number mapping
+  - Footnotes/endnotes now render with sequential numbers (1, 2, 3...) based on document order
+  - Also fixed footnote ordering in the footnotes section to match document order
+  - Updated both regular and paginated rendering modes
+  - See `docs/ooxml_corner_cases.md` for detailed documentation
 - **Legal numbering continuation pattern** - Fixed incorrect multi-level list numbering when items continue a flat sequence at different indentation levels
   - Documents with items like 1., 2., 3. at level 0 followed by item at level 1 (with start=4) now render as "4." instead of "3.4"
   - Added "continuation pattern" detection in `ListItemRetriever.cs` that recognizes when a deeper-level item continues a flat list


### PR DESCRIPTION
## Summary
- Fix footnotes/endnotes displaying raw XML IDs instead of sequential display numbers
- Per ECMA-376, `w:id` is a reference identifier, not the display number
- Display numbers should be sequential (1, 2, 3...) based on document order

## Problem
Documents with footnotes were showing incorrect numbers. For example, a document with 91 footnotes would display them as 2-92 instead of 1-91, because we were using raw XML `w:id` values.

## Solution
Added `FootnoteNumberingTracker` class that:
1. Scans document for `footnoteReference`/`endnoteReference` elements in document order
2. Builds a mapping from XML ID → sequential display number
3. Uses the mapping when rendering both inline references and footnotes section

## Changes
- `Docxodus/WmlToHtmlConverter.cs`: Core fix with new tracker class and updated rendering
- `docs/ooxml_corner_cases.md`: Documentation of the issue and fix
- `CHANGELOG.md`: Entry added

## Test plan
- [x] Tested with NVCA model legal document (91 footnotes)
- [x] Verified footnotes display as 1-91 instead of 2-92
- [x] All 1187 existing tests pass