### PR TITLE
feat(session): FindPlaceholders — typed enumeration of template slots (#142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **`DocxSession.FindPlaceholders` — typed enumeration of template slots** (issue #142). Built on `Grep` (#143); classifies bracketed regions into three kinds an agent treats differently:
+  - `BlankFill` — `[___]` or `$[___]` value slots
+  - `AlternativeClause` — `[entire clause text in brackets]` optional clauses to keep/strip
+  - `Instruction` — `[insert X]`, `[specify Y]`, `[*italicized hint*]` — drafter hints; the inner text is exposed as `Hint` with surrounding asterisks stripped
+  Returns `TemplatePlaceholder` records wrapping the underlying `TextMatch` so the caller has anchor, span, fragment list, and surrounding context for each match without a second pass. `PlaceholderKinds` flag enum lets callers narrow (e.g. just `BlankFill`). The complete template-fill workflow now collapses to: `foreach (var p in session.FindPlaceholders(PlaceholderKinds.BlankFill).OrderByDescending(p => p.Match.Span.Start)) session.ReplaceMatch(p.Match, value);` — the 200-line Bluth-Co fill script replaced by five lines. WASM bridge (`FindPlaceholders` JSExport) + npm wrapper (`session.findPlaceholders()`, `PlaceholderKinds` flag exports). Tests: `DS120`–`DS126`. Architecture: see `docs/architecture/docx_mutation_api.md` (FindPlaceholders section).
 - **`DocxSession.ReplaceTextRange` — surgical text replacement that preserves run formatting** (issue #139). Built on `Grep` (#143). Three public surfaces:
   - `ReplaceTextRange(anchorId, find, replace, options?)` — finds every literal occurrence of `find` in the anchor's flat text and replaces each with `replace`. Returns one `EditResult` per attempted match.
   - `ReplaceMatch(TextMatch, replace)` — convenience for `Grep` results.

--- a/Docxodus.Tests/DocxSessionTests.cs
+++ b/Docxodus.Tests/DocxSessionTests.cs
@@ -1095,4 +1095,121 @@ public class DocxSessionTests
         Assert.True(s.Undo());
         Assert.Equal(before, FlatBodyText(s));
     }
+
+    // ─── Phase 12: FindPlaceholders (#142) ───────────────────────────────
+
+    /// <summary>
+    /// Three-paragraph fixture covering each PlaceholderKind:
+    ///   1. BlankFill — "Name: [_______]" + "Price: $[___]"
+    ///   2. AlternativeClause — "[There shall be no cumulative voting.]"
+    ///   3. Instruction — "[insert percentage] of the outstanding shares" + "[*specify name*]"
+    /// </summary>
+    internal static byte[] BuildDS120_PlaceholderFixture()
+    {
+        XNamespace W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+        using var ms = new MemoryStream();
+        using (var wDoc = WordprocessingDocument.Create(ms, WordprocessingDocumentType.Document))
+        {
+            var main = wDoc.AddMainDocumentPart();
+            main.AddNewPart<StyleDefinitionsPart>().Styles = BuildHeadingStyles();
+            main.AddNewPart<DocumentSettingsPart>().Settings = new Settings();
+
+            XElement Para(string text) => new XElement(W + "p",
+                new XElement(W + "r",
+                    new XElement(W + "t", new XAttribute(XNamespace.Xml + "space", "preserve"), text)));
+
+            var body = new XElement(W + "body",
+                Para("Name: [_______] and price: $[___]"),
+                Para("[There shall be no cumulative voting.]"),
+                Para("Holders of at least [insert percentage] of the outstanding shares of [*specify name*]."));
+
+            var doc = new XElement(W + "document",
+                new XAttribute(XNamespace.Xmlns + "w", W.NamespaceName),
+                body);
+            main.PutXDocument(new XDocument(doc));
+        }
+        return ms.ToArray();
+    }
+
+    [Fact]
+    public void DS120_FindPlaceholders_DetectsBlankFill()
+    {
+        using var s = new DocxSession(BuildDS120_PlaceholderFixture());
+        var placeholders = s.FindPlaceholders(PlaceholderKinds.BlankFill);
+
+        Assert.Equal(2, placeholders.Count);
+        Assert.All(placeholders, p => Assert.Equal(PlaceholderKind.BlankFill, p.Kind));
+        Assert.Contains(placeholders, p => p.Match.Text == "[_______]");
+        Assert.Contains(placeholders, p => p.Match.Text == "$[___]");
+    }
+
+    [Fact]
+    public void DS121_FindPlaceholders_DetectsAlternativeClause()
+    {
+        using var s = new DocxSession(BuildDS120_PlaceholderFixture());
+        var alts = s.FindPlaceholders(PlaceholderKinds.AlternativeClause);
+
+        Assert.Single(alts);
+        Assert.Equal(PlaceholderKind.AlternativeClause, alts[0].Kind);
+        Assert.Equal("[There shall be no cumulative voting.]", alts[0].Match.Text);
+    }
+
+    [Fact]
+    public void DS122_FindPlaceholders_DetectsInstruction_ExtractsHint()
+    {
+        using var s = new DocxSession(BuildDS120_PlaceholderFixture());
+        var instructions = s.FindPlaceholders(PlaceholderKinds.Instruction);
+
+        Assert.Equal(2, instructions.Count);
+        Assert.All(instructions, i => Assert.Equal(PlaceholderKind.Instruction, i.Kind));
+        Assert.Contains(instructions, i => i.Hint == "insert percentage");
+        // Italic-styled instructions ([*specify name*]) strip the asterisks for the hint.
+        Assert.Contains(instructions, i => i.Hint == "specify name");
+    }
+
+    [Fact]
+    public void DS123_FindPlaceholders_DefaultKindsReturnsAll()
+    {
+        using var s = new DocxSession(BuildDS120_PlaceholderFixture());
+        var all = s.FindPlaceholders();
+        // 2 BlankFill + 1 AlternativeClause + 2 Instruction = 5
+        Assert.Equal(5, all.Count);
+    }
+
+    [Fact]
+    public void DS124_FindPlaceholders_KindsFilterCombines()
+    {
+        using var s = new DocxSession(BuildDS120_PlaceholderFixture());
+        var blankAndInstr = s.FindPlaceholders(PlaceholderKinds.BlankFill | PlaceholderKinds.Instruction);
+        Assert.Equal(4, blankAndInstr.Count);
+        Assert.DoesNotContain(blankAndInstr, p => p.Kind == PlaceholderKind.AlternativeClause);
+    }
+
+    [Fact]
+    public void DS125_FindPlaceholders_EmptyDocReturnsEmpty()
+    {
+        // BuildDS001 is two paragraphs with no brackets at all.
+        using var s = new DocxSession(BuildDS001_SimpleTwoParagraphs());
+        Assert.Empty(s.FindPlaceholders());
+    }
+
+    [Fact]
+    public void DS126_FindPlaceholders_ProvidesEnoughInfoForReplaceMatch()
+    {
+        // End-to-end: enumerate placeholders, fill each via ReplaceMatch.
+        // This is the canonical agentic template-fill recipe.
+        using var s = new DocxSession(BuildDS120_PlaceholderFixture());
+
+        // Fill each BlankFill in reverse offset order (per the ReplaceTextRange contract).
+        var fills = s.FindPlaceholders(PlaceholderKinds.BlankFill)
+            .OrderByDescending(p => p.Match.Span.Start);
+        foreach (var p in fills)
+            s.ReplaceMatch(p.Match, p.Match.Text == "$[___]" ? "$42" : "Bluth Co.");
+
+        var flat = FlatBodyText(s);
+        Assert.Contains("Name: Bluth Co. and price: $42", flat);
+        // Remaining placeholders untouched.
+        Assert.Contains("[There shall be no cumulative voting.]", flat);
+        Assert.Contains("[insert percentage]", flat);
+    }
 }

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -107,6 +107,51 @@ public sealed record ReplaceOptions
     public int? MaxReplacements { get; init; }
 }
 
