### PR TITLE
chore(python): bump docx-scalpel to 0.1.0a4

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "docx-scalpel"
-version = "0.1.0a3"
+version = "0.1.0a4"
 description = "Anchor-addressed DOCX editing for LLM agents — a thin client over Docxodus' DocxSession."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps `docx-scalpel` to **0.1.0a4** so the next PyPI alpha ships the DOCX→HTML surface.

The currently published alpha `0.1.0a3` (tag `docx-scalpel-v0.1.0a3`, commit #207) **predates** #212, so `convert_docx_to_html` / `DocxSession.to_html` are not yet on PyPI. Tagging `docx-scalpel-v0.1.0a4` after this merges will publish them (via `python-publish.yml`).

One-line `python/pyproject.toml` version bump, mirroring #199 (a2) and #207 (a3). The publish workflow also pins pyproject to the tag version at build time, so this keeps the source-of-truth in sync.

## After merge
`git tag -a docx-scalpel-v0.1.0a4 -m docx-scalpel-v0.1.0a4 <merged-sha> && git push origin docx-scalpel-v0.1.0a4` → publishes to production PyPI. (Docxodus core / NuGet unaffected — that's the separate `v*` tag.)