### PR TITLE
Render and persist tracked revisions in MCP sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **MCP HTML preserves native tracked changes.** Full and anchored MCP HTML reads now emit pending
+  revisions as `<ins>`/`<del>` instead of implicitly accepting them on the renderer's throwaway
+  document. The shared full, single-block, and batched session render paths expose one consistent
+  review-mode option, without changing the browser editor's clean editing profile. Every
+  newly-authored native revision also enables Word's schema-ordered
+  `w:trackRevisions` setting (creating `settings.xml` when needed), so Word continues tracking
+  subsequent interactive edits. Coverage: DS408 and MCP140.
+
 ### Added
 - **Comments can target tracked revisions by id (issue #341).**
   `DocxSession.AddCommentToRevision(revisionId, author, markdown, ...)` brackets the exact live

--- a/Docxodus.Tests/DocxSessionSurgicalTrackedChangesTests.cs
+++ b/Docxodus.Tests/DocxSessionSurgicalTrackedChangesTests.cs
@@ -56,6 +56,15 @@ public class DocxSessionSurgicalTrackedChangesTests
         return new XElement(document.MainDocumentPart!.GetXDocument().Root!);
     }
 
+    private static XElement? SettingsRoot(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes);
+        using var document = WordprocessingDocument.Open(stream, false);
+        return document.MainDocumentPart!.DocumentSettingsPart?.GetXDocument().Root is { } root
+            ? new XElement(root)
+            : null;
+    }
+
     private static string AcceptedText(byte[] bytes)
     {
         var accepted = RevisionProcessor.AcceptRevisions(new WmlDocument("accepted.docx", bytes));
@@ -122,6 +131,7 @@ public class DocxSessionSurgicalTrackedChangesTests
 
         Assert.Equal("Prefix replacement suffix", AcceptedText(tracked));
         Assert.Equal("Prefix target suffix", RejectedText(tracked));
+        Assert.NotNull(SettingsRoot(tracked)?.Element(W.trackRevisions));
         AssertSchemaValid(tracked);
 
         using (var selectiveAccept = new DocxSession(tracked))
@@ -137,6 +147,32 @@ public class DocxSessionSurgicalTrackedChangesTests
                 Assert.True(selectiveReject.RejectRevision(revision.Id).Success);
             Assert.Equal("Prefix target suffix", Text(MainRoot(selectiveReject.Save())));
         }
+    }
+
+    [Fact]
+    public void DS408_TrackedEdit_CreatesMissingSettingsPartWithTrackRevisions()
+    {
+        using var stream = new MemoryStream();
+        using (var document = WordprocessingDocument.Create(
+                   stream, WordprocessingDocumentType.Document))
+        {
+            var main = document.AddMainDocumentPart();
+            main.Document = new Document(new Body(new Paragraph(new Run(new Text("before")))));
+            main.AddNewPart<StyleDefinitionsPart>().Styles = new Styles();
+            main.Document.Save();
+        }
+
+        using var session = new DocxSession(stream.ToArray(),
+            new DocxSessionSettings { TrackedChanges = TrackedChangeMode.RenderInline });
+        var anchor = session.Project().AnchorIndex.Values.Single().Anchor.Id;
+
+        var result = session.ReplaceText(anchor, "after");
+
+        Assert.True(result.Success, result.Error?.Message);
+        var tracked = session.Save();
+        var settings = Assert.IsType<XElement>(SettingsRoot(tracked));
+        Assert.Single(settings.Elements(W.trackRevisions));
+        AssertSchemaValid(tracked);
     }
 
     [Fact]

--- a/Docxodus.Tests/McpServerDispatcherTests.cs
+++ b/Docxodus.Tests/McpServerDispatcherTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Xml.Linq;
 using Docxodus.McpServer;
 using Xunit;
 
@@ -92,6 +93,13 @@ public class McpServerDispatcherTests : IDisposable
         using var ms = new MemoryStream(File.ReadAllBytes(path));
         using var doc = DocumentFormat.OpenXml.Packaging.WordprocessingDocument.Open(ms, false);
         return doc.MainDocumentPart!.RootElement!.OuterXml;
+    }
+
+    private static string SavedSettingsXml(string path)
+    {
+        using var ms = new MemoryStream(File.ReadAllBytes(path));
+        using var doc = DocumentFormat.OpenXml.Packaging.WordprocessingDocument.Open(ms, false);
+        return doc.MainDocumentPart!.DocumentSettingsPart?.RootElement?.OuterXml ?? string.Empty;
     }
 
     private static string FirstBodyAnchorId(string sessionId, SessionStore store)
