### PR TITLE
feat(python): DOCX→HTML conversion on the Python surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Python DOCX→HTML conversion** — `convert_docx_to_html(data, options)` and
+  `DocxSession.to_html(options)` in `docx_scalpel`, backed by a new shared
+  `HtmlConversionOps` core renderer that the WASM bridge now also delegates to.
+  New `HtmlOptions` dataclass mirrors the existing WASM/npm conversion options.
+  New stdio-host ops: `convert_to_html`, `session_to_html`.
+
 ## [6.2.0] - 2026-05-28
 
 ### Added

--- a/Docxodus.Tests/HtmlConversionOpsTests.cs
+++ b/Docxodus.Tests/HtmlConversionOpsTests.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.IO;
+using Docxodus;
 using Docxodus.Internal;
 using Xunit;
 
@@ -20,5 +21,36 @@ public class HtmlConversionOpsTests
 
         Assert.Contains("<html", html);
         Assert.Contains("zz-", html);
+    }
+
+    [Fact]
+    public void HCO002_ConvertSession_ReflectsEdit()
+    {
+        using var session = new DocxSession(TourPlanBytes());
+        var projection = session.Project();
+
+        // First body paragraph/heading/list-item anchor, in document order.
+        // C# AnchorTarget nests the anchor: record struct Anchor(Id, Kind, Scope, Unid).
+        string FirstAnchor()
+        {
+            string? best = null;
+            int bestPos = int.MaxValue;
+            foreach (var target in projection.AnchorIndex.Values)
+            {
+                if (target.Anchor.Scope != "body") continue;
+                if (target.Anchor.Kind is not ("p" or "h" or "li")) continue;
+                int pos = projection.Markdown.IndexOf("{#" + target.Anchor.Id + "}", System.StringComparison.Ordinal);
+                if (pos >= 0 && pos < bestPos) { bestPos = pos; best = target.Anchor.Id; }
+            }
+            Assert.NotNull(best);
+            return best!;
+        }
+
+        var edit = session.ReplaceText(FirstAnchor(), "HCO002UNIQUEMARKER edited body.");
+        Assert.True(edit.Success, edit.Error?.Message);
+
+        string html = HtmlConversionOps.ConvertToHtml(session, new HtmlConversionOptions());
+
+        Assert.Contains("HCO002UNIQUEMARKER", html);
     }
 }

--- a/Docxodus.Tests/HtmlConversionOpsTests.cs
+++ b/Docxodus.Tests/HtmlConversionOpsTests.cs
@@ -1,0 +1,24 @@
+#nullable enable
+using System.IO;
+using Docxodus.Internal;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+public class HtmlConversionOpsTests
+{
+    private static byte[] TourPlanBytes() =>
+        File.ReadAllBytes(Path.Combine("..", "..", "..", "..", "TestFiles",
+            "HC001-5DayTourPlanTemplate.docx"));
+
+    [Fact]
+    public void HCO001_ConvertBytes_ProducesHtmlWithPrefix()
+    {
+        var options = new HtmlConversionOptions { CssClassPrefix = "zz-" };
+
+        string html = HtmlConversionOps.ConvertToHtml(TourPlanBytes(), options);
+
+        Assert.Contains("<html", html);
+        Assert.Contains("zz-", html);
+    }
+}

--- a/Docxodus/Internal/HtmlConversionOps.cs
+++ b/Docxodus/Internal/HtmlConversionOps.cs
@@ -50,6 +50,7 @@ internal static class HtmlConversionOps
     {
         if (docxBytes == null || docxBytes.Length == 0)
             throw new ArgumentException("No document data provided", nameof(docxBytes));
+        ArgumentNullException.ThrowIfNull(options);
 
         // Writable stream required: WmlToHtmlConverter runs RevisionAccepter internally.
         using var memoryStream = new MemoryStream();

--- a/Docxodus/Internal/HtmlConversionOps.cs
+++ b/Docxodus/Internal/HtmlConversionOps.cs
@@ -98,6 +98,17 @@ internal static class HtmlConversionOps
         return htmlElement.ToString(SaveOptions.DisableFormatting);
     }
 
