### PR TITLE
Fix numbering child schema ordering

### DIFF
--- a/Docxodus.Tests/DocxSessionTests.cs
+++ b/Docxodus.Tests/DocxSessionTests.cs
@@ -137,6 +137,23 @@ public class DocxSessionTests
         return ms.ToArray();
     }
 
+    private static byte[] BuildDocumentWithNumberingCleanup()
+    {
+        using var ms = new MemoryStream();
+        var source = BuildDS001_SimpleTwoParagraphs();
+        ms.Write(source);
+        ms.Position = 0;
+        using (var doc = WordprocessingDocument.Open(ms, true))
+        {
+            var numbering = BuildBulletNumbering();
+            numbering.Append(new NumberingIdMacAtCleanup { Val = 1 });
+            var part = doc.MainDocumentPart!.AddNewPart<NumberingDefinitionsPart>();
+            part.Numbering = numbering;
+            numbering.Save();
+        }
+        return ms.ToArray();
+    }
+
     /// <summary>
     /// Single-item list where the paragraph carries only a <c>pStyle</c> pointing
     /// at a custom style that contributes the <c>numPr</c>. Used to verify
@@ -1867,6 +1884,29 @@ public class DocxSessionTests
         Assert.Equal(ListFormat.UpperRomanParenthesis, Docxodus.Internal.DocxSessionJson.ParseListFormat("upperRomanParenthesis"));
         Assert.Equal(ListFormat.UpperLetter, Docxodus.Internal.DocxSessionJson.ParseListFormat("UPPERLETTER")); // case-insensitive
         Assert.Equal(ListFormat.None, Docxodus.Internal.DocxSessionJson.ParseListFormat("wingding")); // lenient fallback
+    }
+
+    [Fact]
+    public void DS348_ApplyListFormat_KeepsNumberingCleanupLast()
+    {
+        using var s = new DocxSession(BuildDocumentWithNumberingCleanup());
+        var p = s.Project().AnchorIndex.Keys.First(k => k.StartsWith("p:"));
+
+        var result = s.ApplyListFormat(p, ListFormat.Decimal);
+        Assert.True(result.Success, result.Error?.Message);
+
+        using var ms = new MemoryStream(s.Save());
+        using var doc = WordprocessingDocument.Open(ms, false);
+        var numberingPart = doc.MainDocumentPart!.NumberingDefinitionsPart!;
+        var root = numberingPart.GetXDocument().Root!;
+        XNamespace w = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+        Assert.Equal(w + "numIdMacAtCleanup", root.Elements().Last().Name);
+        Assert.Equal(2, root.Elements(w + "num").Count());
+
+        var errors = new DocumentFormat.OpenXml.Validation.OpenXmlValidator(FileFormatVersions.Office2019)
+            .Validate(numberingPart)
+            .ToList();
+        Assert.Empty(errors);
     }
 
     // ─── SetListStartOverride / ClearListStartOverride (issue #314) ─────────

--- a/Docxodus/DocumentBuilder.cs
+++ b/Docxodus/DocumentBuilder.cs
@@ -1670,10 +1670,8 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                                             newAbstractElement = new XElement(abstractElement);
                                             newAbstractElement.Attribute(W.abstractNumId).Value = abstractNumber.ToString();
                                             abstractNumber++;
-                                            if (newNumbering.Root.Elements(W.abstractNum).Any())
-                                                newNumbering.Root.Elements(W.abstractNum).Last().AddAfterSelf(newAbstractElement);
-                                            else
-                                                newNumbering.Root.Add(newAbstractElement);
+                                            WordprocessingMLUtil.InsertNumberingChildInOrder(
+                                                newNumbering.Root, newAbstractElement);
 
                                             foreach (XElement pictId in newAbstractElement.Descendants(W.lvlPicBulletId))
                                             {
@@ -1689,7 +1687,8 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                                                 XElement newNumPicBullet = new XElement(numPicBullet);
                                                 newNumPicBullet.Attribute(W.numPicBulletId).Value = maxNumPicBulletId.ToString();
                                                 pictId.Attribute(W.val).Value = maxNumPicBulletId.ToString();
-                                                newNumbering.Root.AddFirst(newNumPicBullet);
+                                                WordprocessingMLUtil.InsertNumberingChildInOrder(
+                                                    newNumbering.Root, newNumPicBullet);
                                             }
                                         }
                                         string newAbstractId = newAbstractElement.Attribute(W.abstractNumId).Value;
