### PR TITLE
Add round-three MCP DOCX smoke workflow

### DIFF
--- a/Docxodus.Tests/DocxSessionCommentAuthoringTests.cs
+++ b/Docxodus.Tests/DocxSessionCommentAuthoringTests.cs
@@ -812,6 +812,28 @@ public class DocxSessionCommentAuthoringTests
     }
 
     [Fact]
+    public void DS401b_SetCommentResolved_PropagatesThroughReplySubtree()
+    {
+        using var session = new DocxSession(BuildSingleParagraphDoc("Resolve this thread"));
+        var host = FirstBodyParagraph(session);
+        var made = session.AddComment(host, null, "Alice", "Root comment.");
+        Assert.True(made.Success, made.Error?.Message);
+        var rootAnchor = made.Created.First(a => a.Kind == "cmt").Id;
+        var reply = session.AddCommentReply(rootAnchor, "Bob", "Reply comment.");
+        Assert.True(reply.Success, reply.Error?.Message);
+
+        var resolved = session.SetCommentResolved(rootAnchor, true);
+
+        Assert.True(resolved.Success, resolved.Error?.Message);
+        Assert.Equal(2, resolved.Modified.Count);
+        Assert.All(session.ListComments(), comment => Assert.True(comment.Resolved));
+
+        var reopened = session.SetCommentResolved(rootAnchor, false);
+        Assert.True(reopened.Success, reopened.Error?.Message);
+        Assert.All(session.ListComments(), comment => Assert.False(comment.Resolved));
+    }
+
+    [Fact]
     public void DS402_ExistingThread_ListsParentAndResolveState_WithoutLosingParentage()
     {
         using var session = new DocxSession(BuildDocWithReferenceOnlyReply());

--- a/Docxodus.Tests/DocxSessionTableEditTests.cs
+++ b/Docxodus.Tests/DocxSessionTableEditTests.cs
@@ -268,6 +268,49 @@ public class DocxSessionTableEditTests
     }
 
     [Fact]
+    public void DT214b_SetTableRowOptions_WritesHeightAndPageSplitPolicy()
+    {
+        var (session, cells) = NewTable(2, 2);
+        var on = session.SetTableRowOptions(cells[0], new TableRowOptions
+        {
+            RepeatHeader = true,
+            AllowBreakAcrossPages = false,
+            HeightTwips = 480,
+            HeightRule = TableRowHeightRule.AtLeast,
+        });
+        Assert.True(on.Success, on.Error?.Message);
+
+        var trPr = SingleTable(session).Elements(W + "tr").First().Element(W + "trPr")!;
+        Assert.NotNull(trPr.Element(W + "cantSplit"));
+        Assert.NotNull(trPr.Element(W + "tblHeader"));
+        Assert.Equal("480", (string)trPr.Element(W + "trHeight")!.Attribute(W + "val"));
+        Assert.Equal("atLeast", (string)trPr.Element(W + "trHeight")!.Attribute(W + "hRule"));
+        AssertSchemaValid(session.Save());
+
+        var off = session.SetTableRowOptions(cells[0], new TableRowOptions
+        {
+            AllowBreakAcrossPages = true,
+            HeightTwips = 0,
+        });
+        Assert.True(off.Success, off.Error?.Message);
+        trPr = SingleTable(session).Elements(W + "tr").First().Element(W + "trPr")!;
+        Assert.Null(trPr.Element(W + "cantSplit"));
+        Assert.Null(trPr.Element(W + "trHeight"));
+        Assert.NotNull(trPr.Element(W + "tblHeader"));
+        AssertSchemaValid(session.Save());
+    }
+
+    [Fact]
+    public void DT214c_SetTableRowOptions_NegativeHeightIsRejected()
+    {
+        var (session, cells) = NewTable(1, 1);
+        var result = session.SetTableRowOptions(cells[0],
+            new TableRowOptions { HeightTwips = -1 });
+        Assert.False(result.Success);
+        Assert.Equal(EditErrorCode.InvalidTableStyling, result.Error!.Code);
+    }
+
+    [Fact]
     public void DT215_TableStyling_NonCellAnchor_IsRejected()
     {
         var session = new DocxSession(DocxSessionTests.BuildDS001_SimpleTwoParagraphs());

--- a/Docxodus.Tests/DocxSessionTests.cs
+++ b/Docxodus.Tests/DocxSessionTests.cs
@@ -2079,6 +2079,84 @@ public class DocxSessionTests
         Assert.Contains(r.Modified, a => a.Kind == "p");
     }
 
+    [Fact]
+    public void DS055b_RemoveListMembership_OverridesStyleInheritedNumbering()
+    {
+        using var s = new DocxSession(BuildStyleListSingleLevel());
+        var firstLi = s.Project().AnchorIndex.Keys.First(k => k.StartsWith("li:"));
+
+        var r = s.RemoveListMembership(firstLi);
+
+        Assert.True(r.Success, r.Error?.Message);
+        Assert.Contains(r.Modified, a => a.Kind == "p");
+        using var ms = new MemoryStream(s.Save());
+        using var doc = WordprocessingDocument.Open(ms, false);
+        XNamespace w = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+        var firstP = doc.MainDocumentPart!.GetXDocument().Root!.Descendants(w + "p").First();
+        Assert.Equal("0", (string?)firstP.Element(w + "pPr")?.Element(w + "numPr")?
+            .Element(w + "numId")?.Attribute(w + "val"));
+    }
+
+    [Fact]
+    public void DS055c_RemoveListMembership_AcceptsNumberedHeadingAnchor()
+    {
+        using var s = new DocxSession(BuildNumberedHeadingDoc("Numbered heading"));
+        var heading = s.Project().AnchorIndex.Keys.First(k => k.StartsWith("h:"));
+
+        var r = s.RemoveListMembership(heading);
+
+        Assert.True(r.Success, r.Error?.Message);
+        Assert.Contains(r.Modified, a => a.Kind == "h");
+        using var ms = new MemoryStream(s.Save());
+        using var doc = WordprocessingDocument.Open(ms, false);
+        XNamespace w = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+        var firstP = doc.MainDocumentPart!.GetXDocument().Root!.Descendants(w + "p").First();
+        Assert.Null(firstP.Element(w + "pPr")?.Element(w + "numPr"));
+    }
+
+    [Fact]
+    public void DS055d_RemoveListMembership_DirectNumberingStillOverridesNumberedStyle()
+    {
+        var source = BuildStyleListSingleLevel();
+        using var editable = new MemoryStream();
+        editable.Write(source);
+        editable.Position = 0;
+        using (var doc = WordprocessingDocument.Open(editable, true))
+        {
+            var first = doc.MainDocumentPart!.Document.Body!.Elements<Paragraph>().First();
+            first.ParagraphProperties!.NumberingProperties = new NumberingProperties(
+                new NumberingLevelReference { Val = 0 },
+                new NumberingId { Val = 1 });
+        }
+
+        using var s = new DocxSession(editable.ToArray());
+        var firstLi = s.Project().AnchorIndex.Keys.First(k => k.StartsWith("li:"));
+        var result = s.RemoveListMembership(firstLi);
+
+        Assert.True(result.Success, result.Error?.Message);
+        using var saved = new MemoryStream(s.Save());
+        using var verify = WordprocessingDocument.Open(saved, false);
+        XNamespace w = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+        var firstP = verify.MainDocumentPart!.GetXDocument().Root!.Descendants(w + "p").First();
+        Assert.Equal("0", (string?)firstP.Element(w + "pPr")?.Element(w + "numPr")?
+            .Element(w + "numId")?.Attribute(w + "val"));
+    }
+
+    [Fact]
+    public void DS056_MarkdownHeading_ExplicitlySuppressesStyleNumbering()
+    {
+        var parsed = Docxodus.Internal.MarkdownPayloadParser.Parse("## Unnumbered heading");
+        Assert.True(parsed.Success, parsed.Error?.Message);
+
+        var paragraph = DocxSession.BuildParagraphFromParsedBlock(Assert.Single(parsed.Blocks));
+
+        XNamespace w = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+        var numPr = paragraph.Element(w + "pPr")?.Element(w + "numPr");
+        Assert.NotNull(numPr);
+        Assert.Equal("0", (string?)numPr!.Element(w + "numId")?.Attribute(w + "val"));
+        Assert.Equal("0", (string?)numPr.Element(w + "ilvl")?.Attribute(w + "val"));
+    }
+
     // ─── Phase 6: cell content + tracked-change mode ─────────────────────
 
     [Fact]

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -273,6 +273,21 @@ public enum TableBorderScope { All, Outside, Inside }
 /// anchor sits in, or every cell of its row (header-row banding).</summary>
 public enum TableShadingScope { Cell, Row }
 
+/// <summary>Height rule for <see cref="TableRowOptions.HeightTwips"/>. Values map to
+/// <c>w:trHeight/@w:hRule</c>.</summary>
+public enum TableRowHeightRule { Auto, AtLeast, Exact }
+
+/// <summary>Row-level table properties written by <see cref="DocxSession.SetTableRowOptions"/>.
+/// Null values leave the corresponding property untouched. A zero <see cref="HeightTwips"/>
+/// removes any explicit row height.</summary>
+public sealed record TableRowOptions
+{
+    public bool? RepeatHeader { get; init; }
+    public bool? AllowBreakAcrossPages { get; init; }
+    public int? HeightTwips { get; init; }
+    public TableRowHeightRule HeightRule { get; init; } = TableRowHeightRule.AtLeast;
+}
+
 /// <summary>Border specification for <see cref="DocxSession.SetTableBorders"/>. Written as
 /// explicit <c>w:tblBorders</c> edges, so it overrides any style-inherited borders; edges
 /// outside <see cref="Scope"/> are left untouched.</summary>
