### PR TITLE
ci(python): extend python-publish matrix to all 5 RIDs

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,8 +9,11 @@ name: python-publish
 # bump for unrelated work. Compatibility is handled by bundling: each wheel
 # embeds a docxodus-pyhost built from the same commit the tag points to.
 #
-# v1 scope: linux-x64 wheel + sdist. Other RIDs (linux-arm64, osx-x64,
-# osx-arm64, win-x64) are mechanical add-ons; see python/RELEASING.md.
+# Matrix builds wheels for linux-x64, linux-arm64, osx-x64, osx-arm64, win-x64
+# (each carrying a self-contained docxodus-pyhost for its RID) plus a single
+# sdist. The publish job collects every dist-* artifact and uploads them as
+# one PyPI release. fail-fast: false in the matrix surfaces all RID failures
+# at once, but publish still gates on every matrix entry succeeding.
 
 on:
   push:
@@ -37,9 +40,6 @@ permissions:
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
-  # Match the lowest manylinux baseline we're willing to support. .NET 8
-  # self-contained linux-x64 builds depend on glibc 2.27+, so 2_28 is safe.
-  WHEEL_PLATFORM_TAG_LINUX_X64: manylinux_2_28_x86_64
 
 jobs:
   resolve:
@@ -68,10 +68,47 @@ jobs:
           echo "target=$tgt"  >> "$GITHUB_OUTPUT"
           echo "Resolved: version=$ver target=$tgt"
 
-  build-wheel-linux-x64:
-    name: Build wheel (linux-x64)
+  build-wheel:
+    name: Build wheel (${{ matrix.rid }})
     needs: resolve
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      # One RID's failure shouldn't hide the others' — surface all problems at
+      # once so we can fix them in a single follow-up. publish still gates on
+      # ALL matrix entries succeeding (GH Actions matrix-job semantics), so a
+      # broken RID still blocks the release.
+      fail-fast: false
+      matrix:
+        include:
+          - rid: linux-x64
+            runner: ubuntu-latest
+            wheel-platform: manylinux_2_28_x86_64
+            binary: docxodus-pyhost
+          - rid: linux-arm64
+            # GitHub-hosted free ARM runner (GA for public repos since 2025).
+            runner: ubuntu-22.04-arm
+            wheel-platform: manylinux_2_28_aarch64
+            binary: docxodus-pyhost
+          - rid: osx-x64
+            # Intel Mac runner — being deprecated in 2026 but still works.
+            runner: macos-13
+            wheel-platform: macosx_11_0_x86_64
+            binary: docxodus-pyhost
+          - rid: osx-arm64
+            # Apple Silicon runner.
+            runner: macos-14
+            wheel-platform: macosx_11_0_arm64
+            binary: docxodus-pyhost
+          - rid: win-x64
+            runner: windows-latest
+            wheel-platform: win_amd64
+            binary: docxodus-pyhost.exe
+    defaults:
+      run:
+        # Use bash uniformly — windows-latest ships Git Bash, which handles the
+        # mkdir / cp / chmod / heredoc / glob syntax exactly the way the unix
+        # runners do. Saves us from forking the script per platform.
+        shell: bash
     steps:
       - uses: actions/checkout@v4
 
@@ -97,29 +134,33 @@ jobs:
         env:
           VER: ${{ needs.resolve.outputs.version }}
 
-      - name: Publish docxodus-pyhost (linux-x64, self-contained, single-file)
+      - name: Publish docxodus-pyhost (${{ matrix.rid }}, self-contained, single-file)
         run: |
           dotnet publish tools/python-host/pyhost.csproj \
             -c Release \
-            -r linux-x64 \
+            -r '${{ matrix.rid }}' \
             --self-contained true \
             -p:PublishSingleFile=true \
             -p:PublishReadyToRun=true \
             -p:IncludeNativeLibrariesForSelfExtract=true \
-            -o python/vendor/linux-x64
+            -o 'python/vendor/${{ matrix.rid }}'
 
       - name: Stage binary into wheel layout
         run: |
