### PR TITLE
Fix session run-property schema ordering

### DIFF
--- a/Docxodus.Tests/DocxSessionS1FeaturesTests.cs
+++ b/Docxodus.Tests/DocxSessionS1FeaturesTests.cs
@@ -31,6 +31,23 @@ public class DocxSessionS1FeaturesTests
         return doc.MainDocumentPart!.GetXDocument().Root!;
     }
 
+    private static byte[] BuildDocumentWithLateRunProperties()
+    {
+        using var ms = new MemoryStream();
+        var source = DocxSessionTests.BuildDS001_SimpleTwoParagraphs();
+        ms.Write(source);
+        ms.Position = 0;
+        using (var doc = WordprocessingDocument.Open(ms, true))
+        {
+            var run = doc.MainDocumentPart!.GetXDocument().Root!.Descendants(W + "r").First();
+            run.AddFirst(new XElement(W + "rPr",
+                new XElement(W + "szCs", new XAttribute(W + "val", "22")),
+                new XElement(W + "u", new XAttribute(W + "val", "single"))));
+            doc.MainDocumentPart.PutXDocument();
+        }
+        return ms.ToArray();
+    }
+
     // ─── F1: font size ──────────────────────────────────────────────────
 
     [Fact]
@@ -111,6 +128,43 @@ public class DocxSessionS1FeaturesTests
         using var ms = new MemoryStream(bytes);
         using var doc = WordprocessingDocument.Open(ms, false);
         var errors = new DocumentFormat.OpenXml.Validation.OpenXmlValidator().Validate(doc).ToList();