@@ -6219,10 +6234,11 @@ public sealed class DocxSession : IDisposable
     }
 
     /// <summary>
-    /// Mark a comment resolved or reopened by setting <c>w15:done</c>. A flat comment is upgraded
-    /// in place: its last paragraph receives a deterministic <c>w14:paraId</c>, and
-    /// <c>commentsExtended.xml</c>/<c>commentsIds.xml</c> are find-or-created. Existing reply
-    /// parentage is preserved. The mutation is fully undoable, including first-time part creation.
+    /// Mark a comment and its reply subtree resolved or reopened by setting <c>w15:done</c>. A flat
+    /// comment is upgraded in place: its last paragraph receives a deterministic
+    /// <c>w14:paraId</c>, and <c>commentsExtended.xml</c>/<c>commentsIds.xml</c> are
+    /// find-or-created. Existing reply parentage is preserved. The mutation is fully undoable,
+    /// including first-time part creation.
     /// </summary>
     public EditResult SetCommentResolved(string commentAnchorId, bool resolved)
     {
@@ -6246,12 +6262,48 @@ public sealed class DocxSession : IDisposable
         _history.RecordPreOp(TakeSnapshot());
         try
         {
-            Internal.CommentOps.EnsureThreadingMetadata(main, comment, resolved: resolved);
+            var rootParaId = Internal.CommentOps.EnsureThreadingMetadata(main, comment, resolved: resolved);
+
+            // Word treats resolution as a thread/subtree state. Walk paraIdParent edges so
+            // resolving a root also marks every reply, while resolving a nested reply affects
+            // only that reply and its descendants.
+            var exPart = main.WordprocessingCommentsExPart!;
+            var exEntries = exPart.GetXDocument().Root!
+                .Elements(Internal.CommentOps.W15 + "commentEx").ToList();
+            var affectedParaIds = new HashSet<string>(StringComparer.Ordinal) { rootParaId };
+            bool expanded;
+            do
+            {
+                expanded = false;
+                foreach (var entry in exEntries)
+                {
+                    var paraId = (string?)entry.Attribute(Internal.CommentOps.W15 + "paraId");
+                    var parentParaId = (string?)entry.Attribute(Internal.CommentOps.W15 + "paraIdParent");
+                    if (paraId is not null && parentParaId is not null
+                        && affectedParaIds.Contains(parentParaId) && affectedParaIds.Add(paraId))
+                        expanded = true;
+                }
+            } while (expanded);
+
+            foreach (var entry in exEntries.Where(e =>
+                         affectedParaIds.Contains((string?)e.Attribute(Internal.CommentOps.W15 + "paraId") ?? "")))
+                entry.SetAttributeValue(Internal.CommentOps.W15 + "done", resolved ? "1" : "0");
+            exPart.PutXDocument();
+
             InvalidateProjectionCache();
+            var modified = new List<Anchor>();
+            foreach (var affectedComment in main.WordprocessingCommentsPart.GetXDocument().Root!
+                         .Elements(W.comment))
+            {
+                var paraId = (string?)affectedComment.Elements(W.p).LastOrDefault()?.Attribute(W14.paraId);
+                var unid = (string?)affectedComment.Attribute(PtOpenXml.Unid);
+                if (paraId is not null && unid is not null && affectedParaIds.Contains(paraId))
+                    modified.Add(new Anchor($"cmt:cmt:{unid}", "cmt", "cmt", unid));
+            }
             return new EditResult
             {
                 Success = true,
-                Modified = new[] { target.Anchor },
+                Modified = modified.Count == 0 ? new[] { target.Anchor } : modified,
                 Patch = PatchFor(target),
             };
         }
@@ -7020,27 +7072,77 @@ public sealed class DocxSession : IDisposable
     /// it elsewhere is legal but ignored by renderers.
     /// </summary>
     public EditResult SetRepeatHeaderRow(string cellAnchorId, bool repeat)
+        => SetTableRowOptions(cellAnchorId, new TableRowOptions { RepeatHeader = repeat });
+
+    /// <summary>
+    /// Set row-level layout properties for the row containing <paramref name="cellAnchorId"/>:
+    /// repeat-header (<c>w:tblHeader</c>), page-split policy (<c>w:cantSplit</c>), and explicit
+    /// height (<c>w:trHeight</c>). Null properties are left unchanged; height zero clears it.
+    /// </summary>
+    public EditResult SetTableRowOptions(string cellAnchorId, TableRowOptions? options = null)
     {
         if (ResolveCell(cellAnchorId, out _, out _, out var tr, out _, out _, out var target) is { } err)
             return err;
+
+        var opts = options ?? new TableRowOptions();
+        if (opts.HeightTwips is < 0)
+            return EditResult.Fail(EditErrorCode.InvalidTableStyling,
+                "row height in twips must be >= 0", cellAnchorId);
 
         _history.RecordPreOp(TakeSnapshot());
         try
         {
             var trPr = tr!.Element(W.trPr);
-            if (repeat)
+
+            if (opts.RepeatHeader is { } repeat)
             {
-                if (trPr is null) { trPr = new XElement(W.trPr); tr.AddFirst(trPr); }
-                SetChildInOrder(trPr, new XElement(W.tblHeader), TrPrChildOrder);
+                if (repeat)
+                {
+                    if (trPr is null) { trPr = new XElement(W.trPr); tr.AddFirst(trPr); }
+                    SetChildInOrder(trPr, new XElement(W.tblHeader), TrPrChildOrder);
+                }
+                else
+                {
+                    trPr?.Elements(W.tblHeader).Remove();
+                }
             }
-            else if (trPr is not null)
+
+            if (opts.AllowBreakAcrossPages is { } allowBreak)
             {
-                trPr.Elements(W.tblHeader).Remove();
-                // An emptied trPr is dropped entirely. Only element children matter: CT_TrPr has
-                // no schema attributes, and the in-memory tree may carry pt bookkeeping attributes
-                // (Unid) that Save() strips anyway.
-                if (!trPr.HasElements) trPr.Remove();
+                if (allowBreak)
+                    trPr?.Elements(W.cantSplit).Remove();
+                else
+                {
+                    if (trPr is null) { trPr = new XElement(W.trPr); tr.AddFirst(trPr); }
+                    SetChildInOrder(trPr, new XElement(W.cantSplit), TrPrChildOrder);
+                }
             }
+
+            if (opts.HeightTwips is { } height)
+            {
+                if (height == 0)
+                    trPr?.Elements(W.trHeight).Remove();
+                else
+                {
+                    if (trPr is null) { trPr = new XElement(W.trPr); tr.AddFirst(trPr); }
+                    var rule = opts.HeightRule switch
+                    {
+                        TableRowHeightRule.Auto => "auto",
+                        TableRowHeightRule.Exact => "exact",
+                        _ => "atLeast",
+                    };
+                    SetChildInOrder(trPr,
+                        new XElement(W.trHeight,
+                            new XAttribute(W.val, height),
+                            new XAttribute(W.hRule, rule)),
+                        TrPrChildOrder);
+                }
+            }
+
+            // An emptied trPr is dropped entirely. Only element children matter: CT_TrPr has
+            // no schema attributes, and the in-memory tree may carry pt bookkeeping attributes
+            // (Unid) that Save() strips anyway.
+            if (trPr is not null && !trPr.HasElements) trPr.Remove();
 
             return TableStyleResult(target!);
         }
@@ -7160,15 +7262,30 @@ public sealed class DocxSession : IDisposable
         var target = FindAnchor(anchorId);
         if (target is null)
             return EditResult.Fail(EditErrorCode.AnchorNotFound, "anchor not found", anchorId);
-        if (target.Anchor.Kind != "li")
-            return EditResult.Fail(EditErrorCode.AnchorWrongKind, "RemoveListMembership requires list-item anchor", anchorId);
+        if (target.Anchor.Kind is not ("p" or "h" or "li"))
+            return EditResult.Fail(EditErrorCode.AnchorWrongKind,
+                "RemoveListMembership requires a paragraph, heading, or list-item anchor", anchorId);
         var element = target.Resolve(_doc!);
         if (element is null) return EditResult.Fail(EditErrorCode.AnchorNotFound, "element null", anchorId);
 
+        var pPr = element.Element(W.pPr);
+        var directNumPr = pPr?.Element(W.numPr);
+        // Removing a direct numPr can expose numbering inherited from the paragraph style.
+        // Materialize Word's numId=0 sentinel in that case so the explicit removal wins over
+        // the style chain. This also lets callers create an unnumbered heading in documents
+        // whose Heading styles carry legal-outline numbering.
+        bool needsStyleOverride = ResolveStyleNumbering(element).numId is not null;
+
         _history.RecordPreOp(TakeSnapshot());
-        element.Element(W.pPr)?.Element(W.numPr)?.Remove();
+        directNumPr?.Remove();
+        if (needsStyleOverride)
+        {
+            if (pPr is null) { pPr = new XElement(W.pPr); element.AddFirst(pPr); }
+            SetPPrChildInOrder(pPr, new XElement(W.numPr,
+                new XElement(W.ilvl, new XAttribute(W.val, 0)),
+                new XElement(W.numId, new XAttribute(W.val, 0))));
+        }
         InvalidateProjectionCache();
-        var fresh = AnchorIndex();
         var updated = AnchorForUnid(target.Unid, target.PartUri) ?? target.Anchor;
         return new EditResult
         {
@@ -8613,6 +8730,12 @@ public sealed class DocxSession : IDisposable
                 {
                     int level = (int)block.Kind - (int)Internal.ParserBlockKind.Heading1 + 1;
                     pPr.Add(new XElement(W.pStyle, new XAttribute(W.val, $"Heading{level}")));
+                    // A document may attach legal-outline numbering to its Heading style.
+                    // Markdown headings are explicit unnumbered blocks; numId=0 prevents the
+                    // inherited prefix from unexpectedly changing the inserted text.
+                    pPr.Add(new XElement(W.numPr,
+                        new XElement(W.ilvl, new XAttribute(W.val, 0)),
+                        new XElement(W.numId, new XAttribute(W.val, 0))));
                     break;
                 }
             case Internal.ParserBlockKind.Quote:
@@ -8661,7 +8784,8 @@ public sealed class DocxSession : IDisposable
                 || styleId.Equals("Title", StringComparison.OrdinalIgnoreCase)
                 || styleId.Equals("Subtitle", StringComparison.OrdinalIgnoreCase)))
             return "h";
-        if (pPr?.Element(W.numPr) is not null) return "li";
+        var directNumId = (int?)pPr?.Element(W.numPr)?.Element(W.numId)?.Attribute(W.val);
+        if (directNumId is not null && directNumId != 0) return "li";
         return "p";
     }
 

