### PR TITLE
Track surgical text-range replacements with native revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ All notable changes to this project will be documented in this file.
 - **README, package metadata and architecture docs rewritten around what the library actually does.** The repo described itself as an "Office XML Redline Engine" — accurate about one of five capabilities, and containing none of the words anyone searches for. Comparison is now one of four peer sections (render / project / edit / compare), each opening with a **real screenshot** captured from the [NVCA model financing documents](https://nvca.org/model-legal-documents/): a redlined voting agreement showing deletion, insertion, token-level substitution and a paired move in one frame; the model charter rendered to HTML with justification, legal numbering and back-referenced footnotes intact; the markdown projection beside the same document's rendered DOM, with one anchor highlighted in both panes to show they share an addressing system. The redline image is genuine engine output end to end — a round of realistic counsel edits applied through `DocxSession`, compared with `DocxDiff.Compare`, rendered with `RenderTrackedChanges`. Also: a "where it runs" table covering the NuGet / npm / PyPI / CLI surfaces (three CLI tools ship, not two), quick starts trimmed to ≤6 lines each so they can't silently rot, and the OpenXmlPowerTools lineage kept but moved out of the lede. Screenshots also land in `ir_diff_engine.md`, `markdown_projection.md`, `docx_converter.md` and the npm package README (which had no mention of the editor, the session API or the projection). Package metadata is aligned for search across all three registries — `Docxodus.csproj` `Description`/`PackageTags`, `npm/package.json` `description`/`keywords`, `pyproject.toml` `keywords`. New `docs/repo-positioning.md` records the GitHub description and topic list a maintainer still has to apply by hand, the keyword→surface map behind them, and how to regenerate the screenshots.
 
 ### Added
+- **Tracked surgical text replacements (issue #330).** `ReplaceTextRange`,
+  `ReplaceTextAtSpan`, `ReplaceMatch`, and `ReplaceInner` now honor
+  `TrackedChangeMode.RenderInline` instead of silently mutating run text directly. A
+  selection is split at its exact boundaries: untouched prefix/suffix text remains in
+  ordinary runs, removed slices retain each source run's formatting under native
+  `w:del/w:r/w:delText`, and the replacement inherits the first affected `w:rPr` under
+  `w:ins/w:r/w:t`. Envelopes carry the session author, one operation timestamp, and fresh
+  revision ids; adjacent selected runs coalesce into the Word-authored multi-run deletion
+  shape. Hyperlink and run-level SDT content stays inside its container, while bookmarks,
+  comment/permission/proofing markers, and note-reference runs stay live outside the
+  revisions. Reverse-offset repeated matches, selective and whole-document accept/reject,
+  undo/redo, and direct mode are preserved. Coverage: DS400–DS407, including Office 2019
+  schema validation of single-run, multi-format, hyperlink/SDT, and semantic-marker output.
 - **List numbering restart — Word's "Set Numbering Value…" (issue #314).** Nothing on any
   surface could write a `w:lvlOverride`/`w:startOverride`, so "restart at 1", "continue
   from the previous list", and "start this exhibit list at 5" were unaddressable — exactly

--- a/Docxodus.Tests/DocxSessionSurgicalTrackedChangesTests.cs
+++ b/Docxodus.Tests/DocxSessionSurgicalTrackedChangesTests.cs
@@ -1,0 +1,394 @@
+#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Docxodus;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+/// <summary>
+/// Surgical text replacements in <see cref="TrackedChangeMode.RenderInline"/>
+/// (issue #330). Test IDs DS400-DS407.
+/// </summary>
+public class DocxSessionSurgicalTrackedChangesTests
+{
+    private static readonly XNamespace Xml = XNamespace.Xml;
+
+    private static XElement Run(string text, params XElement[] properties)
+    {
+        var run = new XElement(W.r);
+        if (properties.Length > 0) run.Add(new XElement(W.rPr, properties));
+        run.Add(new XElement(W.t, new XAttribute(Xml + "space", "preserve"), text));
+        return run;
+    }
+
+    private static byte[] BuildDocument(params object[] bodyChildren)
+    {
+        using var stream = new MemoryStream();
+        using (var document = WordprocessingDocument.Create(
+                   stream, WordprocessingDocumentType.Document))
+        {
+            var main = document.AddMainDocumentPart();
+            main.Document = new Document(new Body());
+            main.AddNewPart<StyleDefinitionsPart>().Styles = new Styles();
+            main.AddNewPart<DocumentSettingsPart>().Settings = new Settings();
+            main.Document.Save();
+
+            var xDocument = main.GetXDocument();
+            xDocument.Root!.Element(W.body)!.ReplaceNodes(bodyChildren);
+            main.PutXDocument();
+        }
+
+        return stream.ToArray();
+    }
+
+    private static XElement MainRoot(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes);
+        using var document = WordprocessingDocument.Open(stream, false);
+        return new XElement(document.MainDocumentPart!.GetXDocument().Root!);
+    }
+
+    private static string AcceptedText(byte[] bytes)
+    {
+        var accepted = RevisionProcessor.AcceptRevisions(new WmlDocument("accepted.docx", bytes));
+        return Text(MainRoot(accepted.DocumentByteArray));
+    }
+
+    private static string RejectedText(byte[] bytes)
+    {
+        var rejected = RevisionProcessor.RejectRevisions(new WmlDocument("rejected.docx", bytes));
+        return Text(MainRoot(rejected.DocumentByteArray));
+    }
+
+    private static string Text(XElement root) =>
+        string.Concat(root.Descendants(W.t).Select(t => t.Value));
+
+    private static void AssertSchemaValid(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes);
+        using var document = WordprocessingDocument.Open(stream, false);
+        var errors = new OpenXmlValidator(FileFormatVersions.Office2019)
+            .Validate(document)
+            .Select(e => $"{e.Part?.Uri}: {e.Description} ({e.Path?.XPath})")
+            .ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void DS400_ReplaceTextAtSpan_TrackedSingleRunUsesWordRevisionEnvelopes()
+    {
+        var source = BuildDocument(
+            new XElement(W.p,
+                Run("Prefix target suffix",
+                    new XElement(W.i),
+                    new XElement(W.color, new XAttribute(W.val, "336699")))));
+        using var session = new DocxSession(source,
+            new DocxSessionSettings
+            {
+                TrackedChanges = TrackedChangeMode.RenderInline,
+                RevisionAuthor = "Range Reviewer",
+            });
+        var anchor = session.Project().AnchorIndex.Values.Single().Anchor.Id;
+
+        var result = session.ReplaceTextAtSpan(anchor, 7, 6, "replacement");
+
+        Assert.True(result.Success, result.Error?.Message);
+        var tracked = session.Save();
+        var paragraph = MainRoot(tracked).Descendants(W.p).Single();
+        var deletion = Assert.Single(paragraph.Elements(W.del));
+        var insertion = Assert.Single(paragraph.Elements(W.ins));
+        Assert.Equal("target", Assert.Single(deletion.Descendants(W.delText)).Value);
+        Assert.Equal("replacement", Assert.Single(insertion.Descendants(W.t)).Value);
+        Assert.Equal("Range Reviewer", (string?)deletion.Attribute(W.author));
+        Assert.Equal("Range Reviewer", (string?)insertion.Attribute(W.author));
+        Assert.Equal((string?)deletion.Attribute(W.date), (string?)insertion.Attribute(W.date));
+        Assert.NotEqual((string?)deletion.Attribute(W.id), (string?)insertion.Attribute(W.id));
+        Assert.Matches(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$",
+            (string)deletion.Attribute(W.date)!);
+
+        var insertedProperties = insertion.Descendants(W.r).Single().Element(W.rPr);
+        Assert.NotNull(insertedProperties?.Element(W.i));
+        Assert.Equal("336699", (string?)insertedProperties?.Element(W.color)?.Attribute(W.val));
+        Assert.Equal("Prefix ", paragraph.Elements(W.r).First().Element(W.t)?.Value);
+        Assert.Equal(" suffix", paragraph.Elements(W.r).Last().Element(W.t)?.Value);
+
+        Assert.Equal("Prefix replacement suffix", AcceptedText(tracked));
+        Assert.Equal("Prefix target suffix", RejectedText(tracked));
+        AssertSchemaValid(tracked);
+
+        using (var selectiveAccept = new DocxSession(tracked))
+        {
+            while (selectiveAccept.ListRevisions().FirstOrDefault() is { } revision)
+                Assert.True(selectiveAccept.AcceptRevision(revision.Id).Success);
+            Assert.Equal("Prefix replacement suffix", Text(MainRoot(selectiveAccept.Save())));
+        }
+
+        using (var selectiveReject = new DocxSession(tracked))
+        {
+            while (selectiveReject.ListRevisions().FirstOrDefault() is { } revision)
+                Assert.True(selectiveReject.RejectRevision(revision.Id).Success);
+            Assert.Equal("Prefix target suffix", Text(MainRoot(selectiveReject.Save())));
+        }
+    }
+
+    [Fact]
+    public void DS401_ReplaceTextRange_TrackedMultiRunPreservesPerRunFormatting()
+    {
+        var source = BuildDocument(
+            new XElement(W.p,
+                Run("Plain ", new XElement(W.u, new XAttribute(W.val, "single"))),
+                Run("BOLD", new XElement(W.b)),
+                Run(" tail", new XElement(W.i))));
+        using var session = new DocxSession(source,
+            new DocxSessionSettings { TrackedChanges = TrackedChangeMode.RenderInline });
+        var anchor = session.Project().AnchorIndex.Values.Single().Anchor.Id;
+
+        var result = Assert.Single(session.ReplaceTextRange(anchor, "ain BOLD ta", "REPL"));
+
+        Assert.True(result.Success, result.Error?.Message);
+        var tracked = session.Save();
+        var paragraph = MainRoot(tracked).Descendants(W.p).Single();
+        var deletion = Assert.Single(paragraph.Elements(W.del));
+        var deletedRuns = deletion.Elements(W.r).ToArray();
+        Assert.Equal(3, deletedRuns.Length);
+        Assert.Equal("ain BOLD ta", string.Concat(deletedRuns
+            .SelectMany(r => r.Elements(W.delText)).Select(t => t.Value)));
+        Assert.NotNull(deletedRuns[0].Element(W.rPr)?.Element(W.u));
+        Assert.NotNull(deletedRuns[1].Element(W.rPr)?.Element(W.b));
+        Assert.NotNull(deletedRuns[2].Element(W.rPr)?.Element(W.i));
+
+        var insertedRun = Assert.Single(Assert.Single(paragraph.Elements(W.ins)).Elements(W.r));
+        Assert.Equal("REPL", insertedRun.Element(W.t)?.Value);
+        Assert.NotNull(insertedRun.Element(W.rPr)?.Element(W.u));
+        Assert.Null(insertedRun.Element(W.rPr)?.Element(W.b));
+        Assert.Null(insertedRun.Element(W.rPr)?.Element(W.i));
+        var suffix = paragraph.Elements(W.r).Single(r => r.Element(W.t)?.Value == "il");
+        Assert.NotNull(suffix.Element(W.rPr)?.Element(W.i));
+
+        Assert.Equal("PlREPLil", AcceptedText(tracked));
+        Assert.Equal("Plain BOLD tail", RejectedText(tracked));
+        AssertSchemaValid(tracked);
+    }
+
+    [Fact]
+    public void DS402_ReplaceMatch_TrackedRepeatedMatchesWorkInReverseOffsetOrder()
+    {
+        var source = BuildDocument(new XElement(W.p, Run("one cat, two cat, three cat")));
+        using var session = new DocxSession(source,
+            new DocxSessionSettings { TrackedChanges = TrackedChangeMode.RenderInline });
+        var matches = session.Grep("cat").OrderByDescending(m => m.Span.Start).ToArray();
+        var replacements = new[] { "C", "B", "A" };
+
+        for (int i = 0; i < matches.Length; i++)
+        {
+            var result = session.ReplaceMatch(matches[i], replacements[i]);
+            Assert.True(result.Success, result.Error?.Message);
+        }
+
+        var tracked = session.Save();
+        var root = MainRoot(tracked);
+        Assert.Equal(3, root.Descendants(W.del).Count());
+        Assert.Equal(3, root.Descendants(W.ins).Count());
+        Assert.Equal(6, root.Descendants()
+            .Where(e => e.Name == W.del || e.Name == W.ins)
+            .Select(e => (string?)e.Attribute(W.id)).Distinct().Count());
+        Assert.Equal("one A, two B, three C", AcceptedText(tracked));
+        Assert.Equal("one cat, two cat, three cat", RejectedText(tracked));
+        AssertSchemaValid(tracked);
+    }
+
+    [Fact]
+    public void DS403_ReplaceTextRange_TrackedIsOneUndoableRedoableOperation()
+    {
+        var source = BuildDocument(new XElement(W.p, Run("cat cat cat")));
+        using var session = new DocxSession(source,
+            new DocxSessionSettings { TrackedChanges = TrackedChangeMode.RenderInline });
+        var anchor = session.Project().AnchorIndex.Values.Single().Anchor.Id;
+
+        Assert.Equal(3, session.ReplaceTextRange(anchor, "cat", "dog").Count);
+        Assert.Equal("dog dog dog", AcceptedText(session.Save()));
+
+        Assert.True(session.Undo());
+        Assert.Equal("cat cat cat", Text(MainRoot(session.Save())));
+        Assert.Empty(MainRoot(session.Save()).Descendants()
+            .Where(e => e.Name == W.del || e.Name == W.ins));
+
+        Assert.True(session.Redo());
+        Assert.Equal("dog dog dog", AcceptedText(session.Save()));
+    }
+
+    [Fact]
+    public void DS404_ReplaceInner_TrackedUsesTheSameSurgicalPath()
+    {
+        var source = BuildDocument(new XElement(W.p, Run("Price: $[___].")));
+        using var session = new DocxSession(source,
+            new DocxSessionSettings { TrackedChanges = TrackedChangeMode.RenderInline });
+        var match = Assert.Single(session.Grep(@"\$?\[_+\]"));
+
+        var result = session.ReplaceInner(match, "0.20");
+
+        Assert.True(result.Success, result.Error?.Message);
+        var tracked = session.Save();
+        var root = MainRoot(tracked);
+        Assert.Equal("$[___]", Assert.Single(root.Descendants(W.delText)).Value);
+        Assert.Equal("$0.20", Assert.Single(root.Descendants(W.ins).Descendants(W.t)).Value);
+        Assert.Equal("Price: $0.20.", AcceptedText(tracked));
+        Assert.Equal("Price: $[___].", RejectedText(tracked));
+    }
+
+    [Fact]
+    public void DS405_TrackedReplacementStaysInsideHyperlinkAndSdtContainers()
+    {
+        var source = BuildDocument(
+            new XElement(W.p,
+                new XElement(W.bookmarkStart,
+                    new XAttribute(W.id, 0), new XAttribute(W.name, "destination")),
+                new XElement(W.bookmarkEnd, new XAttribute(W.id, 0)),
+                new XElement(W.hyperlink,
+                    new XAttribute(W.anchor, "destination"),
+                    Run("linked target", new XElement(W.u, new XAttribute(W.val, "single"))))),
+            new XElement(W.p,
+                new XElement(W.sdt,
+                    new XElement(W.sdtPr,
+                        new XElement(W.tag, new XAttribute(W.val, "field"))),
+                    new XElement(W.sdtContent, Run("controlled target")))));
+        using var session = new DocxSession(source,
+            new DocxSessionSettings { TrackedChanges = TrackedChangeMode.RenderInline });
+        var anchors = session.Project().AnchorIndex.Values
+            .Where(a => a.Anchor.Kind == "p").ToArray();
+
+        Assert.True(Assert.Single(session.ReplaceTextRange(
+            anchors[0].Anchor.Id, "target", "value")).Success);
+        Assert.True(Assert.Single(session.ReplaceTextRange(
+            anchors[1].Anchor.Id, "target", "value")).Success);
+
+        var tracked = session.Save();
+        var root = MainRoot(tracked);
+        var hyperlink = root.Descendants(W.hyperlink).Single();
+        Assert.Single(hyperlink.Elements(W.del));
+        Assert.Single(hyperlink.Elements(W.ins));
+        var content = root.Descendants(W.sdtContent).Single();
+        Assert.Single(content.Elements(W.del));
+        Assert.Single(content.Elements(W.ins));
+        Assert.Equal("linked valuecontrolled value", AcceptedText(tracked));
+        Assert.Equal("linked targetcontrolled target", RejectedText(tracked));
+        AssertSchemaValid(tracked);
+    }
+
+    [Fact]
+    public void DS406_TrackedReplacementRetainsBookmarksCommentsAndNoteReferences()
+    {
+        var source = BuildMarkerDocument();
+        using var session = new DocxSession(source,
+            new DocxSessionSettings { TrackedChanges = TrackedChangeMode.RenderInline });
+        var anchor = session.Project().AnchorIndex.Values
+            .Single(a => a.Anchor.Kind == "p" && a.Anchor.Scope == "body").Anchor.Id;
+
+        var result = Assert.Single(session.ReplaceTextRange(
+            anchor, "before target", "replacement"));
+
+        Assert.True(result.Success, result.Error?.Message);
+        var tracked = session.Save();
+        AssertSemanticMarkers(MainRoot(tracked));
+        Assert.Equal("replacement", AcceptedText(tracked));
+        Assert.Equal("before target", RejectedText(tracked));
+        AssertSchemaValid(tracked);
+
+        var accepted = RevisionProcessor.AcceptRevisions(new WmlDocument("accepted.docx", tracked));
+        var rejected = RevisionProcessor.RejectRevisions(new WmlDocument("rejected.docx", tracked));
+        AssertSemanticMarkers(MainRoot(accepted.DocumentByteArray));
+        AssertSemanticMarkers(MainRoot(rejected.DocumentByteArray));
+    }
+
+    [Fact]
+    public void DS407_DirectModeKeepsTheExistingSurgicalMutationShape()
+    {
+        var source = BuildDocument(new XElement(W.p, Run("Prefix target suffix")));
+        using var session = new DocxSession(source);
+        var anchor = session.Project().AnchorIndex.Values.Single().Anchor.Id;
+
+        var result = session.ReplaceTextAtSpan(anchor, 7, 6, "replacement");
+
+        Assert.True(result.Success, result.Error?.Message);
+        var root = MainRoot(session.Save());
+        Assert.Equal("Prefix replacement suffix", Text(root));
+        Assert.Empty(root.Descendants()
+            .Where(e => e.Name == W.del || e.Name == W.ins || e.Name == W.delText));
+    }
+
+    private static byte[] BuildMarkerDocument()
+    {
+        using var stream = new MemoryStream();
+        using (var document = WordprocessingDocument.Create(
+                   stream, WordprocessingDocumentType.Document))
+        {
+            var main = document.AddMainDocumentPart();
+            main.Document = new Document(new Body());
+            main.AddNewPart<StyleDefinitionsPart>().Styles = new Styles();
+            main.AddNewPart<DocumentSettingsPart>().Settings = new Settings();
+
+            var commentsPart = main.AddNewPart<WordprocessingCommentsPart>();
+            commentsPart.Comments = new Comments(
+                new Comment(
+                    new Paragraph(new Run(new Text("Comment body."))))
+                {
+                    Id = "0",
+                    Author = "Reviewer",
+                    Initials = "R",
+                });
+            commentsPart.Comments.Save();
+
+            var footnotesPart = main.AddNewPart<FootnotesPart>();
+            footnotesPart.Footnotes = new Footnotes(
+                new Footnote(new Paragraph(new Run(new SeparatorMark()))) { Id = -1 },
+                new Footnote(new Paragraph(new Run(new ContinuationSeparatorMark()))) { Id = 0 },
+                new Footnote(
+                    new Paragraph(
+                        new Run(new FootnoteReferenceMark()),
+                        new Run(new Text("Note body."))))
+                {
+                    Id = 2,
+                });
+            footnotesPart.Footnotes.Save();
+
+            main.Document.Save();
+            var xDocument = main.GetXDocument();
+            xDocument.Root!.Element(W.body)!.ReplaceNodes(
+                new XElement(W.p,
+                    new XElement(W.bookmarkStart,
+                        new XAttribute(W.id, 0), new XAttribute(W.name, "range")),
+                    new XElement(W.commentRangeStart, new XAttribute(W.id, 0)),
+                    Run("before "),
+                    new XElement(W.r,
+                        new XElement(W.footnoteReference, new XAttribute(W.id, 2))),
+                    Run("target"),
+                    new XElement(W.commentRangeEnd, new XAttribute(W.id, 0)),
+                    new XElement(W.r,
+                        new XElement(W.rPr,
+                            new XElement(W.rStyle, new XAttribute(W.val, "CommentReference"))),
+                        new XElement(W.commentReference, new XAttribute(W.id, 0))),
+                    new XElement(W.bookmarkEnd, new XAttribute(W.id, 0))));
+            main.PutXDocument();
+        }
+
+        return stream.ToArray();
+    }
+
+    private static void AssertSemanticMarkers(XElement root)
+    {
+        Assert.Single(root.Descendants(W.bookmarkStart));
+        Assert.Single(root.Descendants(W.bookmarkEnd));
+        Assert.Single(root.Descendants(W.commentRangeStart));
+        Assert.Single(root.Descendants(W.commentRangeEnd));
+        Assert.Single(root.Descendants(W.commentReference));
+        Assert.Single(root.Descendants(W.footnoteReference));
+    }
+}

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -1208,8 +1208,9 @@ public sealed class DocxSessionSettings
     public bool PersistAnchorIds { get; init; } = false;
 
     /// <summary>
-    /// When <c>true</c>, <c>ReplaceText</c>/<c>ReplaceTextRange</c>/<c>ReplaceMatch</c>
-    /// payloads (and replacements passed to <c>InsertParagraph</c> / <c>ReplaceCellContent</c>)
+    /// When <c>true</c>, <c>ReplaceText</c>/<c>ReplaceTextRange</c>/<c>ReplaceMatch</c>/
+    /// <c>ReplaceTextAtSpan</c>/<c>ReplaceInner</c> payloads (and replacements passed to
+    /// <c>InsertParagraph</c> / <c>ReplaceCellContent</c>)
     /// have ASCII <c>"</c> and <c>'</c> converted to typographic curly quotes
     /// (U+201C/U+201D and U+2018/U+2019) based on context — open quote at the start
     /// of a string, after whitespace, or after an open-bracket; close quote elsewhere.
@@ -2494,6 +2495,12 @@ public sealed class DocxSession : IDisposable
     /// paragraph don't invalidate each other's offsets. The whole call records a single undo
     /// snapshot — <see cref="Undo"/> rolls back every replacement together.
     /// </para>
+    /// <para>
+    /// In <see cref="TrackedChangeMode.RenderInline"/>, the untouched prefix/suffix runs stay
+    /// ordinary text, the selected slices are copied (with their original run properties) to
+    /// <c>w:del/w:r/w:delText</c>, and one first-run-formatted replacement is emitted as
+    /// <c>w:ins/w:r/w:t</c>. Inline containers and zero-width semantic markers remain in place.
+    /// </para>
     /// </remarks>
     public IReadOnlyList<EditResult> ReplaceTextRange(
         string anchorId,
@@ -2533,10 +2540,22 @@ public sealed class DocxSession : IDisposable
         _history.RecordPreOp(TakeSnapshot());
         try
         {
+            var tracked = _trackedChanges == TrackedChangeMode.RenderInline;
+            var revisionAuthor = _revisionAuthor ?? "docxodus";
+            var revisionDate = tracked
+                ? DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")
+                : null;
+
             // Reverse offset order so earlier-offset matches' SpanInElement stays valid
             // after later-offset edits land — see DS112/DS115.
             foreach (var match in matches.OrderByDescending(m => m.Span.Start))
-                ApplyFragmentReplacement(element, match, replace);
+            {
+                if (tracked)
+                    ApplyFragmentReplacementTracked(
+                        element, match, replace, revisionAuthor, revisionDate!);
+                else
+                    ApplyFragmentReplacement(element, match, replace);
+            }
 
             InvalidateProjectionCache();
             var success = new EditResult
@@ -2595,7 +2614,7 @@ public sealed class DocxSession : IDisposable
     }
 
     /// <summary>
-    /// Surgical replacement of an exact byte range within one block's flat text.
+    /// Surgical replacement of an exact character range within one block's flat text.
     /// The natural pair to <see cref="Grep"/>: pass the <see cref="TextMatch.EnclosingAnchor"/>'s
     /// id plus the <see cref="TextMatch.Span"/> coordinates to replace one specific match
     /// even when several identical needles share the same paragraph (the template-filling
@@ -2652,7 +2671,19 @@ public sealed class DocxSession : IDisposable
         _history.RecordPreOp(TakeSnapshot());
         try
         {
-            ApplyFragmentReplacement(element, synthetic, replace);
+            if (_trackedChanges == TrackedChangeMode.RenderInline)
+            {
+                ApplyFragmentReplacementTracked(
+                    element,
+                    synthetic,
+                    replace,
+                    _revisionAuthor ?? "docxodus",
+                    DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"));
+            }
+            else
+            {
+                ApplyFragmentReplacement(element, synthetic, replace);
+            }
             InvalidateProjectionCache();
             return new EditResult
             {
@@ -3429,6 +3460,185 @@ public sealed class DocxSession : IDisposable
                 newText));
         }
     }
+
+    /// <summary>
+    /// Tracked-change counterpart to <see cref="ApplyFragmentReplacement"/>. Each selected
+    /// run slice becomes a formatting-preserving <c>w:r/w:delText</c> inside one or more
+    /// <c>w:del</c> envelopes, while the replacement is a single <c>w:r/w:t</c> inside
+    /// <c>w:ins</c> and inherits the first affected run's <c>w:rPr</c>. Runs are split at
+    /// the selection boundaries so untouched prefixes/suffixes remain ordinary text.
+    /// Zero-width siblings (bookmarks, comment ranges, note-reference runs, proofing markers)
+    /// are never moved into revision envelopes; when one separates selected runs it simply
+    /// splits the deletion into adjacent Word-style envelopes around that marker.
+    /// </summary>
+    private void ApplyFragmentReplacementTracked(
+        XElement blockElement,
+        TextMatch match,
+        string replace,
+        string author,
+        string date)
+    {
+        if (match.Fragments.Count == 0) return;
+
+        var runsByUnid = new Dictionary<string, XElement>(StringComparer.Ordinal);
+        foreach (var run in InlineRuns(blockElement))
+        {
+            var unid = (string?)run.Attribute(PtOpenXml.Unid);
+            if (unid is not null) runsByUnid[unid] = run;
+        }
+
+        var deletedRuns = new List<XElement>(match.Fragments.Count);
+        XElement? insertedRun = null;
+
+        for (int i = 0; i < match.Fragments.Count; i++)
+        {
+            var fragment = match.Fragments[i];
+            if (!runsByUnid.TryGetValue(fragment.Unid, out var run))
+                throw new InvalidOperationException(
+                    $"tracked replacement run no longer exists: {fragment.Unid}");
+
+            var concat = RunText(run);
+            var start = fragment.SpanInElement.Start;
+            var len = fragment.SpanInElement.Length;
+            if (start < 0 || len <= 0 || start + len > concat.Length)
+                throw new InvalidOperationException(
+                    $"tracked replacement slice {start}+{len} is outside run text length {concat.Length}");
+
+            var before = concat[..start];
+            var removed = concat.Substring(start, len);
+            var after = concat[(start + len)..];
+
+            // Snapshot the original formatting before changing/reusing the live run.
+            var deletedRun = CloneRunWithRevisionText(run, W.delText, removed);
+            if (i == 0 && replace.Length > 0)
+                insertedRun = CloneRunWithRevisionText(run, W.t, replace);
+
+            var replacementNodes = new List<XElement>(4);
+            if (before.Length > 0)
+            {
+                SetRunText(run, before);
+                replacementNodes.Add(run);
+            }
+            else if (after.Length == 0 && HasNonTextRunContent(run))
+            {
+                // A text-bearing marker run is unusual but legal (notably note/comment
+                // references). Keep its zero-width payload exactly once when all w:t text
+                // was selected instead of dropping it with the old text.
+                SetRunText(run, null);
+                replacementNodes.Add(run);
+            }
+
+            replacementNodes.Add(deletedRun);
+
+            if (after.Length > 0)
+            {
+                if (before.Length == 0)
+                {
+                    SetRunText(run, after);
+                    replacementNodes.Add(run);
+                }
+                else
+                {
+                    replacementNodes.Add(CloneRunWithRevisionText(run, W.t, after));
+                }
+            }
+
+            run.ReplaceWith(replacementNodes);
+            deletedRuns.Add(deletedRun);
+        }
+
+        // Coalesce adjacent deleted slices under the same inline parent. This is the
+        // shape Word emits for a replacement spanning differently formatted runs:
+        // one w:del containing each original rPr-bearing run, followed by one w:ins.
+        // A semantic marker or container boundary naturally starts another envelope.
+        var deletionEnvelopes = new List<XElement>();
+        XElement? currentEnvelope = null;
+        foreach (var deletedRun in deletedRuns)
+        {
+            if (currentEnvelope is not null
+                && ReferenceEquals(currentEnvelope.Parent, deletedRun.Parent)
+                && ReferenceEquals(deletedRun.PreviousNode, currentEnvelope))
+            {
+                deletedRun.Remove();
+                currentEnvelope.Add(deletedRun);
+                continue;
+            }
+
+            currentEnvelope = CreateRevisionEnvelope(W.del, author, date);
+            deletedRun.AddBeforeSelf(currentEnvelope);
+            deletedRun.Remove();
+            currentEnvelope.Add(deletedRun);
+            deletionEnvelopes.Add(currentEnvelope);
+        }
+
+        if (insertedRun is null || deletionEnvelopes.Count == 0) return;
+
+        // Keep a replacement wholly inside its original hyperlink/SDT/smartTag/fldSimple.
+        // When every deletion envelope has that same parent, put the insertion after the
+        // final deletion (the canonical Word replacement order). A cross-container match
+        // inserts beside the first slice so it retains the first run's inline semantics.
+        var firstEnvelope = deletionEnvelopes[0];
+        var insertionAnchor = deletionEnvelopes.All(e => ReferenceEquals(e.Parent, firstEnvelope.Parent))
+            ? deletionEnvelopes[^1]
+            : firstEnvelope;
+        var insertionEnvelope = CreateRevisionEnvelope(W.ins, author, date);
+        insertionEnvelope.Add(insertedRun);
+        insertionAnchor.AddAfterSelf(insertionEnvelope);
+    }
+
+    private XElement CreateRevisionEnvelope(XName name, string author, string date) =>
+        new(name,
+            new XAttribute(W.id, NextRevisionId()),
+            new XAttribute(W.author, author),
+            new XAttribute(W.date, date));
+
+    /// <summary>Create a text-only run that retains the source run's formatting/rsid
+    /// attributes but gets its own internal Unid. <paramref name="textName"/> is
+    /// <c>w:t</c> for ordinary/inserted text and <c>w:delText</c> for deletions.</summary>
+    private static XElement CloneRunWithRevisionText(XElement source, XName textName, string text)
+    {
+        var clone = new XElement(W.r,
+            source.Attributes()
+                .Where(a => a.Name != PtOpenXml.Unid)
+                .Select(a => new XAttribute(a)),
+            source.Element(W.rPr) is { } rPr ? new XElement(rPr) : null,
+            new XElement(textName,
+                new XAttribute(XNamespace.Xml + "space", "preserve"),
+                text));
+        UnidHelper.AssignToSelfAndDescendants(clone);
+        return clone;
+    }
+
+    /// <summary>Replace a run's direct w:t sequence with one text node while retaining
+    /// rPr and every non-text child in place. Null removes text without adding an empty
+    /// node (used to preserve a zero-width marker run).</summary>
+    private static void SetRunText(XElement run, string? text)
+    {
+        var textNodes = run.Elements(W.t).ToList();
+        if (textNodes.Count > 0)
+        {
+            if (text is null)
+            {
+                foreach (var t in textNodes) t.Remove();
+                return;
+            }
+
+            var replacement = new XElement(W.t,
+                new XAttribute(XNamespace.Xml + "space", "preserve"),
+                text);
+            textNodes[0].ReplaceWith(replacement);
+            foreach (var t in textNodes.Skip(1)) t.Remove();
+            return;
+        }
+
+        if (text is not null)
+            run.Add(new XElement(W.t,
+                new XAttribute(XNamespace.Xml + "space", "preserve"),
+                text));
+    }
+
+    private static bool HasNonTextRunContent(XElement run) =>
+        run.Elements().Any(e => e.Name != W.rPr && e.Name != W.t);
 
     /// <summary>
     /// When <see cref="DocxSessionSettings.SmartQuotes"/> is on, replace ASCII <c>"</c>

--- a/docs/architecture/docx_mutation_api.md
+++ b/docs/architecture/docx_mutation_api.md
@@ -1143,6 +1143,12 @@ The replacement text inherits the formatting of the FIRST run the match spanned.
 
 If you need different per-fragment behavior (e.g., the replacement should be bold even when the first fragment was plain), use `Grep` + bespoke `Raw.GetXml` mutation today, or wait for a future inline-markdown-aware overload.
 
+### Tracked-change behavior
+
+With `TrackedChanges = RenderInline`, all three entry points retain the same surgical boundaries but record them as native Word revisions. Text before and after the span remains in ordinary runs; the selected slices become formatting-preserving `w:r/w:delText` children under `w:del`; and the replacement becomes one `w:r/w:t` under `w:ins`, carrying the first affected run's `w:rPr`. The envelopes use the session revision author, operation timestamp, and fresh revision ids.
+
+Revision wrappers stay inside a match's hyperlink, run-level SDT, `smartTag`, or `fldSimple` container. A match that crosses formatting boundaries keeps one deleted run per source format. Zero-width bookmark/comment/permission/proofing markers and footnote/endnote reference runs remain outside the revision envelopes, so accepting or rejecting the edit cannot silently destroy their relationships. `AcceptRevision`/`RejectRevision`, whole-document accept/reject, and undo/redo therefore resolve surgical edits the same way as full-block tracked replacements. `TrackedChanges = Accept` retains the original direct run-mutation behavior.
+
 ### Ordering and atomicity
 
 Multiple matches in the same paragraph are applied in **reverse document order** so each earlier-offset match's span stays valid after later edits land — the same trick the projector uses for tracked-change accept passes. The whole call records **one** snapshot; `Undo()` rolls every replacement back together.


### PR DESCRIPTION
## Summary

- make `ReplaceTextRange`, `ReplaceTextAtSpan`, `ReplaceMatch`, and `ReplaceInner` honor `TrackedChangeMode.RenderInline`
- split affected runs at exact selection boundaries and emit Word-style `w:del`/`w:delText` plus `w:ins`/`w:t` envelopes
- preserve first-run insertion formatting, per-run deleted formatting, inline containers, and zero-width semantic markers
- retain existing direct-mode behavior and compatibility with undo/redo and revision accept/reject

## Root cause

The surgical replacement path always called the direct run-text mutation helper. Unlike full-block `ReplaceText`, it never branched on the session tracked-change mode, so granular edits could not be reviewed, accepted, or rejected in Word.

## OOXML behavior

Tracked replacements now keep untouched prefixes and suffixes as ordinary runs, coalesce adjacent selected fragments into Word-style multi-run deletion envelopes, and add one insertion run carrying the first affected run's `w:rPr`. Hyperlink and run-level SDT content remains inside its container; bookmarks, comment markers, and note-reference runs remain live outside revision envelopes. Each envelope receives the session author, operation timestamp, and a fresh revision ID.

## Validation

- 8 focused issue tests covering DS400–DS407
- Office 2019 `OpenXmlValidator` checks for single-run, multi-format, hyperlink/SDT, and semantic-marker packages
- targeted session/revision suite: 321 passed
- complete repository suite: 3,326 passed, 3 configured skips, 0 failed
- `git diff --check` clean

Closes #330