+          set -euo pipefail
           mkdir -p python/src/docx_scalpel/_bin
-          cp python/vendor/linux-x64/docxodus-pyhost python/src/docx_scalpel/_bin/
-          chmod +x python/src/docx_scalpel/_bin/docxodus-pyhost
+          cp "python/vendor/${{ matrix.rid }}/${{ matrix.binary }}" \
+             "python/src/docx_scalpel/_bin/${{ matrix.binary }}"
+          # chmod is a no-op on NTFS but a hard requirement on unix runners
+          # and harmless to run unconditionally inside Git Bash.
+          chmod +x "python/src/docx_scalpel/_bin/${{ matrix.binary }}" || true
           ls -la python/src/docx_scalpel/_bin/
 
       - name: Smoke-test the bundled host
         run: |
           set -euo pipefail
           out=$(printf '{"id":1,"op":"ping","args":{}}\n{"id":2,"op":"shutdown","args":{}}\n' \
-              | python/src/docx_scalpel/_bin/docxodus-pyhost)
+              | "python/src/docx_scalpel/_bin/${{ matrix.binary }}")
           echo "$out"
           echo "$out" | grep -q '"pong":true' || { echo "ping failed"; exit 1; }
 
@@ -131,13 +172,15 @@ jobs:
           python -m build --wheel
           ls -la dist/
 
-      - name: Retag wheel for ${{ env.WHEEL_PLATFORM_TAG_LINUX_X64 }}
+      - name: Retag wheel for ${{ matrix.wheel-platform }}
         run: |
           set -euo pipefail
           cd python/dist
-          # Use the wheel project's own CLI (PEP 491-aware), not a filename rename.
-          python -m wheel tags --remove --platform-tag="$WHEEL_PLATFORM_TAG_LINUX_X64" \
-            docx_scalpel-${VER}-py3-none-any.whl
+          # Use the wheel project's own CLI (PEP 491-aware) — updates filename
+          # AND the embedded WHEEL metadata, not just the file rename.
+          python -m wheel tags --remove \
+            --platform-tag='${{ matrix.wheel-platform }}' \
+            "docx_scalpel-${VER}-py3-none-any.whl"
           ls -la
         env:
           VER: ${{ needs.resolve.outputs.version }}
@@ -145,16 +188,26 @@ jobs:
       - name: Run lifecycle tests against the built wheel
         run: |
           set -euo pipefail
