### PR TITLE
Fix text clipping and paragraph spacing in paginated rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this project will be documented in this file.
   - CSS-based label filtering enables responsive toggle without any re-rendering
 
 ### Fixed
+- **Paginated rendering: text clipped at page bottom + inconsistent paragraph spacing (Issue #114)**
+  - Fixed `lineRule` default handling: when `w:lineRule` is absent but `w:line` is present, treat as "auto" per OOXML spec (ISO/IEC 29500). Previously the line value was ignored, causing accumulated line-height mismatches that clipped the last line on pages.
+  - Fixed `contextualSpacing` handling: now suppresses both `spacingAfter` (margin-bottom) AND `spacingBefore` (margin-top) for consecutive same-style paragraphs. Previously only `spacingAfter` was suppressed, leaving inconsistent inter-paragraph gaps.
+  - Fixed pagination engine bottom margin over-reservation: the last block's bottom margin is no longer counted against page space since it's invisible (clipped by `overflow: hidden`). This prevents premature page breaks where content would have been visible.
 - **Annotation projection fails on sanitized HTML (Issue #110)** - `ProjectAnnotationsOntoHtml`, `AddAnnotationToHtml`, and `RemoveAnnotationFromHtml` now handle HTML fragments with multiple root elements (e.g., DOMPurify-sanitized output) and HTML named entities (`&nbsp;`, `&ndash;`, etc.)
   - Root cause: `XElement.Parse()` requires valid XML with a single root element; sanitized HTML strips `<html>`/`<body>` wrappers leaving multiple roots
   - Fix: Auto-wraps multi-root HTML in a synthetic container for parsing, unwraps on serialization; replaces common HTML entities with numeric XML equivalents

--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -2363,7 +2363,8 @@ namespace Docxodus
         private static object ConvertToHtmlTransform(WordprocessingDocument wordDoc,
             WmlToHtmlConverterSettings settings, XNode node,
             bool suppressTrailingWhiteSpace,
-            decimal currentMarginLeft)
+            decimal currentMarginLeft,
+            bool suppressLeadingWhiteSpace = false)
         {
             var element = node as XElement;
             if (element == null) return null;
@@ -2489,7 +2490,7 @@ namespace Docxodus
             // have a style separator).
             if (element.Name == W.p)
             {
-                return ProcessParagraph(wordDoc, settings, element, suppressTrailingWhiteSpace, currentMarginLeft);
+                return ProcessParagraph(wordDoc, settings, element, suppressTrailingWhiteSpace, currentMarginLeft, suppressLeadingWhiteSpace);
             }
 
             // Transform hyperlinks to the XHTML h:a element.
@@ -4276,7 +4277,7 @@ namespace Docxodus
         // the element (e.g., h:h2) created from the w:p element having the (first)
         // style separator (i.e., a w:specVanish element).
         private static object ProcessParagraph(WordprocessingDocument wordDoc, WmlToHtmlConverterSettings settings,
-            XElement element, bool suppressTrailingWhiteSpace, decimal currentMarginLeft)
+            XElement element, bool suppressTrailingWhiteSpace, decimal currentMarginLeft, bool suppressLeadingWhiteSpace = false)
         {
             // Ignore this paragraph if the previous paragraph has a style separator.
             // We have already transformed this one together with the previous one.
@@ -4286,7 +4287,7 @@ namespace Docxodus
             var elementName = GetParagraphElementName(element, wordDoc);
             var isBidi = IsBidi(element);
             var paragraph = (XElement) ConvertParagraph(wordDoc, settings, element, elementName,
-                suppressTrailingWhiteSpace, currentMarginLeft, isBidi);
+                suppressTrailingWhiteSpace, currentMarginLeft, isBidi, suppressLeadingWhiteSpace);
 
             // The paragraph conversion might have created empty spans.
             // These can and should be removed because empty spans are
@@ -4955,7 +4956,7 @@ namespace Docxodus
          * - autoSpaceDE
          * - autoSpaceDN
          * - bidi
-         * - contextualSpacing
+         * - contextualSpacing (handled via GroupAndVerticallySpaceNumberedParagraphs)
          * - divId
          * - framePr
          * - keepLines
@@ -4978,9 +4979,10 @@ namespace Docxodus
          */
 
         private static object ConvertParagraph(WordprocessingDocument wordDoc, WmlToHtmlConverterSettings settings,
-            XElement paragraph, XName elementName, bool suppressTrailingWhiteSpace, decimal currentMarginLeft, bool isBidi)
+            XElement paragraph, XName elementName, bool suppressTrailingWhiteSpace, decimal currentMarginLeft, bool isBidi,
+            bool suppressLeadingWhiteSpace = false)
         {
-            var style = DefineParagraphStyle(paragraph, elementName, suppressTrailingWhiteSpace, currentMarginLeft, isBidi);
+            var style = DefineParagraphStyle(paragraph, elementName, suppressTrailingWhiteSpace, currentMarginLeft, isBidi, suppressLeadingWhiteSpace);
             var rtl = isBidi ? new XAttribute("dir", "rtl") : new XAttribute("dir", "ltr");
             var firstMark = isBidi ? new XEntity("#x200f") : null;
 
@@ -5113,7 +5115,7 @@ namespace Docxodus
         }
 
         private static Dictionary<string, string> DefineParagraphStyle(XElement paragraph, XName elementName,
-            bool suppressTrailingWhiteSpace, decimal currentMarginLeft, bool isBidi)
+            bool suppressTrailingWhiteSpace, decimal currentMarginLeft, bool isBidi, bool suppressLeadingWhiteSpace = false)
         {
             var style = new Dictionary<string, string>();
 
@@ -5124,7 +5126,7 @@ namespace Docxodus
             var pPr = paragraph.Element(W.pPr);
             if (pPr == null) return style;
 
-            CreateStyleFromSpacing(style, pPr.Element(W.spacing), elementName, suppressTrailingWhiteSpace);
+            CreateStyleFromSpacing(style, pPr.Element(W.spacing), elementName, suppressTrailingWhiteSpace, suppressLeadingWhiteSpace);
             CreateStyleFromInd(style, pPr.Element(W.ind), elementName, currentMarginLeft, isBidi);
 
             // todo need to handle
@@ -5217,18 +5219,19 @@ namespace Docxodus
         }
 
         private static void CreateStyleFromSpacing(Dictionary<string, string> style, XElement spacing, XName elementName,
-            bool suppressTrailingWhiteSpace)
+            bool suppressTrailingWhiteSpace, bool suppressLeadingWhiteSpace = false)
         {
             if (spacing == null) return;
 
-            var spacingBefore = (decimal?) spacing.Attribute(W.before);
+            var spacingBefore = suppressLeadingWhiteSpace ? 0 : (decimal?) spacing.Attribute(W.before);
             if (spacingBefore != null && elementName != Xhtml.span)
                 style.AddIfMissing("margin-top",
                     spacingBefore > 0m
                         ? string.Format(NumberFormatInfo.InvariantInfo, "{0}pt", spacingBefore/20.0m)
                         : "0");
 
-            var lineRule = (string) spacing.Attribute(W.lineRule);
+            // Per OOXML spec (ISO/IEC 29500), when lineRule is absent the default is "auto"
+            var lineRule = (string) spacing.Attribute(W.lineRule) ?? (spacing.Attribute(W.line) != null ? "auto" : null);
             if (lineRule == "auto")
             {
                 var line = (decimal) spacing.Attribute(W.line);
@@ -7189,7 +7192,13 @@ namespace Docxodus
                     if (g.Key == "")
                         return g.Select(e => ConvertToHtmlTransform(wordDoc, settings, e, false, currentMarginLeft));
                     var last = g.Count() - 1;
-                    return g.Select((e, i) => ConvertToHtmlTransform(wordDoc, settings, e, i != last, currentMarginLeft));
+                    // For contextualSpacing groups (sty: prefix), suppress both trailing whitespace
+                    // for non-last paragraphs AND leading whitespace for non-first paragraphs.
+                    // Word removes all inter-paragraph spacing for same-style contextualSpacing paragraphs.
+                    var isContextualGroup = g.Key.StartsWith("sty:");
+                    return g.Select((e, i) => ConvertToHtmlTransform(wordDoc, settings, e,
+                        i != last, currentMarginLeft,
+                        suppressLeadingWhiteSpace: isContextualGroup && i != 0));
                 });
             return (IEnumerable<object>)newContent;
         }

