### PR TITLE
fix(DocxSession): default FillOptions.Kinds to All

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **`FillOptions.Kinds` default → `PlaceholderKinds.All`.** The prior default (`BlankFill | Instruction`) silently excluded `AlternativeClause` placeholders, so a picker with `[two]` → `"two"` style bracket-stripping rules would appear to do nothing on those matches — confusing for any caller that wrote a single picker covering every kind it might see. The new default invokes the picker for every kind in the doc; pickers should return `null` for placeholders they don't recognize (the long-standing skip contract). Callers that relied on the prior filter behavior can set `Kinds = PlaceholderKinds.BlankFill | PlaceholderKinds.Instruction` explicitly.
+
 ### Fixed
 - **`tools/python-host/pyhost.csproj` — suppress StyleCop SA1633/SA1636 file-header rules** (issue #173). `dotnet build -c Release tools/python-host/pyhost.csproj` was failing because `Directory.Build.props` sets `TreatWarningsAsErrors=true` for Release and the python-host project inherited the StyleCop ruleset without suppressing the file-header warnings on `Dispatcher.cs` and `Program.cs`. Added `<NoWarn>$(NoWarn);SA1633;SA1636</NoWarn>` to the csproj, matching the existing convention in `wasm/DocxodusWasm/DocxodusWasm.csproj` for tooling/wasm subprojects.
 

--- a/Docxodus.Tests/DocxSessionTests.cs
+++ b/Docxodus.Tests/DocxSessionTests.cs
@@ -539,6 +539,24 @@ public class DocxSessionTests
     }
 
     [Fact]