@@ -376,7 +384,8 @@ public class McpServerDispatcherTests : IDisposable
         var htmlWithBorder = Parse(Dispatcher.Call(_store, "docxodus_get_content", J(
             $$"""{"sessionId":{{sessionArg}},"format":"html"}""")))
             .GetProperty("html").GetString()!;
-        Assert.Contains("border-bottom", htmlWithBorder);
+        Assert.Contains(XElement.Parse(htmlWithBorder).DescendantsAndSelf(),
+            e => ((string?)e.Attribute("style"))?.Contains("border-bottom", StringComparison.Ordinal) == true);
 
         var cleared = Parse(Dispatcher.Call(_store, "docxodus_format", J(
             $$"""{"sessionId":{{sessionArg}},"action":"set_paragraph_format","anchorId":"{{anchor}}","paragraphFormat":{"clearBorders":true} }""")));
@@ -385,7 +394,8 @@ public class McpServerDispatcherTests : IDisposable
         var htmlAfterClear = Parse(Dispatcher.Call(_store, "docxodus_get_content", J(
             $$"""{"sessionId":{{sessionArg}},"format":"html"}""")))
             .GetProperty("html").GetString()!;
-        Assert.DoesNotContain("border-bottom", htmlAfterClear);
+        Assert.DoesNotContain(XElement.Parse(htmlAfterClear).DescendantsAndSelf(),
+            e => ((string?)e.Attribute("style"))?.Contains("border-bottom", StringComparison.Ordinal) == true);
     }
 
     [Fact]
@@ -1272,5 +1282,51 @@ public class McpServerDispatcherTests : IDisposable
             $$"""{"sessionId":{{sessionArg}},"action":"add","anchorId":"{{anchor}}","revisionId":"rev1","author":"Alice"}""")));
         Assert.Throws<McpToolException>(() => Dispatcher.Call(_store, "docxodus_comment", J(
             $$"""{"sessionId":{{sessionArg}},"action":"add","revisionId":"rev1","span":{"start":0,"length":1},"author":"Alice"}""")));
+    }
+
+    [Fact]
+    public void MCP140_HtmlAndSavedSettings_PreserveTrackedRevisionCommentTarget()
+    {
+        var sessionId = OpenSession();
+        var sessionArg = JsonSerializer.Serialize(sessionId);
+        var anchor = FirstBodyAnchorId(sessionId, _store);
+
+        Dispatcher.Call(_store, "docxodus_edit", J(
+            $$"""{"sessionId":{{sessionArg}},"action":"replace_text","anchorId":"{{anchor}}","markdown":"original"}"""));
+        SetMode(sessionId, "render_inline", "Reviewer A");
+        Dispatcher.Call(_store, "docxodus_edit", J(
+            $$"""{"sessionId":{{sessionArg}},"action":"replace_text","anchorId":"{{anchor}}","markdown":"replacement"}"""));
+
+        var revisions = Parse(Dispatcher.Call(_store, "docxodus_track_changes", J(
+            $$"""{"sessionId":{{sessionArg}},"action":"list"}""")))
+            .GetProperty("revisions").EnumerateArray().ToList();
+        var revisionId = Assert.Single(
+                revisions, r => r.GetProperty("type").GetString() == "insert")
+            .GetProperty("id").GetString()!;
+        var comment = Parse(Dispatcher.Call(_store, "docxodus_comment", J(
+            $$"""{"sessionId":{{sessionArg}},"action":"add","revisionId":"{{revisionId}}","author":"Alice","markdown":"Keep this revision."}""")));
+        Assert.True(comment.GetProperty("success").GetBoolean());
+
+        string Render(string? anchorId = null)
+        {
+            var argsJson = $"{{\"sessionId\":{sessionArg},\"format\":\"html\"";
+            if (anchorId is not null)
+                argsJson += $",\"anchorId\":{JsonSerializer.Serialize(anchorId)}";
+            argsJson += "}";
+            return Parse(Dispatcher.Call(_store, "docxodus_get_content", J(argsJson)))
+                .GetProperty("html").GetString()!;
+        }
+
+        foreach (var html in new[] { Render(), Render(anchor) })
+        {
+            Assert.Contains("<ins", html);
+            Assert.Contains("<del", html);
+            Assert.Contains("replacement", html);
+            Assert.Contains("original", html);
+        }
+
+        var savedPath = Path.Combine(_root, "tracked-comment.docx");
+        Save(sessionId, savedPath);
+        Assert.Contains("trackRevisions", SavedSettingsXml(savedPath));
     }
 }

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -3594,11 +3594,50 @@ public sealed class DocxSession : IDisposable
         insertionAnchor.AddAfterSelf(insertionEnvelope);
     }
 