+        Assert.Empty(errors);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void DS223_ApplyFormat_InsertsRunPropertiesInSchemaOrder(bool tracked)
+    {
+        using var session = new DocxSession(BuildDocumentWithLateRunProperties(),
+            new DocxSessionSettings
+            {
+                TrackedChanges = tracked ? TrackedChangeMode.RenderInline : TrackedChangeMode.Accept,
+            });
+        var anchor = FirstBodyParagraph(session);
+
+        var result = session.ApplyFormatToSubstring(anchor, "paragraph", new FormatOp
+        {
+            Italic = true,
+            Strike = true,
+            Color = "336699",
+            Underline = true,
+        });
+        Assert.True(result.Success, result.Error?.Message);
+
+        var bytes = session.Save();
+        var changedRun = DocumentXml(bytes).Descendants(W + "r")
+            .Single(r => (string?)r.Element(W + "t") == "paragraph");
+        var expected = new[] { "i", "strike", "color", "szCs", "u" }
+            .Concat(tracked ? new[] { "rPrChange" } : Array.Empty<string>());
+        Assert.Equal(expected, changedRun.Element(W + "rPr")!.Elements().Select(e => e.Name.LocalName));
+
+        using var ms = new MemoryStream(bytes);
+        using var doc = WordprocessingDocument.Open(ms, false);
+        var errors = new DocumentFormat.OpenXml.Validation.OpenXmlValidator(
+                DocumentFormat.OpenXml.FileFormatVersions.Office2019)
+            .Validate(doc)
+            .ToList();
         Assert.Empty(errors);
     }
 

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -8552,7 +8552,7 @@ public sealed class DocxSession : IDisposable
         {
             var author = _revisionAuthor ?? "docxodus";
             var date = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
-            rPr.Add(new XElement(W.del,
+            WordprocessingMLUtil.InsertRPrChildInOrder(rPr, new XElement(W.del,
                 new XAttribute(W.id, NextRevisionId()),
                 new XAttribute(W.author, author),
                 new XAttribute(W.date, date)));
@@ -8643,7 +8643,8 @@ public sealed class DocxSession : IDisposable
                 // element when one is "missing" would leave that w:val="0" in place and the
                 // toggle would silently do nothing. Normalize: drop the w:val so the bare
                 // element (<w:b/>) means on; add one only when truly absent.
-                if (existing is null) rPr.Add(new XElement(name));
+                if (existing is null)
+                    WordprocessingMLUtil.InsertRPrChildInOrder(rPr, new XElement(name));
                 else existing.Attribute(W.val)?.Remove();
             }
             else existing?.Remove();
@@ -8656,14 +8657,16 @@ public sealed class DocxSession : IDisposable
         if (op.Underline is true)
         {
             rPr.Element(W.u)?.Remove();
-            rPr.Add(new XElement(W.u, new XAttribute(W.val, "single")));
+            WordprocessingMLUtil.InsertRPrChildInOrder(
+                rPr, new XElement(W.u, new XAttribute(W.val, "single")));
         }
         else if (op.Underline is false) rPr.Element(W.u)?.Remove();
 
         if (op.Code is true)
         {
             rPr.Element(W.rStyle)?.Remove();
-            rPr.Add(new XElement(W.rStyle, new XAttribute(W.val, "Code")));
+            WordprocessingMLUtil.InsertRPrChildInOrder(
+                rPr, new XElement(W.rStyle, new XAttribute(W.val, "Code")));
         }
         else if (op.Code is false) rPr.Element(W.rStyle)?.Remove();
 
@@ -8671,14 +8674,16 @@ public sealed class DocxSession : IDisposable
         {
             rPr.Element(W.color)?.Remove();
             if (op.Color.Length > 0)
-                rPr.Add(new XElement(W.color, new XAttribute(W.val, op.Color)));
+                WordprocessingMLUtil.InsertRPrChildInOrder(
+                    rPr, new XElement(W.color, new XAttribute(W.val, op.Color)));
         }
 
         if (op.RunStyle is not null)
         {
             rPr.Element(W.rStyle)?.Remove();
             if (op.RunStyle.Length > 0)
-                rPr.Add(new XElement(W.rStyle, new XAttribute(W.val, op.RunStyle)));
+                WordprocessingMLUtil.InsertRPrChildInOrder(
+                    rPr, new XElement(W.rStyle, new XAttribute(W.val, op.RunStyle)));
         }
 
         if (op.VertAlign is not null)
@@ -8695,7 +8700,8 @@ public sealed class DocxSession : IDisposable
             {
                 if (v is not ("superscript" or "subscript"))
                     throw new ArgumentException($"invalid vertAlign: {op.VertAlign}");
-                rPr.Add(new XElement(W.vertAlign, new XAttribute(W.val, v)));
+                WordprocessingMLUtil.InsertRPrChildInOrder(
+                    rPr, new XElement(W.vertAlign, new XAttribute(W.val, v)));
             }
         }
 
@@ -8709,16 +8715,16 @@ public sealed class DocxSession : IDisposable
             {
                 var halfPts = ((int)System.Math.Round(pts * 2, System.MidpointRounding.AwayFromZero))
                     .ToString(System.Globalization.CultureInfo.InvariantCulture);
-                rPr.Add(new XElement(W.sz, new XAttribute(W.val, halfPts)));
-                rPr.Add(new XElement(W.szCs, new XAttribute(W.val, halfPts)));
+                WordprocessingMLUtil.InsertRPrChildInOrder(
+                    rPr, new XElement(W.sz, new XAttribute(W.val, halfPts)));
+                WordprocessingMLUtil.InsertRPrChildInOrder(
+                    rPr, new XElement(W.szCs, new XAttribute(W.val, halfPts)));
             }
         }
 
         if (op.FontFamily is not null)
         {
-            // w:rFonts is the first EG_RPrBase child after an optional w:rStyle, so it must be
-            // placed there (a bare rPr.Add would append after w:sz/w:vertAlign → out of schema
-            // order). "" clears the explicit font so the run inherits the style/default.
+            // "" clears the explicit font so the run inherits the style/default.
             rPr.Element(W.rFonts)?.Remove();
             if (op.FontFamily.Length > 0)
             {
@@ -8726,9 +8732,7 @@ public sealed class DocxSession : IDisposable
                     new XAttribute(W.ascii, op.FontFamily),
                     new XAttribute(W.hAnsi, op.FontFamily),
                     new XAttribute(W.cs, op.FontFamily));
-                var rStyle = rPr.Element(W.rStyle);
-                if (rStyle is not null) rStyle.AddAfterSelf(rFonts);
-                else rPr.AddFirst(rFonts);
+                WordprocessingMLUtil.InsertRPrChildInOrder(rPr, rFonts);
             }
         }
     }
