### PR TITLE
Fix #210: handle percent-suffixed table/cell widths in WmlToHtmlConverter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Percentage table/cell widths no longer crash `WmlToHtmlConverter`** (issue #210). `convertDocxToHtml` threw `FormatException` ("Format_InvalidStringWithValue, 100%") whenever a table-level (`w:tblW`) or cell-level (`w:tcW`) width used `w:type="pct"` with a percent-suffixed value such as `w:w="100%"` / `w:w="50%"`. This is the form the `docx` npm library emits for `WidthType.PERCENTAGE`, and it is valid per the OOXML `ST_TblWidth` / `ST_MeasurementOrPercent` schema (which permits either a plain integer in fiftieths-of-a-percent **or** a `"<number>%"` string). The converter cast the attribute straight to `int`, which throws on `"100%"`; DXA (twips) widths were unaffected because they are always plain integers. Width parsing for `w:tblW`/`w:tcW` now goes through a single `ParseTblWidthValue` helper that tolerates the percent-suffixed form: an explicit `"100%"` is treated as a literal percentage, while a bare integer under `pct` is still interpreted as fiftieths of a percent (`5000` → `100%`). Non-numeric/garbage widths are ignored gracefully instead of throwing. Tests: `HcTablePercentageWidthTests` in `Docxodus.Tests/HtmlConverterTablePercentageWidthTests.cs`.
+
 ## [6.2.0] - 2026-05-28
 
 ### Added