--- a/npm/src/pagination.ts
+++ b/npm/src/pagination.ts
@@ -1024,8 +1024,11 @@ export class PaginationEngine {
         // Margin collapsing: use the larger of the two adjacent margins
         effectiveMarginTop = Math.max(block.marginTopPt, prevMarginBottomPt) - prevMarginBottomPt;
       }
-      // Total height = top margin gap + content + bottom margin + footnote space
-      const blockSpace = effectiveMarginTop + block.heightPt + block.marginBottomPt + additionalFootnoteHeight;
+      // Visible height = top margin gap + content + footnote space
+      // Note: bottom margin is NOT included in the fit check because the last block's
+      // bottom margin extends beyond the content area and is clipped by overflow:hidden.
+      // It is still tracked in remainingHeight for correct margin collapsing with the next block.
+      const blockSpace = effectiveMarginTop + block.heightPt + additionalFootnoteHeight;
 
       // Calculate needed height (including keepWithNext)
       let neededHeight = blockSpace;
@@ -1033,7 +1036,7 @@ export class PaginationEngine {
         // For keepWithNext, include the next block with collapsed margins
         const collapsedMargin = Math.max(block.marginBottomPt, nextBlock.marginTopPt);
         neededHeight = effectiveMarginTop + block.heightPt + collapsedMargin +
-                       nextBlock.heightPt + nextBlock.marginBottomPt + additionalFootnoteHeight;
+                       nextBlock.heightPt + additionalFootnoteHeight;
       }
 
       // Effective remaining height (content area minus footnotes already on page)
