### PR TITLE
chore(python): bump docx-scalpel to 0.1.0a3

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "docx-scalpel"
-version = "0.1.0a2"
+version = "0.1.0a3"
 description = "Anchor-addressed DOCX editing for LLM agents — a thin client over Docxodus' DocxSession."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bump `python/pyproject.toml` version `0.1.0a2` → `0.1.0a3` so the next docx-scalpel PyPI release can ship with all the Python work that landed since the original a2 publish on 2026-05-26.

## Why a3 instead of re-tagging a2

PyPI already has `docx-scalpel==0.1.0a2` from commit `109d98b` (just the version bump). Since then we shipped:
- Annotation write surface in #204 (Python wrapper)
- Block-metadata reads in #205 (Python wrapper)
- `re-export block-metadata types from package root` fix

PyPI is immutable, so the new code must ship under a new version. a3 keeps the alpha cadence.

After merge, I'll tag `docx-scalpel-v0.1.0a3` on main → the `python-publish.yml` workflow auto-publishes to PyPI.

## Test plan
- [x] One-line version bump; no code changes.