-    private XElement CreateRevisionEnvelope(XName name, string author, string date) =>
-        new(name,
+    /// <summary>Create native revision markup and keep Word's document-level recording flag in
+    /// sync. The flag does not make existing revisions render; it tells Word to track subsequent
+    /// interactive edits after the generated document is opened.</summary>
+    private XElement CreateRevisionEnvelope(
+        XName name, string author, string date, params object[] content)
+    {
+        EnsureTrackRevisionsEnabled();
+        var envelope = new XElement(name,
             new XAttribute(W.id, NextRevisionId()),
             new XAttribute(W.author, author),
             new XAttribute(W.date, date));
+        envelope.Add(content);
+        return envelope;
+    }
+
+    private void EnsureTrackRevisionsEnabled()
+    {
+        var main = _doc!.MainDocumentPart
+            ?? throw new InvalidOperationException("document has no main document part");
+        var settingsPart = main.DocumentSettingsPart ?? main.AddNewPart<DocumentSettingsPart>();
+        var xDoc = settingsPart.GetXDocument();
+        var root = xDoc.Root;
+        if (root is null)
+        {
+            root = new XElement(W.settings, new XAttribute(XNamespace.Xmlns + "w", W.w));
+            xDoc.Add(root);
+        }
+
+        if (root.Element(W.trackRevisions) is { } existing)
+        {
+            // Bare CT_OnOff is the canonical enabled form. In particular, do not leave an
+            // inherited w:val="false" in place after this session has emitted a revision.
+            if (existing.Attribute(W.val) is { } disabledOrExplicit)
+            {
+                disabledOrExplicit.Remove();
+                settingsPart.PutXDocument();
+            }
+            return;
+        }
+
+        if (WordprocessingMLUtil.EnsureSettingsChildInOrder(
+                root, new XElement(W.trackRevisions)))
+            settingsPart.PutXDocument();
+    }
 
     /// <summary>Create a text-only run that retains the source run's formatting/rsid
     /// attributes but gets its own internal Unid. <paramref name="textName"/> is
@@ -8555,10 +8594,7 @@ public sealed class DocxSession : IDisposable
         XElement? del = null;
         if (existingRuns.Count > 0)
         {
-            del = new XElement(W.del,
-                new XAttribute(W.id, NextRevisionId()),
-                new XAttribute(W.author, author),
-                new XAttribute(W.date, date));
+            del = CreateRevisionEnvelope(W.del, author, date);
             foreach (var run in existingRuns)
             {
                 run.Remove();
@@ -8576,10 +8612,7 @@ public sealed class DocxSession : IDisposable
         XElement? ins = null;
         if (blocks.Count > 0 && blocks[0].RunElements.Count > 0)
         {
-            ins = new XElement(W.ins,
-                new XAttribute(W.id, NextRevisionId()),
-                new XAttribute(W.author, author),
-                new XAttribute(W.date, date));
+            ins = CreateRevisionEnvelope(W.ins, author, date);
             foreach (var run in blocks[0].RunElements)
                 ins.Add(new XElement(run));
         }
@@ -8601,11 +8634,7 @@ public sealed class DocxSession : IDisposable
                 t.ReplaceWith(new XElement(W.delText,
                     new XAttribute(XNamespace.Xml + "space", "preserve"),
                     (string)t));
-            var del = new XElement(W.del,
-                new XAttribute(W.id, NextRevisionId()),
-                new XAttribute(W.author, author),
-                new XAttribute(W.date, date),
-                run);
+            var del = CreateRevisionEnvelope(W.del, author, date, run);
             element.Add(del);
         }
     }
@@ -8638,10 +8667,8 @@ public sealed class DocxSession : IDisposable
         {
             var author = _revisionAuthor ?? "docxodus";
             var date = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
-            WordprocessingMLUtil.InsertRPrChildInOrder(rPr, new XElement(W.del,
-                new XAttribute(W.id, NextRevisionId()),
-                new XAttribute(W.author, author),
-                new XAttribute(W.date, date)));
+            WordprocessingMLUtil.InsertRPrChildInOrder(
+                rPr, CreateRevisionEnvelope(W.del, author, date));
         }
     }
 
