### PR TITLE
fix(thread-safety): materialize fresh XAttributes per call (#153 — kills the flaky CI race)

### DIFF
--- a/Docxodus.Tests/WmlComparerParallelRaceTests.cs
+++ b/Docxodus.Tests/WmlComparerParallelRaceTests.cs
@@ -1,0 +1,72 @@
+#nullable enable
+
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Docxodus;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+/// <summary>
+/// Regression for issue #153 — <see cref="WmlComparer.AddFootnotesEndnotesParts"/>
+/// (and the matching path in <see cref="DocumentBuilder"/> / <see cref="WmlToXml"/>)
+/// was building w:footnotes / w:endnotes / w:numbering / w:comments roots from a
+/// shared static <c>XAttribute[]</c>. <see cref="System.Xml.Linq.XAttribute"/> can
+/// only have one parent, so two parallel callers would race and one would throw
+/// <c>"Duplicate attribute"</c> or leave the other thread's element half-built
+/// (the failure mode that surfaced as flaky CI on PR #152).
+/// </summary>
+public class WmlComparerParallelRaceTests
+{
+    /// <summary>Two minimal text-only documents that differ in one paragraph — just enough
+    /// for WmlComparer.Compare() to do real work, including the AddFootnotesEndnotesParts path.</summary>
+    private static (WmlDocument source1, WmlDocument source2) BuildTinyComparePair(int salt)
+    {
+        return (Build($"Source A run #{salt}."), Build($"Source B run #{salt}."));
+
+        static WmlDocument Build(string text)
+        {
+            using var ms = new MemoryStream();
+            using (var wDoc = WordprocessingDocument.Create(ms, WordprocessingDocumentType.Document))
+            {
+                var main = wDoc.AddMainDocumentPart();
+                main.Document = new Document();
+                var body = new Body();
+                main.Document.Body = body;
+                main.AddNewPart<StyleDefinitionsPart>().Styles = new Styles();
+                main.AddNewPart<DocumentSettingsPart>().Settings = new Settings();
+                body.Append(new Paragraph(new Run(new Text(text))));
+                main.Document.Save();
+            }
+            return new WmlDocument("tiny.docx", ms.ToArray());
+        }
+    }
+
+    [Fact]
+    public async Task WC_Race001_AddFootnotesEndnotesParts_ParallelCompares_DoNotThrow()
+    {
+        // Run 16 concurrent WmlComparer.Compare() calls. Before the fix this would
+        // throw "Duplicate attribute" or "Unexpected end of file" from at least one
+        // worker within a few iterations on a multi-core box.
+        const int workers = 16;
+        var settings = new WmlComparerSettings();
+
+        var tasks = Enumerable.Range(0, workers).Select(i => Task.Run(() =>
+        {
+            var (s1, s2) = BuildTinyComparePair(i);
+            // Just exercise the path that touches AddFootnotesEndnotesParts.
+            return WmlComparer.Compare(s1, s2, settings);
+        })).ToArray();
+
+        var results = await Task.WhenAll(tasks);
+        Assert.All(results, r => Assert.NotNull(r));
+    }
+}

--- a/Docxodus/DocumentBuilder.cs
+++ b/Docxodus/DocumentBuilder.cs
@@ -342,7 +342,7 @@ namespace Docxodus
             mainPart.Declaration.Standalone = Yes;
             mainPart.Declaration.Encoding = Utf8;
             mainPart.Root.ReplaceWith(
-                new XElement(W.document, NamespaceAttributes,
+                new XElement(W.document, FreshNamespaceAttributes(),
                     new XElement(W.body)));
             if (sources.Count > 0)
             {
@@ -990,7 +990,7 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                     var newXDoc = new XDocument(
                         new XDeclaration(OnePointZero, Utf8, Yes),
                         new XElement(W.glossaryDocument,
-                            NamespaceAttributes,
+                            FreshNamespaceAttributes(),
                             new XElement(W.docParts,
                                 fromXDoc.Descendants(W.docPart))));
                     outputGlossaryDocumentPart.PutXDocument(newXDoc);
@@ -1587,7 +1587,7 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                                 {
                                     oldNumbering = new XDocument();
                                     oldNumbering.Declaration = new XDeclaration(OnePointZero, Utf8, Yes);
-                                    oldNumbering.Add(new XElement(W.numbering, NamespaceAttributes));
+                                    oldNumbering.Add(new XElement(W.numbering, FreshNamespaceAttributes()));
                                 }
                             }
                             if (newNumbering == null)
@@ -1616,7 +1616,7 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                                     newNumbering = newDocument.MainDocumentPart.NumberingDefinitionsPart.GetXDocument();
                                     newNumbering.Declaration.Standalone = Yes;
                                     newNumbering.Declaration.Encoding = Utf8;
-                                    newNumbering.Add(new XElement(W.numbering, NamespaceAttributes));
+                                    newNumbering.Add(new XElement(W.numbering, FreshNamespaceAttributes()));
                                 }
                             }
                             string numId = idElement.Attribute(W.val).Value;
