### PR TITLE
chore(python): bump docx-scalpel to 0.1.0a2

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "docx-scalpel"
-version = "0.1.0a2.dev0"
+version = "0.1.0a2"
 description = "Anchor-addressed DOCX editing for LLM agents — a thin client over Docxodus' DocxSession."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bump `python/pyproject.toml` from `0.1.0a2.dev0` → `0.1.0a2` to match the just-pushed `docx-scalpel-v0.1.0a2` tag.

The tag (commit `109d98b`) is already triggering `python-publish.yml`; the published wheel reads its version from the tag, not pyproject. This PR is purely to bring the in-tree value in sync with the published one so editable installs from `main` don't report `.dev0`.

Closes the 0.1.0a2 release flow for #192 (items 1, 3, 4). Item 2 (undo/redo → `EditResult`) remains open as a deferred follow-up.

## Test plan
- [ ] CI green on `python-publish.yml` for tag `docx-scalpel-v0.1.0a2`
- [ ] `pip install docx-scalpel==0.1.0a2 --pre` resolves and `__version__` reports `0.1.0a2`