### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,6 +108,8 @@ jobs:
   build-binaries:
     needs: build-test-publish
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -156,6 +158,8 @@ jobs:
   build-docx2html-binaries:
     needs: build-test-publish
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -204,6 +208,8 @@ jobs:
   build-docx2oc-binaries:
     needs: build-test-publish
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Summary

- Adds explicit `permissions: contents: read` to all GitHub Actions workflow jobs that were missing permissions blocks
- Resolves all 7 open CodeQL `actions/missing-workflow-permissions` security alerts

### Changes

- **playwright.yml** — workflow-level `permissions` block (1 job)
- **ci.yml** — workflow-level `permissions` block (3 jobs)
- **publish.yml** — job-level `permissions` on `build-binaries`, `build-docx2html-binaries`, `build-docx2oc-binaries` (3 jobs already had permissions)

## Test plan

- [ ] CI workflows still pass (checkout, build, test, upload-artifact all only need `contents: read`)
- [ ] Publish workflow still works on next tag push