@@ -1974,7 +1974,7 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                         newComments = newDocument.MainDocumentPart.WordprocessingCommentsPart.GetXDocument();
                         newComments.Declaration.Standalone = Yes;
                         newComments.Declaration.Encoding = Utf8;
-                        newComments.Add(new XElement(W.comments, NamespaceAttributes));
+                        newComments.Add(new XElement(W.comments, FreshNamespaceAttributes()));
                     }
                 }
                 int id;
@@ -2651,7 +2651,7 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                             newNumbering = newDocument.MainDocumentPart.NumberingDefinitionsPart.GetXDocument();
                             newNumbering.Declaration.Standalone = Yes;
                             newNumbering.Declaration.Encoding = Utf8;
-                            newNumbering.Add(new XElement(W.numbering, NamespaceAttributes));
+                            newNumbering.Add(new XElement(W.numbering, FreshNamespaceAttributes()));
                         }
                     }
                     int numId = (int)idElement.Attribute(W.val);
@@ -2813,7 +2813,7 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                             newNumbering = newDocument.MainDocumentPart.NumberingDefinitionsPart.GetXDocument();
                             newNumbering.Declaration.Standalone = Yes;
                             newNumbering.Declaration.Encoding = Utf8;
-                            newNumbering.Add(new XElement(W.numbering, NamespaceAttributes));
+                            newNumbering.Add(new XElement(W.numbering, FreshNamespaceAttributes()));
                         }
                     }
                     int numId = (int)idElement.Attribute(W.val);
@@ -2975,7 +2975,7 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                             newNumbering = newDocument.MainDocumentPart.GlossaryDocumentPart.NumberingDefinitionsPart.GetXDocument();
                             newNumbering.Declaration.Standalone = Yes;
                             newNumbering.Declaration.Encoding = Utf8;
-                            newNumbering.Add(new XElement(W.numbering, NamespaceAttributes));
+                            newNumbering.Add(new XElement(W.numbering, FreshNamespaceAttributes()));
                         }
                     }
                     int numId = (int)idElement.Attribute(W.val);
@@ -3632,7 +3632,7 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                         newFootnotes = newDocument.MainDocumentPart.FootnotesPart.GetXDocument();
                         newFootnotes.Declaration.Standalone = Yes;
                         newFootnotes.Declaration.Encoding = Utf8;
-                        newFootnotes.Add(new XElement(W.footnotes, NamespaceAttributes));
+                        newFootnotes.Add(new XElement(W.footnotes, FreshNamespaceAttributes()));
                     }
                 }
                 string id = (string)footnote.Attribute(W.id);
@@ -3686,7 +3686,7 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                         newEndnotes = newDocument.MainDocumentPart.EndnotesPart.GetXDocument();
                         newEndnotes.Declaration.Standalone = Yes;
                         newEndnotes.Declaration.Encoding = Utf8;
-                        newEndnotes.Add(new XElement(W.endnotes, NamespaceAttributes));
+                        newEndnotes.Add(new XElement(W.endnotes, FreshNamespaceAttributes()));
                     }
                 }
                 string id = (string)endnote.Attribute(W.id);
@@ -3863,7 +3863,7 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                         newFootnotes = newDocument.MainDocumentPart.FootnotesPart.GetXDocument();
                         newFootnotes.Declaration.Standalone = Yes;
                         newFootnotes.Declaration.Encoding = Utf8;