@@ -1712,7 +1711,8 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                                                 .Attribute(W.val).Value = newAbstractId;
                                             newElement.Attribute(W.numId).Value = number.ToString();
                                             number++;
-                                            newNumbering.Root.Add(newElement);
+                                            WordprocessingMLUtil.InsertNumberingChildInOrder(
+                                                newNumbering.Root, newElement);
                                         }
                                         idElement.Attribute(W.val).Value = newElement.Attribute(W.numId).Value;
                                     }
@@ -2701,10 +2701,8 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                             newAbstractElement = new XElement(abstractElement);
                             newAbstractElement.Attribute(W.abstractNumId).Value = abstractNumber.ToString();
                             abstractNumber++;
-                            if (newNumbering.Root.Elements(W.abstractNum).Any())
-                                newNumbering.Root.Elements(W.abstractNum).Last().AddAfterSelf(newAbstractElement);
-                            else
-                                newNumbering.Root.Add(newAbstractElement);
+                            WordprocessingMLUtil.InsertNumberingChildInOrder(
+                                newNumbering.Root, newAbstractElement);
 
                             foreach (XElement pictId in newAbstractElement.Descendants(W.lvlPicBulletId))
                             {
@@ -2720,7 +2718,8 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                                 XElement newNumPicBullet = new XElement(numPicBullet);
                                 newNumPicBullet.Attribute(W.numPicBulletId).Value = maxNumPicBulletId.ToString();
                                 pictId.Attribute(W.val).Value = maxNumPicBulletId.ToString();
-                                newNumbering.Root.AddFirst(newNumPicBullet);
+                                WordprocessingMLUtil.InsertNumberingChildInOrder(
+                                    newNumbering.Root, newNumPicBullet);
                             }
                         }
                         string newAbstractId = newAbstractElement.Attribute(W.abstractNumId).Value;
@@ -2746,7 +2745,8 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                             newElement.Attribute(W.numId).Value = number.ToString();
                             numIdMap.Add(numId, number);
                             number++;
-                            newNumbering.Root.Add(newElement);
+                            WordprocessingMLUtil.InsertNumberingChildInOrder(
+                                newNumbering.Root, newElement);
                         }
                         idElement.Attribute(W.val).Value = newElement.Attribute(W.numId).Value;
                     }
@@ -2862,10 +2862,8 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                             newAbstractElement = new XElement(abstractElement);
                             newAbstractElement.Attribute(W.abstractNumId).Value = abstractNumber.ToString();
                             abstractNumber++;
-                            if (newNumbering.Root.Elements(W.abstractNum).Any())
-                                newNumbering.Root.Elements(W.abstractNum).Last().AddAfterSelf(newAbstractElement);
-                            else
-                                newNumbering.Root.Add(newAbstractElement);
+                            WordprocessingMLUtil.InsertNumberingChildInOrder(
+                                newNumbering.Root, newAbstractElement);
 
                             foreach (XElement pictId in newAbstractElement.Descendants(W.lvlPicBulletId))
                             {
@@ -2881,7 +2879,8 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                                 XElement newNumPicBullet = new XElement(numPicBullet);
                                 newNumPicBullet.Attribute(W.numPicBulletId).Value = maxNumPicBulletId.ToString();
                                 pictId.Attribute(W.val).Value = maxNumPicBulletId.ToString();
-                                newNumbering.Root.AddFirst(newNumPicBullet);
+                                WordprocessingMLUtil.InsertNumberingChildInOrder(
+                                    newNumbering.Root, newNumPicBullet);
                             }
                         }
                         string newAbstractId = newAbstractElement.Attribute(W.abstractNumId).Value;
@@ -2907,7 +2906,8 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                             newElement.Attribute(W.numId).Value = number.ToString();
                             numIdMap.Add(numId, number);
                             number++;
-                            newNumbering.Root.Add(newElement);
+                            WordprocessingMLUtil.InsertNumberingChildInOrder(
+                                newNumbering.Root, newElement);
                         }
                         idElement.Attribute(W.val).Value = newElement.Attribute(W.numId).Value;
                     }
@@ -3024,10 +3024,8 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                             newAbstractElement = new XElement(abstractElement);
                             newAbstractElement.Attribute(W.abstractNumId).Value = abstractNumber.ToString();
                             abstractNumber++;