@@ -1055,9 +1058,9 @@ export class PaginationEngine {
           currentFootnoteIds.push(...newFootnoteIds);
           currentFootnoteHeight += additionalFootnoteHeight;
         }
-      } else if (block.heightPt + block.marginTopPt + block.marginBottomPt <= effectiveContentHeight) {
+      } else if (block.heightPt + block.marginTopPt <= effectiveContentHeight) {
         // Block doesn't fit with current allocation - try expanding footnote area
-        const blockSpaceWithoutFootnotes = effectiveMarginTop + block.heightPt + block.marginBottomPt;
+        const blockSpaceWithoutFootnotes = effectiveMarginTop + block.heightPt;
 
         // Check if block fits if we expand footnote area
         // We can expand footnotes up to maxFootnoteArea, leaving room for body content


### PR DESCRIPTION
## Summary
This PR fixes three related issues affecting paginated rendering that caused text to be clipped at page bottoms and inconsistent paragraph spacing:

1. **Line height calculation**: Fixed `lineRule` default handling per OOXML spec (ISO/IEC 29500)
2. **Contextual spacing**: Properly suppress spacing for consecutive same-style paragraphs
3. **Pagination logic**: Corrected bottom margin accounting in page break calculations

## Key Changes

### WmlToHtmlConverter.cs
- Added `suppressLeadingWhiteSpace` parameter to `ConvertToHtmlTransform()`, `ProcessParagraph()`, `ConvertParagraph()`, `DefineParagraphStyle()`, and `CreateStyleFromSpacing()` methods to enable suppression of leading whitespace in paragraphs
- Modified `CreateStyleFromSpacing()` to:
  - Set `spacingBefore` to 0 when `suppressLeadingWhiteSpace` is true
  - Fixed `lineRule` default: when `w:lineRule` attribute is absent but `w:line` is present, treat as "auto" per OOXML spec (previously the line value was ignored)
- Updated `GroupAndVerticallySpaceNumberedParagraphs()` to:
  - Identify contextual spacing groups (those with "sty:" prefix)
  - Suppress both trailing whitespace for non-last paragraphs AND leading whitespace for non-first paragraphs in contextual groups
  - This matches Word's behavior of removing all inter-paragraph spacing for same-style contextualSpacing paragraphs
- Updated comment for `contextualSpacing` to note it's handled via `GroupAndVerticallySpaceNumberedParagraphs`

### pagination.ts
- Fixed bottom margin over-reservation in page break calculations:
  - Removed `block.marginBottomPt` from `blockSpace` calculation since the last block's bottom margin extends beyond the content area and is clipped by `overflow: hidden`
  - Updated `keepWithNext` logic to exclude bottom margin from the next block's space calculation
  - Corrected two conditional checks that were incorrectly including bottom margins in fit calculations
  - Bottom margin is still tracked in `remainingHeight` for correct margin collapsing with subsequent blocks

### CHANGELOG.md
- Documented all three fixes with detailed explanations of root causes and solutions

## Implementation Details
The contextual spacing fix leverages the existing grouping mechanism in `GroupAndVerticallySpaceNumberedParagraphs()` which already groups paragraphs by style. The new `suppressLeadingWhiteSpace` parameter threads through the conversion pipeline to suppress `margin-top` at the CSS level for non-first paragraphs in contextual groups, while the existing `suppressTrailingWhiteSpace` parameter handles `margin-bottom` for non-last paragraphs.

The pagination fix recognizes that in a paginated layout with `overflow: hidden`, the last block's bottom margin is invisible and should not count against available page space, preventing unnecessary page breaks when content would actually be visible.

https://claude.ai/code/session_01VoQ3xgQrJ1H1xe9t76GeoT