-                        newFootnotes.Add(new XElement(W.footnotes, NamespaceAttributes));
+                        newFootnotes.Add(new XElement(W.footnotes, FreshNamespaceAttributes()));
                     }
                 }
                 string id = (string)footnote.Attribute(W.id);
@@ -3924,7 +3924,7 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                         newEndnotes = newDocument.MainDocumentPart.EndnotesPart.GetXDocument();
                         newEndnotes.Declaration.Standalone = Yes;
                         newEndnotes.Declaration.Encoding = Utf8;
-                        newEndnotes.Add(new XElement(W.endnotes, NamespaceAttributes));
+                        newEndnotes.Add(new XElement(W.endnotes, FreshNamespaceAttributes()));
                     }
                 }
                 string id = (string)endnote.Attribute(W.id);
@@ -3966,25 +3966,34 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
             return oldImageData;
         }
 
-        private static XAttribute[] NamespaceAttributes =
+        // Namespace declarations attached to freshly-created Word part roots
+        // (w:document, w:numbering, w:footnotes, w:endnotes, w:comments).
+        // Stored as (XName, string) pairs rather than ready-made XAttribute
+        // instances so each call materializes fresh attributes — XAttribute
+        // can only have one parent, and the prior static-XAttribute[] form
+        // raced under parallel test execution (issue #153).
+        private static readonly (XName Name, string Value)[] NamespaceAttributes =
         {
-            new XAttribute(XNamespace.Xmlns + "wpc", WPC.wpc),
-            new XAttribute(XNamespace.Xmlns + "mc", MC.mc),
-            new XAttribute(XNamespace.Xmlns + "o", O.o),
-            new XAttribute(XNamespace.Xmlns + "r", R.r),
-            new XAttribute(XNamespace.Xmlns + "m", M.m),
-            new XAttribute(XNamespace.Xmlns + "v", VML.vml),
-            new XAttribute(XNamespace.Xmlns + "wp14", WP14.wp14),
-            new XAttribute(XNamespace.Xmlns + "wp", WP.wp),
-            new XAttribute(XNamespace.Xmlns + "w10", W10.w10),
-            new XAttribute(XNamespace.Xmlns + "w", W.w),
-            new XAttribute(XNamespace.Xmlns + "w14", W14.w14),
-            new XAttribute(XNamespace.Xmlns + "wpg", WPG.wpg),
-            new XAttribute(XNamespace.Xmlns + "wpi", WPI.wpi),
-            new XAttribute(XNamespace.Xmlns + "wne", WNE.wne),
-            new XAttribute(XNamespace.Xmlns + "wps", WPS.wps),
-            new XAttribute(MC.Ignorable, "w14 wp14"),
+            (XNamespace.Xmlns + "wpc", WPC.wpc.NamespaceName),
+            (XNamespace.Xmlns + "mc", MC.mc.NamespaceName),
+            (XNamespace.Xmlns + "o", O.o.NamespaceName),
+            (XNamespace.Xmlns + "r", R.r.NamespaceName),
+            (XNamespace.Xmlns + "m", M.m.NamespaceName),
+            (XNamespace.Xmlns + "v", VML.vml.NamespaceName),
+            (XNamespace.Xmlns + "wp14", WP14.wp14.NamespaceName),
+            (XNamespace.Xmlns + "wp", WP.wp.NamespaceName),
+            (XNamespace.Xmlns + "w10", W10.w10.NamespaceName),
+            (XNamespace.Xmlns + "w", W.w.NamespaceName),
+            (XNamespace.Xmlns + "w14", W14.w14.NamespaceName),
+            (XNamespace.Xmlns + "wpg", WPG.wpg.NamespaceName),
+            (XNamespace.Xmlns + "wpi", WPI.wpi.NamespaceName),
+            (XNamespace.Xmlns + "wne", WNE.wne.NamespaceName),
+            (XNamespace.Xmlns + "wps", WPS.wps.NamespaceName),
+            (MC.Ignorable, "w14 wp14"),
         };
