### PR TITLE
chore(python): dynamic __version__ + bump to 0.1.0a2.dev0 + README install section

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -4,7 +4,21 @@
 
 `docx-scalpel` exposes Docxodus' stateful DOCX editor over a long-running .NET subprocess (`docxodus-pyhost`). The session lives in the host's memory until you explicitly release it, so an LLM agent can issue dozens of small edits against one document without paying the OOXML parse + Unid annotation + projection cost on every call.
 
-> **Status:** `0.1.0a0` — scaffold complete, smoke + lifecycle tests passing against a dev binary. Wheel packaging (`cibuildwheel` per-RID, bundled self-contained host) is a follow-up branch.
+> **Status:** Alpha. linux-x64 wheels ship with a bundled `docxodus-pyhost`; other RIDs require a dev clone of Docxodus until the wheel matrix is extended (tracked in `RELEASING.md`).
+
+## Installation
+
+```bash
+pip install docx-scalpel
+```
+
+linux-x64 today; pre-release tags ship as `0.1.0a*`, so use `--pre` if you want to opt in:
+
+```bash
+pip install --pre docx-scalpel
+```
+
+Source installs (`pip install` of the sdist, or `pip install -e .` from a dev clone) don't include a bundled host. Set `DOCXODUS_HOST=/path/to/docxodus-pyhost` to point at one you built, or run `dotnet build tools/python-host/pyhost.csproj` inside a Docxodus monorepo clone — the locator auto-discovers it.
 
 ## Quick start
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "docx-scalpel"
-version = "0.1.0a0"
+version = "0.1.0a2.dev0"
 description = "Anchor-addressed DOCX editing for LLM agents — a thin client over Docxodus' DocxSession."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/src/docx_scalpel/__init__.py
+++ b/python/src/docx_scalpel/__init__.py
@@ -28,6 +28,8 @@ parse + Unid annotation + projection cost every time.
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
 from ._transport import shutdown_host
 from .enums import (
     AnchorIdRendering,
@@ -72,7 +74,14 @@ from .types import (
     WmlToMarkdownConverterSettings,
 )
 
-__version__ = "0.1.0a0"
+try:
+    # Read from the installed wheel's METADATA so __version__ always matches
+    # what was actually published, not a constant that drifts from pyproject.
+    __version__ = _pkg_version("docx-scalpel")
+except PackageNotFoundError:
+    # Unpackaged source checkout (e.g. running tests against `git clone` with
+    # no editable install yet). Leave a sentinel so callers can detect this.
+    __version__ = "0.0.0+source"
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
Addresses **item 3** of #192 (`__version__ == "0.1.0a0"` while the PyPI release is `"0.1.0a1"`).

## Summary

Post-release cleanup after `docx-scalpel-v0.1.0a1` went out on PyPI. Three small, related fixes.

## What's in

1. **Dynamic `__version__`** — `python/src/docx_scalpel/__init__.py` now reads from `importlib.metadata.version("docx-scalpel")` instead of a hardcoded constant.
   - **Why**: the 0.1.0a1 release shipped with `from docx_scalpel import __version__` reporting `"0.1.0a0"`. CI overwrites `pyproject.toml` at build time but never touched `__init__.py`, so the constant drifted from the published metadata. `importlib.metadata` reads the wheel's METADATA file directly — no more drift.
   - Fallback to `"0.0.0+source"` for unpackaged source checkouts (rare, but possible during the moment between cloning and the first editable install).

2. **Bump pyproject to `0.1.0a2.dev0`** — PEP 440 dev-release marker on the path to a2.
   - **Why**: standard post-release practice. After we ship `0.1.0a1`, the in-tree version moves forward so future editable installs don't claim to be the just-published release. `.dev0` keeps it pre-release so it can't accidentally outsort the next real release.

3. **Add Installation section to README** — pip install pointer now that the package is publishable.
   - Notes that pre-release tags need `--pre`.
   - Documents that sdist / source installs still need `DOCXODUS_HOST` or a dev clone until the per-RID wheel matrix lands.

## Verification

```bash
cd python && .venv/bin/pip install -e . --quiet
.venv/bin/python -c "from docx_scalpel import __version__; print(__version__)"
# → 0.1.0a2.dev0  (matches pyproject)
.venv/bin/pytest -q
# → 10 passed in 1.45s
```

## Why this isn't a release

This branch only touches the in-tree files. No new tag. The next release (`docx-scalpel-v0.1.0a2` or `v0.2.0a0`) will pick up these changes automatically and ship them as part of that release.

## Test plan

- [x] `pip install -e .` returns 0.1.0a2.dev0 via importlib.metadata
- [x] All 10 lifecycle + smoke tests still pass
- [x] README renders cleanly on GitHub (uses standard markdown)
- [ ] Reviewer: confirm the `0.0.0+source` fallback is the right sentinel for unpackaged dev — could also raise, but I'd rather not crash importing the package just because someone hasn't run `pip install -e .` yet