--- a/Docxodus.Tests/HtmlConverterTablePercentageWidthTests.cs
+++ b/Docxodus.Tests/HtmlConverterTablePercentageWidthTests.cs
@@ -36,6 +36,25 @@ namespace OxPt
             {
                 var mainPart = doc.AddMainDocumentPart();
 
+                // WmlToHtmlConverter routes through FormattingAssembler, which
+                // dereferences MainDocumentPart.StyleDefinitionsPart. A minimal
+                // in-memory document must supply one (plus default run props) or
+                // conversion throws ArgumentNullException before any width parsing.
+                var stylesPart = mainPart.AddNewPart<StyleDefinitionsPart>();
+                stylesPart.Styles = new W.Styles(
+                    new W.DocDefaults(
+                        new W.RunPropertiesDefault(
+                            new W.RunPropertiesBaseStyle(
+                                new W.RunFonts { Ascii = "Calibri", HighAnsi = "Calibri" },
+                                new W.FontSize { Val = "24" }))));
+                stylesPart.Styles.Save();
+
+                // ConvertToHtml also dereferences MainDocumentPart.DocumentSettingsPart
+                // (CalculateSpanWidthForTabs reads w:defaultTabStop).
+                var settingsPart = mainPart.AddNewPart<DocumentSettingsPart>();
+                settingsPart.Settings = new W.Settings();
+                settingsPart.Settings.Save();
+
                 W.TableCell MakeCell(string text) => new W.TableCell(
                     new W.TableCellProperties(
                         new W.TableCellWidth { Width = cellWidth, Type = cellType }),

--- a/Docxodus.Tests/HtmlConverterTablePercentageWidthTests.cs
+++ b/Docxodus.Tests/HtmlConverterTablePercentageWidthTests.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using Xunit;
+using Docxodus;
+using W = DocumentFormat.OpenXml.Wordprocessing;
+
+#if !ELIDE_XUNIT_TESTS
+
+namespace OxPt
+{
+    // Regression coverage for issue #210: WmlToHtmlConverter threw
+    // FormatException ("Format_InvalidStringWithValue, 100%") when a table or
+    // cell width used w:type="pct" with a percent-suffixed value (e.g.
+    // w:w="100%"), the form emitted by the `docx` JS library. Per the OOXML
+    // ST_TblWidth / ST_MeasurementOrPercent schema the value may be either a
+    // plain integer (fiftieths of a percent) OR a "<number>%" string.
+    public class HcTablePercentageWidthTests
+    {
+        // Builds a minimal in-memory .docx with a single 2x1 table.
+        // tblWidth/tblType set the table-level w:tblW; cellWidth/cellType set
+        // the per-cell w:tcW. Widths are passed through verbatim as the raw
+        // OOXML attribute string so we can exercise the "100%" / "50%" forms.
+        private static byte[] CreateDocxWithTableWidth(
+            string tblWidth, W.TableWidthUnitValues tblType,
+            string cellWidth, W.TableWidthUnitValues cellType)
+        {
+            using var ms = new MemoryStream();
+            using (var doc = WordprocessingDocument.Create(ms, WordprocessingDocumentType.Document))
+            {
+                var mainPart = doc.AddMainDocumentPart();
+
+                W.TableCell MakeCell(string text) => new W.TableCell(
+                    new W.TableCellProperties(
+                        new W.TableCellWidth { Width = cellWidth, Type = cellType }),
+                    new W.Paragraph(
+                        new W.Run(
+                            new W.Text(text) { Space = SpaceProcessingModeValues.Preserve })));
+
+                var table = new W.Table(
+                    new W.TableProperties(
+                        new W.TableWidth { Width = tblWidth, Type = tblType }),
+                    new W.TableGrid(
+                        new W.GridColumn { Width = "4500" },
+                        new W.GridColumn { Width = "4500" }),
+                    new W.TableRow(MakeCell("Item"), MakeCell("Amount")),
+                    new W.TableRow(MakeCell("Fee"), MakeCell("1000")));
+
+                mainPart.Document = new W.Document(
+                    new W.Body(
+                        new W.Paragraph(
+                            new W.Run(
+                                new W.Text("Header") { Space = SpaceProcessingModeValues.Preserve })),
+                        table,
+                        new W.SectionProperties(
+                            new W.PageSize { Width = 12240, Height = 15840 },
+                            new W.PageMargin { Top = 1440, Bottom = 1440, Left = 1440, Right = 1440 })));
+                mainPart.Document.Save();
+            }
+            return ms.ToArray();
+        }
+
+        private static string RenderToHtml(byte[] docxBytes)
+        {
+            var wmlDoc = new WmlDocument("test.docx", docxBytes);
+            var settings = new WmlToHtmlConverterSettings();
+            var html = WmlToHtmlConverter.ConvertToHtml(wmlDoc, settings);
+            return html.ToString(SaveOptions.DisableFormatting);
+        }
+
+        // Issue #210 core repro: percent-suffixed string widths (what `docx`
+        // emits for WidthType.PERCENTAGE). Previously threw FormatException.
+        [Fact]
+        public void HC_Pct_PercentSuffixString_DoesNotThrow_AndEmitsPercentWidths()
+        {
+            var bytes = CreateDocxWithTableWidth(
+                "100%", W.TableWidthUnitValues.Pct,
+                "50%", W.TableWidthUnitValues.Pct);
+
+            string html = null;
+            var ex = Record.Exception(() => html = RenderToHtml(bytes));
+
+            Assert.Null(ex);                       // #210: must not throw
+            Assert.NotNull(html);
+
+            var normalized = html.Replace(" ", "");
+            // Explicit "100%" is already a percentage (not fiftieths).
+            Assert.Contains("width:100%", normalized);
+            // Explicit "50%" cell width -> rendered with one decimal place.
+            Assert.Contains("width:50.0%", normalized);
+        }
+
+        // The integer fiftieths-of-a-percent form must keep working: 5000 -> 100%,
+        // 2500 -> 50.0%.
+        [Fact]
+        public void HC_Pct_IntegerFiftieths_StillYieldsPercentWidths()
+        {
+            var bytes = CreateDocxWithTableWidth(
+                "5000", W.TableWidthUnitValues.Pct,
+                "2500", W.TableWidthUnitValues.Pct);
+
+            var html = RenderToHtml(bytes);
+            var normalized = html.Replace(" ", "");
+
+            Assert.Contains("width:100%", normalized);
+            Assert.Contains("width:50.0%", normalized);
+        }
+
+        // DXA (twips) widths are unaffected by the fix: 9000 twips -> 450pt,
+        // 4500 twips -> 225pt.
+        [Fact]
+        public void HC_Dxa_TwipsWidths_StillYieldPointWidths()
+        {
+            var bytes = CreateDocxWithTableWidth(
+                "9000", W.TableWidthUnitValues.Dxa,
+                "4500", W.TableWidthUnitValues.Dxa);
+
+            var html = RenderToHtml(bytes);
+            var normalized = html.Replace(" ", "");
+
+            Assert.Contains("width:450pt", normalized);
+            Assert.Contains("width:225pt", normalized);
+        }
+
+        // A malformed / non-numeric width must be ignored gracefully rather than
+        // throwing — the helper returns null and no width is emitted.
+        [Fact]
+        public void HC_Pct_GarbageWidth_IsIgnored_DoesNotThrow()
+        {
+            var bytes = CreateDocxWithTableWidth(
+                "not-a-number", W.TableWidthUnitValues.Pct,
+                "2500", W.TableWidthUnitValues.Pct);
+
+            string html = null;
+            var ex = Record.Exception(() => html = RenderToHtml(bytes));
+
+            Assert.Null(ex);
+            Assert.NotNull(html);
+            // Cell width still parses (2500 -> 50.0%); table width silently dropped.
+            Assert.Contains("width:50.0%", html.Replace(" ", ""));
+        }
+    }
+}
+
+#endif

--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -4417,6 +4417,28 @@ namespace Docxodus
             }
         }
 