-                            if (newNumbering.Root.Elements(W.abstractNum).Any())
-                                newNumbering.Root.Elements(W.abstractNum).Last().AddAfterSelf(newAbstractElement);
-                            else
-                                newNumbering.Root.Add(newAbstractElement);
+                            WordprocessingMLUtil.InsertNumberingChildInOrder(
+                                newNumbering.Root, newAbstractElement);
 
                             foreach (XElement pictId in newAbstractElement.Descendants(W.lvlPicBulletId))
                             {
@@ -3043,7 +3041,8 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                                 XElement newNumPicBullet = new XElement(numPicBullet);
                                 newNumPicBullet.Attribute(W.numPicBulletId).Value = maxNumPicBulletId.ToString();
                                 pictId.Attribute(W.val).Value = maxNumPicBulletId.ToString();
-                                newNumbering.Root.AddFirst(newNumPicBullet);
+                                WordprocessingMLUtil.InsertNumberingChildInOrder(
+                                    newNumbering.Root, newNumPicBullet);
                             }
                         }
                         string newAbstractId = newAbstractElement.Attribute(W.abstractNumId).Value;
@@ -3069,7 +3068,8 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                             newElement.Attribute(W.numId).Value = number.ToString();
                             numIdMap.Add(numId, number);
                             number++;
-                            newNumbering.Root.Add(newElement);
+                            WordprocessingMLUtil.InsertNumberingChildInOrder(
+                                newNumbering.Root, newElement);
                         }
                         idElement.Attribute(W.val).Value = newElement.Attribute(W.numId).Value;
                     }

--- a/Docxodus/HtmlToWmlConverterCore.cs
+++ b/Docxodus/HtmlToWmlConverterCore.cs
@@ -4540,7 +4540,7 @@ namespace Docxodus.HtmlToWml
                     if (list.Name == XhtmlNoNamespace.ul)
                     {
                         XElement bulletAbstract = XElement.Parse(String.Format(BulletAbstractXml, currentAbstractId++));
-                        numberingXDoc.Root.Add(bulletAbstract);
+                        WordprocessingMLUtil.InsertNumberingChildInOrder(numberingXDoc.Root, bulletAbstract);
                     }
                     if (list.Name == XhtmlNoNamespace.ol)
                     {
@@ -4592,16 +4592,16 @@ namespace Docxodus.HtmlToWml
 
                         XElement simpleNumAbstract = XElement.Parse(String.Format(OrderedListAbstractXml, currentAbstractId++,
                             numFmt[0], just[0], numFmt[1], just[1], numFmt[2], just[2], numFmt[3], just[3], numFmt[4], just[4], numFmt[5], just[5], numFmt[6], just[6], numFmt[7], just[7], numFmt[8], just[8]));
-                        numberingXDoc.Root.Add(simpleNumAbstract);
+                        WordprocessingMLUtil.InsertNumberingChildInOrder(numberingXDoc.Root, simpleNumAbstract);
                     }
                 }
             }
 
             foreach (var list in numToAbstractNum)
             {
-                numberingXDoc.Root.Add(
+                WordprocessingMLUtil.InsertNumberingChildInOrder(numberingXDoc.Root,
                     new XElement(W.num, new XAttribute(W.numId, list.Key),
-                    new XElement(W.abstractNumId, new XAttribute(W.val, list.Value))));
+                        new XElement(W.abstractNumId, new XAttribute(W.val, list.Value))));
             }
 
             wDoc.MainDocumentPart.NumberingDefinitionsPart.PutXDocument();

--- a/Docxodus/Internal/NumberingFactory.cs
+++ b/Docxodus/Internal/NumberingFactory.cs
@@ -71,15 +71,7 @@ internal static class NumberingFactory
         {
             int absId = NextId(root, "abstractNum", "abstractNumId");
             abstractNum = BuildAbstractNum(fmt, absId, nsid);
-            // CT_Numbering order: numPicBullet*, abstractNum*, num* — keep abstractNums grouped.
-            var lastAbstract = root.Elements(W + "abstractNum").LastOrDefault();
-            if (lastAbstract is not null) lastAbstract.AddAfterSelf(abstractNum);
-            else
-            {
-                var firstNum = root.Elements(W + "num").FirstOrDefault();
-                if (firstNum is not null) firstNum.AddBeforeSelf(abstractNum);
-                else root.Add(abstractNum);
-            }
+            WordprocessingMLUtil.InsertNumberingChildInOrder(root, abstractNum);
         }
 
         var abstractId = (string)abstractNum.Attribute(W + "abstractNumId")!;
