### PR TITLE
Release v6.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [6.4.0] - 2026-05-30
+
 ### Added
 - **npm `DocxSession` find-by surface** (issue #171). The TypeScript wrapper at
   `npm/src/session.ts` now exposes the six `DocxSession` methods whose bridge


### PR DESCRIPTION
Cut the **v6.4.0** release notes (changelog-only; no csproj/package.json version bump, per the documented release process).

Minor bump (v6.3.0 → v6.4.0) — the `[Unreleased]` section carries an `### Added` entry:

### Added
- npm `DocxSession` find-by surface (#171 / #215) — `exists`, `findByText`, `findAllByText`, `findByRegex`, `findByKind` on the typed TS wrapper, plus the `FindOptions` type.

### Fixed
- Python `FindOptions` scope filtering was a silent no-op (#217) — `scopes` (flag set) vs `scope_filter` (named part) now map to the correct wire keys/types.

After merge: pull main and push the annotated `v6.4.0` tag.