--- a/Docxodus/Internal/DocxSessionJson.cs
+++ b/Docxodus/Internal/DocxSessionJson.cs
@@ -319,6 +319,15 @@ internal static class DocxSessionJson
         string.Equals(scope, "row", System.StringComparison.OrdinalIgnoreCase)
             ? TableShadingScope.Row : TableShadingScope.Cell;
 
+    /// <summary>Parse the OOXML row-height rule token used by the bridge.</summary>
+    public static TableRowHeightRule ParseTableRowHeightRule(string? rule) =>
+        rule?.ToLowerInvariant() switch
+        {
+            "auto" => TableRowHeightRule.Auto,
+            "exact" => TableRowHeightRule.Exact,
+            _ => TableRowHeightRule.AtLeast,
+        };
+
     /// <summary>
     /// Parse a list-format kind token (case-insensitive camelCase of the <see cref="ListFormat"/>
     /// member: "bullet", "decimal", "lowerLetter", "upperRoman", "decimalParenthesis", …; "none"

--- a/Docxodus/Internal/DocxSessionOps.cs
+++ b/Docxodus/Internal/DocxSessionOps.cs
@@ -403,6 +403,17 @@ internal static class DocxSessionOps
     public static string SetRepeatHeaderRow(int handle, string cellAnchorId, bool repeat) =>
         DocxSessionJson.Serialize(SessionRegistry.Get(handle).SetRepeatHeaderRow(cellAnchorId, repeat));
 
+    public static string SetTableRowOptions(int handle, string cellAnchorId, bool? repeatHeader,
+        bool? allowBreakAcrossPages, int? heightTwips, string? heightRule) =>
+        DocxSessionJson.Serialize(SessionRegistry.Get(handle).SetTableRowOptions(cellAnchorId,
+            new TableRowOptions
+            {
+                RepeatHeader = repeatHeader,
+                AllowBreakAcrossPages = allowBreakAcrossPages,
+                HeightTwips = heightTwips,
+                HeightRule = DocxSessionJson.ParseTableRowHeightRule(heightRule),
+            }));
+
     // ─── Raw escape hatch ───────────────────────────────────────────────
 
     public static string RawGetXml(int handle, string anchorId) =>

--- a/Docxodus/WmlToMarkdownConverter.cs
+++ b/Docxodus/WmlToMarkdownConverter.cs
@@ -575,8 +575,12 @@ public static class WmlToMarkdownConverter
 
     internal static bool IsListItem(XElement p)
     {
-        // Inline w:numPr wins.
-        if (p.Element(W.pPr)?.Element(W.numPr) != null) return true;
+        // Inline w:numPr wins. numId=0 is Word's explicit "remove numbering" sentinel;
+        // a numPr containing only ilvl still falls through to the style chain.
+        var directNumPr = p.Element(W.pPr)?.Element(W.numPr);
+        var directNumId = (int?)directNumPr?.Element(W.numId)?.Attribute(W.val);
+        if (directNumId is not null) return directNumId != 0;
+        if (directNumPr is not null && directNumPr.Element(W.ilvl) is null) return true;
         // Otherwise the paragraph is a list item if its pStyle chain contributes numPr.
         // Resolved via the styles part reachable from the in-memory OpenXmlPart annotation
         // that BuildAnchorIndex stashes on each scope root.

--- a/tools/mcp-server/Dispatcher.cs
+++ b/tools/mcp-server/Dispatcher.cs
@@ -666,6 +666,10 @@ internal static class Dispatcher
             OptStr(args, "shadingScope") ?? "cell"),
         "set_repeat_header_row" => DocxSessionOps.SetRepeatHeaderRow(
             session.Handle, Str(args, "cellAnchorId"), BoolOpt(args, "repeat", true)),
+        "set_row_options" => DocxSessionOps.SetTableRowOptions(
+            session.Handle, Str(args, "cellAnchorId"), OptBool(args, "repeat"),
+            OptBool(args, "allowBreakAcrossPages"), OptInt(args, "heightTwips"),
+            OptStr(args, "heightRule")),
         _ => throw new McpToolException($"unknown docxodus_table action: {action}"),
     };
 
@@ -716,6 +720,10 @@ internal static class Dispatcher
     private static int IntOpt(JsonElement args, string name, int fallback) =>
         args.ValueKind == JsonValueKind.Object && args.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number
             ? v.GetInt32() : fallback;
+
+    private static int? OptInt(JsonElement args, string name) =>
+        args.ValueKind == JsonValueKind.Object && args.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number
+            ? v.GetInt32() : null;
 
     private static bool BoolOpt(JsonElement args, string name, bool fallback) =>
         OptBool(args, name) ?? fallback;

