### PR TITLE
ci(publish): set deployment URLs so the Publisher environment shows active

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,7 +75,11 @@ jobs:
   publish-nuget:
     needs: build-test-publish
     runs-on: ubuntu-latest
-    environment: Publisher
+    # The url keeps the deployment non-transient so the Publisher environment
+    # shows as active on the repo sidebar instead of auto-inactivating.
+    environment:
+      name: Publisher
+      url: https://www.nuget.org/packages/Docxodus
     permissions:
       contents: read
       id-token: write
@@ -258,7 +262,9 @@ jobs:
   build-npm:
     needs: build-test-publish
     runs-on: ubuntu-latest
-    environment: Publisher
+    environment:
+      name: Publisher
+      url: https://www.npmjs.com/package/docxodus
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## What

Adds an `environment.url` to the two `publish.yml` jobs that deploy to the **Publisher** environment:

- `publish-nuget` → https://www.nuget.org/packages/Docxodus
- `build-npm` → https://www.npmjs.com/package/docxodus

## Why

A deployment with no environment URL is transient — GitHub auto-inactivates it as soon as the job finishes, so Publisher always showed as **inactive** on the repo sidebar even minutes after a successful release (e.g. v7.0.1). `python-publish.yml`'s `pypi`/`testpypi` environments already set `url` and show as active; this mirrors that.

## Safety

The environment **name** is unchanged, so the OIDC trusted-publishing subject claim (`repo:JSv4/Docxodus:environment:Publisher`) that nuget.org / npmjs.com validate is untouched. No trigger, job, or step changes — the workflow only runs on `v*` tags / manual dispatch, so this PR runs nothing.