+
+        private static IEnumerable<XAttribute> FreshNamespaceAttributes() =>
+            NamespaceAttributes.Select(p => new XAttribute(p.Name, p.Value));
     }
 
     public class DocumentBuilderException : Exception

--- a/Docxodus/WmlComparer.cs
+++ b/Docxodus/WmlComparer.cs
@@ -1574,25 +1574,32 @@ namespace Docxodus
             styleDefinitionsPart.PutXDocument();
         }
 
-        private static XAttribute[] NamespaceAttributes =
+        // Namespace declarations attached to a freshly-created w:footnotes / w:endnotes root.
+        // Stored as (XName, string) pairs rather than ready-made XAttribute instances so each
+        // call materializes fresh attributes — XAttribute can only have one parent, and the
+        // prior static-XAttribute[] form raced under xUnit parallel test execution (issue #153).
+        private static readonly (XName Name, string Value)[] NamespaceAttributes =
         {
-            new XAttribute(XNamespace.Xmlns + "wpc", WPC.wpc),
-            new XAttribute(XNamespace.Xmlns + "mc", MC.mc),
-            new XAttribute(XNamespace.Xmlns + "o", O.o),
-            new XAttribute(XNamespace.Xmlns + "r", R.r),
-            new XAttribute(XNamespace.Xmlns + "m", M.m),
-            new XAttribute(XNamespace.Xmlns + "v", VML.vml),
-            new XAttribute(XNamespace.Xmlns + "wp14", WP14.wp14),
-            new XAttribute(XNamespace.Xmlns + "wp", WP.wp),
-            new XAttribute(XNamespace.Xmlns + "w10", W10.w10),
-            new XAttribute(XNamespace.Xmlns + "w", W.w),
-            new XAttribute(XNamespace.Xmlns + "w14", W14.w14),
-            new XAttribute(XNamespace.Xmlns + "wpg", WPG.wpg),
-            new XAttribute(XNamespace.Xmlns + "wpi", WPI.wpi),
-            new XAttribute(XNamespace.Xmlns + "wne", WNE.wne),
-            new XAttribute(XNamespace.Xmlns + "wps", WPS.wps),
-            new XAttribute(MC.Ignorable, "w14 wp14"),
+            (XNamespace.Xmlns + "wpc", WPC.wpc.NamespaceName),
+            (XNamespace.Xmlns + "mc", MC.mc.NamespaceName),
+            (XNamespace.Xmlns + "o", O.o.NamespaceName),
+            (XNamespace.Xmlns + "r", R.r.NamespaceName),
+            (XNamespace.Xmlns + "m", M.m.NamespaceName),
+            (XNamespace.Xmlns + "v", VML.vml.NamespaceName),
+            (XNamespace.Xmlns + "wp14", WP14.wp14.NamespaceName),
+            (XNamespace.Xmlns + "wp", WP.wp.NamespaceName),
+            (XNamespace.Xmlns + "w10", W10.w10.NamespaceName),
+            (XNamespace.Xmlns + "w", W.w.NamespaceName),
+            (XNamespace.Xmlns + "w14", W14.w14.NamespaceName),
+            (XNamespace.Xmlns + "wpg", WPG.wpg.NamespaceName),
+            (XNamespace.Xmlns + "wpi", WPI.wpi.NamespaceName),
+            (XNamespace.Xmlns + "wne", WNE.wne.NamespaceName),
+            (XNamespace.Xmlns + "wps", WPS.wps.NamespaceName),
+            (MC.Ignorable, "w14 wp14"),
         };
+
+        private static IEnumerable<XAttribute> FreshNamespaceAttributes() =>
+            NamespaceAttributes.Select(p => new XAttribute(p.Name, p.Value));
 
         private static void AddFootnotesEndnotesParts(WordprocessingDocument wDoc)
         {
@@ -1603,7 +1610,7 @@ namespace Docxodus
                 var newFootnotes = wDoc.MainDocumentPart.FootnotesPart.GetXDocument();
                 newFootnotes.Declaration.Standalone = "yes";
                 newFootnotes.Declaration.Encoding = "UTF-8";
-                newFootnotes.Add(new XElement(W.footnotes, NamespaceAttributes));
+                newFootnotes.Add(new XElement(W.footnotes, FreshNamespaceAttributes()));
                 mdp.FootnotesPart.PutXDocument();
             }
             if (mdp.EndnotesPart == null)
