### PR TITLE
chore(python): bump docx-scalpel to 0.1.0a5

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "docx-scalpel"
-version = "0.1.0a4"
+version = "0.1.0a5"
 description = "Anchor-addressed DOCX editing for LLM agents — a thin client over Docxodus' DocxSession."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bump `docx-scalpel` `0.1.0a4` → `0.1.0a5` ahead of tagging `docx-scalpel-v0.1.0a5` (which triggers the PyPI publish workflow).

Picks up the breaking-ish Python API change from #217: `FindOptions.scope_filter` is now `str` (was `ProjectionScopes`), and category filtering moves to the new `scopes: ProjectionScopes | None` field. Still in the `0.1.0aN` alpha line, so the change rides an alpha bump.

(Pre-release alpha bump only; the publish workflow re-pins pyproject to the tag version at build time, but keeping the source in sync matches the prior #214 bump.)