### PR TITLE
ci(python-publish): cross-publish osx-x64 from macos-14 runner

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -90,8 +90,12 @@ jobs:
             wheel-platform: manylinux_2_28_aarch64
             binary: docxodus-pyhost
           - rid: osx-x64
-            # Intel Mac runner — being deprecated in 2026 but still works.
-            runner: macos-13
+            # macos-13 Intel runners were retired for public repos in 2026;
+            # cross-publish from the Apple Silicon runner instead. The .NET 8
+            # SDK supports cross-rid publish out of the box, and the
+            # smoke-test step installs Rosetta so the x86_64 binary executes
+            # on the arm64 host.
+            runner: macos-14
             wheel-platform: macosx_11_0_x86_64
             binary: docxodus-pyhost
           - rid: osx-arm64
@@ -155,6 +159,13 @@ jobs:
           # and harmless to run unconditionally inside Git Bash.
           chmod +x "python/src/docx_scalpel/_bin/${{ matrix.binary }}" || true
           ls -la python/src/docx_scalpel/_bin/
+
+      - name: Install Rosetta (osx-x64 cross-publish from arm64 host)
+        # macos-14 is Apple Silicon; the freshly-cross-published osx-x64 binary
+        # is x86_64 and can only execute on this host through Rosetta 2. Skipped
+        # for every other matrix entry (each runs on its native arch).
+        if: matrix.rid == 'osx-x64'
+        run: softwareupdate --install-rosetta --agree-to-license
 
       - name: Smoke-test the bundled host
         run: |


### PR DESCRIPTION
`macos-13` (Intel) GitHub-hosted runners were retired for public repos in 2026, so the `osx-x64` matrix entry now hangs forever waiting for a runner label that the pool no longer serves. The current 0.1.0a2 retry run ([26453809883](https://github.com/JSv4/Docxodus/actions/runs/26453809883)) is sitting in the same `Waiting for a runner to pick up this job…` state for osx-x64.

Switch the runner to `macos-14` (Apple Silicon) and let `dotnet publish -r osx-x64` cross-compile the self-contained binary. The wheel platform tag stays `macosx_11_0_x86_64` so pip on Intel Macs still resolves the right wheel.

The smoke-test step executes the freshly-built binary; an x86_64 binary won't run on the arm64 host without Rosetta, so add a `softwareupdate --install-rosetta` step gated to `matrix.rid == 'osx-x64'` (every other entry runs on its native arch and pays no cost).

## After merge

The in-flight run for `0.1.0a2` will still hang on osx-x64. Cancel it and re-dispatch with the new workflow.

## Test plan
- [ ] CI green on this PR (osx-x64 job lands on macos-14 and completes)
- [ ] workflow_dispatch run for `0.1.0a2 / pypi` passes all 5 RID wheel builds