+/// <summary>
+/// Categories of bracketed placeholders that <see cref="DocxSession.FindPlaceholders"/>
+/// recognizes. Templates routinely mix these — a real-world COI has dozens of value
+/// blanks, dozens of optional clauses, and dozens of drafter hints, all inside
+/// square brackets — and an agent fills each kind differently.
+/// </summary>
+public enum PlaceholderKind
+{
+    /// <summary><c>[_______]</c> or <c>$[_______]</c> — a value slot the agent fills with text.</summary>
+    BlankFill,
+
+    /// <summary><c>[entire clause text in brackets]</c> — an optional clause the agent keeps or strips.</summary>
+    AlternativeClause,
+
+    /// <summary><c>[insert X]</c>, <c>[specify Y]</c>, <c>[*italicized hint*]</c> — a drafter hint the agent treats as a parameter description.</summary>
+    Instruction,
+}
+
+/// <summary>Flag set for narrowing <see cref="DocxSession.FindPlaceholders"/>.</summary>
+[System.Flags]
+public enum PlaceholderKinds
+{
+    BlankFill = 1,
+    AlternativeClause = 2,
+    Instruction = 4,
+    All = BlankFill | AlternativeClause | Instruction,
+}
+
+/// <summary>
+/// A single placeholder found by <see cref="DocxSession.FindPlaceholders"/>. Wraps the
+/// underlying <see cref="TextMatch"/> with a classified <see cref="Kind"/> and (for
+/// <see cref="PlaceholderKind.Instruction"/> placeholders) a parsed <see cref="Hint"/>.
+/// </summary>
+public sealed record TemplatePlaceholder
+{
+    required public TextMatch Match { get; init; }
+    required public PlaceholderKind Kind { get; init; }
+
+    /// <summary>For <see cref="PlaceholderKind.Instruction"/>: the inner text with
+    /// surrounding brackets/asterisks stripped (e.g. <c>"[insert percentage]"</c> →
+    /// <c>"insert percentage"</c>; <c>"[*specify name*]"</c> → <c>"specify name"</c>).
+    /// <c>null</c> for other kinds.</summary>
+    public string? Hint { get; init; }
+}
+
 public sealed record AnchorInfo(string Id, string Kind, string Scope, string TextPreview);
 
 public sealed record MarkdownPatch(string ScopeAnchorId, string Markdown);
