### PR TITLE
Fix TypeScript subpath exports resolution under node moduleResolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - .NET 8 / Open XML SDK 3.x Migration
 
+### Fixed (npm)
+- **TypeScript subpath exports not resolving under `moduleResolution: "node"` (Issue #113)** - Added `typesVersions` fallback to npm package.json so `docxodus/react` and `docxodus/worker` subpath imports resolve types correctly under all TypeScript module resolution modes. Also reordered export conditions to put `types` before `import` per TypeScript requirements.
+
 ### Added
 - **Incremental annotation overlay API (Issue #106)** - Decouple HTML conversion from annotation projection to avoid full WASM re-conversion
   - `ProjectAnnotationsOntoHtml()` - Project a full annotation set onto already-converted HTML

--- a/npm/package.json
+++ b/npm/package.json
@@ -8,16 +8,22 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     },
     "./react": {
-      "import": "./dist/react.js",
-      "types": "./dist/react.d.ts"
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js"
     },
     "./worker": {
-      "import": "./dist/worker-proxy.js",
-      "types": "./dist/worker-proxy.d.ts"
+      "types": "./dist/worker-proxy.d.ts",
+      "import": "./dist/worker-proxy.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "react": ["./dist/react.d.ts"],
+      "worker": ["./dist/worker-proxy.d.ts"]
     }
   },
   "files": [


### PR DESCRIPTION
## Summary
Fixed TypeScript subpath exports (`docxodus/react` and `docxodus/worker`) not resolving correctly under `moduleResolution: "node"` by adding a `typesVersions` fallback configuration to package.json.

## Changes
- **Reordered export conditions**: Moved `types` field before `import` in all export entries (`.`, `./react`, `./worker`) to comply with TypeScript's requirement that type conditions appear first
- **Added typesVersions fallback**: Introduced `typesVersions` configuration mapping subpath exports to their corresponding `.d.ts` files, ensuring type resolution works under all TypeScript module resolution modes (node, bundler, etc.)

## Details
The `typesVersions` field acts as a fallback for TypeScript versions that don't fully support the conditional exports syntax, allowing subpath imports like `import type { ... } from 'docxodus/react'` to correctly resolve their type definitions regardless of the consumer's `moduleResolution` setting.

https://claude.ai/code/session_01DFuL5c7KNRiu4QgifBBGWV