--- a/tools/mcp-server/ToolCatalog.cs
+++ b/tools/mcp-server/ToolCatalog.cs
@@ -215,7 +215,7 @@ internal static class ToolCatalog
               "properties": {
                 "sessionId": { "type": "string" },
                 "action": { "type": "string", "enum": ["apply_format", "apply_format_range", "set_level", "set_start", "clear_start", "remove", "get_membership"] },
-                "anchorId": { "type": "string", "description": "Target paragraph for every action except apply_format_range." },
+                "anchorId": { "type": "string", "description": "Target paragraph for every action except apply_format_range. remove accepts paragraph, heading, or list-item anchors and overrides style-inherited numbering when necessary." },
                 "startValue": { "type": "integer", "description": "set_start: the number the item restarts at (>= 0), e.g. 5 to make this item render as '5.'" },
                 "firstAnchorId": { "type": "string", "description": "apply_format_range: first paragraph of the contiguous sibling run (inclusive)." },
                 "lastAnchorId": { "type": "string", "description": "apply_format_range: last paragraph of the run (inclusive; either document order)." },
@@ -321,13 +321,13 @@ internal static class ToolCatalog
             """),
         new ToolDefinition(
             "docxodus_table",
-            "Create tables, edit their rows/columns/cell content, and style them after insert (column widths, borders, shading, repeat-header row).",
+            "Create tables, edit their rows/columns/cell content, and style them after insert (column widths, borders, shading, and row layout).",
             """
             {
               "type": "object",
               "properties": {
                 "sessionId": { "type": "string" },
-                "action": { "type": "string", "enum": ["insert", "insert_row", "insert_column", "delete_row", "delete_column", "replace_cell_content", "set_column_widths", "set_borders", "set_shading", "set_repeat_header_row"] },
+                "action": { "type": "string", "enum": ["insert", "insert_row", "insert_column", "delete_row", "delete_column", "replace_cell_content", "set_column_widths", "set_borders", "set_shading", "set_repeat_header_row", "set_row_options"] },
                 "anchorId": { "type": "string", "description": "insert: reference block (paired with position)." },
                 "position": { "type": "string", "enum": ["before", "after"], "description": "insert: relative to anchorId. insert_row/insert_column: relative to cellAnchorId." },
                 "rows": { "type": "integer" }, "columns": { "type": "integer" },
@@ -344,7 +344,10 @@ internal static class ToolCatalog
                 "borderColor": { "type": "string", "description": "set_borders: hex RRGGBB (no '#') or auto (default)." },
                 "fill": { "type": "string", "description": "set_shading: hex RRGGBB (leading '#' tolerated) or auto; omit/empty to remove the shading." },
                 "shadingScope": { "type": "string", "enum": ["cell", "row"], "description": "set_shading: just the anchor's cell (default) or every cell of its row — header-row banding." },
-                "repeat": { "type": "boolean", "description": "set_repeat_header_row: true (default) marks the anchor's row as a repeating header row (w:tblHeader; Word honors it on a run of rows starting at row 1), false unmarks." }
+                "repeat": { "type": "boolean", "description": "set_repeat_header_row/set_row_options: true marks the anchor's row as a repeating header row (w:tblHeader; Word honors it on a run of rows starting at row 1), false unmarks." },
+                "allowBreakAcrossPages": { "type": "boolean", "description": "set_row_options: true permits a row to split across pages; false writes w:cantSplit." },
+                "heightTwips": { "type": "integer", "minimum": 0, "description": "set_row_options: explicit row height in twips (20 twips = 1pt); zero removes an existing height." },
+                "heightRule": { "type": "string", "enum": ["auto", "atLeast", "exact"], "description": "set_row_options: how Word interprets a positive heightTwips value (default atLeast)." }
               },
               "required": ["sessionId", "action"]
             }

--- a/tools/mcp-server/smoke/README.md
+++ b/tools/mcp-server/smoke/README.md
@@ -1,0 +1,59 @@
+# Round-three DOCX MCP smoke workflow
+
+This directory contains a reproducible replacement-server workflow for the October 2025 model certificate of incorporation. It is intentionally heterogeneous: the sequence reads a large existing package, previews and rolls back a mutation batch, accepts and rejects tracked changes, performs undo/redo, formats runs and paragraphs, authors a resolved comment thread, creates and restarts a nested Roman list, and creates a styled table with explicit row-layout properties.
+
+The workflow does not assume stable anchor IDs. It discovers anchors by content, captures IDs from tool responses, and substitutes captured values into later calls. The full sequence has 56 tool calls and saves back to `local.docx` under the configured storage root.
+
+## Files
+
+- `round-three-workflow.json` — replacement-server tool sequence.
+- `round-three-validation.json` — independent close/reopen assertions through the MCP surface.
+- `mcp_probe.py` — generic stdio JSON-RPC runner with variable capture and a full trace.
+- `analyze_docx.py` — package and semantic-observable comparator for source, reference, and replacement DOCX files.
+- `RESULTS.md` — the verified comparison snapshot and material differences.
+
+## Run
+
+Build the server, place a pristine source document at `$DOCXODUS_STORAGE_ROOT/local.docx`, and run:
+
+```bash
+dotnet build tools/mcp-server/mcpserver.csproj
+
+python3 tools/mcp-server/smoke/mcp_probe.py \
+  --calls tools/mcp-server/smoke/round-three-workflow.json \
+  --trace /tmp/round-three-local-trace.json \
+  -- tools/mcp-server/bin/Debug/net10.0/docxodus-mcp
+
+python3 tools/mcp-server/smoke/mcp_probe.py \
+  --calls tools/mcp-server/smoke/round-three-validation.json \
+  --trace /tmp/round-three-local-validation-trace.json \
+  -- tools/mcp-server/bin/Debug/net10.0/docxodus-mcp
+```
+
+The runner exits nonzero for a transport error, an MCP tool error, an edit result with `success: false`, a mutation batch with `failed`/`partial` status, or a failed workflow `expect` assertion.
+
+Given the pristine source, a separately produced reference output, and the replacement output, compare their packages with:
+
+```bash
+python3 tools/mcp-server/smoke/analyze_docx.py \
+  source.docx reference.docx local.docx
+```
+
+The comparator reports exact package differences and a workflow-equivalence verdict. Equivalence requires identical expected/rejected markers, comment-thread state, revision state, and table properties; column widths permit a 5-twip rounding tolerance.
+
+## Coverage
+
+The edit path exercises:
+
+- paragraph, heading, list-item, table, cell, comment, and revision anchors;
+- atomic preview rollback and apply batches;
+- direct and tracked text replacement, revision enumeration, accept, and reject;
+- undo and redo;
+- bold, italic, underline, strikeout, superscript, subscript, color, font size, and font family;
+- alignment, indentation, first-line indentation, before/after spacing, and line spacing;
+- root/reply comment creation, update, resolve, persistence, and reopen;
+- upper-Roman numbering, nesting, and start override;
+- table creation, unequal fixed widths, borders, row shading, repeat header, minimum row height, no page split, header text color/bold/alignment;
+- preservation checks for bookmarks, fields, four sections, 94 footnote references, eight header parts, and ten footer parts.
+
+The source is intentionally not checked into this directory. Retrieve it from <https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-COI-10-1-2025.docx>.

--- a/tools/mcp-server/smoke/RESULTS.md
+++ b/tools/mcp-server/smoke/RESULTS.md
@@ -1,0 +1,67 @@
+# Round-three MCP comparison results
+
+Verified 2026-08-02 on branch `smoke-test-mcp-round-three` using the requested October 2025 DOCX, the replacement server built for .NET 10, and LibreOffice 25.8.7.3 for independent PDF rendering.
+
+## Outcome
+
+The mapped workflows are semantically equivalent for the exercised operations. The replacement run completed 56/56 calls and eight embedded assertions with zero failures; the reference run completed 64/64 calls with zero final workflow failures. A separate close/reopen pass completed 9/9 calls and nine assertions, confirming all expected markers, one created table, two resolved threaded comments, and zero remaining revisions.
+
+Both outputs render as 49 US-letter pages. Their extracted text is identical apart from whitespace placement in the final table region. The final page has the same visible text, inline formatting, Roman-list hierarchy, header shading, borders, row-height behavior, and resolved-review content.
+
+| Observable | Reference output | Replacement output |
+| --- | ---: | ---: |
+| Expected marker occurrences | 9 | 9 |
+| Preview/rejected marker occurrences | 0 | 0 |
+| Comments / replies / resolved thread entries | 2 / 1 / 2 | 2 / 1 / 2 |
+| Remaining insertions / deletions | 0 / 0 | 0 / 0 |
+| Added paragraphs / numbering properties | 18 / 4 | 18 / 4 |
+| Table rows / cells | 3 / 9 | 3 / 9 |
+| Table widths, twips | 3000 / 3795 / 2400 | 3000 / 3800 / 2400 |
+| Repeat header / no split / minimum height | yes / yes / 480 | yes / yes / 480 |
+| PDF pages | 49 | 49 |
+| DOCX file parts | 46 | 47 |
+| DOCX compressed bytes | 146,686 | 218,417 |
+| DOCX uncompressed bytes | 1,113,421 | 1,101,694 |
+
+The 5-twip middle-column variance is 0.25 point and is below visible significance. The replacement writes the requested 190-point width exactly; the reference output rounds it down.
+
+## Material differences
+
+1. The servers are semantic substitutes, not wire-protocol substitutes. Tool names, grouping, argument shapes, result shapes, and call counts differ. An existing client needs an adapter; simply changing the server command is not sufficient.
+
+2. Surgical range replacement under the replacement server's tracked-change mode currently writes direct text instead of `w:del`/`w:ins`. The workflow uses full-block tracked replacement for accept/reject coverage. This is material for clients that require tracked edits within only part of a paragraph.
+
+3. The reference surface advertised tracking on some direct replacement, structural-create, and comment paths that did not behave consistently at runtime: direct calls rejected the tracking argument in some cases, while tracked structural creation did not produce revisions. The completed reference workflow therefore used its mutation-batch path for tracked rewrites.
+
+4. Non-body story addressing differs. Reference story locators required opaque story identifiers not supplied by ordinary discovery, and an incompletely identified footnote request fell back to the body. The replacement exposes named header/footer/footnote scopes directly. The smoke workflow inventories all stories but limits mutations to the body to keep the cross-server workload deterministic.
+
+5. Package rewrite strategies differ materially. Both outputs changed 24 of 44 original parts by byte hash, but the affected parts are different. The reference output rewrote custom XML, core/custom properties, styles, settings, theme, font table, web settings, and expanded `footnotes.xml` by 8,141 bytes. The replacement preserved those parts byte-for-byte while its projected header/footer/endnote/footnote XML parts each changed by only three serialization bytes.
+
+6. The reference output coalesced field-instruction nodes from 201 to 135, while the replacement retained the source's 201 nodes. Both retain 405 field characters and the canonical field-instruction token stream has the same SHA-256 across source and both outputs, so this is normalization rather than a field-semantic difference.
+
+7. The replacement package is 48.9% larger on disk despite being smaller uncompressed. This is a ZIP compression-efficiency difference, not added document content. It is material for storage/bandwidth-sensitive use.
+
+8. Thread metadata differs by one part: the replacement writes `commentsIds.xml` in addition to `comments.xml` and `commentsExtended.xml`; the reference output writes the latter two. Both persist the same root/reply relationship and resolved state.
+
+## Conformance fixes produced by the smoke test
+
+The comparison exposed and fixed four replacement-side gaps:
+
+- inserted headings now write an explicit no-numbering override so legally numbered source styles cannot prefix new headings;
+- list removal now works for heading/list-item anchors and style-inherited numbering;
+- resolving or reopening a root comment propagates through its reply subtree;
+- table row options now support repeat-header state, page-split prevention, and auto/at-least/exact row heights.
+
+Focused regressions cover each behavior. The final selections passed 5/5 list/heading tests and 98/98 MCP-dispatcher, table-edit, and comment-authoring tests; the complete replacement workflow also passes after rebuilding and reopening the saved output.
+
+## Evidence snapshot
+
+- Source SHA-256: `d75600769c12724990de48149d7a2bb161f3522daa54b1783672f93697d87d29`
+- Reference output SHA-256: `3b9fddcdca57656597a41c2590c1b73b5f4cd2bd3f619084d4c8c66440d375e4`
+- Replacement output SHA-256: `6202717691c9837290a51a51aa9c9446e1fd6a18c495b045ab67e47af2d49d64`
+- Replacement trace: `/tmp/docxodus-mcp-round-three/local-trace.json`
+- Reopen-validation trace: `/tmp/docxodus-mcp-round-three/local-validation-trace.json`
+- Package comparison: `/tmp/docxodus-mcp-round-three/comparison.json`
+- Rendered outputs: `/tmp/docxodus-mcp-round-three/render/reference/reference.pdf` and `/tmp/docxodus-mcp-round-three/render/local-final4/local.pdf`
+
+The replacement hash changes across reruns because newly authored comment/thread identifiers are generated per session; the semantic and package-shape assertions remain stable.

--- a/tools/mcp-server/smoke/analyze_docx.py
+++ b/tools/mcp-server/smoke/analyze_docx.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Compare package preservation and workflow observables across three DOCX files."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import zipfile
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree as ET
+
+
+W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+W15 = "http://schemas.microsoft.com/office/word/2012/wordml"
+NS = {"w": W, "w15": W15}
+WA = f"{{{W}}}"
+W15A = f"{{{W15}}}"
+
+MARKERS = [
+    "MCP ROUND THREE REVIEW SCHEDULE",
+    "DOES HEREBY CERTIFY AND ACKNOWLEDGE:",
+    "MCP ROUND THREE CORPORATION",
+    "Round-three comment anchor phrase remains visible after review.",
+    "Round-three item alpha — text and styles",
+    "Round-three item beta — numbering and nesting",
+    "Round-three item gamma — comments and revisions",
+    "RT3 Feature",
+    "Tracked rejection anchor: BASE.",
+    "BASE TEMPORARY",
+    "PREVIEW-ONLY-MARKER",
+]
+
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def xml_root(archive: zipfile.ZipFile, name: str) -> ET.Element | None:
+    try:
+        return ET.fromstring(archive.read(name))
+    except KeyError:
+        return None
+
+
+def visible_text(element: ET.Element | None) -> str:
+    if element is None:
+        return ""
+    return "".join(
+        node.text or ""
+        for node in element.iter()
+        if node.tag in {WA + "t", WA + "delText"}
+    )
+
+
+def count(root: ET.Element | None, local_name: str) -> int:
+    return 0 if root is None else sum(1 for _ in root.iter(WA + local_name))
+
+
+def canonical_field_instructions(root: ET.Element | None) -> str:
+    if root is None:
+        return ""
+    values = [node.text or "" for node in root.iter(WA + "instrText")]
+    return " ".join(" ".join(values).split())
+
+
+def inserted_table(document: ET.Element | None) -> dict[str, Any] | None:
+    if document is None:
+        return None
+    table = next(
+        (candidate for candidate in document.iter(WA + "tbl") if "RT3 Feature" in visible_text(candidate)),
+        None,
+    )
+    if table is None:
+        return None
+
+    rows = table.findall("w:tr", NS)
+    header = rows[0] if rows else None
+    tr_pr = None if header is None else header.find("w:trPr", NS)
+    height = None if tr_pr is None else tr_pr.find("w:trHeight", NS)
+    grid = table.find("w:tblGrid", NS)
+    borders = table.find("w:tblPr/w:tblBorders", NS)
+    header_cells = [] if header is None else header.findall("w:tc", NS)
+
+    return {
+        "rows": len(rows),
+        "columns": len(header_cells),
+        "columnWidthsTwips": []
+        if grid is None
+        else [int(column.get(WA + "w", "0")) for column in grid.findall("w:gridCol", NS)],
+        "repeatHeader": tr_pr is not None and tr_pr.find("w:tblHeader", NS) is not None,
+        "allowBreakAcrossPages": not (
+            tr_pr is not None and tr_pr.find("w:cantSplit", NS) is not None
+        ),
+        "heightTwips": None if height is None else int(height.get(WA + "val", "0")),
+        "heightRule": None if height is None else height.get(WA + "hRule"),
+        "headerFills": [
+            cell.find("w:tcPr/w:shd", NS).get(WA + "fill")
+            if cell.find("w:tcPr/w:shd", NS) is not None
+            else None
+            for cell in header_cells
+        ],
+        "borderStyles": {}
+        if borders is None
+        else {
+            edge: (
+                None
+                if borders.find(f"w:{edge}", NS) is None
+                else borders.find(f"w:{edge}", NS).get(WA + "val")
+            )
+            for edge in ("top", "left", "bottom", "right", "insideH", "insideV")
+        },
+    }
+
+
+def package(path: Path) -> dict[str, Any]:
+    raw = path.read_bytes()
+    with zipfile.ZipFile(path) as archive:
+        file_infos = [info for info in archive.infolist() if not info.is_dir()]
+        part_hashes = {info.filename: sha256(archive.read(info.filename)) for info in file_infos}
+        part_sizes = {info.filename: info.file_size for info in file_infos}
+        document = xml_root(archive, "word/document.xml")
+        comments = xml_root(archive, "word/comments.xml")
+        comments_ex = xml_root(archive, "word/commentsExtended.xml")
+        all_text = visible_text(document)
+        field_instructions = canonical_field_instructions(document)
+
+        return {
+            "path": str(path),
+            "sha256": sha256(raw),
+            "compressedBytes": len(raw),
+            "fileParts": len(file_infos),
+            "uncompressedBytes": sum(info.file_size for info in file_infos),
+            "partHashes": part_hashes,
+            "partSizes": part_sizes,
+            "markers": {marker: all_text.count(marker) for marker in MARKERS},
+            "structure": {
+                "paragraphs": count(document, "p"),
+                "tables": count(document, "tbl"),
+                "tableRows": count(document, "tr"),
+                "tableCells": count(document, "tc"),
+                "numberingProperties": count(document, "numPr"),
+                "sections": count(document, "sectPr"),
+                "bookmarks": count(document, "bookmarkStart"),
+                "fieldCharacters": count(document, "fldChar"),
+                "fieldInstructions": count(document, "instrText"),
+                "fieldInstructionTokens": len(field_instructions.split()),
+                "fieldInstructionCanonicalSha256": sha256(field_instructions.encode()),
+                "insertions": count(document, "ins"),
+                "deletions": count(document, "del"),
+                "footnoteReferences": count(document, "footnoteReference"),
+                "headerParts": sum(
+                    name.startswith("word/header") and name.endswith(".xml")
+                    for name in part_hashes
+                ),
+                "footerParts": sum(
+                    name.startswith("word/footer") and name.endswith(".xml")
+                    for name in part_hashes
+                ),
+            },
+            "comments": {
+                "count": 0 if comments is None else len(comments.findall("w:comment", NS)),
+                "threadEntries": 0
+                if comments_ex is None
+                else len(comments_ex.findall("w15:commentEx", NS)),
+                "resolvedThreadEntries": 0
+                if comments_ex is None
+                else sum(
+                    item.get(W15A + "done") in {"1", "true", "on"}
+                    for item in comments_ex.findall("w15:commentEx", NS)
+                ),
+                "replyEntries": 0
+                if comments_ex is None
+                else sum(
+                    item.get(W15A + "paraIdParent") is not None
+                    for item in comments_ex.findall("w15:commentEx", NS)
+                ),
+            },
+            "insertedTable": inserted_table(document),
+        }
+
+
+def preservation(source: dict[str, Any], output: dict[str, Any]) -> dict[str, Any]:
+    source_parts = source["partHashes"]
+    output_parts = output["partHashes"]
+    source_sizes = source["partSizes"]
+    output_sizes = output["partSizes"]
+    common = sorted(source_parts.keys() & output_parts.keys())
+    unchanged = [name for name in common if source_parts[name] == output_parts[name]]
+    changed = [name for name in common if source_parts[name] != output_parts[name]]
+    return {
+        "sourcePartsUnchanged": len(unchanged),
+        "sourcePartsChanged": len(changed),
+        "changedParts": changed,
+        "changedPartSizeDeltas": {
+            name: output_sizes[name] - source_sizes[name] for name in changed
+        },
+        "addedParts": sorted(output_parts.keys() - source_parts.keys()),
+        "removedParts": sorted(source_parts.keys() - output_parts.keys()),
+    }
+
+
+def workflow_observables(document: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "markers": document["markers"],
+        "comments": document["comments"],
+        "insertedTable": document["insertedTable"],
+        "remainingRevisions": document["structure"]["insertions"]
+        + document["structure"]["deletions"],
+    }
+
+
+def workflow_equivalent(reference: dict[str, Any], replacement: dict[str, Any]) -> bool:
+    left = workflow_observables(reference)
+    right = workflow_observables(replacement)
+    left_table = dict(left.pop("insertedTable") or {})
+    right_table = dict(right.pop("insertedTable") or {})
+    left_widths = left_table.pop("columnWidthsTwips", [])
+    right_widths = right_table.pop("columnWidthsTwips", [])
+    return (
+        left == right
+        and left_table == right_table
+        and len(left_widths) == len(right_widths)
+        and all(abs(a - b) <= 5 for a, b in zip(left_widths, right_widths))
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path)
+    parser.add_argument("reference", type=Path)
+    parser.add_argument("replacement", type=Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    source = package(args.source)
+    reference = package(args.reference)
+    replacement = package(args.replacement)
+    source.pop("partHashes")
+    source.pop("partSizes")
+    reference_hashes = reference["partHashes"]
+    reference_sizes = reference["partSizes"]
+    replacement_hashes = replacement["partHashes"]
+    replacement_sizes = replacement["partSizes"]
+
+    # Re-open the source hashes for preservation calculations after keeping the public
+    # report compact and free of one hash per package part.
+    source_with_hashes = package(args.source)
+    report = {
+        "source": source,
+        "reference": {
+            key: value for key, value in reference.items() if key not in {"partHashes", "partSizes"}
+        },
+        "replacement": {
+            key: value for key, value in replacement.items() if key not in {"partHashes", "partSizes"}
+        },
+        "preservation": {
+            "reference": preservation(
+                source_with_hashes,
+                {"partHashes": reference_hashes, "partSizes": reference_sizes},
+            ),
+            "replacement": preservation(
+                source_with_hashes,
+                {"partHashes": replacement_hashes, "partSizes": replacement_sizes},
+            ),
+        },
+        "workflowObservablesExact": workflow_observables(reference)
+        == workflow_observables(replacement),
+        "workflowObservablesEquivalent": workflow_equivalent(reference, replacement),
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/mcp-server/smoke/mcp_probe.py
+++ b/tools/mcp-server/smoke/mcp_probe.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Run a captured, variable-aware MCP tool sequence over stdio JSON-RPC."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+
+
+def send(process: subprocess.Popen[str], message: dict[str, Any]) -> None:
+    assert process.stdin is not None
+    process.stdin.write(json.dumps(message, separators=(",", ":")) + "\n")
+    process.stdin.flush()
+
+
+def receive(process: subprocess.Popen[str], request_id: int) -> dict[str, Any]:
+    assert process.stdout is not None
+    for line in process.stdout:
+        if not line.strip():
+            continue
+        message = json.loads(line)
+        if message.get("id") == request_id:
+            return message
+    raise RuntimeError(f"server closed before response {request_id}")
+
+
+def drain_stderr(process: subprocess.Popen[str], quiet: bool) -> None:
+    assert process.stderr is not None
+    for line in process.stderr:
+        if not quiet:
+            print(line.rstrip(), file=sys.stderr)
+
+
+def substitute(value: Any, variables: dict[str, Any]) -> Any:
+    if isinstance(value, str) and value.startswith("$"):
+        name = value[1:]
+        if name not in variables:
+            raise KeyError(f"workflow variable is not captured yet: {name}")
+        return variables[name]
+    if isinstance(value, list):
+        return [substitute(item, variables) for item in value]
+    if isinstance(value, dict):
+        return {key: substitute(item, variables) for key, item in value.items()}
+    return value
+
+
+def decoded_tool_result(message: dict[str, Any]) -> Any:
+    result = message.get("result", {})
+    content = result.get("content", [])
+    if content and content[0].get("type") == "text":
+        value = content[0].get("text", "")
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value
+    return result.get("structuredContent", result)
+
+
+def capture_path(value: Any, path: str) -> Any:
+    current = value
+    for part in path.split("."):
+        if part == "length" and isinstance(current, (dict, list, str)):
+            current = len(current)
+        else:
+            current = current[int(part)] if isinstance(current, list) else current[part]
+    return current
+
+
+def result_failed(result: Any) -> bool:
+    return isinstance(result, dict) and (
+        result.get("success") is False
+        or result.get("status") in {"failed", "partial"}
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--calls", required=True, type=Path, help="workflow JSON array")
+    parser.add_argument("--trace", required=True, type=Path, help="full JSON trace output")
+    parser.add_argument("--quiet-server", action="store_true", help="suppress server stderr")
+    parser.add_argument("command", nargs=argparse.REMAINDER, help="-- SERVER [ARGS ...]")
+    args = parser.parse_args()
+    if args.command and args.command[0] == "--":
+        args.command = args.command[1:]
+    if not args.command:
+        parser.error("a server command is required after --")
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    calls = json.loads(args.calls.read_text(encoding="utf-8"))
+    if not isinstance(calls, list):
+        raise ValueError("workflow root must be a JSON array")
+
+    process = subprocess.Popen(
+        args.command,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    threading.Thread(
+        target=drain_stderr,
+        args=(process, args.quiet_server),
+        daemon=True,
+    ).start()
+
+    responses: list[dict[str, Any]] = []
+    variables: dict[str, Any] = {}
+    initialized: dict[str, Any] | None = None
+    request_id = 1
+    try:
+        send(
+            process,
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "docx-smoke-probe", "version": "1"},
+                },
+            },
+        )
+        initialized = receive(process, request_id)
+        send(process, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+        for call in calls:
+            request_id += 1
+            call_id = call.get("id", call["name"])
+            print(f"[smoke] {call_id}", file=sys.stderr)
+            arguments = substitute(call.get("arguments", {}), variables)
+            send(
+                process,
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "method": "tools/call",
+                    "params": {"name": call["name"], "arguments": arguments},
+                },
+            )
+            message = receive(process, request_id)
+            decoded = decoded_tool_result(message)
+            entry = {
+                "id": call.get("id"),
+                "tool": call["name"],
+                "arguments": arguments,
+                "isError": bool(message.get("error"))
+                or bool(message.get("result", {}).get("isError", False)),
+                "result": decoded,
+            }
+            assertions = []
+            for path, expected in call.get("expect", {}).items():
+                actual = capture_path(decoded, path)
+                assertions.append(
+                    {
+                        "path": path,
+                        "expected": expected,
+                        "actual": actual,
+                        "passed": actual == expected,
+                    }
+                )
+            if assertions:
+                entry["assertions"] = assertions
+            responses.append(entry)
+            for name, path in call.get("capture", {}).items():
+                variables[name] = capture_path(decoded, path)
+
+        payload = {
+            "initialize": initialized,
+            "responses": responses,
+            "variables": variables,
+        }
+        args.trace.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+        transport_errors = sum(bool(entry["isError"]) for entry in responses)
+        failed_results = sum(result_failed(entry["result"]) for entry in responses)
+        assertion_count = sum(len(entry.get("assertions", [])) for entry in responses)
+        failed_assertions = sum(
+            not assertion["passed"]
+            for entry in responses
+            for assertion in entry.get("assertions", [])
+        )
+        summary = {
+            "calls": len(responses),
+            "transportErrors": transport_errors,
+            "failedResults": failed_results,
+            "assertions": assertion_count,
+            "failedAssertions": failed_assertions,
+            "trace": str(args.trace),
+        }
+        print(json.dumps(summary, indent=2))
+        return 1 if transport_errors or failed_results or failed_assertions else 0
+    finally:
+        if process.poll() is None:
+            request_id += 1
+            try:
+                send(process, {"jsonrpc": "2.0", "id": request_id, "method": "shutdown"})
+                receive(process, request_id)
+            except (BrokenPipeError, RuntimeError):
+                pass
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/mcp-server/smoke/round-three-validation.json
+++ b/tools/mcp-server/smoke/round-three-validation.json
@@ -1,0 +1,59 @@
+[
+  {
+    "id": "open",
+    "name": "docxodus_open",
+    "arguments": { "path": "local.docx", "trackedChanges": "accept" },
+    "capture": { "session_id": "sessionId" }
+  },
+  {
+    "id": "heading",
+    "name": "docxodus_search",
+    "arguments": { "sessionId": "$session_id", "mode": "text", "query": "MCP ROUND THREE REVIEW SCHEDULE", "maxResults": 10 },
+    "expect": { "matches.length": 1 }
+  },
+  {
+    "id": "certification",
+    "name": "docxodus_search",
+    "arguments": { "sessionId": "$session_id", "mode": "text", "query": "DOES HEREBY CERTIFY AND ACKNOWLEDGE:", "maxResults": 10 },
+    "expect": { "matches.length": 1 }
+  },
+  {
+    "id": "replacement",
+    "name": "docxodus_search",
+    "arguments": { "sessionId": "$session_id", "mode": "text", "query": "MCP ROUND THREE CORPORATION", "maxResults": 10 },
+    "expect": { "matches.length": 1 }
+  },
+  {
+    "id": "rejected_marker",
+    "name": "docxodus_search",
+    "arguments": { "sessionId": "$session_id", "mode": "text", "query": "BASE TEMPORARY", "maxResults": 10 },
+    "expect": { "matches.length": 0 }
+  },
+  {
+    "id": "tables",
+    "name": "docxodus_search",
+    "arguments": { "sessionId": "$session_id", "mode": "kind", "query": "tbl", "maxResults": 10 },
+    "expect": { "matches.length": 1 }
+  },
+  {
+    "id": "comments",
+    "name": "docxodus_comment",
+    "arguments": { "sessionId": "$session_id", "action": "list" },
+    "expect": {
+      "comments.length": 2,
+      "comments.0.resolved": true,
+      "comments.1.resolved": true
+    }
+  },
+  {
+    "id": "revisions",
+    "name": "docxodus_track_changes",
+    "arguments": { "sessionId": "$session_id", "action": "list" },
+    "expect": { "revisions.length": 0 }
+  },
+  {
+    "id": "close",
+    "name": "docxodus_close",
+    "arguments": { "sessionId": "$session_id" }
+  }
+]

--- a/tools/mcp-server/smoke/round-three-workflow.json
+++ b/tools/mcp-server/smoke/round-three-workflow.json
@@ -1,0 +1,584 @@
+[
+  {
+    "id": "open",
+    "name": "docxodus_open",
+    "arguments": {
+      "path": "local.docx",
+      "trackedChanges": "accept"
+    },
+    "capture": { "session_id": "sessionId" }
+  },
+  {
+    "id": "info_before",
+    "name": "docxodus_get_content",
+    "arguments": { "sessionId": "$session_id", "format": "info" }
+  },
+  {
+    "id": "find_certification",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "text",
+      "query": "DOES HEREBY CERTIFY:",
+      "maxResults": 1
+    },
+    "capture": { "certification_anchor": "matches.0.enclosingAnchor.id" }
+  },
+  {
+    "id": "find_placeholder",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "text",
+      "query": "[____________]",
+      "maxResults": 1
+    },
+    "capture": { "placeholder_anchor": "matches.0.enclosingAnchor.id" }
+  },
+  {
+    "id": "find_preliminary_notes",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "text",
+      "query": "Preliminary Notes",
+      "maxResults": 1
+    },
+    "capture": { "preliminary_anchor": "matches.0.enclosingAnchor.id" }
+  },
+  {
+    "id": "find_investment_phrase",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "text",
+      "query": "venture capital portfolio investment",
+      "maxResults": 1
+    },
+    "capture": { "investment_anchor": "matches.0.enclosingAnchor.id" }
+  },
+  {
+    "id": "find_document_tail",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "text",
+      "query": "The rights provided hereunder shall inure",
+      "maxResults": 1
+    },
+    "capture": { "tail_anchor": "matches.0.enclosingAnchor.id" }
+  },
+  {
+    "id": "preview_batch",
+    "name": "docxodus_mutations",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "preview",
+      "steps": [
+        {
+          "tool": "docxodus_edit",
+          "args": {
+            "action": "replace_text",
+            "anchorId": "$certification_anchor",
+            "markdown": "PREVIEW-ONLY-MARKER"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "id": "preview_absent",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "text",
+      "query": "PREVIEW-ONLY-MARKER"
+    },
+    "expect": { "matches.length": 0 }
+  },
+  {
+    "id": "tracked_accept_mode",
+    "name": "docxodus_track_changes",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "set_mode",
+      "mode": "render_inline",
+      "revisionAuthor": "MCP Round Three"
+    }
+  },
+  {
+    "id": "tracked_accept_apply",
+    "name": "docxodus_edit",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "replace_text",
+      "anchorId": "$certification_anchor",
+      "markdown": "**DOES HEREBY CERTIFY AND ACKNOWLEDGE:**"
+    }
+  },
+  {
+    "id": "tracked_accept_list",
+    "name": "docxodus_track_changes",
+    "arguments": { "sessionId": "$session_id", "action": "list" },
+    "capture": {
+      "accepted_deletion_id": "revisions.0.id",
+      "accepted_insertion_id": "revisions.1.id"
+    }
+  },
+  {
+    "id": "tracked_accept_deletion",
+    "name": "docxodus_track_changes",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "accept",
+      "revisionId": "$accepted_deletion_id"
+    }
+  },
+  {
+    "id": "tracked_accept_insertion",
+    "name": "docxodus_track_changes",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "accept",
+      "revisionId": "$accepted_insertion_id"
+    }
+  },
+  {
+    "id": "direct_mode",
+    "name": "docxodus_track_changes",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "set_mode",
+      "mode": "accept"
+    }
+  },
+  {
+    "id": "placeholder_replace",
+    "name": "docxodus_edit",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "replace_text_range",
+      "anchorId": "$placeholder_anchor",
+      "find": "[____________]",
+      "replace": "[MCP ROUND THREE CORPORATION]"
+    }
+  },
+  {
+    "id": "undo_replace",
+    "name": "docxodus_edit",
+    "arguments": { "sessionId": "$session_id", "action": "undo" }
+  },
+  {
+    "id": "redo_replace",
+    "name": "docxodus_edit",
+    "arguments": { "sessionId": "$session_id", "action": "redo" }
+  },
+  {
+    "id": "direct_batch",
+    "name": "docxodus_mutations",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "apply",
+      "steps": [
+        {
+          "tool": "docxodus_edit",
+          "args": {
+            "action": "replace_text_range",
+            "anchorId": "$preliminary_anchor",
+            "find": "Preliminary Notes",
+            "replace": "Preliminary Notes — ROUND THREE REVIEW COPY"
+          }
+        },
+        {
+          "tool": "docxodus_edit",
+          "args": {
+            "action": "replace_text_range",
+            "anchorId": "$investment_anchor",
+            "find": "venture capital portfolio investment",
+            "replace": "venture capital portfolio investment review"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "id": "heading_create",
+    "name": "docxodus_create",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "insert_heading",
+      "anchorId": "$tail_anchor",
+      "position": "after",
+      "level": 2,
+      "text": "MCP ROUND THREE REVIEW SCHEDULE"
+    },
+    "capture": { "heading_anchor": "created.0.id" }
+  },
+  {
+    "id": "intro_create",
+    "name": "docxodus_create",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "insert_paragraph",
+      "anchorId": "$heading_anchor",
+      "position": "after",
+      "markdown": "Purpose: exercise structured document operations with stable markers and preserve the surrounding legal form."
+    },
+    "capture": { "intro_anchor": "created.0.id" }
+  },
+  {
+    "id": "rich_create",
+    "name": "docxodus_create",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "insert_paragraph",
+      "anchorId": "$intro_anchor",
+      "position": "after",
+      "markdown": "Inline matrix: bold-token; italic-token; underline-token; strike-token; superscript-token; subscript-token; blue-token."
+    },
+    "capture": { "rich_anchor": "created.0.id" }
+  },
+  {
+    "id": "rich_inline_batch",
+    "name": "docxodus_mutations",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "apply",
+      "steps": [
+        { "tool": "docxodus_format", "args": { "action": "apply_format_by_substring", "anchorId": "$rich_anchor", "substring": "bold-token", "format": { "bold": true } } },
+        { "tool": "docxodus_format", "args": { "action": "apply_format_by_substring", "anchorId": "$rich_anchor", "substring": "italic-token", "format": { "italic": true } } },
+        { "tool": "docxodus_format", "args": { "action": "apply_format_by_substring", "anchorId": "$rich_anchor", "substring": "underline-token", "format": { "underline": true } } },
+        { "tool": "docxodus_format", "args": { "action": "apply_format_by_substring", "anchorId": "$rich_anchor", "substring": "strike-token", "format": { "strike": true } } },
+        { "tool": "docxodus_format", "args": { "action": "apply_format_by_substring", "anchorId": "$rich_anchor", "substring": "superscript-token", "format": { "vertAlign": "superscript" } } },
+        { "tool": "docxodus_format", "args": { "action": "apply_format_by_substring", "anchorId": "$rich_anchor", "substring": "subscript-token", "format": { "vertAlign": "subscript" } } },
+        { "tool": "docxodus_format", "args": { "action": "apply_format_by_substring", "anchorId": "$rich_anchor", "substring": "blue-token", "format": { "color": "1F4E79" } } }
+      ]
+    }
+  },
+  {
+    "id": "rich_paragraph_format",
+    "name": "docxodus_format",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "set_paragraph_format",
+      "anchorId": "$rich_anchor",
+      "paragraphFormat": {
+        "alignment": "justify",
+        "indentDelta": 720,
+        "firstLineIndent": 360,
+        "spacingBefore": 120,
+        "spacingAfter": 120,
+        "lineSpacing": 360,
+        "lineSpacingRule": "auto",
+        "pageBreakBefore": false
+      }
+    }
+  },
+  {
+    "id": "comment_anchor_create",
+    "name": "docxodus_create",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "insert_paragraph",
+      "anchorId": "$rich_anchor",
+      "position": "after",
+      "markdown": "Round-three comment anchor phrase remains visible after review."
+    },
+    "capture": { "comment_host_anchor": "created.0.id" }
+  },
+  {
+    "id": "comment_create",
+    "name": "docxodus_comment",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "add",
+      "anchorId": "$comment_host_anchor",
+      "span": { "start": 12, "length": 21 },
+      "author": "MCP Server",
+      "initials": "MS",
+      "markdown": "Initial round-three review note."
+    },
+    "capture": { "comment_anchor": "created.0.id" }
+  },
+  {
+    "id": "comment_reply",
+    "name": "docxodus_comment",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "reply",
+      "commentAnchorId": "$comment_anchor",
+      "author": "MCP Server",
+      "initials": "MS",
+      "markdown": "Reply confirming threaded review."
+    }
+  },
+  {
+    "id": "comment_update",
+    "name": "docxodus_comment",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "update",
+      "commentAnchorId": "$comment_anchor",
+      "markdown": "Updated round-three review note."
+    }
+  },
+  {
+    "id": "comment_resolve",
+    "name": "docxodus_comment",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "resolve",
+      "commentAnchorId": "$comment_anchor",
+      "resolved": true
+    }
+  },
+  {
+    "id": "comment_list",
+    "name": "docxodus_comment",
+    "arguments": { "sessionId": "$session_id", "action": "list" },
+    "expect": {
+      "comments.length": 2,
+      "comments.0.resolved": true,
+      "comments.1.resolved": true
+    }
+  },
+  {
+    "id": "list_alpha_create",
+    "name": "docxodus_create",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "insert_paragraph",
+      "anchorId": "$comment_host_anchor",
+      "position": "after",
+      "markdown": "Round-three item alpha — text and styles"
+    },
+    "capture": { "list_alpha_anchor": "created.0.id" }
+  },
+  {
+    "id": "list_beta_create",
+    "name": "docxodus_create",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "insert_paragraph",
+      "anchorId": "$list_alpha_anchor",
+      "position": "after",
+      "markdown": "Round-three item beta — numbering and nesting"
+    },
+    "capture": { "list_beta_anchor": "created.0.id" }
+  },
+  {
+    "id": "list_gamma_create",
+    "name": "docxodus_create",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "insert_paragraph",
+      "anchorId": "$list_beta_anchor",
+      "position": "after",
+      "markdown": "Round-three item gamma — comments and revisions"
+    },
+    "capture": { "list_gamma_anchor": "created.0.id" }
+  },
+  {
+    "id": "list_create",
+    "name": "docxodus_list",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "apply_format_range",
+      "firstAnchorId": "$list_alpha_anchor",
+      "lastAnchorId": "$list_gamma_anchor",
+      "listFormat": "upperRoman"
+    },
+    "capture": {
+      "list_alpha_item": "modified.0.id",
+      "list_beta_item": "modified.1.id",
+      "list_gamma_item": "modified.2.id"
+    }
+  },
+  {
+    "id": "list_beta_indent",
+    "name": "docxodus_list",
+    "arguments": { "sessionId": "$session_id", "action": "set_level", "anchorId": "$list_beta_item", "levelDelta": 1 }
+  },
+  {
+    "id": "list_gamma_level",
+    "name": "docxodus_list",
+    "arguments": { "sessionId": "$session_id", "action": "set_level", "anchorId": "$list_gamma_item", "levelDelta": 1 }
+  },
+  {
+    "id": "list_alpha_start",
+    "name": "docxodus_list",
+    "arguments": { "sessionId": "$session_id", "action": "set_start", "anchorId": "$list_alpha_item", "startValue": 3 }
+  },
+  {
+    "id": "table_create",
+    "name": "docxodus_create",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "insert_table",
+      "anchorId": "$list_gamma_item",
+      "position": "after",
+      "rows": 3,
+      "columns": 3,
+      "cellContents": [
+        "RT3 Feature", "RT3 Operation", "RT3 Expected",
+        "Inline formatting", "Seven run properties", "Preserved",
+        "Review metadata", "Thread and decision", "Resolved"
+      ],
+      "columnWidths": [3000, 3800, 2400]
+    },
+    "capture": {
+      "cell_00": "created.0.id",
+      "cell_01": "created.1.id",
+      "cell_02": "created.2.id"
+    }
+  },
+  {
+    "id": "table_borders",
+    "name": "docxodus_table",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "set_borders",
+      "cellAnchorId": "$cell_00",
+      "borderScope": "all",
+      "borderStyle": "single",
+      "borderSize": 8,
+      "borderColor": "1F4E79"
+    }
+  },
+  {
+    "id": "table_header_shading",
+    "name": "docxodus_table",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "set_shading",
+      "cellAnchorId": "$cell_00",
+      "shadingScope": "row",
+      "fill": "1F4E79"
+    }
+  },
+  {
+    "id": "table_header_row_options",
+    "name": "docxodus_table",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "set_row_options",
+      "cellAnchorId": "$cell_00",
+      "repeat": true,
+      "allowBreakAcrossPages": false,
+      "heightTwips": 480,
+      "heightRule": "atLeast"
+    }
+  },
+  {
+    "id": "table_header_format",
+    "name": "docxodus_mutations",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "apply",
+      "steps": [
+        { "tool": "docxodus_format", "args": { "action": "apply_format", "anchorId": "$cell_00", "format": { "bold": true, "color": "FFFFFF" } } },
+        { "tool": "docxodus_format", "args": { "action": "apply_format", "anchorId": "$cell_01", "format": { "bold": true, "color": "FFFFFF" } } },
+        { "tool": "docxodus_format", "args": { "action": "apply_format", "anchorId": "$cell_02", "format": { "bold": true, "color": "FFFFFF" } } },
+        { "tool": "docxodus_format", "args": { "action": "set_paragraph_format", "anchorId": "$cell_00", "paragraphFormat": { "alignment": "center" } } },
+        { "tool": "docxodus_format", "args": { "action": "set_paragraph_format", "anchorId": "$cell_01", "paragraphFormat": { "alignment": "center" } } },
+        { "tool": "docxodus_format", "args": { "action": "set_paragraph_format", "anchorId": "$cell_02", "paragraphFormat": { "alignment": "center" } } }
+      ]
+    }
+  },
+  {
+    "id": "find_created_table",
+    "name": "docxodus_search",
+    "arguments": { "sessionId": "$session_id", "mode": "kind", "query": "tbl" },
+    "expect": { "matches.length": 1 },
+    "capture": { "table_anchor": "matches.0.id" }
+  },
+  {
+    "id": "tracked_reject_anchor",
+    "name": "docxodus_create",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "insert_paragraph",
+      "anchorId": "$table_anchor",
+      "position": "after",
+      "markdown": "Tracked rejection anchor: BASE."
+    },
+    "capture": { "reject_anchor": "created.0.id" }
+  },
+  {
+    "id": "tracked_reject_mode",
+    "name": "docxodus_track_changes",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "set_mode",
+      "mode": "render_inline",
+      "revisionAuthor": "MCP Round Three"
+    }
+  },
+  {
+    "id": "tracked_reject_apply",
+    "name": "docxodus_edit",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "replace_text",
+      "anchorId": "$reject_anchor",
+      "markdown": "Tracked rejection anchor: BASE TEMPORARY."
+    }
+  },
+  {
+    "id": "tracked_reject_list",
+    "name": "docxodus_track_changes",
+    "arguments": { "sessionId": "$session_id", "action": "list" },
+    "capture": {
+      "rejected_deletion_id": "revisions.0.id",
+      "rejected_insertion_id": "revisions.1.id"
+    }
+  },
+  {
+    "id": "tracked_reject_deletion",
+    "name": "docxodus_track_changes",
+    "arguments": { "sessionId": "$session_id", "action": "reject", "revisionId": "$rejected_deletion_id" }
+  },
+  {
+    "id": "tracked_reject_insertion",
+    "name": "docxodus_track_changes",
+    "arguments": { "sessionId": "$session_id", "action": "reject", "revisionId": "$rejected_insertion_id" }
+  },
+  {
+    "id": "final_direct_mode",
+    "name": "docxodus_track_changes",
+    "arguments": { "sessionId": "$session_id", "action": "set_mode", "mode": "accept" }
+  },
+  {
+    "id": "markers_verify",
+    "name": "docxodus_search",
+    "arguments": { "sessionId": "$session_id", "mode": "text", "query": "Round-three", "maxResults": 20 },
+    "expect": { "matches.length": 4 }
+  },
+  {
+    "id": "rejected_absent",
+    "name": "docxodus_search",
+    "arguments": { "sessionId": "$session_id", "mode": "text", "query": "BASE TEMPORARY" },
+    "expect": { "matches.length": 0 }
+  },
+  {
+    "id": "revisions_final",
+    "name": "docxodus_track_changes",
+    "arguments": { "sessionId": "$session_id", "action": "list" },
+    "expect": { "revisions.length": 0 }
+  },
+  {
+    "id": "info_after",
+    "name": "docxodus_get_content",
+    "arguments": { "sessionId": "$session_id", "format": "info" }
+  },
+  {
+    "id": "save",
+    "name": "docxodus_save",
+    "arguments": { "sessionId": "$session_id", "persistAnchorIds": false }
+  },
+  {
+    "id": "close",
+    "name": "docxodus_close",
+    "arguments": { "sessionId": "$session_id" }
+  }
+]