@@ -8666,10 +8693,7 @@ public sealed class DocxSession : IDisposable
             }
             if (trPr.Element(W.del) is null)
             {
-                trPr.Add(new XElement(W.del,
-                    new XAttribute(W.id, NextRevisionId()),
-                    new XAttribute(W.author, author),
-                    new XAttribute(W.date, date)));
+                trPr.Add(CreateRevisionEnvelope(W.del, author, date));
             }
 
             foreach (var cell in row.Elements(W.tc))
@@ -8892,11 +8916,9 @@ public sealed class DocxSession : IDisposable
             return;
         }
 
-        WordprocessingMLUtil.InsertRPrChildInOrder(currentRPr, new XElement(W.rPrChange,
-            new XAttribute(W.id, NextRevisionId()),
-            new XAttribute(W.author, revisionAuthor),
-            new XAttribute(W.date, revisionDate),
-            oldProperties));
+        WordprocessingMLUtil.InsertRPrChildInOrder(currentRPr,
+            CreateRevisionEnvelope(
+                W.rPrChange, revisionAuthor, revisionDate, oldProperties));
     }
 
     /// <summary>

--- a/Docxodus/Internal/DocxSessionOps.cs
+++ b/Docxodus/Internal/DocxSessionOps.cs
@@ -75,18 +75,20 @@ internal static class DocxSessionOps
     /// incremental per-block re-render. Resolves against the live document (no Save /
     /// byte round-trip). Returns the block's HTML element (no html/head wrapper).
     /// </summary>
-    public static string RenderBlockHtml(int handle, string anchorId, string cssPrefix, bool fabricateClasses) =>
+    public static string RenderBlockHtml(int handle, string anchorId, string cssPrefix,
+        bool fabricateClasses, bool renderTrackedChanges = false) =>
         HtmlConversionOps.RenderBlockHtml(SessionRegistry.Get(handle), anchorId,
-            EditorBlockRenderOptions(cssPrefix, fabricateClasses));
+            EditorBlockRenderOptions(cssPrefix, fabricateClasses, renderTrackedChanges));
 
     /// <summary>
     /// Batch single-block render: N anchors, one throwaway document, one converter run.
     /// Returns a JSON object mapping each anchor id to its HTML (null for an anchor that
     /// failed to resolve). See <see cref="HtmlConversionOps.RenderBlocksHtml(DocxSession, System.Collections.Generic.IReadOnlyList{string}, HtmlConversionOptions)"/>.
     /// </summary>
-    public static string RenderBlocksHtml(int handle, string anchorIdsJson, string cssPrefix, bool fabricateClasses) =>
+    public static string RenderBlocksHtml(int handle, string anchorIdsJson, string cssPrefix,
+        bool fabricateClasses, bool renderTrackedChanges = false) =>
         HtmlConversionOps.RenderBlocksHtml(handle, anchorIdsJson,
-            EditorBlockRenderOptions(cssPrefix, fabricateClasses));
+            EditorBlockRenderOptions(cssPrefix, fabricateClasses, renderTrackedChanges));
 
     /// <summary>
     /// The block-render option profile for the editor's incremental swaps. Must agree
@@ -95,12 +97,14 @@ internal static class DocxSessionOps
     /// RenderFootnotesAndEndnotes off, a re-rendered citing paragraph silently loses
     /// its citation marker from the DOM.
     /// </summary>
-    private static HtmlConversionOptions EditorBlockRenderOptions(string cssPrefix, bool fabricateClasses) =>
+    private static HtmlConversionOptions EditorBlockRenderOptions(
+        string cssPrefix, bool fabricateClasses, bool renderTrackedChanges) =>
         new HtmlConversionOptions
         {
             CssClassPrefix = cssPrefix ?? "docx-",
             FabricateCssClasses = fabricateClasses,
             RenderFootnotesAndEndnotes = true,
+            RenderTrackedChanges = renderTrackedChanges,
         };
 
     /// <summary>
