### PR TITLE
ci(python-publish): use `python -m pip` for verify-venv pip upgrade

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -198,7 +198,10 @@ jobs:
           else
             bin="$venv/bin"
           fi
-          "$bin/pip" install --upgrade pip
+          # `pip install --upgrade pip` via pip.exe fails on Windows because
+          # the running exe holds a lock on itself; pip 25+ refuses and tells
+          # you to use `python -m pip` instead. Use that form on every OS.
+          "$bin/python" -m pip install --upgrade pip
           "$bin/pip" install python/dist/*.whl pytest
           # Force the locator to use the wheel's bundled host, not any dev
           # fallback the runner might have lying around.


### PR DESCRIPTION
The Windows verify step in `build-wheel` runs `"$bin/pip" install --upgrade pip` inside the freshly-created venv. On Windows, pip 25+ refuses to upgrade itself when invoked via `pip.exe` because the running exe holds a file lock on itself; the error message explicitly directs you to `python -m pip` instead. The macOS/Linux runs were fine because no such lock exists there.

Caught by the `docx-scalpel-v0.1.0a2` release attempt — [run 26453161747](https://github.com/JSv4/Docxodus/actions/runs/26453161747) win-x64 job failed at:

```
ERROR: To modify pip, please run the following command:
D:\a\_temp\verify-venv\Scripts\python.exe -m pip install --upgrade pip
```

Use `"$bin/python" -m pip` on every OS so the verify step survives the Windows-only pip-self-upgrade interlock.

## After merge

PyPI has nothing at `0.1.0a2` (publish job gates on every matrix entry; win-x64 blocked it). Once this lands on main, re-trigger via workflow_dispatch with `version=0.1.0a2, target=pypi` rather than re-tagging.

## Test plan
- [ ] CI green on this PR
- [ ] workflow_dispatch run for `0.1.0a2 / pypi` passes all 5 RID wheel builds + publish