@@ -93,7 +85,7 @@ internal static class NumberingFactory
             num = new XElement(W + "num",
                 new XAttribute(W + "numId", numId),
                 new XElement(W + "abstractNumId", new XAttribute(W + "val", abstractId)));
-            root.Add(num); // nums come after abstractNums
+            WordprocessingMLUtil.InsertNumberingChildInOrder(root, num);
         }
 
         // Flush the numbering part to its stream — the session's Save only persists the
@@ -275,7 +267,7 @@ internal static class NumberingFactory
             if (!ovr.Elements().Any()) ovr.Remove();
         }
 
-        root.Add(clone); // nums come after abstractNums; appending keeps the group intact
+        WordprocessingMLUtil.InsertNumberingChildInOrder(root, clone);
         part.PutXDocument();
         return newNumId;
     }

--- a/Docxodus/Ir/Diff/IrMarkupRenderer.cs
+++ b/Docxodus/Ir/Diff/IrMarkupRenderer.cs
@@ -6847,9 +6847,6 @@ internal static class IrMarkupRenderer
             .Select(a => int.TryParse((string?)a.Attribute(W.abstractNumId), out var id) ? id : -1)
             .DefaultIfEmpty(-1)
             .Max() + 1;
-        // Schema order inside w:numbering: numPicBullet*, abstractNum*, num* — new abstracts go
-        // before the first existing w:num; the num mappings append at the end.
-        var firstNum = root.Elements(W.num).FirstOrDefault();
         foreach (var id in dangling)
         {
             var abstractNum = new XElement(W.abstractNum,
@@ -6865,11 +6862,8 @@ internal static class IrMarkupRenderer
                         new XElement(W.ind,
                             new XAttribute(W.left, 720 * (i + 1)),
                             new XAttribute(W.hanging, 720))))));
-            if (firstNum is null)
-                root.Add(abstractNum);
-            else
-                firstNum.AddBeforeSelf(abstractNum);
-            root.Add(new XElement(W.num,
+            WordprocessingMLUtil.InsertNumberingChildInOrder(root, abstractNum);
+            WordprocessingMLUtil.InsertNumberingChildInOrder(root, new XElement(W.num,
                 new XAttribute(W.numId, id),
                 new XElement(W.abstractNumId, new XAttribute(W.val, nextAbstract))));
             nextAbstract++;

--- a/Docxodus/PtOpenXmlUtil.cs
+++ b/Docxodus/PtOpenXmlUtil.cs
@@ -1272,6 +1272,29 @@ decimalSymbol
 listSeparator
 #endif
 
+        private static Dictionary<XName, int> Order_numbering = new Dictionary<XName, int>
+        {
+            { W.numPicBullet, 10 },
+            { W.abstractNum, 20 },
+            { W.num, 30 },
+            { W.numIdMacAtCleanup, 40 },
+        };
+
+        /// <summary>
+        /// Insert <paramref name="child"/> into <paramref name="numbering"/> at its CT_Numbering
+        /// schema slot, without reordering existing or extension children.
+        /// </summary>
+        internal static void InsertNumberingChildInOrder(XElement numbering, XElement child)
+        {
+            var rank = Order_numbering[child.Name];
+            var firstLater = numbering.Elements().FirstOrDefault(e =>
+                Order_numbering.TryGetValue(e.Name, out var laterRank) && laterRank > rank);
+            if (firstLater == null)
+                numbering.Add(child);
+            else
+                firstLater.AddBeforeSelf(child);
+        }
+
         /// <summary>
         /// The CT_SectPr child sequence (ECMA-376 §17.6.18). The header/footer references are an
         /// unbounded leading group (EG_HdrFtrReferences), then the CT_SectPrBase properties in this

--- a/Docxodus/WmlComparer.cs
+++ b/Docxodus/WmlComparer.cs
@@ -2270,7 +2270,7 @@ namespace Docxodus
                 cloned.SetAttributeValue(W.abstractNumId, targetId);
                 abstractNumIdMap[fromAbstractNumId.Value] = targetId;
 
-                AddNumberingChildInSchemaOrder(toNumberingXDoc.Root, cloned);
+                WordprocessingMLUtil.InsertNumberingChildInOrder(toNumberingXDoc.Root, cloned);
             }
 
             // Copy num elements that don't exist in destination
@@ -2307,7 +2307,7 @@ namespace Docxodus
                     var abstractNumIdElement = cloned.Element(W.abstractNumId);
                     if (abstractNumIdElement != null)
                         abstractNumIdElement.SetAttributeValue(W.val, mappedAbstractNumId);
-                    AddNumberingChildInSchemaOrder(toNumberingXDoc.Root, cloned);
+                    WordprocessingMLUtil.InsertNumberingChildInOrder(toNumberingXDoc.Root, cloned);
                     numIdMap[fromNumId.Value] = maxNumId;
                 }
                 else