@@ -111,7 +115,7 @@ internal static class DocxSessionOps
     /// remount through this path renders byte-identically to the bytes path.
     /// </summary>
     public static string RenderHtml(int handle, string cssPrefix, bool fabricateClasses,
-        bool paginated, double scale) =>
+        bool paginated, double scale, bool renderTrackedChanges = false) =>
         HtmlConversionOps.ConvertToHtml(SessionRegistry.Get(handle), new HtmlConversionOptions
         {
             CssClassPrefix = cssPrefix ?? "docx-",
@@ -125,6 +129,7 @@ internal static class DocxSessionOps
             // with the editor's first-paint profile in npm/src/editor.ts `completeArgs`, which the
             // remount output is required to match byte-for-byte.
             RenderFootnotesAndEndnotes = true,
+            RenderTrackedChanges = renderTrackedChanges,
             StampAnchors = true,
         });
 

--- a/Docxodus/Internal/HtmlConversionOps.cs
+++ b/Docxodus/Internal/HtmlConversionOps.cs
@@ -627,6 +627,11 @@ internal static class HtmlConversionOps
             // returns null and a re-rendered citing paragraph silently loses its
             // citation marker from the DOM (the XML keeps the reference).
             RenderFootnotesAndEndnotes = options.RenderFootnotesAndEndnotes,
+            // These settings affect within-block output too. An incremental swap must not
+            // accept revisions that the matching full render preserves.
+            RenderTrackedChanges = options.RenderTrackedChanges,
+            ShowDeletedContent = options.ShowDeletedContent,
+            RenderMoveOperations = options.RenderMoveOperations,
             // The throwaway doc copies the source's (possibly huge) style gallery verbatim;
             // re-simplifying it every render is the dominant single-block cost (~70ms on a 160-style
             // python-docx doc) and only strips rsids, which never reach the HTML. Skip it — the

--- a/docs/architecture/docx_agent_server.md
+++ b/docs/architecture/docx_agent_server.md
@@ -348,6 +348,12 @@ action existed, flipping the mode meant `docxodus_save` → `docxodus_close` →
 (and, without `persistAnchorIds`, losing every anchor id at that boundary); that dance is no
 longer needed for mode switching.
 
+Once a mutation actually emits native revision markup, the session also enables
+`w:trackRevisions` in `settings.xml` (creating the part when absent), so Word keeps tracking later
+interactive edits. This setting is distinct from display: `docxodus_get_content(format: "html")`
+always renders pending markup as `<ins>`/`<del>`; accepting or rejecting it requires an explicit
+track-changes action.
+
 `list` (issue #318) reads the revision set directly off the live session's markup —
 `DocxSession.ListRevisions` enumerates `w:ins`/`w:del`/`w:moveFrom`/`w:moveTo`, paragraph-mark
 and table-row markers, and the `*PrChange` format-change family across body, headers, footers,

--- a/tools/mcp-server/Dispatcher.cs
+++ b/tools/mcp-server/Dispatcher.cs
@@ -126,8 +126,10 @@ internal static class Dispatcher
             case "html":
                 return $"{{\"html\":{JsonRpcIo.JsonString(
                     anchorId is null
-                        ? DocxSessionOps.RenderHtml(session.Handle, "docx-", false, false, 1.0)
-                        : DocxSessionOps.RenderBlockHtml(session.Handle, anchorId, "docx-", false))}}}";
+                        ? DocxSessionOps.RenderHtml(session.Handle, "docx-", false, false, 1.0,
+                            renderTrackedChanges: true)
+                        : DocxSessionOps.RenderBlockHtml(session.Handle, anchorId, "docx-", false,
+                            renderTrackedChanges: true))}}}";
 
             case "blocks":
             {


### PR DESCRIPTION
## Summary

- Render native tracked insertions, deletions, and moves in MCP HTML reads instead of implicitly accepting them.
- Propagate tracked-change rendering options through block and anchored HTML conversion.
- Enable `<w:trackRevisions/>` whenever the session creates native revision markup, including documents without an existing settings part.
- Add focused coverage for full and anchored MCP HTML, revision comments, settings persistence, and schema validity.

## Root cause

MCP HTML reads used the default `RenderTrackedChanges = false`, so the converter flattened revision markup as accepted content. Incremental block conversion also failed to carry tracked-change options into its temporary document. Separately, native revision elements could be written without enabling revision tracking in `settings.xml`.

## Impact

MCP clients now see inserted and deleted content in review-oriented HTML, while editor rendering retains its existing clean default. Saved documents consistently declare revision tracking when native revisions are authored.

## Validation

- 176 focused .NET tests passed across tracked changes, comments, HTML conversion, and MCP dispatch.
- `npm run typecheck` passed.
- `git diff --check` passed.
- The unfiltered suite was attempted but stalled in existing legacy/corpus coverage; generated fixture rewrites were restored and are not part of this PR.