@@ -8749,8 +8753,8 @@ public sealed class DocxSession : IDisposable
         var oldProperties = SnapshotRunPropertiesForRevision(originalRPr);
 
         // rPrChange is the final CT_RPr child. Detach it while ApplyFormatToRun edits
-        // properties (several setters append) and re-append it below. Taking only the
-        // first also prevents malformed duplicate markers from becoming nested/stacked.
+        // properties, then reinsert it once below. Taking only the first also prevents
+        // malformed duplicate markers from becoming nested/stacked.
         var existingChanges = originalRPr?.Elements(W.rPrChange).ToList()
             ?? new List<XElement>();
         foreach (var change in existingChanges) change.Remove();
@@ -8796,19 +8800,13 @@ public sealed class DocxSession : IDisposable
             return;
         }
 
-        // ApplyFormatToRun historically appends several properties. Once rPrChange makes
-        // schema validity externally observable, normalize the changed outer rPr to the
-        // canonical CT_RPr order before placing the revision marker last.
-        var orderedRPr = (XElement)WordprocessingMLUtil.WmlOrderElementsPerStandard(currentRPr);
-        currentRPr.ReplaceNodes(orderedRPr.Nodes());
-
         if (existingChange is not null)
         {
-            currentRPr.Add(existingChange);
+            WordprocessingMLUtil.InsertRPrChildInOrder(currentRPr, existingChange);
             return;
         }
 
-        currentRPr.Add(new XElement(W.rPrChange,
+        WordprocessingMLUtil.InsertRPrChildInOrder(currentRPr, new XElement(W.rPrChange,
             new XAttribute(W.id, NextRevisionId()),
             new XAttribute(W.author, revisionAuthor),
             new XAttribute(W.date, revisionDate),

--- a/Docxodus/PtOpenXmlUtil.cs
+++ b/Docxodus/PtOpenXmlUtil.cs
@@ -1415,7 +1415,23 @@ listSeparator
             { W.eastAsianLayout, 440 },
             { W.specVanish, 450 },
             { W.oMath, 460 },
+            { W.rPrChange, 470 },
         };
+
+        /// <summary>
+        /// Insert <paramref name="child"/> into <paramref name="rPr"/> at its CT_RPr schema
+        /// slot, without reordering existing or extension children.
+        /// </summary>
+        internal static void InsertRPrChildInOrder(XElement rPr, XElement child)
+        {
+            var rank = Order_rPr[child.Name];
+            var firstLater = rPr.Elements().FirstOrDefault(e =>
+                Order_rPr.TryGetValue(e.Name, out var laterRank) && laterRank > rank);
+            if (firstLater == null)
+                rPr.Add(child);
+            else
+                firstLater.AddBeforeSelf(child);
+        }
 
         private static Dictionary<XName, int> Order_tblPr = new Dictionary<XName, int>
         {


### PR DESCRIPTION
Fixes #342.

## What changed

- Added a single schema-aware insertion helper backed by the canonical `CT_RPr` order table.
- Routed session formatting properties, paragraph-mark deletion metadata, and tracked `w:rPrChange` insertion through that helper.
- Removed the tracked-format path's whole-`w:rPr` reorder workaround, preserving existing and extension children in place.
- Added tracked and untracked regression coverage for formatting runs that already contain `w:szCs` and `w:u`.

## Root cause and impact

`ApplyFormat` appended new run properties to existing `w:rPr` elements. Properties such as italic, strike, and color therefore landed after later schema slots such as `w:szCs`, producing documents that Word tolerated but OpenXmlValidator rejected.

New properties now enter their correct schema slot without rewriting unrelated run-property XML.

## Validation

- `DocxSessionS1FeaturesTests` and `DocxSessionRevisionTests`: 56 passed
- Focused tracked/untracked Office 2019 schema validation: 4 passed