@@ -2320,7 +2320,7 @@ namespace Docxodus
                         if (abstractNumIdElement != null)
                             abstractNumIdElement.SetAttributeValue(W.val, mappedAbstractNumId);
                     }
-                    AddNumberingChildInSchemaOrder(toNumberingXDoc.Root, cloned);
+                    WordprocessingMLUtil.InsertNumberingChildInOrder(toNumberingXDoc.Root, cloned);
                 }
             }
 
@@ -2415,7 +2415,7 @@ namespace Docxodus
                     : ++maxAbstractNumId;
                 var clonedAbstract = new XElement(fromAbstract);
                 clonedAbstract.SetAttributeValue(W.abstractNumId, targetId);
-                AddNumberingChildInSchemaOrder(toNumberingXDoc.Root, clonedAbstract);
+                WordprocessingMLUtil.InsertNumberingChildInOrder(toNumberingXDoc.Root, clonedAbstract);
                 cache[fromAbstractId] = targetId;
                 return targetId;
             }
@@ -2494,33 +2494,10 @@ namespace Docxodus
                 var abstractNumIdElement = clonedNum.Element(W.abstractNumId);
                 if (abstractNumIdElement != null)
                     abstractNumIdElement.SetAttributeValue(W.val, targetAbstractId);
-                AddNumberingChildInSchemaOrder(toNumberingXDoc.Root, clonedNum);
+                WordprocessingMLUtil.InsertNumberingChildInOrder(toNumberingXDoc.Root, clonedNum);
             }
 
             return numIdMap;
-        }
-
-        /// <summary>
-        /// Insert a child into <c>w:numbering</c> respecting the schema order
-        /// <c>w:numPicBullet* w:abstractNum* w:num* w:numIdMacAtCleanup?</c>: place it BEFORE the first existing
-        /// child of a higher rank (so a copied <c>w:num</c> lands before a trailing <c>w:numIdMacAtCleanup</c>
-        /// rather than after it — appending blindly produced a Sch_UnexpectedElementContentExpectingComplex).
-        /// </summary>
-        private static void AddNumberingChildInSchemaOrder(XElement numbering, XElement child)
-        {
-            static int Rank(XElement e) => e.Name.LocalName switch
-            {
-                "numPicBullet" => 0,
-                "abstractNum" => 1,
-                "num" => 2,
-                _ => 3,             // numIdMacAtCleanup (and any trailing element) sorts last
-            };
-            int rank = Rank(child);
-            var firstLater = numbering.Elements().FirstOrDefault(e => Rank(e) > rank);
-            if (firstLater != null)
-                firstLater.AddBeforeSelf(child);
-            else
-                numbering.Add(child);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #343.

## What changed

- Promoted the existing `CT_Numbering` insertion logic into the shared OOXML ordering utility.
- Routed session numbering allocation and list-start clones through that single helper.
- Reused the same helper in comparer imports, IR numbering repair, HTML conversion, and document-builder copy paths.
- Added a regression fixture with trailing `w:numIdMacAtCleanup` and verified new list instances remain before it.

## Root cause and impact

The session's numbering factory appended new `w:num` instances to `word/numbering.xml`. In Word-authored documents that already ended with `w:numIdMacAtCleanup`, the new instances landed after the schema's final optional child and made the part invalid.

All top-level numbering writers now insert `w:numPicBullet`, `w:abstractNum`, and `w:num` into their schema slots while leaving existing and extension children in place.

## Validation

- Clean .NET 10 build
- Directly affected session, comparer, IR repair, HTML converter, and document builder suites: 292 passed
- Regression validates the numbering part with OpenXmlValidator for Office 2019