@@ -511,6 +556,86 @@ public sealed class DocxSession : IDisposable
             if (preOp.ok) RestoreSnapshot(preOp.snapshot);
             return EditResult.Fail(EditErrorCode.InternalError, ex.Message, anchorId);
         }
+    }
+
+    /// <summary>
+    /// Enumerate the template placeholders in the document. A thin classifier over
+    /// <see cref="Grep"/> that distinguishes <c>[___]</c> value blanks, <c>[bracketed
+    /// alternative clauses]</c>, and <c>[insert X]</c> / <c>[*italic hint*]</c>
+    /// instruction placeholders — the three families a template-filling agent treats
+    /// differently. See <see cref="PlaceholderKind"/> for the taxonomy.
+    /// </summary>
+    /// <remarks>
+    /// Nested brackets resolve to the INNERMOST bracket. A construct like
+    /// <c>[under the name [Bluth Co.]]</c> produces a placeholder for the inner
+    /// <c>[Bluth Co.]</c> only — usually what an agent cares about — but the outer
+    /// optional-clause bracket isn't reported separately. Use <see cref="Grep"/> with
+    /// a balanced-bracket regex if you need both.
+    /// </remarks>
+    public IReadOnlyList<TemplatePlaceholder> FindPlaceholders(
+        PlaceholderKinds kinds = PlaceholderKinds.All,
+        ProjectionScopes scope = ProjectionScopes.Body)
+    {
+        ThrowIfDisposed();
+        if (kinds == 0) return Array.Empty<TemplatePlaceholder>();
+
+        // Single bracket-or-dollar-bracket scan; classify by content after the match.
+        // Non-greedy inner content + negated character class keeps the regex from
+        // crossing into a sibling bracket pair on the same line.
+        var matches = Grep(@"\$?\[[^\[\]]+\]", System.Text.RegularExpressions.RegexOptions.None, scope);
+        var results = new List<TemplatePlaceholder>(matches.Count);
+        foreach (var m in matches)
+        {
+            var classified = Classify(m.Text);
+            if (classified is not PlaceholderKind kind) continue;
+            if (!kinds.HasFlag(KindToFlag(kind))) continue;
+            results.Add(new TemplatePlaceholder
+            {
+                Match = m,
+                Kind = kind,
+                Hint = kind == PlaceholderKind.Instruction ? ExtractHint(m.Text) : null,
+            });
+        }
+        return results;
+
+        static PlaceholderKind? Classify(string text)
+        {
+            var inner = text.StartsWith('$') ? text[2..^1] : text[1..^1];
+
+            // BlankFill: 2+ underscores anywhere inside (so "[__]" director-count slots,
+            // "[___ times]" unit-suffix slots, and "[________ __, 20__]" date-shaped
+            // slots all qualify). Tighter than "any underscore" to avoid false positives
+            // on quoted identifiers like "[a_b]". Trade-off in writeup at the FindPlaceholders
+            // section of docs/architecture/docx_mutation_api.md.
+            if (inner.Count(c => c == '_') >= 2) return PlaceholderKind.BlankFill;
+
+            // Instruction: italicized (asterisk-wrapped) text, or starts with the
+            // drafter verbs "insert" / "specify". Conservative leading-word check
+            // so general prose in brackets doesn't mis-classify.
+            if (inner.StartsWith('*') && inner.EndsWith('*') && inner.Length > 2) return PlaceholderKind.Instruction;
+            var firstWord = inner.TakeWhile(char.IsLetter).ToArray();
+            var w = new string(firstWord).ToLowerInvariant();
+            if (w is "insert" or "specify") return PlaceholderKind.Instruction;
+
+            return PlaceholderKind.AlternativeClause;
+        }
+
+        static string ExtractHint(string text)
+        {
+            var inner = text.StartsWith('$') ? text[2..^1] : text[1..^1];
+            // Strip a single pair of surrounding asterisks (italic markers from the projector).
+            if (inner.StartsWith('*') && inner.EndsWith('*') && inner.Length > 2)
+                inner = inner[1..^1];
+            return inner.Trim();
+        }
+
+        static PlaceholderKinds KindToFlag(PlaceholderKind k) => k switch
+        {
+            PlaceholderKind.BlankFill => PlaceholderKinds.BlankFill,
+            PlaceholderKind.AlternativeClause => PlaceholderKinds.AlternativeClause,
+            PlaceholderKind.Instruction => PlaceholderKinds.Instruction,
+            _ => 0,
+        };
     }
 
     /// <summary>