+    public void DS244a_FillPlaceholders_DefaultKindsVisitsAlternativeClauses()
+    {
+        // After the FillOptions.Kinds default change, the picker should be invoked
+        // for AlternativeClause placeholders too — without the caller needing to
+        // opt in via Kinds = All. Picker that unwraps every bracketed match should
+        // strip every alternative in one pass over BuildDocWithBracketPlaceholders.
+        using var session = new DocxSession(BuildDocWithBracketPlaceholders());
+        var result = session.FillPlaceholders(p => p.Kind == PlaceholderKind.AlternativeClause
+            ? p.Match.Text.Trim('[', ']')
+            : null);
+        Assert.True(result.Filled >= 1, "Expected at least one AlternativeClause unwrapped");
+
+        // No AlternativeClause matches should remain after convergence.
+        var leftover = session.FindPlaceholders(PlaceholderKinds.AlternativeClause);
+        Assert.Empty(leftover);
+    }
+
+    [Fact]
     public void DS244_FillPlaceholders_AlternativeClauseMultiPassStripsNestedBrackets()
     {
         // The "[outer [inner] clause]" placeholder is nested; FindPlaceholders returns

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -219,10 +219,17 @@ public sealed record ReplaceOptions
 /// </summary>
 public sealed record FillOptions
 {
-    /// <summary>Which placeholder kinds to fill. Defaults to <c>BlankFill | Instruction</c>
-    /// — the kinds with a single replacement value. Add <c>AlternativeClause</c> to
-    /// run the picker on bracketed clauses too (e.g. for bracket-stripping).</summary>
-    public PlaceholderKinds Kinds { get; init; } = PlaceholderKinds.BlankFill | PlaceholderKinds.Instruction;
+    /// <summary>Which placeholder kinds to fill. Defaults to
+    /// <see cref="PlaceholderKinds.All"/> so the picker is invoked for every kind
+    /// the doc contains — <c>BlankFill</c>, <c>Instruction</c>, *and*
+    /// <c>AlternativeClause</c>. Narrow with e.g. <c>BlankFill | Instruction</c>
+    /// if you only want value-slot fills and intend to ignore bracketed clauses.</summary>
+    /// <remarks>The previous default (<c>BlankFill | Instruction</c>) silently
+    /// excluded <c>AlternativeClause</c> placeholders, which caused pickers with
+    /// bracket-stripping rules to appear to do nothing on those matches. The new
+    /// default lets the picker see everything; pickers that don't recognize a
+    /// kind should simply return <c>null</c> for it.</remarks>
+    public PlaceholderKinds Kinds { get; init; } = PlaceholderKinds.All;
 
     /// <summary>Which package parts to scan. Defaults to body.</summary>
     public ProjectionScopes Scope { get; init; } = ProjectionScopes.Body;

--- a/docs/architecture/docx_mutation_api.md
+++ b/docs/architecture/docx_mutation_api.md
@@ -306,6 +306,8 @@ What `FillPlaceholders` does internally that the recipe doesn't:
 - **`$`-prefix preservation.** The placeholder regex `\$?\[…\]` captures `$[___]` including the leading `$`. With `FillOptions.PreserveDollarPrefix = true` (default), the picker's return value gets `$` prepended when needed so `"0.20"` lands as `$0.20`, not `0.20`.
 - **Multi-pass iteration.** `FindPlaceholders` returns innermost brackets only; stripping the inner can surface a previously-nested outer. The loop re-finds placeholders each pass and stops when a pass makes zero changes (or `MaxPasses` — default 8 — is hit).
 
+The picker is invoked for every kind in `FillOptions.Kinds`, which defaults to `PlaceholderKinds.All` — so a picker that wants to ignore alternative-clause brackets should return `null` for them rather than relying on the option to filter them out. Set `Kinds = BlankFill | Instruction` if you want the prior behavior of leaving alternative clauses untouched.
+
 The picker is invoked once per placeholder per pass; return `null` to skip. `BulkEditResult.Unfilled` lists every placeholder the picker said `null` to (deduplicated across passes). `BulkEditResult.Passes` is the highest iteration pass that actually filled at least one placeholder (so a single-fill convergence reports `Passes = 1`, not 2).
 
 ### `ReplaceInner` — strip brackets while preserving prefix/suffix

--- a/npm/src/session.ts
+++ b/npm/src/session.ts
@@ -262,7 +262,10 @@ export class DocxSession {
     options?: FillOptions,
   ): BulkEditResult {
     const opts = options ?? {};
-    const kinds = opts.kinds ?? (PlaceholderKinds.BlankFill | PlaceholderKinds.Instruction);
+    // Default Kinds = All so the picker is invoked for every kind the doc contains.
+    // Callers that want to ignore AlternativeClause matches should narrow this to
+    // `PlaceholderKinds.BlankFill | PlaceholderKinds.Instruction`.
+    const kinds = opts.kinds ?? PlaceholderKinds.All;
     const scope = opts.scope ?? 1; // Body
     const maxPasses = opts.maxPasses ?? 8;
     const preserveDollarPrefix = opts.preserveDollarPrefix ?? true;

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -953,7 +953,10 @@ export interface TemplatePlaceholder {
  * Options for {@link DocxSession.fillPlaceholders}.
  */
 export interface FillOptions {
-  /** Which placeholder kinds to fill. Defaults to `BlankFill | Instruction`. */
+  /** Which placeholder kinds to fill. Defaults to `PlaceholderKinds.All` so the
+   *  picker is invoked for every kind in the doc. Narrow with e.g.
+   *  `PlaceholderKinds.BlankFill | PlaceholderKinds.Instruction` to ignore
+   *  bracketed alternative clauses. */
   kinds?: number;
   /** Which package parts to scan. Defaults to body (1). */
   scope?: number;

--- a/npm/tests/fill-placeholders.spec.ts
+++ b/npm/tests/fill-placeholders.spec.ts
@@ -95,7 +95,9 @@ test.describe('fill-placeholders (WASM bridge — Issue #163)', () => {
       const bridge = (window as any).Docxodus.DocxSessionBridge;
       const handle = bridge.OpenSession(bin, '');
       try {
-        // Default kinds in the TS wrapper = BlankFill | Instruction = 5.
+        // Test narrows to BlankFill | Instruction = 5 explicitly (the TS wrapper's
+        // default is now PlaceholderKinds.All = 7; we keep 5 here so this test
+        // measures the same surface area it always did).
         const placeholders = JSON.parse(bridge.FindPlaceholders(handle, 5, 1, 80, 0)) as any[];
         const unfilled: any[] = [];
         let filled = 0;


### PR DESCRIPTION
## Summary
- Default `FillOptions.Kinds` changes from `BlankFill | Instruction` to `PlaceholderKinds.All`, so the picker sees every kind in the document by default.
- Mirrored in the TypeScript wrapper (`npm/src/session.ts`) so JS-side and .NET-side defaults match.
- Picker contract is unchanged — return `null` for kinds you don't recognize.

## Why
The previous default silently filtered out `AlternativeClause` placeholders before the picker ran. A picker with bracket-stripping logic for `[two] → "two"` would appear to do nothing on those matches even though the picker itself was correct — the matches never reached it. Surfaced in real usage where a single picker covered every kind it might see in a template; the asymmetry between `FindPlaceholders` (default `All`) and `FillPlaceholders` (default `BlankFill | Instruction`) was a foot-gun.

Callers that relied on the prior filter behavior can opt back in via `Kinds = PlaceholderKinds.BlankFill | PlaceholderKinds.Instruction`.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~DS24"` — 8/8 pass (including new `DS244a`)
- [x] `dotnet test Docxodus.Tests/Docxodus.Tests.csproj` — 1445 pass, 1 expected skip
- [x] New regression `DS244a_FillPlaceholders_DefaultKindsVisitsAlternativeClauses` verifies the default actually visits `AlternativeClause` matches
- [ ] Playwright spec (`fill-placeholders.spec.ts`) — comment updated to reflect new TS default; one explicit-bitmask test continues to pin its specific kinds value