### PR TITLE
ci: bump Node 20→22 across workflows + pin publish npm to 11.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install npm dependencies
         run: cd npm && npm ci

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install npm dependencies
         run: cd npm && npm ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -280,11 +280,15 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Update npm to latest (required for trusted publishers)
-        run: npm install -g npm@latest
+      # Pin npm to 11.x — NOT @latest. npm >= 11.5.1 is required for OIDC trusted
+      # publishing (see the publish step below), and 11.x supports both Node 20 and
+      # Node 22 (engines.node ^20.17.0 || >=22.9.0). Using @latest is what broke this
+      # job: it silently rolled onto npm 12, which dropped Node 20 support.
+      - name: Pin npm (required for trusted publishers)
+        run: npm install -g npm@11
 
       - name: Determine version
         id: version


### PR DESCRIPTION
## Fixes the v7.0.0 publish EBADENGINE failure

The `build-npm` job in `publish.yml` failed with:

```
npm error code EBADENGINE
npm error Not compatible with your version of node/npm: npm@12.0.0
npm error Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

**Root cause:** `npm install -g npm@latest` (publish.yml) resolved to **npm@12.0.0**, which dropped Node 20 support, while `setup-node` pinned **Node 20**. `@latest` silently rolled onto the Node-dropping major. Only `publish.yml` ran the global npm upgrade, so only it broke.

## Changes (Option D — durable fix + hygiene)

- **Bump `node-version` `'20'` → `'22'`** in `ci.yml`, `playwright.yml`, and `publish.yml`. Node 20 is EOL (2026-04-30); Node 22 is a supported LTS. No repo `engines` constraint, and the toolchain (dotnet 10 wasm workloads, `typescript@5.3`, `esbuild@0.28`, `@playwright/test@1.57`) has no Node 22 constraint.
- **Pin the publish npm to `11.x`** instead of `@latest`. npm ≥ 11.5.1 is required for the OIDC **trusted-publishing** path this job uses (`id-token: write` / `environment: Publisher` / `npm publish --access public`, no token). 11.x supports both Node 20 and 22, so the pin is durable and can't silently roll onto a Node-dropping major again. (Removing the step entirely is **not** viable — the bundled npm 10.8.2 can't do the OIDC handshake.)

## Verification

This PR's own CI exercises the bump: **`build-and-test`, `build-npm`, and the Playwright `test` job now run on Node 22**, so a green run confirms the toolchain works on 22. The publish job itself only runs on a tag / `workflow_dispatch`.

## Note

The v7.0.0 npm publish won't retroactively run by merging this — it re-fires via `workflow_dispatch` (version input) or a re-cut tag. I'll trigger it once this merges.

Diagnosis was adversarially verified (npm↔Node compat matrix, trusted-publishing floor, no residual `@latest`).