### PR TITLE
ci(python-publish): drop osx-x64 from the wheel matrix

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,7 +9,7 @@ name: python-publish
 # bump for unrelated work. Compatibility is handled by bundling: each wheel
 # embeds a docxodus-pyhost built from the same commit the tag points to.
 #
-# Matrix builds wheels for linux-x64, linux-arm64, osx-x64, osx-arm64, win-x64
+# Matrix builds wheels for linux-x64, linux-arm64, osx-arm64, win-x64
 # (each carrying a self-contained docxodus-pyhost for its RID) plus a single
 # sdist. The publish job collects every dist-* artifact and uploads them as
 # one PyPI release. fail-fast: false in the matrix surfaces all RID failures
@@ -89,15 +89,13 @@ jobs:
             runner: ubuntu-22.04-arm
             wheel-platform: manylinux_2_28_aarch64
             binary: docxodus-pyhost
-          - rid: osx-x64
-            # macos-13 Intel runners were retired for public repos in 2026;
-            # cross-publish from the Apple Silicon runner instead. The .NET 8
-            # SDK supports cross-rid publish out of the box, and the
-            # smoke-test step installs Rosetta so the x86_64 binary executes
-            # on the arm64 host.
-            runner: macos-14
-            wheel-platform: macosx_11_0_x86_64
-            binary: docxodus-pyhost
+          # osx-x64 was retired from the matrix in 2026 once macos-13 (Intel)
+          # runners stopped serving the public-repo pool. Cross-publishing from
+          # macos-14 via Rosetta was attempted and didn't pan out; Intel Mac
+          # share is small enough that dropping the dedicated wheel is the
+          # right tradeoff. Intel Mac users can `pip install` the sdist if they
+          # need it, or run a docx-scalpel install with `DOCXODUS_HOST` pointed
+          # at a locally-built host.
           - rid: osx-arm64
             # Apple Silicon runner.
             runner: macos-14
@@ -159,13 +157,6 @@ jobs:
           # and harmless to run unconditionally inside Git Bash.
           chmod +x "python/src/docx_scalpel/_bin/${{ matrix.binary }}" || true
           ls -la python/src/docx_scalpel/_bin/
-
-      - name: Install Rosetta (osx-x64 cross-publish from arm64 host)
-        # macos-14 is Apple Silicon; the freshly-cross-published osx-x64 binary
-        # is x86_64 and can only execute on this host through Rosetta 2. Skipped
-        # for every other matrix entry (each runs on its native arch).
-        if: matrix.rid == 'osx-x64'
-        run: softwareupdate --install-rosetta --agree-to-license
 
       - name: Smoke-test the bundled host
         run: |

--- a/python/RELEASING.md
+++ b/python/RELEASING.md
@@ -84,11 +84,12 @@ The workflow ships one wheel per RID plus a single sdist:
 |---|---|---|---|
 | `linux-x64` | `ubuntu-latest` | `manylinux_2_28_x86_64` | `docxodus-pyhost` |
 | `linux-arm64` | `ubuntu-22.04-arm` | `manylinux_2_28_aarch64` | `docxodus-pyhost` |
-| `osx-x64` | `macos-13` | `macosx_11_0_x86_64` | `docxodus-pyhost` |
 | `osx-arm64` | `macos-14` | `macosx_11_0_arm64` | `docxodus-pyhost` |
 | `win-x64` | `windows-latest` | `win_amd64` | `docxodus-pyhost.exe` |
 
 The matrix is in `.github/workflows/python-publish.yml` under `build-wheel`. Each entry runs the same step sequence (publish .NET host → stage → smoke-test → build wheel → retag → lifecycle-test from a fresh-venv install). `fail-fast: false` so all RID failures surface at once, but `publish` still gates on every matrix entry succeeding.
+
+**No `osx-x64` wheel.** GitHub's `macos-13` Intel-runner pool was retired for public repos in 2026, and cross-publishing osx-x64 from `macos-14` via Rosetta proved fragile. Intel Mac users can install the sdist (`pip install docx-scalpel --no-binary docx-scalpel`) and point `DOCXODUS_HOST` at a locally-built host, or run on Rosetta-emulated Python against the osx-arm64 wheel.
 
 `docx_scalpel-${VER}.tar.gz` (the sdist) has **no bundled binary** — install requires `DOCXODUS_HOST` set or a Docxodus monorepo clone with the host built locally.
 


### PR DESCRIPTION
GitHub's `macos-13` (Intel) hosted runners were retired for public repos in 2026, and cross-publishing osx-x64 from `macos-14` via Rosetta turned out fragile (the previous PR's attempt failed in CI). Intel Mac share is small enough that dropping the dedicated wheel is the right tradeoff rather than carrying a flaky cross-compile path.

Intel Mac users can:
- `pip install` the sdist with `DOCXODUS_HOST` pointed at a locally-built host, or
- run Rosetta-emulated Python against the osx-arm64 wheel.

## After merge

The in-flight 0.1.0a2 run is still gated on osx-x64. Cancel it and re-dispatch with the four-RID matrix.

## Test plan
- [ ] CI green on this PR (no osx-x64 job in the matrix)
- [ ] workflow_dispatch run for `0.1.0a2 / pypi` passes all 4 RID wheel builds + publish