### PR TITLE
fix(python): FindOptions scope filtering was a silent no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Python `FindOptions` scope filtering was a silent no-op.** In `docx_scalpel`, `FindOptions` exposed a single `scope_filter: ProjectionScopes` field and serialized it as an **int** under the `scopeFilter` wire key. But the stdio host (and WASM bridge) parse `scopeFilter` as a **string** (a single named part like `"hdr1"`) and read the coarse `ProjectionScopes` flag set from a separate `scopes` (number) key — which the wrapper never emitted. The net effect: `find_by_text` / `find_all_by_text` / `find_by_regex` ignored any scope restriction passed from Python and always searched all scopes. `FindOptions` now mirrors the .NET record's two distinct controls: `scopes: ProjectionScopes | None` (coarse category flag set → wire `scopes`, int) and `scope_filter: str | None` (fine named-part post-filter → wire `scopeFilter`, string). **API change:** `scope_filter` is now a `str` (was `ProjectionScopes`); callers that want category filtering should use the new `scopes` field (e.g. `FindOptions(scopes=ProjectionScopes.HEADERS | ProjectionScopes.FOOTERS)`). Tests: `python/tests/test_find_options_scopes.py` pins the wire mapping and verifies `scopes=ProjectionScopes.BODY` actually drops a footnote-scope hit on HC031.
+
 ## [6.3.0] - 2026-05-30
 
 ### Fixed

--- a/python/src/docx_scalpel/types.py
+++ b/python/src/docx_scalpel/types.py
@@ -654,19 +654,32 @@ class EditSummary:
 
 @dataclass(frozen=True, slots=True)
 class FindOptions:
-    """Optional filters for ``find_by_text`` / ``find_all_by_text`` / ``find_by_regex``."""
+    """Optional filters for ``find_by_text`` / ``find_all_by_text`` / ``find_by_regex``.
+
+    Mirrors the .NET ``FindOptions`` record's two distinct scope controls:
+
+    * ``scopes`` — a :class:`ProjectionScopes` flag set (coarse "which categories
+      of part" filter; wire key ``scopes``). Compose with ``|`` to widen, e.g.
+      ``ProjectionScopes.HEADERS | ProjectionScopes.FOOTERS``. Defaults to all
+      scopes when unset.
+    * ``scope_filter`` — a string naming one specific part such as ``"hdr1"``
+      (wire key ``scopeFilter``), applied as a finer post-filter on top of
+      ``scopes``. Prefer ``scopes`` for whole-category filtering.
+    """
 
     ignore_case: bool = False
     ignore_whitespace: bool = False
     kind_filter: str | None = None
-    scope_filter: ProjectionScopes | None = None
+    scopes: ProjectionScopes | None = None
+    scope_filter: str | None = None
 
     def to_wire(self) -> dict[str, Any]:
         out: dict[str, Any] = {}
         if self.ignore_case: out["ignoreCase"] = True
         if self.ignore_whitespace: out["ignoreWhitespace"] = True
         if self.kind_filter is not None: out["kindFilter"] = self.kind_filter
-        if self.scope_filter is not None: out["scopeFilter"] = int(self.scope_filter)
+        if self.scopes is not None: out["scopes"] = int(self.scopes)
+        if self.scope_filter is not None: out["scopeFilter"] = self.scope_filter
         return out
 
 