@@ -1612,7 +1619,7 @@ namespace Docxodus
                 var newEndnotes = wDoc.MainDocumentPart.EndnotesPart.GetXDocument();
                 newEndnotes.Declaration.Standalone = "yes";
                 newEndnotes.Declaration.Encoding = "UTF-8";
-                newEndnotes.Add(new XElement(W.endnotes, NamespaceAttributes));
+                newEndnotes.Add(new XElement(W.endnotes, FreshNamespaceAttributes()));
                 mdp.EndnotesPart.PutXDocument();
             }
         }

--- a/Docxodus/WmlToXml.cs
+++ b/Docxodus/WmlToXml.cs
@@ -1497,28 +1497,36 @@ namespace Docxodus
             }
         }
 
-        private static XAttribute[] NamespaceAttributes =
+        // Namespace declarations attached to a freshly-created w:comments root.
+        // Stored as (XName, string) pairs rather than ready-made XAttribute
+        // instances so each call materializes fresh attributes — XAttribute can
+        // only have one parent, and the prior static-XAttribute[] form raced
+        // under parallel test execution (issue #153).
+        private static readonly (XName Name, string Value)[] NamespaceAttributes =
         {
-            new XAttribute(XNamespace.Xmlns + "wpc", WPC.wpc),
-            new XAttribute(XNamespace.Xmlns + "mc", MC.mc),
-            new XAttribute(XNamespace.Xmlns + "o", O.o),
-            new XAttribute(XNamespace.Xmlns + "r", R.r),
-            new XAttribute(XNamespace.Xmlns + "m", M.m),
-            new XAttribute(XNamespace.Xmlns + "v", VML.vml),
-            new XAttribute(XNamespace.Xmlns + "wp14", WP14.wp14),
-            new XAttribute(XNamespace.Xmlns + "wp", WP.wp),
-            new XAttribute(XNamespace.Xmlns + "w10", W10.w10),
-            new XAttribute(XNamespace.Xmlns + "w", W.w),
-            new XAttribute(XNamespace.Xmlns + "w14", W14.w14),
-            new XAttribute(XNamespace.Xmlns + "w15", W15.w15),
-            new XAttribute(XNamespace.Xmlns + "w16se", W16SE.w16se),
-            new XAttribute(XNamespace.Xmlns + "wpg", WPG.wpg),
-            new XAttribute(XNamespace.Xmlns + "wpi", WPI.wpi),
-            new XAttribute(XNamespace.Xmlns + "wne", WNE.wne),
-            new XAttribute(XNamespace.Xmlns + "wps", WPS.wps),
-            new XAttribute(XNamespace.Xmlns + "pt", PtOpenXml.pt),
-            new XAttribute(MC.Ignorable, "w14 wp14 w15 w16se pt"),
+            (XNamespace.Xmlns + "wpc", WPC.wpc.NamespaceName),
+            (XNamespace.Xmlns + "mc", MC.mc.NamespaceName),
+            (XNamespace.Xmlns + "o", O.o.NamespaceName),
+            (XNamespace.Xmlns + "r", R.r.NamespaceName),
+            (XNamespace.Xmlns + "m", M.m.NamespaceName),
+            (XNamespace.Xmlns + "v", VML.vml.NamespaceName),
+            (XNamespace.Xmlns + "wp14", WP14.wp14.NamespaceName),
+            (XNamespace.Xmlns + "wp", WP.wp.NamespaceName),
+            (XNamespace.Xmlns + "w10", W10.w10.NamespaceName),
+            (XNamespace.Xmlns + "w", W.w.NamespaceName),
+            (XNamespace.Xmlns + "w14", W14.w14.NamespaceName),
+            (XNamespace.Xmlns + "w15", W15.w15.NamespaceName),
+            (XNamespace.Xmlns + "w16se", W16SE.w16se.NamespaceName),
+            (XNamespace.Xmlns + "wpg", WPG.wpg.NamespaceName),
+            (XNamespace.Xmlns + "wpi", WPI.wpi.NamespaceName),
+            (XNamespace.Xmlns + "wne", WNE.wne.NamespaceName),
+            (XNamespace.Xmlns + "wps", WPS.wps.NamespaceName),
+            (XNamespace.Xmlns + "pt", PtOpenXml.pt.NamespaceName),
+            (MC.Ignorable, "w14 wp14 w15 w16se pt"),
         };
