### PR TITLE
ci: skip claude-review for dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,12 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Dependabot PRs never get repository secrets (including
+    # CLAUDE_CODE_OAUTH_TOKEN) on pull_request-triggered runs — that's a
+    # GitHub security restriction, not something this workflow can work
+    # around. Skip the job there instead of showing a permanently-red,
+    # unfixable check on every dependency-bump PR.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- GitHub withholds repository secrets (including `CLAUDE_CODE_OAUTH_TOKEN`) from `pull_request`-triggered workflow runs authored by `dependabot[bot]` — this is a GitHub security restriction, not something the workflow can work around.
- The `claude-review` job was consequently failing on every open dependency-bump PR with an opaque "App token exchange failed" error, showing a permanently-red, unfixable check.
- Skip the job for that actor instead, using the same author-filter mechanism the workflow already had commented out as an example.

## Test plan
- [x] Workflow YAML change only, no code/build impact — verified the `if:` condition syntax matches GitHub Actions' documented context access for `github.event.pull_request.user.login`.