--- a/python/tests/test_find_options_scopes.py
+++ b/python/tests/test_find_options_scopes.py
@@ -1,0 +1,84 @@
+"""Regression coverage for ``FindOptions`` scope filtering on the Python wrapper.
+
+The .NET ``FindOptions`` record exposes two distinct scope controls:
+
+* ``Scopes`` — a ``ProjectionScopes`` flag set (wire key ``scopes``, an int),
+  the coarse "which categories of part" filter (default = All).
+* ``ScopeFilter`` — a string naming one specific part such as ``"hdr1"``
+  (wire key ``scopeFilter``), a finer post-filter on top of ``Scopes``.
+
+The Python wrapper previously conflated the two: it had a single
+``scope_filter: ProjectionScopes`` field and serialized it as an int under the
+``scopeFilter`` key. The .NET dispatcher reads ``scopeFilter`` as a *string*
+(so the int was dropped) and reads the flag set from ``scopes`` (which the
+wrapper never emitted), so scope filtering from Python was a silent no-op.
+
+These tests pin the corrected wire contract and the end-to-end narrowing.
+HC031-Complicated-Document.docx carries body text plus footnote/endnote/comment
+parts, so restricting ``scopes`` to the body must drop the footnote hit.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from docx_scalpel import DocxSession, open_session
+from docx_scalpel.enums import ProjectionScopes
+from docx_scalpel.types import FindOptions
+
+
+@pytest.fixture
+def multiscope_session(test_files_dir: Path) -> Iterator[DocxSession]:
+    fixture = test_files_dir / "HC031-Complicated-Document.docx"
+    if not fixture.exists():
+        pytest.skip(f"fixture missing: {fixture}")
+    session = open_session(fixture.read_bytes())
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def test_to_wire_maps_scopes_to_int_and_scope_filter_to_string() -> None:
+    combined = ProjectionScopes.HEADERS | ProjectionScopes.FOOTERS
+    wire = FindOptions(scopes=combined, scope_filter="hdr1").to_wire()
+
+    # Coarse flag set → numeric "scopes"; named part → string "scopeFilter".
+    assert wire["scopes"] == int(combined)
+    assert wire["scopeFilter"] == "hdr1"
+    # Never the other way around — the int must not leak into "scopeFilter".
+    assert not isinstance(wire.get("scopeFilter"), int)
+
+
+def test_to_wire_omits_unset_scope_fields() -> None:
+    wire = FindOptions(ignore_case=True).to_wire()
+    assert "scopes" not in wire
+    assert "scopeFilter" not in wire
+
+
+def test_scopes_narrows_find_all_by_text_to_body(multiscope_session: DocxSession) -> None:
+    needle = "footnote"  # present in the footnote part of HC031
+
+    all_hits = multiscope_session.find_all_by_text(needle, FindOptions(ignore_case=True))
+    if not any(h.scope.startswith("fn") for h in all_hits):
+        pytest.skip("fixture footnote text changed; needle no longer in fn scope")
+
+    body_only = multiscope_session.find_all_by_text(
+        needle, FindOptions(ignore_case=True, scopes=ProjectionScopes.BODY)
+    )
+
+    # Restricting to the body must drop the footnote hit (the regression: this
+    # used to be a no-op, so body_only == all_hits).
+    assert all(not h.scope.startswith("fn") for h in body_only)
+    assert len(body_only) < len(all_hits)
+
+
+def test_scopes_footnotes_only_returns_footnote_anchor(multiscope_session: DocxSession) -> None:
+    fn_only = multiscope_session.find_all_by_text(
+        "footnote", FindOptions(ignore_case=True, scopes=ProjectionScopes.FOOTNOTES)
+    )
+    assert len(fn_only) >= 1
+    assert all(h.scope.startswith("fn") for h in fn_only)


### PR DESCRIPTION
Discovered while reviewing the Python find-by surface for #171.

## The bug

`docx_scalpel.FindOptions` had a single field `scope_filter: ProjectionScopes` and serialized it as an **int** under the `scopeFilter` wire key:

```python
if self.scope_filter is not None: out["scopeFilter"] = int(self.scope_filter)
```

But the .NET `FindOptions` record (and the stdio host / WASM bridge that parse the wire) have **two distinct** scope controls:

| .NET field | wire key | type | meaning |
|------------|----------|------|---------|
| `Scopes` | `scopes` | number | coarse `ProjectionScopes` flag set (default All) |
| `ScopeFilter` | `scopeFilter` | string | one specific named part, e.g. `"hdr1"` (fine post-filter) |

`DocxSessionJson.ParseFindOptions` reads `scopes` via `TryGetInt` and `scopeFilter` via `TryGetString`. So Python's `scopeFilter: <int>` was discarded (wrong type for a string-typed key), and the `scopes` flag set was never emitted at all → **scope filtering from Python was a silent no-op**; `find_by_text` / `find_all_by_text` / `find_by_regex` always searched every scope.

### Confirmed end-to-end (HC031-Complicated-Document.docx)

```
needle = "footnote"            # lives in the footnote (fn) scope
find_all_by_text(needle, FindOptions(ignore_case=True))                         -> ['fn']
find_all_by_text(needle, FindOptions(ignore_case=True, scope_filter=BODY))      -> ['fn']   # should be []
FindOptions(ignore_case=True, scope_filter=BODY).to_wire()  -> {'ignoreCase': True, 'scopeFilter': 1}
```

## The fix

Align `FindOptions` with the .NET record (and the npm `FindOptions` from #215):

```python
scopes: ProjectionScopes | None = None   # -> wire "scopes"  (int)   coarse category set
scope_filter: str | None = None          # -> wire "scopeFilter" (str) fine named-part post-filter
```

**API change:** `scope_filter` is now `str` (was `ProjectionScopes`); category filtering moves to the new `scopes` field, e.g. `FindOptions(scopes=ProjectionScopes.HEADERS | ProjectionScopes.FOOTERS)`. The old `ProjectionScopes` value never had any effect, and no caller in the repo used it.

## Tests

`python/tests/test_find_options_scopes.py`:
- `to_wire` maps `scopes` → int and `scope_filter` → string (and the int never leaks into `scopeFilter`)
- unset scope fields are omitted from the wire
- `scopes=ProjectionScopes.BODY` drops the footnote-scope hit (`len(body_only) < len(all_hits)`) — the regression guard
- `scopes=ProjectionScopes.FOOTNOTES` returns only `fn` anchors

Verification: built `docxodus-pyhost`, new file 4 passed, full Python suite **36 passed**, no regressions.