+        // Parses an OOXML table/cell width value (w:w on w:tblW / w:tcW, schema type
+        // ST_TblWidth / ST_MeasurementOrPercent). The value is normally a plain integer,
+        // but the spec (and authoring tools such as the `docx` JS library) also permit a
+        // percent-suffixed form, e.g. "100%" or "50.5%". Returns null when the attribute is
+        // missing or cannot be parsed. `isExplicitPercent` is true when the raw value carried
+        // a trailing '%', meaning it is already a literal percentage (NOT fiftieths-of-a-percent).
+        private static decimal? ParseTblWidthValue(XAttribute widthAttr, out bool isExplicitPercent)
+        {
+            isExplicitPercent = false;
+            var raw = ((string)widthAttr)?.Trim();
+            if (string.IsNullOrEmpty(raw))
+                return null;
+            if (raw.EndsWith("%", StringComparison.Ordinal))
+            {
+                isExplicitPercent = true;
+                raw = raw.Substring(0, raw.Length - 1).Trim();
+            }
+            if (decimal.TryParse(raw, NumberStyles.Number, NumberFormatInfo.InvariantInfo, out var value))
+                return value;
+            return null;
+        }
+
         private static object ProcessTable(WordprocessingDocument wordDoc, WmlToHtmlConverterSettings settings, XElement element, decimal currentMarginLeft)
         {
             var style = new Dictionary<string, string>();
@@ -4433,15 +4455,20 @@ namespace Docxodus
                 var type = (string)tblW.Attribute(W.type);
                 if (type == "pct")
                 {
-                    var w = (int)tblW.Attribute(W._w);
-                    style.AddIfMissing("width", (w / 50) + "%");
+                    var w = ParseTblWidthValue(tblW.Attribute(W._w), out var isExplicitPercent);
+                    if (w != null)
+                    {
+                        // "pct" integers are fiftieths of a percent; an explicit "100%" is already a percent.
+                        var percent = isExplicitPercent ? w.Value : w.Value / 50m;
+                        style.AddIfMissing("width", string.Format(NumberFormatInfo.InvariantInfo, "{0:0.####}%", percent));
+                    }
                 }
                 else if (type == "dxa")
                 {
-                    var w = (decimal?)tblW.Attribute(W._w);
-                    if (w != null && w > 0)
+                    var w = ParseTblWidthValue(tblW.Attribute(W._w), out var isExplicitPercent);
+                    if (w != null && !isExplicitPercent && w > 0m)
                     {
-                        style.AddIfMissing("width", string.Format(NumberFormatInfo.InvariantInfo, "{0}pt", w / 20m));
+                        style.AddIfMissing("width", string.Format(NumberFormatInfo.InvariantInfo, "{0}pt", w.Value / 20m));
                     }
                 }
                 // type == "auto" or type == "nil" means no fixed width (browser default)
@@ -4632,13 +4659,20 @@ namespace Docxodus
 
                 if ((string) tcPr.Elements(W.tcW).Attributes(W.type).FirstOrDefault() == "dxa")
                 {
-                    decimal width = (int) tcPr.Elements(W.tcW).Attributes(W._w).FirstOrDefault();
-                    style.AddIfMissing("width", string.Format(NumberFormatInfo.InvariantInfo, "{0}pt", width/20m));
+                    var width = ParseTblWidthValue(tcPr.Elements(W.tcW).Attributes(W._w).FirstOrDefault(), out var isExplicitPercent);
+                    if (width != null && !isExplicitPercent)
+                    {
+                        style.AddIfMissing("width", string.Format(NumberFormatInfo.InvariantInfo, "{0}pt", width.Value/20m));
+                    }
                 }
                 if ((string) tcPr.Elements(W.tcW).Attributes(W.type).FirstOrDefault() == "pct")
                 {
-                    decimal width = (int) tcPr.Elements(W.tcW).Attributes(W._w).FirstOrDefault();
-                    style.AddIfMissing("width", string.Format(NumberFormatInfo.InvariantInfo, "{0:0.0}%", width/50m));
+                    var width = ParseTblWidthValue(tcPr.Elements(W.tcW).Attributes(W._w).FirstOrDefault(), out var isExplicitPercent);
+                    if (width != null)
+                    {
+                        var percent = isExplicitPercent ? width.Value : width.Value/50m;
+                        style.AddIfMissing("width", string.Format(NumberFormatInfo.InvariantInfo, "{0:0.0}%", percent));
+                    }
                 }
 
                 var tcBorders = tcPr.Element(W.tcBorders);

--- a/docs/ooxml_corner_cases.md
+++ b/docs/ooxml_corner_cases.md
@@ -224,6 +224,73 @@ The ECMA-376 specification clarifies how footnote numbering works:
 
 ---
 
+## Table/Cell Width as Percent-Suffixed String (`w:tblW` / `w:tcW` with `w:type="pct"`)
+
+**Status:** Fixed (2026-05) — Issue #210
+
+### Symptom
+
+`WmlToHtmlConverter.ConvertToHtml` (`convertDocxToHtml` in the npm wrapper) threw
+`FormatException` — `Conversion failed: Format_InvalidStringWithValue, 100%` —
+for any document whose table or cell width was a percentage.
+
+### Minimal XML reproducer
+
+```xml
+<w:tbl>
+  <w:tblPr>
+    <!-- percent-suffixed string form -->
+    <w:tblW w:w="100%" w:type="pct"/>
+  </w:tblPr>
+  <w:tr>
+    <w:tc>
+      <w:tcPr><w:tcW w:w="50%" w:type="pct"/></w:tcPr>
+      <w:p><w:r><w:t>Item</w:t></w:r></w:p>
+    </w:tc>
+  </w:tr>
+</w:tbl>
+```
+
+### The corner case
+
+The `w:w` attribute on `w:tblW` / `w:tcW` has schema type `ST_TblWidth`
+(a union over `ST_MeasurementOrPercent` + `ST_DecimalNumber`). Under
+`w:type="pct"` the value may be expressed **two** schema-valid ways:
+
+| Form | Example | Meaning |
+|------|---------|---------|
+| Integer (fiftieths of a percent) | `w:w="5000"` | 5000 / 50 = 100% |
+| Percent-suffixed string | `w:w="100%"` | a literal 100% |
+
+Microsoft Word writes the integer-fiftieths form. The widely used `docx`
+JavaScript library writes the **percent-suffixed string** form for
+`WidthType.PERCENTAGE` — both are schema-valid, but Docxodus only handled the
+integer form, casting the attribute straight to `int`. `(int)"100%"` throws.
+
+### Renderer comparison
+
+| Width markup | Word | LibreOffice | Docxodus (before) | Docxodus (after) |
+|--------------|------|-------------|-------------------|------------------|
+| `w:w="5000" w:type="pct"` | 100% | 100% | `width: 100%` | `width: 100%` |
+| `w:w="100%" w:type="pct"` | 100% | 100% | **throws** | `width: 100%` |
+| `w:w="9000" w:type="dxa"` | 450pt | 450pt | `width: 450pt` | `width: 450pt` |
+
+### Relevant code
+
+`Docxodus/WmlToHtmlConverter.cs` — `ParseTblWidthValue(XAttribute, out bool isExplicitPercent)`
+centralizes the parse and is called from `ProcessTable` (table-level `w:tblW`)
+and the cell-processing path (`w:tcW`). When the raw value ends with `%`,
+`isExplicitPercent` is set and the number is treated as a literal percentage;
+otherwise a `pct` value is divided by 50 (fiftieths -> percent) as before.
+Non-numeric values return `null` and are skipped instead of throwing.
+
+### Tests
+
+`Docxodus.Tests/HtmlConverterTablePercentageWidthTests.cs`
+(`HcTablePercentageWidthTests`).
+
+---
+
 ## Contributing
 
 When adding new corner cases to this document:


### PR DESCRIPTION
## Summary

Fixes #210. `convertDocxToHtml` (i.e. `WmlToHtmlConverter`) threw `FormatException` — `Conversion failed: Format_InvalidStringWithValue, 100%` — for **any** document containing a table whose width (table-level `w:tblW` or cell-level `w:tcW`) was expressed as a **percentage** with `w:type="pct"` and a percent-suffixed value such as `w:w="100%"` / `w:w="50%"`. DXA (twips) widths converted fine.

## Root cause

The `w:w` attribute on `w:tblW` / `w:tcW` has OOXML schema type `ST_TblWidth` (a union over `ST_MeasurementOrPercent` + `ST_DecimalNumber`). Under `w:type="pct"` the value may be expressed **two** schema-valid ways:

| Form | Example | Meaning |
|------|---------|---------|
| Integer (fiftieths of a percent) | `w:w="5000"` | 5000 / 50 = 100% |
| Percent-suffixed string | `w:w="100%"` | a literal 100% |

Microsoft Word writes the integer-fiftieths form. The widely used [`docx`](https://www.npmjs.com/package/docx) JS library (used in the issue's repro) writes the **percent-suffixed string** form for `WidthType.PERCENTAGE`. Docxodus only handled the integer form — it cast the attribute straight to `int` (`(int)tblW.Attribute(W._w)` / `(int) tcPr...tcW...`), and `(int)"100%"` throws. DXA widths were unaffected because they are always plain integers.

## Fix

Width parsing for `w:tblW` and `w:tcW` now routes through a single helper, `ParseTblWidthValue(XAttribute, out bool isExplicitPercent)`, that:

- strips a trailing `%` and reports it via `isExplicitPercent`,
- parses with `decimal.TryParse` (invariant culture) so a non-numeric/garbage value returns `null` and is skipped instead of throwing,
- lets callers treat an explicit `"100%"` as a literal percentage, while a bare integer under `pct` is still divided by 50 (fiftieths → percent), preserving existing behavior (`5000` → `100%`).

The three call sites (table `pct`, table `dxa`, cell `dxa`+`pct`) were updated to use it. DXA output (`{n}pt`) and integer-`pct` output are unchanged.

## Tests

New `Docxodus.Tests/HtmlConverterTablePercentageWidthTests.cs` (`HcTablePercentageWidthTests`) builds minimal **in-memory** `.docx` documents (no fixtures on disk) with a 2×2 table and asserts:

- **`100%` / `50%` percent-suffixed strings** — conversion does **not** throw (the #210 regression) and the HTML carries `width: 100%` (table) and `width: 50.0%` (cells).
- **`5000` / `2500` integer-fiftieths** — still yields `width: 100%` / `width: 50.0%`.
- **`9000` / `4500` DXA** — still yields `width: 450pt` / `width: 225pt` (regression guard).
- **garbage width** — ignored gracefully, no throw.

## Docs

- `CHANGELOG.md` — entry under `[Unreleased] → Fixed`.
- `docs/ooxml_corner_cases.md` — documents the percent-suffixed `w:w` corner case with a minimal reproducer and a Word/LibreOffice/Docxodus comparison table.

## Notes on similar patterns

Swept the codebase for the same risky cast. `tblInd` already uses a safe `(decimal?)` cast and is DXA-only; `gridCol` / `tcW` reads in `RevisionProcessor.cs` are DXA-only in practice. The user-facing crash was confined to the three `WmlToHtmlConverter` width casts, which now share one tolerant parser.