--- a/docs/architecture/docx_mutation_api.md
+++ b/docs/architecture/docx_mutation_api.md
@@ -200,6 +200,38 @@ Two caveats to internalize while [#132](https://github.com/JSv4/Docxodus/issues/
 
 The agent's prompt should also be aware: it can call `AnnotationManager.GetAnnotations(doc)` once at the start of a session to enumerate available labels (e.g., "you can target: INDEMNIFICATION, TERMINATION, GOVERNING_LAW") and present those as tools rather than asking the LLM to discover them from text.
 
+## FindPlaceholders — template-slot enumeration
+
+`session.FindPlaceholders(kinds?, scope?)` is a thin classifier over `Grep` for the workflow every template-filling agent eventually writes itself. It scans for `\$?\[…\]` regions and tags each one as:
+
+| `PlaceholderKind` | Pattern | What an agent does with it |
+|---|---|---|
+| `BlankFill` | `[___]` or `$[___]` (underscores only) | Fill with a literal value (a name, a number, a date) |
+| `AlternativeClause` | `[clause text]` (anything else in brackets) | Keep, strip, or pick between alternatives |
+| `Instruction` | `[insert X]`, `[specify Y]`, `[*italicized hint*]` | Parameter description — populate based on the hint |
+
+`Instruction` placeholders expose the inner text (asterisks stripped) via the `Hint` field, so the agent can read `"insert percentage"` or `"specify name"` and decide what to put.
+
+`PlaceholderKinds` is a flag enum (`BlankFill | AlternativeClause | Instruction = All`) for narrowing.
+
+### The canonical fill recipe
+
+```csharp
+// Replace every value-blank in the document with a looked-up value.
+foreach (var p in session.FindPlaceholders(PlaceholderKinds.BlankFill)
+                          .OrderByDescending(p => p.Match.Span.Start))
+{
+    var value = LookupValueByContext(p.Match.ContextBefore, p.Match.ContextAfter);
+    session.ReplaceMatch(p.Match, value);
+}
+```
+
+This pattern — `FindPlaceholders` + `OrderByDescending(Span.Start)` + `ReplaceMatch` — collapses the 200-line context-needle-disambiguation script the Bluth-Co smoke test had to write down to a five-line loop. Process in reverse offset order so earlier-offset spans stay valid after later edits land, the same rule that applies to `ReplaceTextRange`'s internal pass.
+
+### Nesting
+
+Nested brackets (e.g. `[under the name [Bluth, Inc.]]`) resolve to the INNERMOST bracket only — usually what the agent cares about, since the inner is the value slot and the outer is the optional-clause wrapper. If you need both, use `Grep` directly with a balanced-bracket pattern.
+
 ## ReplaceTextRange — surgical text edits
 
 `session.ReplaceTextRange(anchorId, find, replace, options?)` finds every literal occurrence of `find` in one paragraph/heading/list-item's flat text and substitutes `replace` for each, returning an `EditResult` per attempted match. Built on `Grep` — same fragment walker, opposite direction.

--- a/npm/src/session.ts
+++ b/npm/src/session.ts
@@ -11,8 +11,10 @@ import type {
   FormatOp,
   GrepOptions,
   ReplaceOptions,
+  TemplatePlaceholder,
   TextMatch,
 } from "./types.js";
+import { PlaceholderKinds } from "./types.js";
 
 /**
  * Stateful in-memory DOCX editing session keyed by markdown-projection anchor ids.
@@ -144,6 +146,24 @@ export class DocxSession {
     ) as EditResult;
   }
 
+  /**
+   * Enumerate template placeholders in the document. Thin classifier over
+   * {@link grep}: distinguishes `[___]` value blanks (`blank_fill`),
+   * `[bracketed alternative clauses]` (`alternative_clause`), and
+   * `[insert X]` / `[*italic hint*]` instructions (`instruction`).
+   *
+   * Combine kinds with bitwise OR: `PlaceholderKinds.BlankFill | PlaceholderKinds.Instruction`.
+   * Default is `PlaceholderKinds.All`; default scope is body only (1).
+   *
+   * @see docs/architecture/docx_mutation_api.md#findplaceholders
+   */
+  findPlaceholders(
+    kinds: number = PlaceholderKinds.All,
+    scope: number = 1,
+  ): TemplatePlaceholder[] {
+    return JSON.parse(this.wasm.FindPlaceholders(this.handle, kinds, scope)) as TemplatePlaceholder[];
+  }
+
   // ─── Lifecycle ───────────────────────────────────────────────────────
 
   undo(): boolean {
@@ -183,4 +203,5 @@ export function openDocxSession(
   return new DocxSession(handle, bridge);
 }
 
-export type { AnchorRef, CharSpan, DocxSessionProjection, DocxSessionSettings, EditError, EditErrorCode, EditResult, FormatOp, GrepOptions, MarkdownPatch, ReplaceOptions, RunFormatting, RunFragment, TextMatch } from "./types.js";
+export type { AnchorRef, CharSpan, DocxSessionProjection, DocxSessionSettings, EditError, EditErrorCode, EditResult, FormatOp, GrepOptions, MarkdownPatch, PlaceholderKind, ReplaceOptions, RunFormatting, RunFragment, TemplatePlaceholder, TextMatch } from "./types.js";
+export { PlaceholderKinds } from "./types.js";

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -671,6 +671,7 @@ export interface DocxodusWasmExports {
     Grep: (handle: number, pattern: string, optionsJson: string) => string;
     ReplaceTextRange: (handle: number, anchor: string, find: string, replace: string, optionsJson: string) => string;
     ReplaceTextAtSpan: (handle: number, anchor: string, spanStart: number, spanLength: number, replace: string) => string;
+    FindPlaceholders: (handle: number, kinds: number, scope: number) => string;
     Undo: (handle: number) => boolean;
     Redo: (handle: number) => boolean;
     Save: (handle: number) => Uint8Array;
@@ -820,6 +821,32 @@ export interface ReplaceOptions {
   ignoreCase?: boolean;
   /** Cap the number of replacements; omitted = unlimited. */
   maxReplacements?: number;
+}
+
+/**
+ * Categories of bracketed placeholders {@link DocxSession.findPlaceholders} recognizes.
+ *
+ * - `blank_fill` — `[___]` or `$[___]` value slots
+ * - `alternative_clause` — `[entire clause text]`
+ * - `instruction` — `[insert X]`, `[specify Y]`, `[*italicized hint*]`
+ */
+export type PlaceholderKind = "blank_fill" | "alternative_clause" | "instruction";
+
+/**
+ * Numeric flag layout matching the .NET `PlaceholderKinds` enum. Combine with bitwise OR.
+ */
+export const PlaceholderKinds = {
+  BlankFill: 1,
+  AlternativeClause: 2,
+  Instruction: 4,
+  All: 7,
+} as const;
+
+export interface TemplatePlaceholder {
+  kind: PlaceholderKind;
+  /** For `instruction` placeholders: the inner text with surrounding brackets/asterisks stripped. */
+  hint?: string;
+  match: TextMatch;
 }
 
 /**

--- a/npm/tests/docx-session.spec.ts
+++ b/npm/tests/docx-session.spec.ts
@@ -154,6 +154,34 @@ test.describe('DocxSession (WASM bridge)', () => {
     expect(result.totalAfter).toBe(result.totalBefore - 1);
   });
 
+  test('findPlaceholders enumerates and classifies template slots', async ({ page }) => {
+    const bytes = readTestFile('HC001-5DayTourPlanTemplate.docx');
+
+    const result = await page.evaluate(async (bytesArray: number[]) => {
+      const bin = new Uint8Array(bytesArray);
+      const bridge = (window as any).Docxodus.DocxSessionBridge;
+      const handle = bridge.OpenSession(bin, '');
+      try {
+        // PlaceholderKinds.All = 7, body scope = 1.
+        const placeholders = JSON.parse(bridge.FindPlaceholders(handle, 7, 1));
+        const kinds = new Set(placeholders.map((p: any) => p.kind));
+        return {
+          total: placeholders.length,
+          kinds: Array.from(kinds),
+          firstKind: placeholders[0]?.kind,
+          firstMatchHasFragments: Array.isArray(placeholders[0]?.match?.fragments),
+        };
+      } finally {
+        bridge.CloseSession(handle);
+      }
+    }, Array.from(bytes));
+
+    // HC001 has bracketed placeholders in every day-section paragraph.
+    expect(result.total).toBeGreaterThan(0);
+    expect(['blank_fill', 'alternative_clause', 'instruction']).toContain(result.firstKind);
+    expect(result.firstMatchHasFragments).toBe(true);
+  });
+
   test('Grep returns matches with run-fragment breakdown', async ({ page }) => {
     // HC001 is a multilingual tour-plan template full of `[placeholder]` slots;
     // search for an opening bracket which is reliably present regardless of language.

--- a/wasm/DocxodusWasm/DocxSessionBridge.cs
+++ b/wasm/DocxodusWasm/DocxSessionBridge.cs
@@ -162,6 +162,19 @@ public static partial class DocxSessionBridge
     public static string ReplaceTextAtSpan(int h, string anchor, int spanStart, int spanLength, string replace) =>
         Serialize(Get(h).ReplaceTextAtSpan(anchor, spanStart, spanLength, replace));
 
+    /// <summary>
+    /// Bridge for <see cref="DocxSession.FindPlaceholders"/>. <paramref name="kinds"/>
+    /// uses the numeric layout of <see cref="PlaceholderKinds"/> (BlankFill=1,
+    /// AlternativeClause=2, Instruction=4, All=7); 0 returns nothing. <paramref name="scope"/>
+    /// uses the <see cref="ProjectionScopes"/> flag layout. Returns a JSON array of placeholders.
+    /// </summary>
+    [JSExport]
+    public static string FindPlaceholders(int h, int kinds, int scope)
+    {
+        var placeholders = Get(h).FindPlaceholders((PlaceholderKinds)kinds, (ProjectionScopes)scope);
+        return SerializePlaceholders(placeholders);
+    }
+
     [JSExport]
     public static bool Undo(int h) => Get(h).Undo();
 
@@ -277,6 +290,65 @@ public static partial class DocxSessionBridge
               .Append('}');
         }
         sb.Append(']');
+    }
+
+    private static string SerializePlaceholders(System.Collections.Generic.IReadOnlyList<TemplatePlaceholder> placeholders)
+    {
+        var sb = new StringBuilder(512);
+        sb.Append('[');
+        for (int i = 0; i < placeholders.Count; i++)
+        {
+            if (i > 0) sb.Append(',');
+            var p = placeholders[i];
+            sb.Append("{\"kind\":\"").Append(p.Kind switch
+            {
+                PlaceholderKind.BlankFill => "blank_fill",
+                PlaceholderKind.AlternativeClause => "alternative_clause",
+                PlaceholderKind.Instruction => "instruction",
+                _ => "unknown",
+            }).Append('"');
+            if (p.Hint is not null)
+                sb.Append(",\"hint\":").Append(JsonString(p.Hint));
+            sb.Append(",\"match\":");
+            AppendMatch(sb, p.Match);
+            sb.Append('}');
+        }
+        sb.Append(']');
+        return sb.ToString();
+    }
+
+    private static void AppendMatch(StringBuilder sb, TextMatch m)
+    {
+        sb.Append("{\"text\":").Append(JsonString(m.Text))
+          .Append(",\"enclosingAnchor\":{")
+          .Append("\"id\":").Append(JsonString(m.EnclosingAnchor.Anchor.Id))
+          .Append(",\"kind\":").Append(JsonString(m.EnclosingAnchor.Anchor.Kind))
+          .Append(",\"scope\":").Append(JsonString(m.EnclosingAnchor.Anchor.Scope))
+          .Append(",\"unid\":").Append(JsonString(m.EnclosingAnchor.Anchor.Unid))
+          .Append('}')
+          .Append(",\"span\":{\"start\":").Append(m.Span.Start).Append(",\"length\":").Append(m.Span.Length).Append('}')
+          .Append(",\"contextBefore\":").Append(JsonString(m.ContextBefore))
+          .Append(",\"contextAfter\":").Append(JsonString(m.ContextAfter))
+          .Append(",\"fragments\":[");
+        for (int f = 0; f < m.Fragments.Count; f++)
+        {
+            if (f > 0) sb.Append(',');
+            var fr = m.Fragments[f];
+            sb.Append("{\"unid\":").Append(JsonString(fr.Unid))
+              .Append(",\"text\":").Append(JsonString(fr.Text))
+              .Append(",\"spanInElement\":{\"start\":").Append(fr.SpanInElement.Start)
+              .Append(",\"length\":").Append(fr.SpanInElement.Length).Append('}')
+              .Append(",\"formatting\":{")
+              .Append("\"bold\":").Append(fr.Formatting.Bold ? "true" : "false")
+              .Append(",\"italic\":").Append(fr.Formatting.Italic ? "true" : "false")
+              .Append(",\"underline\":").Append(fr.Formatting.Underline ? "true" : "false")
+              .Append(",\"strike\":").Append(fr.Formatting.Strike ? "true" : "false")
+              .Append(",\"code\":").Append(fr.Formatting.Code ? "true" : "false")
+              .Append("}}");
+        }
+        sb.Append(']');
+        // Groups omitted from placeholder serialization (rarely useful for this surface).
+        sb.Append('}');
     }
 
     private static string SerializeEditResults(System.Collections.Generic.IReadOnlyList<EditResult> results)


### PR DESCRIPTION
Closes #142.

## Summary

Thin classifier over \`Grep\` (#143) for the workflow every template-filling agent eventually writes itself. Scans for \`\$?[…]\` regions and tags each as:

| \`PlaceholderKind\` | Pattern | What an agent does with it |
|---|---|---|
| \`BlankFill\` | \`[___]\`, \`$[___]\`, \`[________ __, 20__]\`, \`[__ times]\` (2+ underscores anywhere inside) | Fill with a literal value |
| \`AlternativeClause\` | \`[entire bracket text]\` | Keep, strip, or pick between alternatives |
| \`Instruction\` | \`[insert X]\`, \`[specify Y]\`, \`[*italicized hint*]\` | Drafter hint; \`Hint\` exposes the inner text with asterisks stripped |

\`PlaceholderKinds\` flag enum lets callers narrow (e.g. \`PlaceholderKinds.BlankFill | PlaceholderKinds.Instruction\`).

### The canonical recipe

Paired with \`ReplaceMatch\` from #147, the template-fill workflow becomes:

\`\`\`csharp
foreach (var p in session.FindPlaceholders(PlaceholderKinds.BlankFill)
                          .OrderByDescending(p => p.Match.Span.Start))
{
    var value = LookupValueByContext(p.Match.ContextBefore, p.Match.ContextAfter);
    session.ReplaceMatch(p.Match, value);
}
\`\`\`

Five lines. The Bluth-Co smoke-test fill that took 200+ lines of hand-curated context-needle disambiguation is now a loop.

### Smoke on the real NVCA Model COI

\`\`\`
FindPlaceholders ran in 422 ms; found 144 placeholders
  AlternativeClause: 105
  BlankFill: 34          (my prior hand-curated count was 31 — API caught 3 I missed)
  Instruction: 5
\`\`\`

## Test plan

- [x] \`DS120\` — BlankFill detection ([_______] and $[___])
- [x] \`DS121\` — AlternativeClause detection
- [x] \`DS122\` — Instruction detection with Hint extraction ([insert X], [*italic*])
- [x] \`DS123\` — default returns all kinds
- [x] \`DS124\` — flag combining narrows correctly
- [x] \`DS125\` — empty doc returns empty
- [x] \`DS126\` — end-to-end FindPlaceholders + ReplaceMatch (the canonical recipe)
- [x] All 1,358 .NET tests pass (1,352 pre-existing + 7 new for #142, minus the smoke run)
- [x] Release build clean (\`TreatWarningsAsErrors=true\`)
- [x] WASM build clean (\`WASM_BUILD=true\`)
- [x] TypeScript type-check clean
- [x] Playwright \`DocxSession\` suite (6 tests) passes