### PR DESCRIPTION
## Summary

- add a reproducible 56-call MCP workflow for a complex legal DOCX, with captured anchors and embedded assertions
- add an independent close/reopen validation workflow, generic stdio runner, DOCX package comparator, and recorded results
- cover preview rollback, undo/redo, tracked accept/reject, rich run and paragraph formatting, threaded comments, Roman lists, and styled table row layout
- fix inherited heading/list numbering, reply-subtree resolution, and table row options exposed through the MCP server

## Why

This provides a repeatable compatibility smoke test against a feature-rich real-world document and turns discrepancies found during that test into focused conformance fixes.

## Root causes and impact

- source documents can attach legal numbering to heading styles, so newly inserted headings and list removal need an explicit no-numbering override
- comment resolution is thread state and must propagate through replies
- the table surface lacked repeat-header, page-split, and row-height controls needed to preserve the reference layout
- the results report records remaining interface, tracked-range, package-normalization, and compression differences

## Validation

- replacement workflow: 56/56 calls, 8/8 assertions
- independent reopen validation: 9/9 calls, 9/9 assertions
- list/heading regressions: 5/5 passed
- MCP dispatcher, table-edit, and comment-authoring regressions: 98/98 passed
- both rendered outputs: 49 US-letter pages
- build completed with 0 errors