+    /// <summary>Render a live session's current (possibly edited) state to HTML.</summary>
+    public static string ConvertToHtml(DocxSession session, HtmlConversionOptions options)
+    {
+        if (session == null) throw new ArgumentNullException(nameof(session));
+        return ConvertToHtml(session.Save(), options);
+    }
+
+    /// <summary>Render the session registered under <paramref name="handle"/> to HTML.</summary>
+    public static string ConvertToHtml(int handle, HtmlConversionOptions options) =>
+        ConvertToHtml(SessionRegistry.Get(handle), options);
+
     private static Func<ImageInfo, XElement> CreateBase64ImageHandler()
     {
         return imageInfo =>

--- a/Docxodus/Internal/HtmlConversionOps.cs
+++ b/Docxodus/Internal/HtmlConversionOps.cs
@@ -1,0 +1,124 @@
+#nullable enable
+
+using System;
+using System.IO;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace Docxodus.Internal;
+
+/// <summary>
+/// Options for <see cref="HtmlConversionOps"/>. Mirrors the parameter set of the
+/// WASM <c>DocumentConverter.ConvertDocxToHtmlComplete</c> shell so every surface
+/// renders identically. Integer-coded modes match the existing WASM wire contract:
+/// CommentRenderMode -1=disabled,0=Endnote,1=Inline,2=Margin;
+/// PaginationMode 0=None,1=Paginated; AnnotationLabelMode 0=Above,1=Inline,2=Tooltip,3=None.
+/// </summary>
+public sealed class HtmlConversionOptions
+{
+    public string PageTitle { get; init; } = "Document";
+    public string CssClassPrefix { get; init; } = "docx-";
+    public bool FabricateCssClasses { get; init; } = true;
+    public string AdditionalCss { get; init; } = "";
+    public int CommentRenderMode { get; init; } = -1;
+    public string CommentCssClassPrefix { get; init; } = "comment-";
+    public int PaginationMode { get; init; }
+    public double PaginationScale { get; init; } = 1.0;
+    public string PaginationCssClassPrefix { get; init; } = "page-";
+    public bool RenderAnnotations { get; init; }
+    public int AnnotationLabelMode { get; init; }
+    public string AnnotationCssClassPrefix { get; init; } = "annot-";
+    public bool RenderFootnotesAndEndnotes { get; init; }
+    public bool RenderHeadersAndFooters { get; init; }
+    public bool RenderTrackedChanges { get; init; }
+    public bool ShowDeletedContent { get; init; } = true;
+    public bool RenderMoveOperations { get; init; } = true;
+    public bool RenderUnsupportedContentPlaceholders { get; init; }
+    public string? DocumentLanguage { get; init; }
+}
+
+/// <summary>
+/// Single owner of the DOCX-bytes + <see cref="HtmlConversionOptions"/> →
+/// HTML-string mapping. Both the WASM <c>DocumentConverter</c> bridge and the
+/// stdio Python host route through here, so render behavior lives in one place.
+/// Throws on invalid input; callers serialize errors at their boundary.
+/// </summary>
+public static class HtmlConversionOps
+{
+    /// <summary>Render raw DOCX bytes to a self-contained HTML string.</summary>
+    public static string ConvertToHtml(byte[] docxBytes, HtmlConversionOptions options)
+    {
+        if (docxBytes == null || docxBytes.Length == 0)
+            throw new ArgumentException("No document data provided", nameof(docxBytes));
+
+        // Writable stream required: WmlToHtmlConverter runs RevisionAccepter internally.
+        using var memoryStream = new MemoryStream();
+        memoryStream.Write(docxBytes, 0, docxBytes.Length);
+        memoryStream.Position = 0;
+        using var wordDoc = WordprocessingDocument.Open(memoryStream, true);
+
+        var renderComments = options.CommentRenderMode >= 0;
+
+        var settings = new WmlToHtmlConverterSettings
+        {
+            PageTitle = options.PageTitle,
+            CssClassPrefix = options.CssClassPrefix,
+            FabricateCssClasses = options.FabricateCssClasses,
+            AdditionalCss = options.AdditionalCss,
+            GeneralCss = "body { font-family: Arial, sans-serif; margin: 20px; } " +
+                         "span { white-space: pre-wrap; }",
+            RenderComments = renderComments,
+            CommentRenderMode = renderComments
+                ? (CommentRenderMode)options.CommentRenderMode
+                : CommentRenderMode.EndnoteStyle,
+            CommentCssClassPrefix = options.CommentCssClassPrefix,
+            IncludeCommentMetadata = true,
+            RenderPagination = (PaginationMode)options.PaginationMode,
+            PaginationScale = options.PaginationScale > 0 ? options.PaginationScale : 1.0,
+            PaginationCssClassPrefix = options.PaginationCssClassPrefix,
+            RenderAnnotations = options.RenderAnnotations,
+            AnnotationLabelMode = (AnnotationLabelMode)options.AnnotationLabelMode,
+            AnnotationCssClassPrefix = options.AnnotationCssClassPrefix,
+            IncludeAnnotationMetadata = true,
+            RenderFootnotesAndEndnotes = options.RenderFootnotesAndEndnotes,
+            RenderHeadersAndFooters = options.RenderHeadersAndFooters,
+            RenderTrackedChanges = options.RenderTrackedChanges,
+            ShowDeletedContent = options.ShowDeletedContent,
+            RenderMoveOperations = options.RenderMoveOperations,
+            IncludeRevisionMetadata = true,
+            RenderUnsupportedContentPlaceholders = options.RenderUnsupportedContentPlaceholders,
+            UnsupportedContentCssClassPrefix = "unsupported-",
+            IncludeUnsupportedContentMetadata = true,
+            DocumentLanguage = options.DocumentLanguage,
+            // Embed images as base64 data URIs — no SkiaSharp needed (WASM-safe).
+            ImageHandler = CreateBase64ImageHandler(),
+        };
+
+        var htmlElement = WmlToHtmlConverter.ConvertToHtml(wordDoc, settings);
+        return htmlElement.ToString(SaveOptions.DisableFormatting);
+    }
+
+    private static Func<ImageInfo, XElement> CreateBase64ImageHandler()
+    {
+        return imageInfo =>
+        {
+            if (imageInfo.ImageBytes == null || imageInfo.ImageBytes.Length == 0)
+                return null!;
+
+            var mimeType = imageInfo.ContentType ?? "image/png";
+            var base64 = Convert.ToBase64String(imageInfo.ImageBytes);
+            var dataUri = $"data:{mimeType};base64,{base64}";
+
+            var imgElement = new XElement(XhtmlNoNamespace.img,
+                new XAttribute("src", dataUri));
+
+            if (imageInfo.ImgStyleAttribute != null)
+                imgElement.Add(imageInfo.ImgStyleAttribute);
+
+            if (!string.IsNullOrEmpty(imageInfo.AltText))
+                imgElement.Add(new XAttribute("alt", imageInfo.AltText));
+
+            return imgElement;
+        };
+    }
+}

--- a/Docxodus/Internal/HtmlConversionOps.cs
+++ b/Docxodus/Internal/HtmlConversionOps.cs
@@ -14,7 +14,7 @@ namespace Docxodus.Internal;
 /// CommentRenderMode -1=disabled,0=Endnote,1=Inline,2=Margin;
 /// PaginationMode 0=None,1=Paginated; AnnotationLabelMode 0=Above,1=Inline,2=Tooltip,3=None.
 /// </summary>
-public sealed class HtmlConversionOptions
+internal sealed class HtmlConversionOptions
 {
     public string PageTitle { get; init; } = "Document";
     public string CssClassPrefix { get; init; } = "docx-";
@@ -43,7 +43,7 @@ public sealed class HtmlConversionOptions
 /// stdio Python host route through here, so render behavior lives in one place.
 /// Throws on invalid input; callers serialize errors at their boundary.
 /// </summary>
-public static class HtmlConversionOps
+internal static class HtmlConversionOps
 {
     /// <summary>Render raw DOCX bytes to a self-contained HTML string.</summary>
     public static string ConvertToHtml(byte[] docxBytes, HtmlConversionOptions options)

--- a/docs/architecture/python_docxodus.md
+++ b/docs/architecture/python_docxodus.md
@@ -43,7 +43,7 @@ NDJSON over stdio — one JSON object per line, `\n` terminated.
 
 **Bytes:** `open_session.args = {"docxB64": "..."}`; `save` response = `{"docxB64": "..."}`. Base64 inside JSON. ~33% overhead, acceptable for the agentic edit-loop pattern.
 
-**Op names** (~36, all snake_case): `open_session`, `close_session`, `save`, `ping`, `shutdown`, `project`, `replace_text`, `delete_block`, `insert_paragraph`, `split_paragraph`, `merge_paragraphs`, `apply_format`, `apply_format_by_substring`, `set_paragraph_style`, `set_list_level`, `remove_list_membership`, `replace_cell_content`, `raw_get_xml`, `raw_insert_xml`, `raw_replace_xml`, `grep`, `grep_cross_block`, `replace_text_range`, `replace_text_at_span`, `find_placeholders`, `find_by_annotation`, `find_by_label`, `find_by_bookmark`, `list_annotations`, `add_annotation`, `remove_annotation`, `update_annotation`, `move_annotation`, `exists`, `get_anchor_info`, `get_anchor_infos`, `find_by_text`, `find_all_by_text`, `find_by_regex`, `find_by_kind`, `undo`, `redo`.
+**Op names** (~38, all snake_case): `open_session`, `close_session`, `save`, `ping`, `shutdown`, `project`, `replace_text`, `delete_block`, `insert_paragraph`, `split_paragraph`, `merge_paragraphs`, `apply_format`, `apply_format_by_substring`, `set_paragraph_style`, `set_list_level`, `remove_list_membership`, `replace_cell_content`, `raw_get_xml`, `raw_insert_xml`, `raw_replace_xml`, `grep`, `grep_cross_block`, `replace_text_range`, `replace_text_at_span`, `find_placeholders`, `find_by_annotation`, `find_by_label`, `find_by_bookmark`, `list_annotations`, `add_annotation`, `remove_annotation`, `update_annotation`, `move_annotation`, `exists`, `get_anchor_info`, `get_anchor_infos`, `find_by_text`, `find_all_by_text`, `find_by_regex`, `find_by_kind`, `undo`, `redo`, `convert_to_html`, `session_to_html`.
 
 ## Planned Python package layout
 
@@ -191,6 +191,82 @@ carries the affected id on success. New `EditErrorCode` values:
 See `docs/architecture/docx_mutation_api.md` § "Tier E: Annotations" for the
 full semantics.
 
+## DOCX→HTML conversion
+
+Two public functions expose HTML rendering on the Python surface.
+
+### Module-level function (stateless)
+
+```python
+from docx_scalpel import convert_docx_to_html, HtmlOptions
+
+html: str = convert_docx_to_html(docx_bytes, HtmlOptions(page_title="My Doc"))
+```
+
+`convert_docx_to_html(data: bytes, options: HtmlOptions | None = None) -> str`
+renders the supplied bytes directly in the host process — no persistent session
+is created, so it is the right choice when you only need HTML and do not intend
+to edit the document. Maps to the `convert_to_html` stdio-host op.
+
+### Session method (renders current edited state)
+
+```python
+with open_docx_session(docx_bytes) as session:
+    session.replace_text(anchor_id, "updated text")
+    html = session.to_html(HtmlOptions(render_tracked_changes=True))
+```
+
+`DocxSession.to_html(options: HtmlOptions | None = None) -> str`
+renders the session's current, possibly-edited in-memory state. If the session
+is in `TrackedChangeMode.RENDER_INLINE`, tracked insertions and deletions appear
+as `<ins>`/`<del>` in the HTML output when `render_tracked_changes=True`. Maps
+to the `session_to_html` stdio-host op.
+
+### `HtmlOptions` dataclass
+
+`@dataclass(frozen=True, slots=True)` with the following fields and defaults:
+
+| Field | Default | Notes |
+|-------|---------|-------|
+| `page_title` | `"Document"` | Value of the HTML `<title>` element. |
+| `css_class_prefix` | `"docx-"` | Prefix applied to all generated CSS class names. |
+| `fabricate_css_classes` | `True` | Emit a `<style>` block of generated classes in the output. |
+| `additional_css` | `""` | Extra CSS injected into the `<style>` block verbatim. |
+| `comment_render_mode` | `-1` | `-1` = disabled; `0` = endnote-style; `1` = inline; `2` = margin. |
+| `comment_css_class_prefix` | `"comment-"` | CSS prefix for comment elements. |
+| `pagination_mode` | `0` | `0` = none; `1` = paginated (emulates page breaks). |
+| `pagination_scale` | `1.0` | Scale factor applied in paginated mode. |
+| `pagination_css_class_prefix` | `"page-"` | CSS prefix for page-break elements. |
+| `render_annotations` | `False` | Overlay `ExternalAnnotationProjector` annotation spans. |
+| `annotation_label_mode` | `0` | `0` = above; `1` = inline; `2` = tooltip; `3` = none. |
+| `annotation_css_class_prefix` | `"annot-"` | CSS prefix for annotation spans. |
+| `render_footnotes_and_endnotes` | `False` | Append a footnotes/endnotes section to the HTML. |
+| `render_headers_and_footers` | `False` | Include document headers and footers in the output. |
+| `render_tracked_changes` | `False` | Render tracked insertions/deletions as `<ins>`/`<del>`. |
+| `show_deleted_content` | `True` | When rendering tracked changes, include deleted content. |
+| `render_move_operations` | `True` | Distinguish move operations from plain insert/delete. |
+| `render_unsupported_content_placeholders` | `False` | Insert placeholder text for unsupported OOXML elements. |
+| `document_language` | `None` | BCP-47 language tag (e.g. `"en-US"`). Omitted from the wire when `None`. |
+
+Integer-coded mode fields follow the same conventions as the WASM/npm surface:
+any value that is the field's default (e.g. `comment_render_mode=-1`,
+`pagination_mode=0`) is omitted from the JSON args to keep the wire compact.
+
+### Shared core renderer
+
+Both `convert_docx_to_html` and `DocxSession.to_html` are backed by
+`Docxodus.Internal.HtmlConversionOps` — a single `internal` class that
+provides:
+
+- `ConvertToHtml(byte[] docxBytes, HtmlConversionOptions options) → string`
+- `ConvertToHtml(DocxSession session, HtmlConversionOptions options) → string`
+- `ConvertToHtml(int handle, HtmlConversionOptions options) → string`
+
+The WASM `DocumentConverter.ConvertDocxToHtmlComplete` delegates to the same
+renderer, ensuring that .NET, WASM/browser, and Python/stdio produce
+byte-identical HTML for the same input and options. There is no
+Python-specific rendering path.
+
 ## Wire-only internals
 
 Decode helpers (`Anchor._from_wire(d)`, `EditResult._from_wire(d)`, etc.) live on
@@ -231,7 +307,7 @@ Tests import fixtures via `TEST_FILES = Path(__file__).parent.parent.parent / "T
 - **`async` API** — `asyncio.subprocess` facade is straightforward (one asyncio.Lock + request-id matching already on the wire), but doubles the test surface. v0.2.
 - **Multi-process pooling** — one host per Python process is enough for the agentic editing pattern.
 - **Native AOT publish** — `PublishReadyToRun` already eliminates JIT warmup; NAOT would require trim-safety auditing of every `PtOpenXmlUtil` reflection path. High risk for marginal payoff.
-- **HTML conversion / comparison / chart extraction** (the SkiaSharp-dependent surface) — clean additive in v0.3 (new op names, same wire protocol).
+- **HTML conversion** — landed (`convert_docx_to_html` / `DocxSession.to_html`; see "DOCX→HTML conversion" above). **Comparison / chart extraction** (SkiaSharp-dependent) remain deferred — clean additive in v0.3 (new op names, same wire protocol).
 - **Streaming `save`** — even 10 MB documents transit stdio in <100 ms.
 - **Schema validation** — JSON Schema per op alongside the host binary so Python can validate before sending. v0.2.
 - **Nested `ProjectionSettings`** — bridges don't expose them; defer until both transports gain support.

--- a/docs/architecture/python_docxodus.md
+++ b/docs/architecture/python_docxodus.md
@@ -51,7 +51,7 @@ NDJSON over stdio — one JSON object per line, `\n` terminated.
 python/
   pyproject.toml          # hatchling backend; stdlib-only deps
   src/docxodus/
-    __init__.py           # re-export DocxSession, open_docx_session, dataclasses
+    __init__.py           # re-export DocxSession, open_session, dataclasses
     session.py            # public DocxSession class — snake_case methods, 1:1 with C# surface
     types.py              # @dataclass(frozen=True, slots=True) value types
     enums.py              # Position, EditErrorCode, TrackedChangeMode, PlaceholderKind/Kinds, ProjectionScopes, etc.
@@ -78,7 +78,7 @@ python/
 
 **One host process per Python process; many DocxSession handles inside it.**
 
-- Lazy-spawned by `_Transport.get()` on first `open_docx_session(...)` call.
+- Lazy-spawned by `_Transport.get()` on first `open_session(...)` call.
 - `atexit` sends `shutdown` then `wait(timeout=2)` then `terminate()` then `kill()`.
 - Stderr drained on a daemon thread into Python's `logging`.
 - v1 is sync: a `threading.Lock` serializes one request/response round-trip at a time so two threads sharing a session don't interleave NDJSON lines.
@@ -112,7 +112,7 @@ class _Transport:
 ## Lifecycle
 
 ```python
-with open_docx_session(docx_bytes) as session:        # documented contract
+with open_session(docx_bytes) as session:        # documented contract
     proj = session.project()
     for placeholder in session.find_placeholders():
         session.replace_match(placeholder.match, "filled value")
@@ -211,7 +211,7 @@ to edit the document. Maps to the `convert_to_html` stdio-host op.
 ### Session method (renders current edited state)
 
 ```python
-with open_docx_session(docx_bytes) as session:
+with open_session(docx_bytes) as session:
     session.replace_text(anchor_id, "updated text")
     html = session.to_html(HtmlOptions(render_tracked_changes=True))
 ```
@@ -248,9 +248,10 @@ to the `session_to_html` stdio-host op.
 | `render_unsupported_content_placeholders` | `False` | Insert placeholder text for unsupported OOXML elements. |
 | `document_language` | `None` | BCP-47 language tag (e.g. `"en-US"`). Omitted from the wire when `None`. |
 
-Integer-coded mode fields follow the same conventions as the WASM/npm surface:
-any value that is the field's default (e.g. `comment_render_mode=-1`,
-`pagination_mode=0`) is omitted from the JSON args to keep the wire compact.
+Integer-coded mode fields follow the same conventions as the WASM/npm surface.
+`HtmlOptions.to_wire()` always serializes every field except `document_language`,
+which is omitted when `None`; the host's `ParseHtmlOptions` then applies the same
+per-field defaults for any key that is absent.
 
 ### Shared core renderer
 

--- a/docs/superpowers/plans/2026-05-29-python-docx-to-html.md
+++ b/docs/superpowers/plans/2026-05-29-python-docx-to-html.md
@@ -1,0 +1,735 @@
+# DOCX→HTML on the Python Surface — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring DOCX→HTML conversion to the Python (`docx_scalpel`) surface, both stateless (`convert_docx_to_html`) and session-bound (`DocxSession.to_html`), reusing one shared core renderer that the WASM bridge also delegates to.
+
+**Architecture:** Extract the bytes+options→HTML settings mapping (today inlined only in WASM's `ConvertDocxToHtmlComplete`) into `Docxodus/Internal/HtmlConversionOps.cs`. The WASM shell and the stdio Python host both call it. The host gains two NDJSON ops (`convert_to_html`, `session_to_html`); the Python wrapper gains a module function, a `DocxSession.to_html` method, and an `HtmlOptions` dataclass.
+
+**Tech Stack:** C# / .NET 8 (`Docxodus`, `DocxodusWasm`, `docxodus-pyhost`), Python 3 (`docx_scalpel`), xUnit, pytest.
+
+**Branch:** `feat/python-docx-to-html` (already checked out).
+
+---
+
+## File Structure
+
+- **Create** `Docxodus/Internal/HtmlConversionOps.cs` — `HtmlConversionOptions` DTO + `HtmlConversionOps` static class (stateless + session overloads + base64 image handler). Single owner of the settings mapping.
+- **Modify** `wasm/DocxodusWasm/DocumentConverter.cs` — `ConvertDocxToHtmlComplete` builds an `HtmlConversionOptions` and delegates; remove the now-unused private `CreateBase64ImageHandler`.
+- **Modify** `tools/python-host/Dispatcher.cs` — two new ops + `ParseHtmlOptions` helper.
+- **Modify** `python/src/docx_scalpel/types.py` — `HtmlOptions` dataclass.
+- **Modify** `python/src/docx_scalpel/session.py` — `convert_docx_to_html` function + `DocxSession.to_html` method + exports.
+- **Create** `Docxodus.Tests/HtmlConversionOpsTests.cs` — .NET unit tests.
+- **Create** `python/tests/test_to_html.py` — Python tests.
+- **Modify** `CHANGELOG.md`, `docs/architecture/python_docxodus.md`.
+
+---
+
+## Task 1: Core `HtmlConversionOps` (stateless)
+
+**Files:**
+- Create: `Docxodus/Internal/HtmlConversionOps.cs`
+- Test: `Docxodus.Tests/HtmlConversionOpsTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `Docxodus.Tests/HtmlConversionOpsTests.cs`:
+
+```csharp
+#nullable enable
+using System.IO;
+using Docxodus.Internal;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+public class HtmlConversionOpsTests
+{
+    private static byte[] TourPlanBytes() =>
+        File.ReadAllBytes(Path.Combine("..", "..", "..", "..", "TestFiles",
+            "HC001-5DayTourPlanTemplate.docx"));
+
+    [Fact]
+    public void HCO001_ConvertBytes_ProducesHtmlWithPrefix()
+    {
+        var options = new HtmlConversionOptions { CssClassPrefix = "zz-" };
+
+        string html = HtmlConversionOps.ConvertToHtml(TourPlanBytes(), options);
+
+        Assert.Contains("<html", html);
+        Assert.Contains("zz-", html);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test Docxodus.Tests/Docxodus.Tests.csproj --filter "FullyQualifiedName~HCO001"`
+Expected: FAIL — compile error, `HtmlConversionOps` / `HtmlConversionOptions` do not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `Docxodus/Internal/HtmlConversionOps.cs`:
+
+```csharp
+#nullable enable
+
+using System;
+using System.IO;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace Docxodus.Internal;
+
+/// <summary>
+/// Options for <see cref="HtmlConversionOps"/>. Mirrors the parameter set of the
+/// WASM <c>DocumentConverter.ConvertDocxToHtmlComplete</c> shell so every surface
+/// renders identically. Integer-coded modes match the existing WASM wire contract:
+/// CommentRenderMode -1=disabled,0=Endnote,1=Inline,2=Margin;
+/// PaginationMode 0=None,1=Paginated; AnnotationLabelMode 0=Above,1=Inline,2=Tooltip,3=None.
+/// </summary>
+public sealed class HtmlConversionOptions
+{
+    public string PageTitle { get; init; } = "Document";
+    public string CssClassPrefix { get; init; } = "docx-";
+    public bool FabricateCssClasses { get; init; } = true;
+    public string AdditionalCss { get; init; } = "";
+    public int CommentRenderMode { get; init; } = -1;
+    public string CommentCssClassPrefix { get; init; } = "comment-";
+    public int PaginationMode { get; init; }
+    public double PaginationScale { get; init; } = 1.0;
+    public string PaginationCssClassPrefix { get; init; } = "page-";
+    public bool RenderAnnotations { get; init; }
+    public int AnnotationLabelMode { get; init; }
+    public string AnnotationCssClassPrefix { get; init; } = "annot-";
+    public bool RenderFootnotesAndEndnotes { get; init; }
+    public bool RenderHeadersAndFooters { get; init; }
+    public bool RenderTrackedChanges { get; init; }
+    public bool ShowDeletedContent { get; init; } = true;
+    public bool RenderMoveOperations { get; init; } = true;
+    public bool RenderUnsupportedContentPlaceholders { get; init; }
+    public string? DocumentLanguage { get; init; }
+}
+
+/// <summary>
+/// Single owner of the DOCX-bytes + <see cref="HtmlConversionOptions"/> →
+/// HTML-string mapping. Both the WASM <c>DocumentConverter</c> bridge and the
+/// stdio Python host route through here, so render behavior lives in one place.
+/// Throws on invalid input; callers serialize errors at their boundary.
+/// </summary>
+public static class HtmlConversionOps
+{
+    /// <summary>Render raw DOCX bytes to a self-contained HTML string.</summary>
+    public static string ConvertToHtml(byte[] docxBytes, HtmlConversionOptions options)
+    {
+        if (docxBytes == null || docxBytes.Length == 0)
+            throw new ArgumentException("No document data provided", nameof(docxBytes));
+
+        // Writable stream required: WmlToHtmlConverter runs RevisionAccepter internally.
+        using var memoryStream = new MemoryStream();
+        memoryStream.Write(docxBytes, 0, docxBytes.Length);
+        memoryStream.Position = 0;
+        using var wordDoc = WordprocessingDocument.Open(memoryStream, true);
+
+        var renderComments = options.CommentRenderMode >= 0;
+
+        var settings = new WmlToHtmlConverterSettings
+        {
+            PageTitle = options.PageTitle,
+            CssClassPrefix = options.CssClassPrefix,
+            FabricateCssClasses = options.FabricateCssClasses,
+            AdditionalCss = options.AdditionalCss,
+            GeneralCss = "body { font-family: Arial, sans-serif; margin: 20px; } " +
+                         "span { white-space: pre-wrap; }",
+            RenderComments = renderComments,
+            CommentRenderMode = renderComments
+                ? (CommentRenderMode)options.CommentRenderMode
+                : CommentRenderMode.EndnoteStyle,
+            CommentCssClassPrefix = options.CommentCssClassPrefix,
+            IncludeCommentMetadata = true,
+            RenderPagination = (PaginationMode)options.PaginationMode,
+            PaginationScale = options.PaginationScale > 0 ? options.PaginationScale : 1.0,
+            PaginationCssClassPrefix = options.PaginationCssClassPrefix,
+            RenderAnnotations = options.RenderAnnotations,
+            AnnotationLabelMode = (AnnotationLabelMode)options.AnnotationLabelMode,
+            AnnotationCssClassPrefix = options.AnnotationCssClassPrefix,
+            IncludeAnnotationMetadata = true,
+            RenderFootnotesAndEndnotes = options.RenderFootnotesAndEndnotes,
+            RenderHeadersAndFooters = options.RenderHeadersAndFooters,
+            RenderTrackedChanges = options.RenderTrackedChanges,
+            ShowDeletedContent = options.ShowDeletedContent,
+            RenderMoveOperations = options.RenderMoveOperations,
+            IncludeRevisionMetadata = true,
+            RenderUnsupportedContentPlaceholders = options.RenderUnsupportedContentPlaceholders,
+            UnsupportedContentCssClassPrefix = "unsupported-",
+            IncludeUnsupportedContentMetadata = true,
+            DocumentLanguage = options.DocumentLanguage,
+            // Embed images as base64 data URIs — no SkiaSharp needed (WASM-safe).
+            ImageHandler = CreateBase64ImageHandler(),
+        };
+
+        var htmlElement = WmlToHtmlConverter.ConvertToHtml(wordDoc, settings);
+        return htmlElement.ToString(SaveOptions.DisableFormatting);
+    }
+
+    private static Func<ImageInfo, XElement> CreateBase64ImageHandler()
+    {
+        return imageInfo =>
+        {
+            if (imageInfo.ImageBytes == null || imageInfo.ImageBytes.Length == 0)
+                return null!;
+
+            var mimeType = imageInfo.ContentType ?? "image/png";
+            var base64 = Convert.ToBase64String(imageInfo.ImageBytes);
+            var dataUri = $"data:{mimeType};base64,{base64}";
+
+            var imgElement = new XElement(XhtmlNoNamespace.img,
+                new XAttribute("src", dataUri));
+
+            if (imageInfo.ImgStyleAttribute != null)
+                imgElement.Add(imageInfo.ImgStyleAttribute);
+
+            if (!string.IsNullOrEmpty(imageInfo.AltText))
+                imgElement.Add(new XAttribute("alt", imageInfo.AltText));
+
+            return imgElement;
+        };
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test Docxodus.Tests/Docxodus.Tests.csproj --filter "FullyQualifiedName~HCO001"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Docxodus/Internal/HtmlConversionOps.cs Docxodus.Tests/HtmlConversionOpsTests.cs
+git commit -m "feat(core): HtmlConversionOps shared DOCX->HTML renderer"
+```
+
+---
+
+## Task 2: Core `HtmlConversionOps` session overloads
+
+**Files:**
+- Modify: `Docxodus/Internal/HtmlConversionOps.cs`
+- Test: `Docxodus.Tests/HtmlConversionOpsTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `HtmlConversionOpsTests.cs` (inside the class):
+
+```csharp
+    [Fact]
+    public void HCO002_ConvertSession_ReflectsEdit()
+    {
+        using var session = new DocxSession(TourPlanBytes());
+        var projection = session.Project();
+
+        // First body paragraph/heading/list-item anchor, in document order.
+        // C# AnchorTarget nests the anchor: record struct Anchor(Id, Kind, Scope, Unid).
+        string FirstAnchor()
+        {
+            string? best = null;
+            int bestPos = int.MaxValue;
+            foreach (var target in projection.AnchorIndex.Values)
+            {
+                if (target.Anchor.Scope != "body") continue;
+                if (target.Anchor.Kind is not ("p" or "h" or "li")) continue;
+                int pos = projection.Markdown.IndexOf("{#" + target.Anchor.Id + "}", System.StringComparison.Ordinal);
+                if (pos >= 0 && pos < bestPos) { bestPos = pos; best = target.Anchor.Id; }
+            }
+            Assert.NotNull(best);
+            return best!;
+        }
+
+        var edit = session.ReplaceText(FirstAnchor(), "HCO002UNIQUEMARKER edited body.");
+        Assert.True(edit.Success, edit.Error?.Message);
+
+        string html = HtmlConversionOps.ConvertToHtml(session, new HtmlConversionOptions());
+
+        Assert.Contains("HCO002UNIQUEMARKER", html);
+    }
+```
+
+Verified names: `MarkdownProjection.Markdown` / `.AnchorIndex` (dict keyed by anchor id → `AnchorTarget`); `AnchorTarget.Anchor` is `record struct Anchor(string Id, string Kind, string Scope, string Unid)`; `EditResult.Success` / `.Error`; `EditError` is `record EditError(EditErrorCode Code, string Message, string? AnchorId)`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test Docxodus.Tests/Docxodus.Tests.csproj --filter "FullyQualifiedName~HCO002"`
+Expected: FAIL — no `ConvertToHtml(DocxSession, ...)` overload.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `HtmlConversionOps.cs`, add these two overloads to the `HtmlConversionOps` class (after the `byte[]` overload):
+
+```csharp
+    /// <summary>Render a live session's current (possibly edited) state to HTML.</summary>
+    public static string ConvertToHtml(DocxSession session, HtmlConversionOptions options)
+    {
+        if (session == null) throw new ArgumentNullException(nameof(session));
+        return ConvertToHtml(session.Save(), options);
+    }
+
+    /// <summary>Render the session registered under <paramref name="handle"/> to HTML.</summary>
+    public static string ConvertToHtml(int handle, HtmlConversionOptions options) =>
+        ConvertToHtml(SessionRegistry.Get(handle), options);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test Docxodus.Tests/Docxodus.Tests.csproj --filter "FullyQualifiedName~HtmlConversionOpsTests"`
+Expected: PASS (both HCO001 and HCO002).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Docxodus/Internal/HtmlConversionOps.cs Docxodus.Tests/HtmlConversionOpsTests.cs
+git commit -m "feat(core): HtmlConversionOps session + handle overloads"
+```
+
+---
+
+## Task 3: WASM dedupe — delegate `ConvertDocxToHtmlComplete`
+
+**Files:**
+- Modify: `wasm/DocxodusWasm/DocumentConverter.cs` (the body of `ConvertDocxToHtmlComplete`, ~line 229; and remove the private `CreateBase64ImageHandler`, ~line 1996)
+
+- [ ] **Step 1: Replace the method body**
+
+In `ConvertDocxToHtmlComplete`, replace the `try { ... }` block's settings-construction + conversion (everything from `using var memoryStream` through `return htmlElement.ToString(...)`) with a delegation. The final method body becomes:
+
+```csharp
+        if (docxBytes == null || docxBytes.Length == 0)
+        {
+            return SerializeError("No document data provided");
+        }
+
+        try
+        {
+            var options = new Docxodus.Internal.HtmlConversionOptions
+            {
+                PageTitle = pageTitle ?? "Document",
+                CssClassPrefix = cssPrefix ?? "docx-",
+                FabricateCssClasses = fabricateClasses,
+                AdditionalCss = additionalCss ?? "",
+                CommentRenderMode = commentRenderMode,
+                CommentCssClassPrefix = commentCssClassPrefix ?? "comment-",
+                PaginationMode = paginationMode,
+                PaginationScale = paginationScale,
+                PaginationCssClassPrefix = paginationCssClassPrefix ?? "page-",
+                RenderAnnotations = renderAnnotations,
+                AnnotationLabelMode = annotationLabelMode,
+                AnnotationCssClassPrefix = annotationCssClassPrefix ?? "annot-",
+                RenderFootnotesAndEndnotes = renderFootnotesAndEndnotes,
+                RenderHeadersAndFooters = renderHeadersAndFooters,
+                RenderTrackedChanges = renderTrackedChanges,
+                ShowDeletedContent = showDeletedContent,
+                RenderMoveOperations = renderMoveOperations,
+                RenderUnsupportedContentPlaceholders = renderUnsupportedContentPlaceholders,
+                DocumentLanguage = documentLanguage,
+            };
+            return Docxodus.Internal.HtmlConversionOps.ConvertToHtml(docxBytes, options);
+        }
+        catch (Exception ex)
+        {
+            return SerializeError(ex.Message, ex.GetType().Name, ex.StackTrace);
+        }
+```
+
+> Note: this changes the default `CssClassPrefix` fallback to `"docx-"` (was already `"docx-"` in the original) — unchanged. The old body's `PaginationScale = paginationScale > 0 ? paginationScale : 1.0` guard now lives inside `HtmlConversionOps`, so passing `paginationScale` straight through is correct.
+
+- [ ] **Step 2: Remove the now-unused private helper**
+
+Delete the entire `private static Func<ImageInfo, XElement> CreateBase64ImageHandler()` method (~line 1996) from `DocumentConverter.cs` **only if** no other method still references it.
+
+Run: `grep -n "CreateBase64ImageHandler" wasm/DocxodusWasm/DocumentConverter.cs`
+- If matches remain (other converters like the annotation/external-annotation paths use it), **leave it in place** and skip this step.
+- If the only match was the definition, delete the method.
+
+- [ ] **Step 3: Build to verify (non-WASM compile of the shared lib + WASM project compiles)**
+
+Run: `dotnet build Docxodus/Docxodus.csproj`
+Expected: Build succeeded.
+
+Then the WASM build:
+Run: `./scripts/build-wasm.sh`
+Expected: completes without error.
+
+> If you switch back to `dotnet test` after a WASM build, run `dotnet clean Docxodus.sln` first (see CLAUDE.md "Switching back from a WASM build").
+
+- [ ] **Step 4: WASM regression test**
+
+Run:
+```bash
+cd npm && npm run build && npm test -- --grep "convert" 2>/dev/null || npm test
+```
+Expected: existing DOCX→HTML conversion specs PASS (behavior unchanged by the dedupe).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/jman/Code/Docxodus
+git add wasm/DocxodusWasm/DocumentConverter.cs
+git commit -m "refactor(wasm): ConvertDocxToHtmlComplete delegates to HtmlConversionOps"
+```
+
+---
+
+## Task 4: Python host ops — `convert_to_html`, `session_to_html`
+
+**Files:**
+- Modify: `tools/python-host/Dispatcher.cs`
+
+- [ ] **Step 1: Add the two op cases**
+
+In the `Dispatch` switch (after the `"save"` case near line 30), add:
+
+```csharp
+        "convert_to_html" => ConvertToHtml(args),
+        "session_to_html" => SessionToHtml(args),
+```
+
+- [ ] **Step 2: Add the op + options-parsing helpers**
+
+Add these private methods to `Dispatcher` (place near `Save`):
+
+```csharp
+    private static string ConvertToHtml(JsonElement args)
+    {
+        var bytes = Convert.FromBase64String(Str(args, "docxB64"));
+        var html = HtmlConversionOps.ConvertToHtml(bytes, ParseHtmlOptions(args));
+        return JsonString(html);
+    }
+
+    private static string SessionToHtml(JsonElement args)
+    {
+        var html = HtmlConversionOps.ConvertToHtml(Handle(args), ParseHtmlOptions(args));
+        return JsonString(html);
+    }
+
+    private static HtmlConversionOptions ParseHtmlOptions(JsonElement args)
+    {
+        if (args.ValueKind != JsonValueKind.Object
+            || !args.TryGetProperty("options", out var o)
+            || o.ValueKind != JsonValueKind.Object)
+        {
+            return new HtmlConversionOptions();
+        }
+
+        string StrOpt(string name, string fallback) =>
+            o.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String
+                ? v.GetString()! : fallback;
+        int IntOpt(string name, int fallback) =>
+            o.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number
+                ? v.GetInt32() : fallback;
+        double DblOpt(string name, double fallback) =>
+            o.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number
+                ? v.GetDouble() : fallback;
+        bool BoolOpt(string name, bool fallback) =>
+            o.TryGetProperty(name, out var v) && (v.ValueKind == JsonValueKind.True || v.ValueKind == JsonValueKind.False)
+                ? v.GetBoolean() : fallback;
+
+        var defaults = new HtmlConversionOptions();
+        return new HtmlConversionOptions
+        {
+            PageTitle = StrOpt("pageTitle", defaults.PageTitle),
+            CssClassPrefix = StrOpt("cssClassPrefix", defaults.CssClassPrefix),
+            FabricateCssClasses = BoolOpt("fabricateCssClasses", defaults.FabricateCssClasses),
+            AdditionalCss = StrOpt("additionalCss", defaults.AdditionalCss),
+            CommentRenderMode = IntOpt("commentRenderMode", defaults.CommentRenderMode),
+            CommentCssClassPrefix = StrOpt("commentCssClassPrefix", defaults.CommentCssClassPrefix),
+            PaginationMode = IntOpt("paginationMode", defaults.PaginationMode),
+            PaginationScale = DblOpt("paginationScale", defaults.PaginationScale),
+            PaginationCssClassPrefix = StrOpt("paginationCssClassPrefix", defaults.PaginationCssClassPrefix),
+            RenderAnnotations = BoolOpt("renderAnnotations", defaults.RenderAnnotations),
+            AnnotationLabelMode = IntOpt("annotationLabelMode", defaults.AnnotationLabelMode),
+            AnnotationCssClassPrefix = StrOpt("annotationCssClassPrefix", defaults.AnnotationCssClassPrefix),
+            RenderFootnotesAndEndnotes = BoolOpt("renderFootnotesAndEndnotes", defaults.RenderFootnotesAndEndnotes),
+            RenderHeadersAndFooters = BoolOpt("renderHeadersAndFooters", defaults.RenderHeadersAndFooters),
+            RenderTrackedChanges = BoolOpt("renderTrackedChanges", defaults.RenderTrackedChanges),
+            ShowDeletedContent = BoolOpt("showDeletedContent", defaults.ShowDeletedContent),
+            RenderMoveOperations = BoolOpt("renderMoveOperations", defaults.RenderMoveOperations),
+            RenderUnsupportedContentPlaceholders = BoolOpt("renderUnsupportedContentPlaceholders", defaults.RenderUnsupportedContentPlaceholders),
+            DocumentLanguage = o.TryGetProperty("documentLanguage", out var dl) && dl.ValueKind == JsonValueKind.String
+                ? dl.GetString() : defaults.DocumentLanguage,
+        };
+    }
+```
+
+`HtmlConversionOptions` / `HtmlConversionOps` resolve via the existing `using Docxodus.Internal;` at the top of the file.
+
+- [ ] **Step 3: Build the host**
+
+Run: `dotnet build tools/python-host/docxodus-pyhost.csproj`
+Expected: Build succeeded. (If the csproj name differs, run `ls tools/python-host/*.csproj` and use that path.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/python-host/Dispatcher.cs
+git commit -m "feat(pyhost): convert_to_html + session_to_html ops"
+```
+
+---
+
+## Task 5: Python wrapper — `HtmlOptions`, `convert_docx_to_html`, `to_html`
+
+**Files:**
+- Modify: `python/src/docx_scalpel/types.py`
+- Modify: `python/src/docx_scalpel/session.py`
+
+- [ ] **Step 1: Add the `HtmlOptions` dataclass**
+
+In `python/src/docx_scalpel/types.py`, add (near the other frozen dataclasses; ensure `from dataclasses import dataclass, field` is imported — check the file's existing imports):
+
+```python
+@dataclass(frozen=True, slots=True)
+class HtmlOptions:
+    """Options for DOCX→HTML conversion. Mirrors the .NET ``HtmlConversionOptions``.
+
+    Integer-coded modes match the wire contract:
+    ``comment_render_mode`` -1=disabled,0=endnote,1=inline,2=margin;
+    ``pagination_mode`` 0=none,1=paginated;
+    ``annotation_label_mode`` 0=above,1=inline,2=tooltip,3=none.
+    """
+
+    page_title: str = "Document"
+    css_class_prefix: str = "docx-"
+    fabricate_css_classes: bool = True
+    additional_css: str = ""
+    comment_render_mode: int = -1
+    comment_css_class_prefix: str = "comment-"
+    pagination_mode: int = 0
+    pagination_scale: float = 1.0
+    pagination_css_class_prefix: str = "page-"
+    render_annotations: bool = False
+    annotation_label_mode: int = 0
+    annotation_css_class_prefix: str = "annot-"
+    render_footnotes_and_endnotes: bool = False
+    render_headers_and_footers: bool = False
+    render_tracked_changes: bool = False
+    show_deleted_content: bool = True
+    render_move_operations: bool = True
+    render_unsupported_content_placeholders: bool = False
+    document_language: str | None = None
+
+    def to_wire(self) -> dict[str, Any]:
+        """camelCase keys the host dispatcher's ``ParseHtmlOptions`` reads."""
+        wire: dict[str, Any] = {
+            "pageTitle": self.page_title,
+            "cssClassPrefix": self.css_class_prefix,
+            "fabricateCssClasses": self.fabricate_css_classes,
+            "additionalCss": self.additional_css,
+            "commentRenderMode": self.comment_render_mode,
+            "commentCssClassPrefix": self.comment_css_class_prefix,
+            "paginationMode": self.pagination_mode,
+            "paginationScale": self.pagination_scale,
+            "paginationCssClassPrefix": self.pagination_css_class_prefix,
+            "renderAnnotations": self.render_annotations,
+            "annotationLabelMode": self.annotation_label_mode,
+            "annotationCssClassPrefix": self.annotation_css_class_prefix,
+            "renderFootnotesAndEndnotes": self.render_footnotes_and_endnotes,
+            "renderHeadersAndFooters": self.render_headers_and_footers,
+            "renderTrackedChanges": self.render_tracked_changes,
+            "showDeletedContent": self.show_deleted_content,
+            "renderMoveOperations": self.render_move_operations,
+            "renderUnsupportedContentPlaceholders": self.render_unsupported_content_placeholders,
+        }
+        if self.document_language is not None:
+            wire["documentLanguage"] = self.document_language
+        return wire
+```
+
+If `types.py` does not already import `Any`, add `from typing import Any` (verify existing imports first). Add `"HtmlOptions"` to the module's `__all__` if it has one.
+
+- [ ] **Step 2: Wire it through `session.py`**
+
+In `python/src/docx_scalpel/session.py`:
+
+(a) Add `HtmlOptions` to the `from .types import (...)` block.
+
+(b) Update `__all__`:
+
+```python
+__all__ = ["DocxSession", "open_session", "ping", "convert_docx_to_html"]
+```
+
+(c) Add the module-level function (place near `open_session`):
+
+```python
+def convert_docx_to_html(
+    data: bytes, options: HtmlOptions | None = None
+) -> str:
+    """Convert DOCX bytes to a self-contained HTML string (stateless).
+
+    Mirrors the WASM/npm ``convertDocxToHtml``. Opens a throwaway session in the
+    host, renders, and discards it — use :meth:`DocxSession.to_html` to render the
+    current state of an already-open editing session instead.
+    """
+    args: dict[str, Any] = {"docxB64": base64.b64encode(data).decode("ascii")}
+    if options is not None:
+        args["options"] = options.to_wire()
+    html = _call("convert_to_html", args)
+    if not isinstance(html, str):
+        raise TypeError(f"convert_to_html: expected str, got {type(html).__name__}")
+    return html
+```
+
+(d) Add the session method (inside `class DocxSession`, near `save`):
+
+```python
+    def to_html(self, options: HtmlOptions | None = None) -> str:
+        """Render this session's current (possibly edited) state to HTML."""
+        args: dict[str, Any] = {"handle": self._handle}
+        if options is not None:
+            args["options"] = options.to_wire()
+        html = _call("session_to_html", args)
+        if not isinstance(html, str):
+            raise TypeError(f"session_to_html: expected str, got {type(html).__name__}")
+        return html
+```
+
+- [ ] **Step 3: Re-export from the package root if applicable**
+
+Run: `grep -n "convert_docx_to_html\|open_session\|HtmlOptions\|__all__" python/src/docx_scalpel/__init__.py`
+If `__init__.py` re-exports `open_session` / public types, add `convert_docx_to_html` and `HtmlOptions` to its imports and `__all__` following the existing pattern.
+
+- [ ] **Step 4: Type-check / import smoke**
+
+Run: `cd python && python -c "from docx_scalpel import convert_docx_to_html, HtmlOptions; print('ok')"`
+Expected: `ok` (no ImportError).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/jman/Code/Docxodus
+git add python/src/docx_scalpel/types.py python/src/docx_scalpel/session.py python/src/docx_scalpel/__init__.py
+git commit -m "feat(python): convert_docx_to_html + DocxSession.to_html"
+```
+
+---
+
+## Task 6: Python tests
+
+**Files:**
+- Create: `python/tests/test_to_html.py`
+
+- [ ] **Step 1: Write the tests**
+
+Create `python/tests/test_to_html.py`:
+
+```python
+"""DOCX→HTML conversion on the Python surface — stateless + session-bound."""
+
+from __future__ import annotations
+
+from docx_scalpel import HtmlOptions, convert_docx_to_html, open_session
+
+
+def test_th001_stateless_convert_produces_html(tour_plan_bytes: bytes) -> None:
+    html = convert_docx_to_html(tour_plan_bytes)
+    assert "<html" in html
+    assert "</html>" in html
+
+
+def test_th002_css_prefix_option_applied(tour_plan_bytes: bytes) -> None:
+    html = convert_docx_to_html(tour_plan_bytes, HtmlOptions(css_class_prefix="zz-"))
+    assert "zz-" in html
+
+
+def test_th003_session_to_html_reflects_edit(tour_plan_bytes: bytes) -> None:
+    marker = "TH003UNIQUEMARKER"
+    with open_session(tour_plan_bytes) as session:
+        projection = session.project()
+        # First body paragraph/heading/list-item anchor in document order.
+        candidates = [
+            t
+            for t in projection.anchor_index.values()
+            if t.kind in ("p", "h", "li") and t.scope == "body"
+        ]
+        anchor = min(
+            candidates,
+            key=lambda t: (
+                projection.markdown.find("{#" + t.id + "}")
+                if projection.markdown.find("{#" + t.id + "}") >= 0
+                else 1 << 30
+            ),
+        )
+        result = session.replace_text(anchor.id, f"{marker} edited body.")
+        assert result.success, result.error
+
+        edited_html = session.to_html()
+        assert marker in edited_html
+
+    # Stateless conversion of the ORIGINAL bytes must not contain the edit.
+    original_html = convert_docx_to_html(tour_plan_bytes)
+    assert marker not in original_html
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cd python && python -m pytest tests/test_to_html.py -v`
+Expected: 3 passed. (Tests build/launch the host; if the host binary is stale, the suite's conftest/transport rebuilds or points at it — confirm `dotnet build tools/python-host/*.csproj` from Task 4 ran.)
+
+- [ ] **Step 3: Run the full Python suite (regression)**
+
+Run: `cd python && python -m pytest -q`
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/jman/Code/Docxodus
+git add python/tests/test_to_html.py
+git commit -m "test(python): DOCX->HTML stateless + session_to_html"
+```
+
+---
+
+## Task 7: Documentation
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `docs/architecture/python_docxodus.md`
+
+- [ ] **Step 1: CHANGELOG entry**
+
+Under the `[Unreleased]` section's `### Added` (create the heading if absent), add:
+
+```markdown
+- **Python DOCX→HTML conversion** — `convert_docx_to_html(data, options)` and
+  `DocxSession.to_html(options)` in `docx_scalpel`, backed by a new shared
+  `HtmlConversionOps` core renderer that the WASM bridge now also delegates to.
+  New `HtmlOptions` dataclass mirrors the existing WASM/npm conversion options.
+  New stdio-host ops: `convert_to_html`, `session_to_html`.
+```
+
+- [ ] **Step 2: Architecture doc**
+
+In `docs/architecture/python_docxodus.md`, add a section documenting the two ops, the `HtmlOptions` fields + defaults, and that `to_html` renders live edited state while `convert_docx_to_html` is stateless. Note that `HtmlConversionOps` is the single shared renderer for both WASM and the host.
+
+- [ ] **Step 3: Verify CLAUDE.md op list (if present)**
+
+Run: `grep -n "convert_to_html\|session_to_html\|to_html" CLAUDE.md`
+The `DocxSession.cs` bullet in CLAUDE.md lists inspection ops; if it enumerates host ops, add the two new ops. Otherwise no change needed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md docs/architecture/python_docxodus.md CLAUDE.md
+git commit -m "docs: Python DOCX->HTML conversion surface"
+```
+
+---
+
+## Final Verification
+
+- [ ] `dotnet clean Docxodus.sln` (if a WASM build ran since the last `dotnet test`)
+- [ ] `dotnet test Docxodus.Tests/Docxodus.Tests.csproj --filter "FullyQualifiedName~HtmlConversionOpsTests"` → PASS
+- [ ] `cd python && python -m pytest -q` → all PASS
+- [ ] `dotnet build -c Release Docxodus.sln` → no warnings-as-errors regressions
+- [ ] Review the full diff: `git diff main...feat/python-docx-to-html --stat`

--- a/docs/superpowers/specs/2026-05-29-python-docx-to-html-design.md
+++ b/docs/superpowers/specs/2026-05-29-python-docx-to-html-design.md
@@ -1,0 +1,195 @@
+# Design: DOCX→HTML conversion on the Python surface
+
+**Date:** 2026-05-29
+**Status:** Approved (pending spec review)
+**Branch:** `feat/python-docx-to-html`
+
+## Background
+
+This work is the first step toward a "convert a DOCX to images" capability. The
+agreed image path is DOCX → HTML → screenshot, with the screenshot engine kept
+out of the core library. Rather than build the whole pipeline at once, we land
+the HTML foundation first.
+
+DOCX→HTML already ships on three of the four surfaces:
+
+| Surface | Existing entry point |
+|---------|----------------------|
+| .NET core | `WmlToHtmlConverter.ConvertToHtml(WordprocessingDocument, WmlToHtmlConverterSettings)` + the `docx2html` CLI tool |
+| WASM | `DocumentConverter.ConvertDocxToHtml` / `WithOptions` / `WithPagination` / `Full` / `Complete` |
+| npm/TS | `convertDocxToHtml(file, options)` |
+| **Python (`docx_scalpel`)** | **— none —** |
+
+The Python package is entirely session-handle-based (`DocxSessionOps`,
+`Dispatcher`, `DocxSession`) and has no DOCX→HTML path. This design fills that
+gap with parity options, and in doing so centralizes the bytes+options→HTML
+settings mapping that currently lives only in the WASM shell.
+
+## Goals
+
+1. Python callers can convert DOCX bytes to an HTML string with the same option
+   set the other surfaces expose.
+2. Python callers can render the **current (possibly edited)** state of an open
+   `DocxSession` to HTML.
+3. The settings-mapping logic lives in exactly one place in the core library,
+   shared by both the WASM bridge and the stdio host — consistent with the
+   `DocxSessionOps` / `DocxSessionJson` "wire shapes in one place" principle.
+
+## Non-goals (deferred)
+
+- The screenshot / page-rasterization step (the eventual "to images" feature).
+- Any new WASM `[JSExport]` method or npm function — those surfaces are already
+  complete and their public behavior does not change.
+- A Python CLI binary. `docx_scalpel` is a library; the existing `docx2html`
+  .NET CLI covers the command-line use case.
+
+## Architecture
+
+### 1. Core — shared conversion helper
+
+New file `Docxodus/Internal/HtmlConversionOps.cs` (sits beside
+`DocxSessionOps.cs`). It owns the canonical bytes+options→HTML mapping that is
+currently inlined in `wasm/DocxodusWasm/DocumentConverter.cs::ConvertDocxToHtmlComplete`.
+
+Shape:
+
+```csharp
+#nullable enable
+namespace Docxodus.Internal;
+
+public sealed class HtmlConversionOptions
+{
+    public string PageTitle { get; init; } = "Document";
+    public string CssClassPrefix { get; init; } = "docx-";
+    public bool FabricateCssClasses { get; init; } = true;
+    public string AdditionalCss { get; init; } = "";
+    public int CommentRenderMode { get; init; } = -1;   // -1=disabled,0=Endnote,1=Inline,2=Margin
+    public string CommentCssClassPrefix { get; init; } = "comment-";
+    public int PaginationMode { get; init; } = 0;        // 0=None,1=Paginated
+    public double PaginationScale { get; init; } = 1.0;
+    public string PaginationCssClassPrefix { get; init; } = "page-";
+    public bool RenderAnnotations { get; init; }
+    public int AnnotationLabelMode { get; init; }        // 0=Above,1=Inline,2=Tooltip,3=None
+    public string AnnotationCssClassPrefix { get; init; } = "annot-";
+    public bool RenderFootnotesAndEndnotes { get; init; }
+    public bool RenderHeadersAndFooters { get; init; }
+    public bool RenderTrackedChanges { get; init; }
+    public bool ShowDeletedContent { get; init; } = true;
+    public bool RenderMoveOperations { get; init; } = true;
+    public bool RenderUnsupportedContentPlaceholders { get; init; }
+    public string? DocumentLanguage { get; init; }
+}
+
+public static class HtmlConversionOps
+{
+    // Stateless: parse bytes, render. Used by WASM and the host's convert_to_html.
+    public static string ConvertToHtml(byte[] docxBytes, HtmlConversionOptions options);
+
+    // Session-bound: render the live session's current Save() bytes.
+    // Used by the host's session_to_html.
+    public static string ConvertToHtml(int sessionHandle, HtmlConversionOptions options);
+}
+```
+
+The single private core builds the `WmlToHtmlConverterSettings` exactly as
+`ConvertDocxToHtmlComplete` does today — including the base64 image handler
+(`CreateBase64ImageHandler()`), so output is self-contained and the WASM path
+needs no SkiaSharp. The session overload calls `SessionRegistry.Get(handle)`,
+takes its current `Save()` bytes, and routes into the same stateless core.
+
+The base64 image-handler helper currently lives as a private method in
+`DocumentConverter.cs`. It moves into `HtmlConversionOps` as the single owner;
+`DocumentConverter` no longer needs its own copy once it delegates. Errors
+propagate as thrown exceptions — the bridges keep their existing JSON-error
+serialization at the boundary.
+
+### 2. WASM refactor (dedupe)
+
+`DocumentConverter.ConvertDocxToHtmlComplete` is rewritten to build an
+`HtmlConversionOptions` from its parameters and delegate to
+`HtmlConversionOps.ConvertToHtml(bytes, options)`. The five public
+`[JSExport]` signatures and their JSON-error behavior are unchanged — this is a
+pure internal dedupe so WASM and Python share one renderer. Existing WASM tests
+guard the behavior.
+
+### 3. Python host — `tools/python-host/Dispatcher.cs`
+
+Two new NDJSON ops:
+
+| Op | Args | Routes to |
+|----|------|-----------|
+| `convert_to_html` | `docxB64` (base64 string), `options` (object, optional) | `HtmlConversionOps.ConvertToHtml(bytes, options)` |
+| `session_to_html` | `handle` (int), `options` (object, optional) | `HtmlConversionOps.ConvertToHtml(handle, options)` |
+
+A small `ParseHtmlOptions(JsonElement)` helper in the dispatcher decodes the
+`options` object into `HtmlConversionOptions`, applying the same defaults as the
+DTO when a field is absent. Both ops return the raw HTML string via the existing
+`JsonString(...)` wrapper (the wire carries it as a JSON string value).
+
+### 4. Python wrapper — `docx_scalpel`
+
+`types.py`: new `@dataclass(frozen=True, slots=True) HtmlOptions` mirroring the
+DTO fields (snake_case), with matching defaults and a `to_wire()` that emits the
+camelCase keys the dispatcher reads. Enums (`CommentRenderMode`,
+`PaginationMode`, `AnnotationLabelMode`) may be modeled as `IntEnum`s in
+`enums.py` for ergonomics, but the wire values stay integers.
+
+`session.py`:
+- Module-level `convert_docx_to_html(data: bytes, options: HtmlOptions | None = None) -> str`
+  — base64-encodes `data`, calls `_call("convert_to_html", {...})`. Added to
+  `__all__`.
+- `DocxSession.to_html(self, options: HtmlOptions | None = None) -> str`
+  — calls `_call("session_to_html", {"handle": self._handle, ...})`; renders
+  current edited state.
+
+## Data flow
+
+```
+convert_docx_to_html(bytes, opts)
+  → NDJSON {op:"convert_to_html", docxB64, options}
+  → Dispatcher.ParseHtmlOptions → HtmlConversionOps.ConvertToHtml(bytes, opts)
+  → WmlToHtmlConverter.ConvertToHtml → html string → JSON string → Python str
+
+session.to_html(opts)
+  → NDJSON {op:"session_to_html", handle, options}
+  → SessionRegistry.Get(handle).Save() → HtmlConversionOps.ConvertToHtml(bytes, opts)
+  → html string → Python str
+```
+
+## Error handling
+
+- Empty/null bytes → host throws; dispatcher surfaces the existing error
+  envelope; Python `_transport` raises as it does for every other op.
+- Unknown session handle on `session_to_html` → `SessionRegistry.Get` throws the
+  same "unknown handle" error used by all session ops.
+- Malformed `options` object → dispatcher falls back to per-field defaults
+  rather than failing (absent field = default), matching how the other surfaces
+  treat omitted parameters.
+
+## Testing
+
+- **.NET** (`Docxodus.Tests`): a test for `HtmlConversionOps.ConvertToHtml(bytes, options)`
+  asserting key structural markers (e.g. `<html`, the css prefix, a known
+  paragraph's text) on an existing `TestFiles/HC*` document. A second test that
+  opens a session, mutates a block, and asserts the session overload's HTML
+  reflects the edit.
+- **WASM**: existing `DocumentConverter` HTML tests must still pass unchanged
+  (regression guard for the refactor) — run `npm run build` then `npm test`.
+- **Python** (`python/tests`): round-trip a known DOCX through
+  `convert_docx_to_html` and assert structural markers; open a session, edit a
+  paragraph, and assert `session.to_html()` contains the new text and the
+  stateless conversion of the original bytes does not.
+
+## Documentation
+
+- `CHANGELOG.md`: entry under `[Unreleased]`.
+- `docs/architecture/python_docxodus.md`: document the two new ops, `HtmlOptions`,
+  and the `to_html` / `convert_docx_to_html` surface.
+- `CLAUDE.md`: add the new ops to the python-host dispatcher description if the
+  op list is enumerated there (verify during implementation).
+
+## Open question resolved during design
+
+- **Python shape:** both a stateless `convert_docx_to_html` and a
+  `session.to_html` (chosen over either alone) — parity with other surfaces plus
+  the ability to render mid-edit state.

--- a/python/src/docx_scalpel/__init__.py
+++ b/python/src/docx_scalpel/__init__.py
@@ -49,7 +49,7 @@ from .enums import (
     WhitespaceMode,
 )
 from .errors import DocxodusHostNotFoundError, DocxodusTransportError, DocxScalpelError
-from .session import DocxSession, open_session, ping
+from .session import DocxSession, convert_docx_to_html, open_session, ping
 from .types import (
     Anchor,
     AnchorInfo,
@@ -68,6 +68,7 @@ from .types import (
     FillOptions,
     FindOptions,
     FormatOp,
+    HtmlOptions,
     ListMembership,
     MarkdownPatch,
     MarkdownProjection,
@@ -94,6 +95,7 @@ __all__ = [
     "__version__",
     # entry points
     "DocxSession",
+    "convert_docx_to_html",
     "open_session",
     "ping",
     "shutdown_host",
@@ -115,6 +117,7 @@ __all__ = [
     "FillOptions",
     "FindOptions",
     "FormatOp",
+    "HtmlOptions",
     "ListMembership",
     "MarkdownPatch",
     "MarkdownProjection",

--- a/python/src/docx_scalpel/session.py
+++ b/python/src/docx_scalpel/session.py
@@ -50,6 +50,7 @@ from .types import (
     FillOptions,
     FindOptions,
     FormatOp,
+    HtmlOptions,
     ListMembership,
     MarkdownProjection,
     ReplaceOptions,
@@ -58,7 +59,7 @@ from .types import (
     TextMatch,
 )
 
-__all__ = ["DocxSession", "open_session", "ping"]
+__all__ = ["DocxSession", "open_session", "ping", "convert_docx_to_html"]
 
 
 def ping() -> dict[str, Any]:
@@ -83,6 +84,25 @@ def open_session(
     if not isinstance(handle, int):
         raise TypeError(f"open_session: expected int handle, got {type(handle).__name__}: {handle!r}")
     return DocxSession(handle)
+
+
+def convert_docx_to_html(
+    data: bytes, options: HtmlOptions | None = None
+) -> str:
+    """Convert DOCX bytes to a self-contained HTML string (stateless).
+
+    Mirrors the WASM/npm ``convertDocxToHtml``. Renders the bytes directly in
+    the host without creating a persistent session — use
+    :meth:`DocxSession.to_html` to render the current state of an already-open
+    editing session instead.
+    """
+    args: dict[str, Any] = {"docxB64": base64.b64encode(data).decode("ascii")}
+    if options is not None:
+        args["options"] = options.to_wire()
+    html = _call("convert_to_html", args)
+    if not isinstance(html, str):
+        raise TypeError(f"convert_to_html: expected str, got {type(html).__name__}")
+    return html
 
 
 class DocxSession:
@@ -142,6 +162,16 @@ class DocxSession:
         """Serialize the (mutated) document back to DOCX bytes. Does not close the session."""
         result = self._call("save", {})
         return base64.b64decode(result["docxB64"])
+
+    def to_html(self, options: HtmlOptions | None = None) -> str:
+        """Render this session's current (possibly edited) state to HTML."""
+        args: dict[str, Any] = {"handle": self._handle}
+        if options is not None:
+            args["options"] = options.to_wire()
+        html = _call("session_to_html", args)
+        if not isinstance(html, str):
+            raise TypeError(f"session_to_html: expected str, got {type(html).__name__}")
+        return html
 
     def undo(self) -> bool:
         """Undo one snapshot. Returns ``True`` if the undo ring had something to pop."""

--- a/python/src/docx_scalpel/session.py
+++ b/python/src/docx_scalpel/session.py
@@ -165,10 +165,10 @@ class DocxSession:
 
     def to_html(self, options: HtmlOptions | None = None) -> str:
         """Render this session's current (possibly edited) state to HTML."""
-        args: dict[str, Any] = {"handle": self._handle}
+        args: dict[str, Any] = {}
         if options is not None:
             args["options"] = options.to_wire()
-        html = _call("session_to_html", args)
+        html = self._call("session_to_html", args)
         if not isinstance(html, str):
             raise TypeError(f"session_to_html: expected str, got {type(html).__name__}")
         return html

--- a/python/src/docx_scalpel/types.py
+++ b/python/src/docx_scalpel/types.py
@@ -42,6 +42,10 @@ __all__ = [
     "AnchorTarget",
     "AnchorInfo",
     "BlockMetadata",
+    "BulkEditResult",
+    "FillOptions",
+    "FindOptions",
+    "HtmlOptions",
     "ListMembership",
     "NumberFormat",
     "RunFormatting",
@@ -57,10 +61,7 @@ __all__ = [
     "DocumentAnnotation",
     "AnnotationUpdate",
     "EditSummary",
-    "FindOptions",
     "ReplaceOptions",
-    "FillOptions",
-    "BulkEditResult",
 ]
 
 
@@ -686,6 +687,63 @@ class ReplaceOptions:
 # ---------------------------------------------------------------------------
 # Fill placeholders (client-side multi-pass loop; see DocxSession.fill_placeholders)
 # ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class HtmlOptions:
+    """Options for DOCX→HTML conversion. Mirrors the .NET ``HtmlConversionOptions``.
+
+    Integer-coded modes match the wire contract:
+    ``comment_render_mode`` -1=disabled,0=endnote,1=inline,2=margin;
+    ``pagination_mode`` 0=none,1=paginated;
+    ``annotation_label_mode`` 0=above,1=inline,2=tooltip,3=none.
+    """
+
+    page_title: str = "Document"
+    css_class_prefix: str = "docx-"
+    fabricate_css_classes: bool = True
+    additional_css: str = ""
+    comment_render_mode: int = -1
+    comment_css_class_prefix: str = "comment-"
+    pagination_mode: int = 0
+    pagination_scale: float = 1.0
+    pagination_css_class_prefix: str = "page-"
+    render_annotations: bool = False
+    annotation_label_mode: int = 0
+    annotation_css_class_prefix: str = "annot-"
+    render_footnotes_and_endnotes: bool = False
+    render_headers_and_footers: bool = False
+    render_tracked_changes: bool = False
+    show_deleted_content: bool = True
+    render_move_operations: bool = True
+    render_unsupported_content_placeholders: bool = False
+    document_language: str | None = None
+
+    def to_wire(self) -> dict[str, Any]:
+        """camelCase keys the host dispatcher's ``ParseHtmlOptions`` reads."""
+        wire: dict[str, Any] = {
+            "pageTitle": self.page_title,
+            "cssClassPrefix": self.css_class_prefix,
+            "fabricateCssClasses": self.fabricate_css_classes,
+            "additionalCss": self.additional_css,
+            "commentRenderMode": self.comment_render_mode,
+            "commentCssClassPrefix": self.comment_css_class_prefix,
+            "paginationMode": self.pagination_mode,
+            "paginationScale": self.pagination_scale,
+            "paginationCssClassPrefix": self.pagination_css_class_prefix,
+            "renderAnnotations": self.render_annotations,
+            "annotationLabelMode": self.annotation_label_mode,
+            "annotationCssClassPrefix": self.annotation_css_class_prefix,
+            "renderFootnotesAndEndnotes": self.render_footnotes_and_endnotes,
+            "renderHeadersAndFooters": self.render_headers_and_footers,
+            "renderTrackedChanges": self.render_tracked_changes,
+            "showDeletedContent": self.show_deleted_content,
+            "renderMoveOperations": self.render_move_operations,
+            "renderUnsupportedContentPlaceholders": self.render_unsupported_content_placeholders,
+        }
+        if self.document_language is not None:
+            wire["documentLanguage"] = self.document_language
+        return wire
 
 
 @dataclass(frozen=True, slots=True)

--- a/python/src/docx_scalpel/types.py
+++ b/python/src/docx_scalpel/types.py
@@ -685,7 +685,7 @@ class ReplaceOptions:
 
 
 # ---------------------------------------------------------------------------
-# Fill placeholders (client-side multi-pass loop; see DocxSession.fill_placeholders)
+# DOCX → HTML conversion options (see convert_docx_to_html / DocxSession.to_html)
 # ---------------------------------------------------------------------------
 
 
@@ -744,6 +744,11 @@ class HtmlOptions:
         if self.document_language is not None:
             wire["documentLanguage"] = self.document_language
         return wire
+
+
+# ---------------------------------------------------------------------------
+# Fill placeholders (client-side multi-pass loop; see DocxSession.fill_placeholders)
+# ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True, slots=True)

--- a/python/tests/test_to_html.py
+++ b/python/tests/test_to_html.py
@@ -1,0 +1,45 @@
+"""DOCX->HTML conversion on the Python surface -- stateless + session-bound."""
+
+from __future__ import annotations
+
+from docx_scalpel import HtmlOptions, convert_docx_to_html, open_session
+
+
+def test_th001_stateless_convert_produces_html(tour_plan_bytes: bytes) -> None:
+    html = convert_docx_to_html(tour_plan_bytes)
+    assert "<html" in html
+    assert "</html>" in html
+
+
+def test_th002_css_prefix_option_applied(tour_plan_bytes: bytes) -> None:
+    html = convert_docx_to_html(tour_plan_bytes, HtmlOptions(css_class_prefix="zz-"))
+    assert "zz-" in html
+
+
+def test_th003_session_to_html_reflects_edit(tour_plan_bytes: bytes) -> None:
+    marker = "TH003UNIQUEMARKER"
+    with open_session(tour_plan_bytes) as session:
+        projection = session.project()
+        # First body paragraph/heading/list-item anchor in document order.
+        candidates = [
+            t
+            for t in projection.anchor_index.values()
+            if t.kind in ("p", "h", "li") and t.scope == "body"
+        ]
+        anchor = min(
+            candidates,
+            key=lambda t: (
+                projection.markdown.find("{#" + t.id + "}")
+                if projection.markdown.find("{#" + t.id + "}") >= 0
+                else 1 << 30
+            ),
+        )
+        result = session.replace_text(anchor.id, f"{marker} edited body.")
+        assert result.success, result.error
+
+        edited_html = session.to_html()
+        assert marker in edited_html
+
+    # Stateless conversion of the ORIGINAL bytes must not contain the edit.
+    original_html = convert_docx_to_html(tour_plan_bytes)
+    assert marker not in original_html

--- a/python/tests/test_to_html.py
+++ b/python/tests/test_to_html.py
@@ -5,6 +5,16 @@ from __future__ import annotations
 from docx_scalpel import HtmlOptions, convert_docx_to_html, open_session
 
 
+def _document_order(markdown: str, anchor_id: str) -> int:
+    """Position of an anchor's marker in the projection, for document-order sort.
+
+    Mirrors the helper in ``test_smoke.py``; kept local for the same reason
+    (conftest functions are not reliably importable by name).
+    """
+    i = markdown.find("{#" + anchor_id + "}")
+    return i if i >= 0 else 1 << 30
+
+
 def test_th001_stateless_convert_produces_html(tour_plan_bytes: bytes) -> None:
     html = convert_docx_to_html(tour_plan_bytes)
     assert "<html" in html
@@ -28,11 +38,7 @@ def test_th003_session_to_html_reflects_edit(tour_plan_bytes: bytes) -> None:
         ]
         anchor = min(
             candidates,
-            key=lambda t: (
-                projection.markdown.find("{#" + t.id + "}")
-                if projection.markdown.find("{#" + t.id + "}") >= 0
-                else 1 << 30
-            ),
+            key=lambda t: _document_order(projection.markdown, t.id),
         )
         result = session.replace_text(anchor.id, f"{marker} edited body.")
         assert result.success, result.error

--- a/tools/python-host/Dispatcher.cs
+++ b/tools/python-host/Dispatcher.cs
@@ -28,6 +28,8 @@ internal static class Dispatcher
         "open_session" => OpenSession(args),
         "close_session" => CloseSession(args),
         "save" => Save(args),
+        "convert_to_html" => ConvertToHtml(args),
+        "session_to_html" => SessionToHtml(args),
         "project" => DocxSessionOps.Project(Handle(args)),
         "project_anchor" => DocxSessionOps.ProjectAnchor(
             Handle(args), Str(args, "anchorId"),
@@ -168,6 +170,67 @@ internal static class Dispatcher
     {
         var bytes = DocxSessionOps.Save(Handle(args));
         return "{\"docxB64\":" + DocxSessionJson.JsonString(Convert.ToBase64String(bytes)) + "}";
+    }
+
+    private static string ConvertToHtml(JsonElement args)
+    {
+        var bytes = Convert.FromBase64String(Str(args, "docxB64"));
+        var html = HtmlConversionOps.ConvertToHtml(bytes, ParseHtmlOptions(args));
+        return JsonString(html);
+    }
+
+    private static string SessionToHtml(JsonElement args)
+    {
+        var html = HtmlConversionOps.ConvertToHtml(Handle(args), ParseHtmlOptions(args));
+        return JsonString(html);
+    }
+
+    private static HtmlConversionOptions ParseHtmlOptions(JsonElement args)
+    {
+        if (args.ValueKind != JsonValueKind.Object
+            || !args.TryGetProperty("options", out var o)
+            || o.ValueKind != JsonValueKind.Object)
+        {
+            return new HtmlConversionOptions();
+        }
+
+        string StrOpt(string name, string fallback) =>
+            o.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String
+                ? v.GetString()! : fallback;
+        int IntOpt(string name, int fallback) =>
+            o.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number
+                ? v.GetInt32() : fallback;
+        double DblOpt(string name, double fallback) =>
+            o.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number
+                ? v.GetDouble() : fallback;
+        bool BoolOpt(string name, bool fallback) =>
+            o.TryGetProperty(name, out var v) && (v.ValueKind == JsonValueKind.True || v.ValueKind == JsonValueKind.False)
+                ? v.GetBoolean() : fallback;
+
+        var defaults = new HtmlConversionOptions();
+        return new HtmlConversionOptions
+        {
+            PageTitle = StrOpt("pageTitle", defaults.PageTitle),
+            CssClassPrefix = StrOpt("cssClassPrefix", defaults.CssClassPrefix),
+            FabricateCssClasses = BoolOpt("fabricateCssClasses", defaults.FabricateCssClasses),
+            AdditionalCss = StrOpt("additionalCss", defaults.AdditionalCss),
+            CommentRenderMode = IntOpt("commentRenderMode", defaults.CommentRenderMode),
+            CommentCssClassPrefix = StrOpt("commentCssClassPrefix", defaults.CommentCssClassPrefix),
+            PaginationMode = IntOpt("paginationMode", defaults.PaginationMode),
+            PaginationScale = DblOpt("paginationScale", defaults.PaginationScale),
+            PaginationCssClassPrefix = StrOpt("paginationCssClassPrefix", defaults.PaginationCssClassPrefix),
+            RenderAnnotations = BoolOpt("renderAnnotations", defaults.RenderAnnotations),
+            AnnotationLabelMode = IntOpt("annotationLabelMode", defaults.AnnotationLabelMode),
+            AnnotationCssClassPrefix = StrOpt("annotationCssClassPrefix", defaults.AnnotationCssClassPrefix),
+            RenderFootnotesAndEndnotes = BoolOpt("renderFootnotesAndEndnotes", defaults.RenderFootnotesAndEndnotes),
+            RenderHeadersAndFooters = BoolOpt("renderHeadersAndFooters", defaults.RenderHeadersAndFooters),
+            RenderTrackedChanges = BoolOpt("renderTrackedChanges", defaults.RenderTrackedChanges),
+            ShowDeletedContent = BoolOpt("showDeletedContent", defaults.ShowDeletedContent),
+            RenderMoveOperations = BoolOpt("renderMoveOperations", defaults.RenderMoveOperations),
+            RenderUnsupportedContentPlaceholders = BoolOpt("renderUnsupportedContentPlaceholders", defaults.RenderUnsupportedContentPlaceholders),
+            DocumentLanguage = o.TryGetProperty("documentLanguage", out var dl) && dl.ValueKind == JsonValueKind.String
+                ? dl.GetString() : defaults.DocumentLanguage,
+        };
     }
 
     private static string Grep(JsonElement args, bool crossBlock)

--- a/tools/python-host/Dispatcher.cs
+++ b/tools/python-host/Dispatcher.cs
@@ -206,6 +206,9 @@ internal static class Dispatcher
         bool BoolOpt(string name, bool fallback) =>
             o.TryGetProperty(name, out var v) && (v.ValueKind == JsonValueKind.True || v.ValueKind == JsonValueKind.False)
                 ? v.GetBoolean() : fallback;
+        string? StrOptNullable(string name, string? fallback) =>
+            o.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String
+                ? v.GetString() : fallback;
 
         var defaults = new HtmlConversionOptions();
         return new HtmlConversionOptions
@@ -228,8 +231,7 @@ internal static class Dispatcher
             ShowDeletedContent = BoolOpt("showDeletedContent", defaults.ShowDeletedContent),
             RenderMoveOperations = BoolOpt("renderMoveOperations", defaults.RenderMoveOperations),
             RenderUnsupportedContentPlaceholders = BoolOpt("renderUnsupportedContentPlaceholders", defaults.RenderUnsupportedContentPlaceholders),
-            DocumentLanguage = o.TryGetProperty("documentLanguage", out var dl) && dl.ValueKind == JsonValueKind.String
-                ? dl.GetString() : defaults.DocumentLanguage,
+            DocumentLanguage = StrOptNullable("documentLanguage", defaults.DocumentLanguage),
         };
     }
 

--- a/wasm/DocxodusWasm/DocumentConverter.cs
+++ b/wasm/DocxodusWasm/DocumentConverter.cs
@@ -255,49 +255,29 @@ public partial class DocumentConverter
 
         try
         {
-            // Must use writable stream - WmlToHtmlConverter calls RevisionAccepter internally
-            using var memoryStream = new MemoryStream();
-            memoryStream.Write(docxBytes, 0, docxBytes.Length);
-            memoryStream.Position = 0;
-            using var wordDoc = WordprocessingDocument.Open(memoryStream, true);
-
-            var renderComments = commentRenderMode >= 0;
-
-            var settings = new WmlToHtmlConverterSettings
+            var options = new Docxodus.Internal.HtmlConversionOptions
             {
                 PageTitle = pageTitle ?? "Document",
                 CssClassPrefix = cssPrefix ?? "docx-",
                 FabricateCssClasses = fabricateClasses,
                 AdditionalCss = additionalCss ?? "",
-                GeneralCss = "body { font-family: Arial, sans-serif; margin: 20px; } " +
-                             "span { white-space: pre-wrap; }",
-                RenderComments = renderComments,
-                CommentRenderMode = renderComments ? (CommentRenderMode)commentRenderMode : CommentRenderMode.EndnoteStyle,
+                CommentRenderMode = commentRenderMode,
                 CommentCssClassPrefix = commentCssClassPrefix ?? "comment-",
-                IncludeCommentMetadata = true,
-                RenderPagination = (PaginationMode)paginationMode,
-                PaginationScale = paginationScale > 0 ? paginationScale : 1.0,
+                PaginationMode = paginationMode,
+                PaginationScale = paginationScale,
                 PaginationCssClassPrefix = paginationCssClassPrefix ?? "page-",
                 RenderAnnotations = renderAnnotations,
-                AnnotationLabelMode = (AnnotationLabelMode)annotationLabelMode,
+                AnnotationLabelMode = annotationLabelMode,
                 AnnotationCssClassPrefix = annotationCssClassPrefix ?? "annot-",
-                IncludeAnnotationMetadata = true,
                 RenderFootnotesAndEndnotes = renderFootnotesAndEndnotes,
                 RenderHeadersAndFooters = renderHeadersAndFooters,
                 RenderTrackedChanges = renderTrackedChanges,
                 ShowDeletedContent = showDeletedContent,
                 RenderMoveOperations = renderMoveOperations,
-                IncludeRevisionMetadata = true,
                 RenderUnsupportedContentPlaceholders = renderUnsupportedContentPlaceholders,
-                UnsupportedContentCssClassPrefix = "unsupported-",
-                IncludeUnsupportedContentMetadata = true,
                 DocumentLanguage = documentLanguage,
-                // Embed images as base64 data URIs - no SkiaSharp needed
-                ImageHandler = CreateBase64ImageHandler()
             };
-
-            var htmlElement = WmlToHtmlConverter.ConvertToHtml(wordDoc, settings);
-            return htmlElement.ToString(SaveOptions.DisableFormatting);
+            return Docxodus.Internal.HtmlConversionOps.ConvertToHtml(docxBytes, options);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary

Adds DOCX→HTML conversion to the **Python** surface of `docx_scalpel`. The .NET core, WASM, and npm surfaces already had this; Python was the only one missing it. In the process, the bytes+options→HTML settings mapping (previously inlined only in the WASM shell) is extracted into a shared core renderer that the WASM bridge now delegates to — one source of truth across surfaces.

- **Core:** new `Docxodus/Internal/HtmlConversionOps.cs` — `internal` renderer with `ConvertToHtml(byte[]/DocxSession/int handle, HtmlConversionOptions)`. The session/handle overloads render the live (possibly edited) session state via `Save()`.
- **WASM:** `DocumentConverter.ConvertDocxToHtmlComplete` refactored to delegate to `HtmlConversionOps` (pure dedupe — no public `[JSExport]` / npm API change).
- **Host:** two new NDJSON ops in `tools/python-host/Dispatcher.cs` — `convert_to_html` (stateless bytes) and `session_to_html` (live handle).
- **Python:** module-level `convert_docx_to_html(data, options)`, `DocxSession.to_html(options)`, and a new `HtmlOptions` frozen dataclass mirroring the WASM/npm option set.
- **Docs:** CHANGELOG entry + `docs/architecture/python_docxodus.md` section. Design spec and implementation plan under `docs/superpowers/`.

The eventual "DOCX → images" goal (DOCX → HTML → screenshot) is intentionally **out of scope** here — this lands the HTML foundation first; the screenshot engine is deferred and kept out of the core library.

## Test Plan

- [x] `.NET` — `HtmlConversionOpsTests` (stateless prefix applied; session overload reflects an edit): 2/2 pass
- [x] `Python` — `python/tests/test_to_html.py` (stateless HTML; css-prefix option flows through; `to_html` reflects a session edit while stateless conversion of original bytes does not): full suite 32/32 pass
- [x] `WASM` — Playwright regression suite 174/174 pass (verifies the delegation refactor is behavior-preserving)
- [x] `Release` build clean (`dotnet build -c Release Docxodus.sln`, warnings-as-errors gate)

## Follow-ups (non-blocking, noted in review)

- The Python CI job (`python-publish.yml`) runs only `test_lifecycle.py` by filename, so the new Python tests aren't gated in CI (pre-existing systemic gap). Consider broadening to `pytest python/tests` after building the host.
- The base64 image-handler helper now exists in both `HtmlConversionOps.cs` and `DocumentConverter.cs`; the WASM copy survives because three unrelated external-annotation conversion methods still use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)