### PR TITLE
feat(npm): expose findBy*/exists on the typed DocxSession wrapper (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **npm `DocxSession` find-by surface** (issue #171). The TypeScript wrapper at
+  `npm/src/session.ts` now exposes the six `DocxSession` methods whose bridge
+  shells landed in #168 but were unreachable from the typed API: `exists`,
+  `findByText`, `findAllByText`, `findByRegex`, and `findByKind` (`replaceMatch`
+  was already present). New `FindOptions` type in `npm/src/types.ts`
+  (`ignoreCase` / `ignoreWhitespace` / `kindFilter` / `scopes` / `scopeFilter`,
+  matching the .NET `FindOptions` record), and the corresponding `Exists` /
+  `FindByText` / `FindAllByText` / `FindByRegex` / `FindByKind` signatures added
+  to the `DocxSessionBridge` exports interface. Wire shapes are byte-identical to
+  what `tools/python-host` consumes, preserving the cross-transport parity
+  invariant. Tests: `npm/tests/find-by.spec.ts` exercises the *typed* wrapper
+  (via a new `window.Docxodus.openTypedSession` harness helper backed by an
+  IIFE-bundled `session.ts`), covering case-sensitive/insensitive text search,
+  broad-pattern regex, kind+scope filtering, existence probes, and the
+  `grep → replaceMatch` round-trip.
+
 ## [6.3.0] - 2026-05-30
 
 ### Fixed

--- a/npm/package.json
+++ b/npm/package.json
@@ -33,9 +33,10 @@
     "build:wasm": "../scripts/build-wasm.sh",
     "build:ts": "tsc",
     "build:pagination-bundle": "esbuild src/pagination.ts --bundle --format=iife --global-name=DocxodusPagination --outfile=dist/pagination.bundle.js",
+    "build:session-bundle": "esbuild src/session.ts --bundle --format=iife --global-name=DocxodusSession --outfile=dist/session.bundle.js",
     "build:worker-bundle": "esbuild src/docxodus.worker.ts --bundle --format=esm --outfile=dist/docxodus.worker.js && esbuild src/worker-proxy.ts --bundle --format=esm --outfile=dist/worker-proxy.bundle.js",
-    "build": "npm run build:wasm && npm run build:ts && npm run build:pagination-bundle && npm run build:worker-bundle",
-    "pretest": "cp tests/test-harness.html dist/wasm/ && cp tests/worker-test-harness.html dist/wasm/ && cp tests/profiling-harness.html dist/wasm/ && cp dist/pagination.bundle.js dist/wasm/ && cp dist/docxodus.worker.js dist/wasm/ && cp dist/worker-proxy.bundle.js dist/wasm/worker-proxy.js",
+    "build": "npm run build:wasm && npm run build:ts && npm run build:pagination-bundle && npm run build:session-bundle && npm run build:worker-bundle",
+    "pretest": "cp tests/test-harness.html dist/wasm/ && cp tests/worker-test-harness.html dist/wasm/ && cp tests/profiling-harness.html dist/wasm/ && cp dist/pagination.bundle.js dist/wasm/ && cp dist/session.bundle.js dist/wasm/ && cp dist/docxodus.worker.js dist/wasm/ && cp dist/worker-proxy.bundle.js dist/wasm/worker-proxy.js",
     "test": "playwright test",
     "test:ui": "playwright test --ui",
     "prepublishOnly": "npm run build"

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -64,6 +64,7 @@ export type {
   EditError,
   EditErrorCode,
   EditResult,
+  FindOptions,
   FormatOp,
   ListMembership,
   MarkdownPatch,

--- a/npm/src/session.ts
+++ b/npm/src/session.ts
@@ -19,6 +19,7 @@ import type {
   EditResult,
   EditSummary,
   FillOptions,
+  FindOptions,
   FormatOp,
   GrepOptions,
   ListMembership,
@@ -524,6 +525,65 @@ export class DocxSession {
     return JSON.parse(this.wasm.FindByBookmark(this.handle, bookmarkName)) as AnchorTargetRef[];
   }
 
+  // ─── Text/kind-based anchor discovery (#171) ─────────────────────────
+
+  /**
+   * True when `anchorId` resolves to a live element in the current session.
+   * Cheap existence probe — use it to guard an anchor obtained from an earlier
+   * projection before handing it to a mutation (anchors can be invalidated by
+   * intervening edits; see the anchor lifecycle table in the mutation docs).
+   */
+  exists(anchorId: string): boolean {
+    return this.wasm.Exists(this.handle, anchorId);
+  }
+
+  /**
+   * Find the first block-level anchor (in document order) whose flat text
+   * contains `needle`, or `null` when nothing matches. `options` tune case /
+   * whitespace handling and narrow the search by kind or scope. For all
+   * matches use {@link findAllByText}.
+   */
+  findByText(needle: string, options?: FindOptions): AnchorTargetRef | null {
+    return JSON.parse(
+      this.wasm.FindByText(this.handle, needle, options ? JSON.stringify(options) : ""),
+    ) as AnchorTargetRef | null;
+  }
+
+  /**
+   * Like {@link findByText} but returns every matching anchor in document
+   * order (empty when nothing matches).
+   */
+  findAllByText(needle: string, options?: FindOptions): AnchorTargetRef[] {
+    return JSON.parse(
+      this.wasm.FindAllByText(this.handle, needle, options ? JSON.stringify(options) : ""),
+    ) as AnchorTargetRef[];
+  }
+
+  /**
+   * Find every block-level anchor whose flat text matches the regular
+   * expression `pattern`, in document order. `regexOptions` uses the numeric
+   * layout of .NET `RegexOptions` (e.g. `1` = IgnoreCase); `options` is the
+   * same shape as {@link findByText} (its `ignoreCase` composes with the regex
+   * flag). Defaults to `regexOptions = 0` (none).
+   */
+  findByRegex(pattern: string, regexOptions = 0, options?: FindOptions): AnchorTargetRef[] {
+    return JSON.parse(
+      this.wasm.FindByRegex(this.handle, pattern, regexOptions, options ? JSON.stringify(options) : ""),
+    ) as AnchorTargetRef[];
+  }
+
+  /**
+   * Return every anchor of the given `kind` (`"p"`, `"h"`, `"li"`, `"tbl"`,
+   * `"row"`, `"cell"`, …), in document order. Reads the projection's anchor
+   * index directly — no text scan. Pass `scope` (e.g. `"body"`) to restrict to
+   * a single part; omit it to span all scopes.
+   */
+  findByKind(kind: string, scope?: string): AnchorTargetRef[] {
+    return JSON.parse(
+      this.wasm.FindByKind(this.handle, kind, scope ?? ""),
+    ) as AnchorTargetRef[];
+  }
+
   /**
    * Look up a single anchor's preview info — `{ id, kind, scope, textPreview }`.
    * Returns null when the anchor id is unknown.
@@ -670,5 +730,5 @@ export function openDocxSession(
   return new DocxSession(handle, bridge);
 }
 
-export type { AnchorInfo, AnchorRef, AnchorTargetRef, BlockSlice, CharSpan, CrossBlockMatch, DocumentAnnotation, DocxSessionProjection, DocxSessionSettings, EditError, EditErrorCode, EditResult, FormatOp, GrepOptions, MarkdownPatch, PlaceholderKind, ReplaceOptions, RunFormatting, RunFragment, TemplatePlaceholder, TextMatch } from "./types.js";
+export type { AnchorInfo, AnchorRef, AnchorTargetRef, BlockSlice, CharSpan, CrossBlockMatch, DocumentAnnotation, DocxSessionProjection, DocxSessionSettings, EditError, EditErrorCode, EditResult, FindOptions, FormatOp, GrepOptions, MarkdownPatch, PlaceholderKind, ReplaceOptions, RunFormatting, RunFragment, TemplatePlaceholder, TextMatch } from "./types.js";
 export { ContextBoundary, PlaceholderKinds } from "./types.js";

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -769,6 +769,11 @@ export interface DocxodusWasmExports {
     FindByAnnotation: (handle: number, annotationId: string) => string;
     FindByLabel: (handle: number, labelId: string) => string;
     FindByBookmark: (handle: number, bookmarkName: string) => string;
+    Exists: (handle: number, anchorId: string) => boolean;
+    FindByText: (handle: number, needle: string, optionsJson: string) => string;
+    FindAllByText: (handle: number, needle: string, optionsJson: string) => string;
+    FindByRegex: (handle: number, pattern: string, regexOptions: number, optionsJson: string) => string;
+    FindByKind: (handle: number, kind: string, scope: string) => string;
     GetAnchorInfo: (handle: number, anchorId: string) => string;
     GetAnchorInfos: (handle: number, anchorIdsJson: string) => string;
     GetBlockMetadata: (handle: number, anchorId: string) => string;
@@ -1174,6 +1179,32 @@ export interface GrepOptions {
    * `contextChars`.
    */
   boundary?: number;
+}
+
+/**
+ * Options that tune the `findBy*` helpers on {@link DocxSession}. Mirrors the
+ * .NET `FindOptions` record; wire keys are already camelCase, so this object is
+ * serialized straight to the bridge. Omit it (or pass `{}`) for the defaults
+ * (case-sensitive, whitespace-preserving, all scopes, no kind filter).
+ */
+export interface FindOptions {
+  /** Case-insensitive matching. */
+  ignoreCase?: boolean;
+  /** Fold NBSP / narrow-NBSP / thin-space to ASCII space before matching. */
+  ignoreWhitespace?: boolean;
+  /** Only return anchors of this kind (e.g. `"h"` for headings, `"p"` for paragraphs). */
+  kindFilter?: string;
+  /**
+   * Coarse-grained scope flag set (Body / Headers / Footers / Footnotes /
+   * Endnotes / Comments). Numeric layout matching the .NET `ProjectionScopes`
+   * flags enum; use {@link ProjectionScopes}. Defaults to all scopes.
+   */
+  scopes?: number;
+  /**
+   * Target a single named package part (e.g. `"hdr1"`). Prefer {@link scopes}
+   * for whole-category filtering; this is for the rare single-part case.
+   */
+  scopeFilter?: string;
 }
 
 /**

--- a/npm/tests/find-by.spec.ts
+++ b/npm/tests/find-by.spec.ts
@@ -1,0 +1,168 @@
+import { test, expect, Page } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const TEST_FILES_DIR = path.join(__dirname, '../../TestFiles');
+
+function readTestFile(relativePath: string): Uint8Array {
+  return new Uint8Array(fs.readFileSync(path.join(TEST_FILES_DIR, relativePath)));
+}
+
+async function waitForDocxodus(page: Page) {
+  await page.waitForFunction(() => (window as any).DocxodusReady === true, { timeout: 30000 });
+}
+
+// Exercises the *typed* DocxSession wrapper (Issue #171): findByText /
+// findAllByText / findByRegex / findByKind / exists / replaceMatch. The harness
+// exposes `window.Docxodus.openTypedSession(bytes)` which returns a real
+// `DocxSession` instance (the IIFE-bundled TS wrapper), so these tests run the
+// wrapper code, not just the raw [JSExport] bridge.
+//
+// Fixture: HC006-Test-01.docx — English body text (so text search has Latin
+// words to match), multiple headings, and paragraphs. (HC001's body is CJK,
+// with no Latin words for the regex needles to hit.)
+test.describe('DocxSession find-by surface (typed wrapper — Issue #171)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/test-harness.html');
+    await waitForDocxodus(page);
+  });
+
+  test('exists() true for a real anchor, false for a bogus id', async ({ page }) => {
+    const bytes = readTestFile('HC006-Test-01.docx');
+    const result = await page.evaluate(async (bytesArray: number[]) => {
+      const session = (window as any).Docxodus.openTypedSession(new Uint8Array(bytesArray));
+      try {
+        const proj = session.project();
+        const realId = Object.keys(proj.anchorIndex)[0];
+        return {
+          realId,
+          realExists: session.exists(realId),
+          bogusExists: session.exists('p:body:deadbeefdeadbeef'),
+        };
+      } finally {
+        session.close();
+      }
+    }, Array.from(bytes));
+
+    expect(result.realExists).toBe(true);
+    expect(result.bogusExists).toBe(false);
+  });
+
+  test('findByText / findAllByText locate a real needle and honor ignoreCase', async ({ page }) => {
+    const bytes = readTestFile('HC006-Test-01.docx');
+    const result = await page.evaluate(async (bytesArray: number[]) => {
+      const session = (window as any).Docxodus.openTypedSession(new Uint8Array(bytesArray));
+      try {
+        // Pull a real ≥5-letter word out of the body via grep so the needle is
+        // not hard-coded to fixture text.
+        const matches = session.grep('[A-Za-z]{5,}');
+        const needle = matches[0].text as string;
+
+        const single = session.findByText(needle);
+        const all = session.findAllByText(needle);
+
+        const upper = needle.toUpperCase();
+        const upperStrict = session.findAllByText(upper);            // case-sensitive
+        const upperLoose = session.findAllByText(upper, { ignoreCase: true });
+
+        return {
+          needle,
+          single,                                  // AnchorTargetRef | null
+          allCount: all.length,
+          missing: session.findByText('zzqx_no_such_needle_42'),
+          strictCount: upperStrict.length,
+          looseCount: upperLoose.length,
+        };
+      } finally {
+        session.close();
+      }
+    }, Array.from(bytes));
+
+    expect(result.single).not.toBeNull();
+    expect(result.single.id).toBeTruthy();
+    expect(result.allCount).toBeGreaterThanOrEqual(1);
+    expect(result.missing).toBeNull();
+    // ignoreCase never finds fewer than the strict search, and finds the
+    // original-cased occurrence(s).
+    expect(result.looseCount).toBeGreaterThanOrEqual(result.strictCount);
+    expect(result.looseCount).toBeGreaterThanOrEqual(1);
+  });
+
+  test('findByRegex returns multiple anchors for a broad pattern', async ({ page }) => {
+    const bytes = readTestFile('HC006-Test-01.docx');
+    const result = await page.evaluate(async (bytesArray: number[]) => {
+      const session = (window as any).Docxodus.openTypedSession(new Uint8Array(bytesArray));
+      try {
+        const hits = session.findByRegex('\\S+');   // any non-whitespace text
+        const ids = hits.map((h: any) => h.id);
+        return { count: hits.length, distinct: new Set(ids).size };
+      } finally {
+        session.close();
+      }
+    }, Array.from(bytes));
+
+    expect(result.count).toBeGreaterThanOrEqual(2);
+    expect(result.distinct).toBe(result.count);   // anchors are unique
+  });
+
+  test('findByKind("p") returns body paragraphs; ("h","body") filters by scope', async ({ page }) => {
+    const bytes = readTestFile('HC006-Test-01.docx');
+    const result = await page.evaluate(async (bytesArray: number[]) => {
+      const session = (window as any).Docxodus.openTypedSession(new Uint8Array(bytesArray));
+      try {
+        const paras = session.findByKind('p');
+        const headings = session.findByKind('h', 'body');
+        return {
+          paraCount: paras.length,
+          allParaKindP: paras.every((p: any) => p.kind === 'p'),
+          headingCount: headings.length,
+          allHeadingsScoped: headings.every((h: any) => h.kind === 'h' && h.scope === 'body'),
+        };
+      } finally {
+        session.close();
+      }
+    }, Array.from(bytes));
+
+    expect(result.paraCount).toBeGreaterThanOrEqual(1);
+    expect(result.allParaKindP).toBe(true);
+    expect(result.headingCount).toBeGreaterThanOrEqual(1);
+    expect(result.allHeadingsScoped).toBe(true);
+  });
+
+  test('replaceMatch workflow: grep → replaceMatch → text updated in place', async ({ page }) => {
+    const bytes = readTestFile('HC006-Test-01.docx');
+    const result = await page.evaluate(async (bytesArray: number[]) => {
+      const session = (window as any).Docxodus.openTypedSession(new Uint8Array(bytesArray));
+      try {
+        const matches = session.grep('[A-Za-z]{5,}');
+        const match = matches[0];
+        const original = match.text as string;
+
+        const edit = session.replaceMatch(match, 'ZZMARKERZZ');
+
+        const afterMarker = session.findAllByText('ZZMARKERZZ').length;
+        // The replaced span no longer matches the original text at that anchor.
+        const stillHasOriginalAtAnchor = session
+          .grep('[A-Za-z]{5,}')
+          .some((m: any) => m.enclosingAnchor.id === match.enclosingAnchor.id &&
+                            m.span.start === match.span.start &&
+                            m.text === original);
+
+        return {
+          editSuccess: edit.success,
+          afterMarker,
+          stillHasOriginalAtAnchor,
+        };
+      } finally {
+        session.close();
+      }
+    }, Array.from(bytes));
+
+    expect(result.editSuccess).toBe(true);
+    expect(result.afterMarker).toBeGreaterThanOrEqual(1);
+    expect(result.stillHasOriginalAtAnchor).toBe(false);
+  });
+});

--- a/npm/tests/test-harness.html
+++ b/npm/tests/test-harness.html
@@ -9,6 +9,11 @@
     <div id="status">Loading...</div>
     <pre id="output"></pre>
 
+    <!-- Typed TS wrapper (DocxSession class + openDocxSession), IIFE-bundled to
+         window.DocxodusSession so specs can exercise the typed API, not just the
+         raw [JSExport] bridge. Built by `npm run build:session-bundle`. -->
+    <script src="./session.bundle.js"></script>
+
     <script type="module">
         import { dotnet } from './_framework/dotnet.js';
 
@@ -23,7 +28,14 @@
         window.Docxodus = {
             DocumentConverter: exports.DocxodusWasm.DocumentConverter,
             DocumentComparer: exports.DocxodusWasm.DocumentComparer,
-            DocxSessionBridge: exports.DocxodusWasm.DocxSessionBridge
+            DocxSessionBridge: exports.DocxodusWasm.DocxSessionBridge,
+            // Typed wrapper class from the IIFE bundle above; constructor takes
+            // (handle, bridge). openTypedSession opens + wraps in one call.
+            DocxSession: window.DocxodusSession.DocxSession,
+            openTypedSession: (bytes, settingsJson) => new window.DocxodusSession.DocxSession(
+                exports.DocxodusWasm.DocxSessionBridge.OpenSession(bytes, settingsJson || ''),
+                exports.DocxodusWasm.DocxSessionBridge
+            )
         };
 
         // Test helper functions


### PR DESCRIPTION
Closes #171.

## Context

PR #168 landed the `[JSExport]` bridge shells for six previously-unreachable `DocxSession` methods, but the typed TypeScript wrapper at `npm/src/session.ts` never surfaced five of them — so they were callable from the raw WASM exports yet unreachable from the typed `DocxSession` API consumers actually use. This closes that parity gap.

## Changes

- **`npm/src/session.ts`** — add `exists`, `findByText`, `findAllByText`, `findByRegex`, `findByKind` (`replaceMatch` already existed). Thin passthroughs mirroring the existing `findByAnnotation`/`findByLabel` pattern: serialize `FindOptions` to `optionsJson`, parse the `AnchorTargetRef` JSON, handle the nullable `findByText` result.
- **`npm/src/types.ts`** — add `FindOptions` interface (`ignoreCase` / `ignoreWhitespace` / `kindFilter` / `scopes` / `scopeFilter`, matching the .NET `FindOptions` record) and the `Exists` / `FindByText` / `FindAllByText` / `FindByRegex` / `FindByKind` signatures on the `DocxSessionBridge` exports interface.
- **`npm/src/index.ts`** — re-export `FindOptions` for public consumers.
- **`npm/tests/find-by.spec.ts`** — Playwright spec exercising the *typed* wrapper, not just the raw bridge. Adds a `window.Docxodus.openTypedSession` harness helper backed by a new IIFE session bundle (`build:session-bundle` + `pretest` copy + harness `<script>`) so the wrapper code runs in-browser. Covers case-sensitive/insensitive text search, broad-pattern regex, kind+scope filtering, existence probes, and the `grep → replaceMatch` round-trip. Uses the English `HC006-Test-01` fixture (HC001's body is CJK, with no Latin words for the regex needles to hit).

Wire shapes are byte-identical to what `tools/python-host` consumes, preserving the cross-transport parity invariant. Per the issue, the React hook layer and worker proxy are out of scope.

## Verification

- `npx tsc --noEmit` — clean
- `npm run build` — clean (wasm + ts + all bundles)
- `npm test` — **179 passed**, no regressions from the harness change (the 5 new find-by tests included)