### PR TITLE
Release v6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [6.3.0] - 2026-05-30
+
 ### Fixed
 - **Percentage table/cell widths no longer crash `WmlToHtmlConverter`** (issue #210). `convertDocxToHtml` threw `FormatException` ("Format_InvalidStringWithValue, 100%") whenever a table-level (`w:tblW`) or cell-level (`w:tcW`) width used `w:type="pct"` with a percent-suffixed value such as `w:w="100%"` / `w:w="50%"`. This is the form the `docx` npm library emits for `WidthType.PERCENTAGE`, and it is valid per the OOXML `ST_TblWidth` / `ST_MeasurementOrPercent` schema (which permits either a plain integer in fiftieths-of-a-percent **or** a `"<number>%"` string). The converter cast the attribute straight to `int`, which throws on `"100%"`; DXA (twips) widths were unaffected because they are always plain integers. Width parsing for `w:tblW`/`w:tcW` now goes through a single `ParseTblWidthValue` helper that tolerates the percent-suffixed form: an explicit `"100%"` is treated as a literal percentage, while a bare integer under `pct` is still interpreted as fiftieths of a percent (`5000` → `100%`). Non-numeric/garbage widths are ignored gracefully instead of throwing. Tests: `HcTablePercentageWidthTests` in `Docxodus.Tests/HtmlConverterTablePercentageWidthTests.cs`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,35 @@ dotnet test            # Run .NET tests
 | Internal refactor | ✓ | ✓ | - | - | - |
 | New module | ✓ | ✓ | ✓ | ✓ | ✓ |
 
+## Release Process
+
+Releases are **CHANGELOG + annotated git tag only** — no version bump in
+`Docxodus.csproj` (`<Version>` is intentionally left at `1.0.0`) or
+`npm/package.json`; those are not tied to the release tags.
+
+Versioning is **semver** on tags of the form `vMAJOR.MINOR.PATCH` (e.g.
+`v6.3.0`). Pick the bump from what landed in `[Unreleased]` since the last tag:
+
+| Bump | When |
+|------|------|
+| Patch (`v6.2.0` → `v6.2.1`) | only `### Fixed` entries (bug fixes) |
+| Minor (`v6.2.0` → `v6.3.0`) | any `### Added`/`### Changed` (new feature/surface, no breaking change) |
+| Major (`v6.x` → `v7.0.0`) | a breaking public-API change |
+
+To cut a release from an up-to-date `main`:
+
+1. Edit `CHANGELOG.md`: insert `## [X.Y.Z] - YYYY-MM-DD` immediately under the
+   `## [Unreleased]` header, leaving the accumulated `### Added`/`### Fixed`/etc.
+   entries beneath it as the released section and `## [Unreleased]` empty above.
+   (Do not add per-release version commits to csproj/package.json.)
+2. Commit changelog-only with message `docs(changelog): cut vX.Y.0 release notes`.
+3. Create an **annotated** tag whose message is the version string:
+   `git tag -a vX.Y.Z -m vX.Y.Z`.
+4. `git push origin main` then `git push origin vX.Y.Z`.
+
+Prior release-cut commits (`#206`, `#209`) and tags (`v6.1.0`, `v6.2.0`) are the
+reference for the exact diff shape.
+
 ## Build Commands
 
 ```bash


### PR DESCRIPTION
Cuts the **v6.3.0** release (minor bump from v6.2.0).

## Changelog
Moves the accumulated `[Unreleased]` entries into a dated `## [6.3.0] - 2026-05-30` section:

- **Added** — Python DOCX→HTML conversion (`convert_docx_to_html` / `DocxSession.to_html`, shared `HtmlConversionOps`, new stdio-host ops) (#212)
- **Fixed** — percent-suffixed table/cell widths no longer crash `WmlToHtmlConverter` (#210, #211)

The `### Added` (new Python surface) is what makes this a **minor** release.

## Also
- Documents the **Release Process** in `CLAUDE.md`: changelog-only cuts, the semver bump table, the annotated `vX.Y.Z` tag step (which triggers the NuGet publish workflow), and the fact that `Docxodus.csproj` `<Version>` / `npm/package.json` are intentionally *not* bumped per-release.

## After merge
Tag the merged cut commit `v6.3.0` and push it — `publish.yml` (`on: push: tags: v*`) then publishes to NuGet. (PyPI `docx-scalpel` is unaffected; it needs a separate `docx-scalpel-v*` tag.)