### PR TITLE
docx2html: add --track-changes and story rendering flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **`docx2html` CLI: tracked-changes and story rendering flags.** The `docx2html` tool previously always accepted revisions before converting, so a redline document rendered as if every change had been applied — there was no way to preview a redline in a browser. New flags map straight onto the existing `WmlToHtmlConverterSettings`: `--track-changes` (render revisions as `ins`/`del`/move markup instead of accepting them — `RenderTrackedChanges`), `--no-render-moves` (lower move markup to plain ins/del — `RenderMoveOperations`), `--render-comments`, `--render-footnotes`, and `--render-headers-footers`. Defaults are unchanged (all off, moves on), so existing invocations behave identically. This is the preview half of the docx-redlines GitHub Action (JSv4/Python-Redlines#12): the action redlines changed `.docx` files with the `redline` CLI and uses `docx2html --track-changes` to publish browser-viewable previews.
+
 ## [7.0.1] - 2026-07-11
 
 ### Changed

--- a/tools/docx2html/Program.cs
+++ b/tools/docx2html/Program.cs
@@ -13,7 +13,7 @@ namespace Docx2Html;
 
 class Program
 {
-    const string Version = "1.0.0";
+    const string Version = "1.1.0";
 
     static int Main(string[] args)
     {
@@ -36,6 +36,11 @@ class Program
         string cssPrefix = "pt-";
         bool embedImages = true;
         bool inlineStyles = false;
+        bool trackChanges = false;
+        bool renderMoves = true;
+        bool renderComments = false;
+        bool renderFootnotes = false;
+        bool renderHeadersFooters = false;
 
         for (int i = 0; i < args.Length; i++)
         {
@@ -56,6 +61,26 @@ class Program
                 else if (args[i] == "--extract-images")
                 {
                     embedImages = false;
+                }
+                else if (args[i] == "--track-changes")
+                {
+                    trackChanges = true;
+                }
+                else if (args[i] == "--no-render-moves")
+                {
+                    renderMoves = false;
+                }
+                else if (args[i] == "--render-comments")
+                {
+                    renderComments = true;
+                }
+                else if (args[i] == "--render-footnotes")
+                {
+                    renderFootnotes = true;
+                }
+                else if (args[i] == "--render-headers-footers")
+                {
+                    renderHeadersFooters = true;
                 }
                 else if (args[i].StartsWith("-"))
                 {
@@ -138,6 +163,11 @@ class Program
                 CssClassPrefix = cssPrefix,
                 RestrictToSupportedLanguages = false,
                 RestrictToSupportedNumberingFormats = false,
+                RenderTrackedChanges = trackChanges,
+                RenderMoveOperations = renderMoves,
+                RenderComments = renderComments,
+                RenderFootnotesAndEndnotes = renderFootnotes,
+                RenderHeadersAndFooters = renderHeadersFooters,
                 ImageHandler = imageInfo =>
                 {
                     if (imageInfo.ContentType == null)
@@ -293,6 +323,11 @@ class Program
         Console.WriteLine("  --css-prefix=<text>  CSS class prefix (default: pt-)");
         Console.WriteLine("  --inline-styles      Use inline styles instead of CSS classes");
         Console.WriteLine("  --extract-images     Save images to separate files instead of embedding");
+        Console.WriteLine("  --track-changes      Render tracked changes as ins/del markup instead of accepting them");
+        Console.WriteLine("  --no-render-moves    Render moves as plain ins/del (only with --track-changes)");
+        Console.WriteLine("  --render-comments    Render document comments");
+        Console.WriteLine("  --render-footnotes   Render footnotes and endnotes");
+        Console.WriteLine("  --render-headers-footers  Render document headers and footers");
         Console.WriteLine("  -h, --help           Show this help message");
         Console.WriteLine("  -v, --version        Show version information");
         Console.WriteLine();
@@ -301,6 +336,7 @@ class Program
         Console.WriteLine("  docx2html document.docx output.html");
         Console.WriteLine("  docx2html document.docx --title=\"My Document\"");
         Console.WriteLine("  docx2html document.docx --extract-images --inline-styles");
+        Console.WriteLine("  docx2html redline.docx --track-changes --render-footnotes");
         Console.WriteLine();
         Console.WriteLine("Environment Variables:");
         Console.WriteLine("  DOCX2HTML_DEBUG=1    Show detailed error information");


### PR DESCRIPTION
The `docx2html` CLI always accepted revisions before converting (the `RenderTrackedChanges = false` default), so a redline document rendered as if every change had already been applied — there was no way to preview a redline in a browser from the command line, even though `WmlToHtmlConverter` has supported it for a long time.

This adds CLI flags mapping straight onto the existing `WmlToHtmlConverterSettings` (no library changes):

| Flag | Setting |
|---|---|
| `--track-changes` | `RenderTrackedChanges = true` — render revisions as `ins`/`del`/move markup |
| `--no-render-moves` | `RenderMoveOperations = false` — lower move markup to plain ins/del |
| `--render-comments` | `RenderComments = true` |
| `--render-footnotes` | `RenderFootnotesAndEndnotes = true` |
| `--render-headers-footers` | `RenderHeadersAndFooters = true` |

Defaults are unchanged (all off, moves on), so existing invocations behave identically. Tool version const bumped to 1.1.0; CHANGELOG entry under `[Unreleased]` (an `### Added` entry, so the next release is a minor per the release process).

## Motivation

This is the preview half of the docx-redlines GitHub Action requested in JSv4/Python-Redlines#12 and implemented in JSv4/Python-Redlines#27: the action redlines the `.docx` files a PR changes using the `redline` CLI, then runs `docx2html --track-changes` over each redline to publish browser-viewable previews alongside the `.docx` artifacts. The action's `html-preview: auto` mode probes `docx2html --help` for `--track-changes`, so it lights up automatically once this lands in a NuGet release of the `Docx2Html` tool.

## Verification

Built with the .NET 10 SDK and exercised over `TestFiles/WC/WC001-Digits{,-Mod}.docx`:

- `redline` reports 4 revisions on the pair.
- Converting the redline **without** the flag: 0 `ins`/`del` elements (revisions accepted — prior behavior, unchanged).
- Converting **with** `--track-changes`: 4 `ins`/`del` elements with the converter's tracked-changes CSS.

The flags are thin passthroughs to converter settings already covered by `HtmlConverterTests`; the CLI tools have no test project, matching the existing pattern for `tools/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0142X9VTMpdo639kHKQa4PE1)_