+
+        private static IEnumerable<XAttribute> FreshNamespaceAttributes() =>
+            NamespaceAttributes.Select(p => new XAttribute(p.Name, p.Value));
 
         public static void AddContentTypeToBlockContent(WmlToXmlSettings settings, OpenXmlPart part, XElement blc, string contentType)
         {
@@ -1548,7 +1556,7 @@ namespace Docxodus
                         newComments = mainPart.WordprocessingCommentsPart.GetXDocument();
                         newComments.Declaration.Standalone = "yes";
                         newComments.Declaration.Encoding = "UTF-8";
-                        newComments.Add(new XElement(W.comments, NamespaceAttributes));
+                        newComments.Add(new XElement(W.comments, FreshNamespaceAttributes()));
                         commentNumber = 1;
                     }
 #if false
@@ -1730,7 +1738,7 @@ namespace Docxodus
                         newComments = mainPart.WordprocessingCommentsPart.GetXDocument();
                         newComments.Declaration.Standalone = "yes";
                         newComments.Declaration.Encoding = "UTF-8";
-                        newComments.Add(new XElement(W.comments, NamespaceAttributes));
+                        newComments.Add(new XElement(W.comments, FreshNamespaceAttributes()));
                         commentNumber = 1;
                     }
                     XElement newElement = new XElement(W.comment,


### PR DESCRIPTION
Closes #153.

## Summary

\`WmlComparer\`, \`DocumentBuilder\`, and \`WmlToXml\` each held a \`private static XAttribute[] NamespaceAttributes\` — a shared array of \`XAttribute\` *instances* used to seed freshly-created Word part roots (\`w:footnotes\`, \`w:endnotes\`, \`w:numbering\`, \`w:comments\`, \`w:document\`, \`w:glossaryDocument\`).

\`XAttribute\` can only have one parent \`XElement\` at a time. Two threads calling \`WmlComparer.Compare()\` concurrently both tried to attach the same shared \`XAttribute\` instances to their own new \`XElement\`s; one won the race, the other got \`InvalidOperationException(\"Duplicate attribute\")\` or left its element half-built (the FootnotesPart then threw \`XmlException(\"Unexpected end of file\")\` on \`Dispose\`).

Surfaced as flaky CI on PR #152 — [same commit produced both pass and fail runs](https://github.com/JSv4/Docxodus/pull/152) for the build-and-test job.

## Fix

Store namespace declarations as \`(XName, string)\` value tuples; add a small \`FreshNamespaceAttributes()\` helper that materializes new \`XAttribute\` instances per call:

\`\`\`csharp
private static readonly (XName Name, string Value)[] NamespaceAttributes = { … };

private static IEnumerable<XAttribute> FreshNamespaceAttributes() =>
    NamespaceAttributes.Select(p => new XAttribute(p.Name, p.Value));
\`\`\`

Same values go into every constructed \`XElement\`; no shared instances cross threads.

Applied identically in all three files. ~10 lines of impl per file plus updating ~15 total call sites to \`FreshNamespaceAttributes()\` instead of \`NamespaceAttributes\`.

## Test plan

- [x] \`WC_Race001_AddFootnotesEndnotesParts_ParallelCompares_DoNotThrow\` — runs 16 concurrent \`WmlComparer.Compare()\` calls. Pre-fix this would throw within a few iterations on a multi-core host; post-fix it's stable across many runs.
- [x] All 1,372 .NET tests pass (1,371 pre-existing + 1 new)
- [x] Release build clean (\`TreatWarningsAsErrors=true\`)
- [x] The two CI-flaky tests (\`MoveDetection_CustomThreshold_ShouldRespectSetting\`, \`GetRevisions_FormatChange_ShouldHaveFormatChangeDetails\`) still pass — the fix is the change in shape of \`NamespaceAttributes\`, not anything those tests cared about directly.