-          python -m venv /tmp/verify-venv
-          /tmp/verify-venv/bin/pip install --upgrade pip
-          /tmp/verify-venv/bin/pip install python/dist/*.whl pytest
-          # Use the wheel's bundled host, not the dev fallback.
+          # $RUNNER_TEMP is set by GH Actions on every platform — /tmp wouldn't
+          # exist on windows-latest.
+          venv="$RUNNER_TEMP/verify-venv"
+          python -m venv "$venv"
+          # venv bin layout: unix has bin/, windows has Scripts/
+          if [[ -d "$venv/Scripts" ]]; then
+            bin="$venv/Scripts"
+          else
+            bin="$venv/bin"
+          fi
+          "$bin/pip" install --upgrade pip
+          "$bin/pip" install python/dist/*.whl pytest
+          # Force the locator to use the wheel's bundled host, not any dev
+          # fallback the runner might have lying around.
           unset DOCXODUS_HOST
-          /tmp/verify-venv/bin/pytest python/tests/test_lifecycle.py -v
+          "$bin/pytest" python/tests/test_lifecycle.py -v
 
       - uses: actions/upload-artifact@v4
         with:
-          name: dist-linux-x64
+          name: dist-${{ matrix.rid }}
           path: python/dist/*.whl
           if-no-files-found: error
 
@@ -199,7 +252,7 @@ jobs:
     name: Publish to ${{ needs.resolve.outputs.target }}
     needs:
       - resolve
-      - build-wheel-linux-x64
+      - build-wheel
       - build-sdist
     runs-on: ubuntu-latest
     # The environment must be configured in repo Settings → Environments AND

--- a/python/RELEASING.md
+++ b/python/RELEASING.md
@@ -76,32 +76,27 @@ The two tag namespaces are independent. A docx-scalpel point-release doesn't dra
 
 PyPI accepts PEP 440 pre-release identifiers — `0.1.0a1`, `0.1.0b2`, `0.1.0rc1`, `0.1.0.dev3`. Use the tag form `docx-scalpel-v0.1.0a1` and pip will only install pre-releases when `--pre` is passed.
 
-## Wheel scope (v1)
+## Wheel scope
 
-Today the workflow ships:
+The workflow ships one wheel per RID plus a single sdist:
 
-- `docx_scalpel-${VER}-py3-none-manylinux_2_28_x86_64.whl` — linux-x64, bundled `docxodus-pyhost`
-- `docx_scalpel-${VER}.tar.gz` — sdist (no bundled binary; install requires `DOCXODUS_HOST` env var or a dev clone of Docxodus)
+| RID | Runner | Wheel platform tag | Binary |
+|---|---|---|---|
+| `linux-x64` | `ubuntu-latest` | `manylinux_2_28_x86_64` | `docxodus-pyhost` |
+| `linux-arm64` | `ubuntu-22.04-arm` | `manylinux_2_28_aarch64` | `docxodus-pyhost` |
+| `osx-x64` | `macos-13` | `macosx_11_0_x86_64` | `docxodus-pyhost` |
+| `osx-arm64` | `macos-14` | `macosx_11_0_arm64` | `docxodus-pyhost` |
+| `win-x64` | `windows-latest` | `win_amd64` | `docxodus-pyhost.exe` |
 
-To install on linux-x64 the user does `pip install docx-scalpel` and gets the bundled host transparently. On other platforms today, the sdist install path requires building the host out-of-band — temporary until we add the other RIDs.
+The matrix is in `.github/workflows/python-publish.yml` under `build-wheel`. Each entry runs the same step sequence (publish .NET host → stage → smoke-test → build wheel → retag → lifecycle-test from a fresh-venv install). `fail-fast: false` so all RID failures surface at once, but `publish` still gates on every matrix entry succeeding.
 
-## Adding more RIDs
+`docx_scalpel-${VER}.tar.gz` (the sdist) has **no bundled binary** — install requires `DOCXODUS_HOST` set or a Docxodus monorepo clone with the host built locally.
 
-The matrix is the obvious one. Adding `linux-arm64`, `osx-x64`, `osx-arm64`, `win-x64` is a mechanical extension of `build-wheel-linux-x64`:
+### Known gaps
 
-1. Duplicate the `build-wheel-linux-x64` job per RID, parameterized by:
-   - `runs-on`: `ubuntu-22.04-arm` (linux-arm64), `macos-13` (osx-x64), `macos-14` (osx-arm64), `windows-latest` (win-x64)
-   - `-r <rid>` for `dotnet publish`
-   - Platform tag passed to `wheel tags`:
-     - `manylinux_2_28_aarch64`
-     - `macosx_11_0_x86_64`
-     - `macosx_11_0_arm64`
-     - `win_amd64`
-2. Linux ARM may need a manylinux container to ensure glibc compliance — see `auditwheel` if it does.
-3. Windows: the host binary is `docxodus-pyhost.exe`; everything else is identical. Use a bash shell for the wheel/sed steps (`shell: bash` or rewrite in PowerShell).
-4. Add the new artifact name to the `publish` job's `pattern: dist-*` glob (already wildcard-covered).
-
-Each per-RID wheel is independent — the publish job collects all artifacts from `dist-*` and uploads them as one PyPI release.
+- **Code signing on macOS** — wheels ship an unsigned `docxodus-pyhost`. First launch may trigger a Gatekeeper warning; user can bypass via right-click → Open or `xattr -d com.apple.quarantine`. Proper signing + notarization is a future ask; needs an Apple Developer ID and an `APPLE_*` secret bundle in CI.
+- **Authenticode signing on Windows** — same story. Unsigned `.exe` triggers SmartScreen on first run. Needs a code-signing cert.
+- **Glibc compliance for Linux ARM** — `ubuntu-22.04-arm` runner has glibc 2.35; we claim `manylinux_2_28_aarch64`. The .NET 8 self-contained binary should be glibc-2.28-compatible but we don't run `auditwheel` to enforce it. If users on older arm64 distros report `GLIBC_2.34 not found`, build inside a `quay.io/pypa/manylinux_2_28_aarch64` container instead.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Replaces the single `build-wheel-linux-x64` job in `python-publish.yml` with a matrix covering five RIDs. Each one builds a self-contained `docxodus-pyhost`, stages it into the wheel layout, smoke-tests the host, builds the wheel, retags for the platform, and installs the wheel into a fresh venv to confirm `_host_locator` finds the bundled binary.

| RID | Runner | Platform tag | Binary |
|---|---|---|---|
| `linux-x64` | `ubuntu-latest` | `manylinux_2_28_x86_64` | `docxodus-pyhost` |
| `linux-arm64` | `ubuntu-22.04-arm` | `manylinux_2_28_aarch64` | `docxodus-pyhost` |
| `osx-x64` | `macos-13` | `macosx_11_0_x86_64` | `docxodus-pyhost` |
| `osx-arm64` | `macos-14` | `macosx_11_0_arm64` | `docxodus-pyhost` |
| `win-x64` | `windows-latest` | `win_amd64` | `docxodus-pyhost.exe` |

`fail-fast: false` so every RID failure surfaces at once. `publish` still gates on the full matrix succeeding (default GH Actions matrix-job semantics).

## Cross-platform implementation notes

- **`shell: bash` everywhere.** Windows-latest ships Git Bash, which handles `mkdir`, `cp`, `chmod`, `printf` heredocs, and glob expansion identically to the unix runners. Saves us from forking the script.
- **`$RUNNER_TEMP` replaces `/tmp`** for the verify-venv staging path — `/tmp` doesn't exist on `windows-latest`.
- **venv bin layout probe** — unix has `bin/`, Windows has `Scripts/`. The lifecycle-test step detects which one is present.
- **`chmod +x ... || true`** — required on unix runners, no-op but harmless on NTFS.
- **`matrix.binary`** carries the per-RID executable name so the same `cp` step handles both `docxodus-pyhost` and `docxodus-pyhost.exe`.

## What this PR doesn't do

- **README update.** The README still says "linux-x64 today" — PR #190 has README touches in flight, so leaving README updates for a post-merge follow-up to avoid resolution friction.
- **No actual release.** This branch only changes the workflow; the next `docx-scalpel-v*` tag picks up the matrix.
- **No code signing.** macOS + Windows wheels ship unsigned. First-launch warnings (Gatekeeper / SmartScreen) are documented in `RELEASING.md` as a known gap.

## Test plan

The matrix can't be exercised end-to-end without pushing a tag (which would publish to production PyPI). Two options for verifying before the next real release:

- [ ] **workflow_dispatch dry-run** — run the workflow on this branch with `version=0.1.0a3` + `target=testpypi`. Confirms all 5 build jobs succeed and the TestPyPI publish step works. Recommended.
- [ ] **Inspect only** — YAML validates (`python3 -c \"import yaml; yaml.safe_load(...)\"` returns clean), matrix expands to 5 entries, `publish.needs` correctly references the renamed job. Acceptable if you'd rather wait until the next real release.

Either way the linux-x64 path is already proven by `docx-scalpel-v0.1.0a1` — the matrix just adds 4 parameterized clones of that working pipeline.

## Risks

- `ubuntu-22.04-arm` is the most likely to break — newer runner, less battle-tested. If it fails for runner-availability reasons, easiest fix is to drop linux-arm64 from the matrix and ship the other 4. (Documented in commit message.)
- `manylinux_2_28_aarch64` is an aspirational tag — we don't run `auditwheel`. If users on older arm64 distros hit `GLIBC_2.34 not found`, the fix is to move that one runner to a manylinux container (`quay.io/pypa/manylinux_2_28_aarch64`). Tracked in `RELEASING.md`.