### PR TITLE
Cut editor interactive latency 52–98% per operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- **Editor interactive latency cut 52–98 % per operation.** Measured end-to-end on a real
+  document (`HC031`, Chromium/WASM, warm) by the new standing benchmark
+  `npm/tests/editor-latency-bench.spec.ts`: text commit 102 → 30 ms, Enter-split
+  137 → 41 ms, bold 108 → 52 ms, font size 88 → 34 ms, Backspace-merge 79 → 25 ms,
+  insert table 1.49 s → 130 ms, insert row 1.25 s → 85 ms, delete block 1.2 s → 24 ms,
+  undo/redo ~1.2 s → 124/54 ms. Five compounding fixes to the editor's hot paths:
+  - *The per-block render shell now stays open across renders.* The session-attached
+    single-block render (`HtmlConversionOps.RenderTargetsFromShell`) used to re-open its
+    cached shell bytes — package open + styles/numbering XML parse — on every keystroke
+    commit; the shell `WordprocessingDocument` is now kept open on the session and each
+    render replaces only the main part's body document, so the parse and the converter's
+    style/numbering resolution caches persist (guarded by the existing formatting
+    signature; `FormattingAssembler` additionally caches its style indexes on the styles
+    `XDocument` with a style-count guard, and `MarkupSimplifier` skips the settings-part
+    rewrite when there are no rsids to strip).
+  - *`ListBlocks` now mirrors the renderer for block-level content controls.* A body-level
+    `w:sdt` (a TOC is the everyday case) contributes its `w:sdtContent` blocks as top-level
+    render units, matching the flattening the HTML converter performs — before this, any
+    document containing one diffed as 100 % churn and the incremental structural reconcile
+    permanently fell back to the multi-second full remount (insert row / delete block /
+    undo / redo each cost a whole-document convert on such documents).
+  - *Reconcile substitutions pair by unid first* (positional pairing only as fallback), and
+    a same-unid leaf render may swap into a border-wrapped slot when the old node is
+    provably from a single-block swap (no `data-render-sig`) — border-changing ops still
+    remount.
+  - *Per-op fixed costs removed:* `SetParagraphFormat` no longer eagerly rebuilds the whole
+    anchor index (pPr writes can't change an anchor's kind/scope/unid), `SplitParagraph`
+    derives the new paragraph's kind locally via the projector's `KindFor` instead of a
+    whole-document index rebuild, the block-render path resolves body anchors by a direct
+    unid walk when the index cache is cold, and the editor's Enter path renders both split
+    halves in one batched `RenderBlocksHtml` call.
+  - *The session's per-op index-only rebuild no longer flushes parts.* After every mutation
+    the anchor-index rebuild re-serialized any part where a Unid was assigned — a whole
+    main-part XML write per keystroke that nothing in the session flow reads (ops and
+    renders read the cached XDocuments; both `DocxSession.Save` paths flush every projected
+    part themselves). The full projection path keeps the flush for external callers.
 - **The live demo now opens a purpose-built Docxodus product guide instead of a generic test
   fixture.** The four-page, branded DOCX opens with the literal “Edit this document. It’s real.”
   and teaches through precise editable exercises, control walkthroughs, a preservation matrix, and

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -1462,10 +1462,17 @@ public sealed class DocxSession : IDisposable
 
     private IReadOnlyDictionary<string, AnchorTarget>? _cachedAnchorIndex;
 
+    /// <summary>Whether an anchor index is currently cached (a lookup now would be a dictionary
+    /// hit rather than a whole-document rebuild). Lets the block-render path choose a cheaper
+    /// resolution strategy right after a mutation invalidated the cache.</summary>
+    internal bool HasCachedAnchorIndex => _cachedProjection is not null || _cachedAnchorIndex is not null;
+
     /// <summary>
     /// The ordered top-level render units per scope container — see <see cref="RenderPlan"/>.
-    /// Body = the main body's direct children in document order (each <c>w:p</c> under its
-    /// projected kind, each <c>w:tbl</c> as ONE <c>tbl</c> unit); Footnotes/Endnotes = the
+    /// Body = the main body's blocks in document order (each <c>w:p</c> under its
+    /// projected kind, each <c>w:tbl</c> as ONE <c>tbl</c> unit), with a block-level
+    /// <c>w:sdt</c> flattened to its <c>w:sdtContent</c> blocks — mirroring the renderer,
+    /// which strips content controls; Footnotes/Endnotes = the
     /// non-boilerplate note definitions in part order. Elements the projection does not
     /// address (e.g. <c>w:sectPr</c>) are skipped. Unlike the projection itself, empty
     /// paragraphs are ALWAYS listed — the plan mirrors the rendered DOM, which contains
@@ -1480,15 +1487,30 @@ public sealed class DocxSession : IDisposable
         var bodyEl = _doc!.MainDocumentPart?.GetXDocument().Root?.Element(W.body);
         if (bodyEl is not null)
         {
-            foreach (var el in bodyEl.Elements())
+            // Mirrors the RENDERER's top-level block sequence, which is the only contract
+            // that lets a DOM diff work. The converter strips content controls
+            // (RemoveContentControls) and flows their block content inline, so a block-level
+            // w:sdt (a TOC is the everyday case) contributes its w:sdtContent blocks as
+            // top-level units here — without this, every document containing one diffs as
+            // full churn and the incremental reconcile permanently falls back to remount.
+            void AddUnits(XElement container)
             {
-                string? kind =
-                    el.Name == W.tbl ? "tbl" :
-                    el.Name == W.p ? WmlToMarkdownConverter.KindFor(el) : null;
-                var unid = (string?)el.Attribute(PtOpenXml.Unid);
-                if (kind is null || unid is null) continue;
-                body.Add(new RenderUnit($"{kind}:body:{unid}", kind, UnidHelper.ContentHash(el)));
+                foreach (var el in container.Elements())
+                {
+                    if (el.Name == W.sdt)
+                    {
+                        if (el.Element(W.sdtContent) is { } content) AddUnits(content);
+                        continue;
+                    }
+                    string? kind =
+                        el.Name == W.tbl ? "tbl" :
+                        el.Name == W.p ? WmlToMarkdownConverter.KindFor(el) : null;
+                    var unid = (string?)el.Attribute(PtOpenXml.Unid);
+                    if (kind is null || unid is null) continue;
+                    body.Add(new RenderUnit($"{kind}:body:{unid}", kind, UnidHelper.ContentHash(el)));
+                }
             }
+            AddUnits(bodyEl);
         }
 
         List<RenderUnit> Notes(XElement? root, XName noteName, bool endnotes, string kindScope)
@@ -4555,13 +4577,14 @@ public sealed class DocxSession : IDisposable
             InvalidateProjectionCache();
 
             // The new paragraph's kind can differ from the original (Heading -> Normal via the
-            // next-paragraph style), so resolve its anchor from the fresh projection rather than
-            // assuming the original kind.
-            var secondAnchor =
-                AnchorForUnid(secondUnid, target.PartUri)
-                ?? new Anchor(
-                    $"{target.Anchor.Kind}:{target.Anchor.Scope}:{secondUnid}",
-                    target.Anchor.Kind, target.Anchor.Scope, secondUnid);
+            // next-paragraph style), so derive it from the element itself with the projector's
+            // own KindFor — the same derivation a full index rebuild would apply, minus the
+            // whole-document walk that made Enter the second-most expensive part of a split.
+            // `second` is already attached, so KindFor's style-chain lookup resolves.
+            var secondKind = WmlToMarkdownConverter.KindFor(second) ?? target.Anchor.Kind;
+            var secondAnchor = new Anchor(
+                $"{secondKind}:{target.Anchor.Scope}:{secondUnid}",
+                secondKind, target.Anchor.Scope, secondUnid);
 
             return new EditResult
             {
@@ -4699,15 +4722,27 @@ public sealed class DocxSession : IDisposable
     }
 
     // Cached formatting "shell" for session-attached single-block rendering (see
-    // Internal.HtmlConversionOps.RenderBlockHtml). A serialized throwaway .docx holding the
-    // formatting parts (styles/numbering/theme/fontTable/settings) + an empty body, built ONCE and
-    // reused across renders so a keystroke commit doesn't re-clone the (potentially huge) style
-    // gallery every time. HtmlConversionOps owns these; it rebuilds the shell when
+    // Internal.HtmlConversionOps.RenderBlockHtml): an OPEN throwaway .docx holding the formatting
+    // parts (styles/numbering/theme/fontTable/settings) + a body that each render replaces
+    // wholesale. Kept open across renders so a keystroke commit pays neither the part clone NOR
+    // the package re-open + styles/numbering XML re-parse — those parses (and the style/numbering
+    // resolution caches the converter annotates onto the part XDocuments) are the dominant fixed
+    // cost of a single-block render. HtmlConversionOps owns these; it rebuilds the shell when
     // <see cref="RenderShellSignature"/> (a cheap content signature of the formatting parts) changes
     // — i.e. when a format op adds a style / numbering level. Text edits never touch those parts, so
-    // the shell survives normal typing. Disposed implicitly with the session (plain GC).
-    internal byte[]? RenderShellBytes;
+    // the shell survives normal typing.
+    internal WordprocessingDocument? RenderShellDoc;
+    internal MemoryStream? RenderShellStream;
     internal long RenderShellSignature;
+
+    /// <summary>Release the cached block-render shell (rebuild happens lazily on next render).</summary>
+    internal void DisposeRenderShell()
+    {
+        RenderShellDoc?.Dispose();
+        RenderShellStream?.Dispose();
+        RenderShellDoc = null;
+        RenderShellStream = null;
+    }
 
     internal EditResult RawInsertXmlInternal(string anchorId, Position pos, string xml)
     {
@@ -5319,13 +5354,15 @@ public sealed class DocxSession : IDisposable
                 ApplyParagraphBorders(pPr, op.TopBorder, op.BottomBorder, op.ClearBorders is true);
 
             InvalidateProjectionCache();
-            var freshIndex = AnchorIndex();
-            var updated = AnchorForUnid(target.Unid, target.PartUri) ?? target.Anchor;
-
+            // pPr-only writes (jc/ind/spacing/pBdr/pageBreakBefore) can't change an anchor's
+            // kind — KindFor derives it from pStyle/numPr, which this op never touches — nor
+            // its scope or unid, so the cached anchor stays valid. Skipping the eager
+            // whole-document index rebuild here roughly halves this op's latency on a real
+            // document (the invalidated cache refills lazily on the next lookup).
             return new EditResult
             {
                 Success = true,
-                Modified = new[] { updated },
+                Modified = new[] { target.Anchor },
                 Patch = PatchFor(target),
             };
         }
@@ -8172,6 +8209,7 @@ public sealed class DocxSession : IDisposable
     {
         if (_disposed) return;
         _disposed = true;
+        DisposeRenderShell();
         _doc?.Dispose();
         _stream?.Dispose();
         _doc = null;

--- a/Docxodus/FormattingAssembler.cs
+++ b/Docxodus/FormattingAssembler.cs
@@ -54,33 +54,47 @@ namespace Docxodus
             // synthesized part stays in wDoc, consistent with this method's in-place mutation.
             Internal.StyleFactory.EnsureStylesPart(wDoc.MainDocumentPart);
 
-            FormattingAssemblerInfo fai = new FormattingAssemblerInfo();
             XDocument sXDoc = wDoc.MainDocumentPart.StyleDefinitionsPart.GetXDocument();
 
-            // Optimization #1: Build style indexes once for O(1) lookups throughout processing
-            IndexStylesDocument(sXDoc, fai);
-
-            // Find default styles using the indexed data (single pass through styles)
-            foreach (var style in sXDoc.Root.Elements(W.style))
+            // The assembler info (style indexes + rolled-up style caches) is derived from the
+            // styles part alone, so it is cached ON the styles XDocument and reused across
+            // conversions of the same in-memory document — the session-attached single-block
+            // render converts through one long-lived shell, and rebuilding these per render was
+            // a fixed cost on every keystroke commit. The style count guards the cache: callers
+            // that add styles between conversions (StyleFactory) get a fresh index.
+            int styleCount = sXDoc.Root.Elements(W.style).Count();
+            FormattingAssemblerInfo fai = sXDoc.Annotation<FormattingAssemblerInfo>();
+            if (fai == null || fai.IndexedStyleCount != styleCount)
             {
-                if (style.Attribute(W._default).ToBoolean() != true)
-                    continue;
+                sXDoc.RemoveAnnotations<FormattingAssemblerInfo>();
+                fai = new FormattingAssemblerInfo { IndexedStyleCount = styleCount };
 
-                var styleType = (string)style.Attribute(W.type);
-                var styleId = (string)style.Attribute(W.styleId);
+                // Optimization #1: Build style indexes once for O(1) lookups throughout processing
+                IndexStylesDocument(sXDoc, fai);
 
-                switch (styleType)
+                // Find default styles using the indexed data (single pass through styles)
+                foreach (var style in sXDoc.Root.Elements(W.style))
                 {
-                    case "paragraph":
-                        fai.DefaultParagraphStyleName = styleId;
-                        break;
-                    case "character":
-                        fai.DefaultCharacterStyleName = styleId;
-                        break;
-                    case "table":
-                        fai.DefaultTableStyleName = styleId;
-                        break;
+                    if (style.Attribute(W._default).ToBoolean() != true)
+                        continue;
+
+                    var styleType = (string)style.Attribute(W.type);
+                    var styleId = (string)style.Attribute(W.styleId);
+
+                    switch (styleType)
+                    {
+                        case "paragraph":
+                            fai.DefaultParagraphStyleName = styleId;
+                            break;
+                        case "character":
+                            fai.DefaultCharacterStyleName = styleId;
+                            break;
+                        case "table":
+                            fai.DefaultTableStyleName = styleId;
+                            break;
+                    }
                 }
+                sXDoc.AddAnnotation(fai);
             }
 
             ListItemRetrieverSettings listItemRetrieverSettings = new ListItemRetrieverSettings();
@@ -4022,6 +4036,8 @@ namespace Docxodus
             public string DefaultParagraphStyleName;
             public string DefaultCharacterStyleName;
             public string DefaultTableStyleName;
+            /// <summary>Style-element count at index time — cache guard (see AssembleFormatting).</summary>
+            public int IndexedStyleCount;
             public Dictionary<string, XElement> RolledCharacterStyles;
 
             // Optimization #1: Pre-indexed style lookups (O(1) instead of O(n) linear search)

--- a/Docxodus/Internal/HtmlConversionOps.cs
+++ b/Docxodus/Internal/HtmlConversionOps.cs
@@ -346,12 +346,29 @@ internal static class HtmlConversionOps
     /// default/first/even header stories), unid-scan fallback, one projection retry for
     /// anchors not yet on the live tree.
     /// </summary>
+    /// <remarks>
+    /// When the session's anchor-index cache is COLD (the preceding mutation invalidated
+    /// it — i.e. on every single-block re-render an editor performs), a body-scope anchor
+    /// resolves by a direct unid walk of the main part instead: the walk costs a fraction
+    /// of the whole-document index rebuild <see cref="DocxSession.FindAnchor"/> would
+    /// trigger, and for main-part elements it is exactly as authoritative (a body/unid
+    /// collision resolves to the main part in both). Non-body scopes keep the index path —
+    /// only the index knows which header/footer part owns a colliding unid.
+    /// </remarks>
     private static XElement? ResolveSessionAnchor(DocxSession session, string anchorId)
     {
         if (string.IsNullOrWhiteSpace(anchorId)) return null;
         var liveDoc = session.LiveDocument;
-        var el = session.FindAnchor(anchorId)?.Resolve(liveDoc);
         var unid = AnchorUnid(anchorId);
+
+        XElement? el = null;
+        if (!session.HasCachedAnchorIndex && AnchorScope(anchorId) == "body")
+        {
+            bool Match(XElement e) => (string?)e.Attribute(PtOpenXml.Unid) == unid;
+            el = liveDoc.MainDocumentPart?.GetXDocument().Root?.DescendantsAndSelf().FirstOrDefault(Match);
+        }
+
+        el ??= session.FindAnchor(anchorId)?.Resolve(liveDoc);
         el ??= FindByUnid(liveDoc, unid);
         if (el is null)
         {
@@ -359,6 +376,14 @@ internal static class HtmlConversionOps
             el = session.FindAnchor(anchorId)?.Resolve(liveDoc) ?? FindByUnid(liveDoc, unid);
         }
         return el;
+    }
+
+    /// <summary>The scope segment of a <c>kind:scope:unid</c> anchor id ("" when malformed).</summary>
+    private static string AnchorScope(string anchorId)
+    {
+        int first = anchorId.IndexOf(':');
+        int last = anchorId.LastIndexOf(':');
+        return first >= 0 && last > first ? anchorId.Substring(first + 1, last - first - 1) : "";
     }
 
     /// <summary>
@@ -372,9 +397,15 @@ internal static class HtmlConversionOps
         DocxSession session, WordprocessingDocument liveDoc, List<XElement> targets, HtmlConversionOptions options)
     {
         long sig = ComputeFormattingSignature(liveDoc);
-        if (session.RenderShellBytes is null || session.RenderShellSignature != sig)
+        if (session.RenderShellDoc is null || session.RenderShellSignature != sig)
         {
-            session.RenderShellBytes = BuildShellDocBytes(liveDoc);
+            session.DisposeRenderShell();
+            var shellBytes = BuildShellDocBytes(liveDoc);
+            var shellStream = new MemoryStream();
+            shellStream.Write(shellBytes, 0, shellBytes.Length);
+            shellStream.Position = 0;
+            session.RenderShellStream = shellStream;
+            session.RenderShellDoc = WordprocessingDocument.Open(shellStream, true);
             session.RenderShellSignature = sig;
         }
 
@@ -415,13 +446,17 @@ internal static class HtmlConversionOps
         var htmlByUnid = new Dictionary<string, string?>(StringComparer.Ordinal);
         if (bodyContent.Count == 0) return htmlByUnid;
 
-        using var ms = new MemoryStream();
-        ms.Write(session.RenderShellBytes, 0, session.RenderShellBytes.Length);
-        ms.Position = 0;
-        using var renderDoc = WordprocessingDocument.Open(ms, true);
-        var bodyEl = renderDoc.MainDocumentPart!.GetXDocument().Root!.Element(W.body)!;
-        bodyEl.RemoveNodes();
-        foreach (var el in bodyContent) bodyEl.Add(el);
+        // Render through the OPEN shell. Each render replaces the main part's XDocument with a
+        // brand-new body document (PutXDocument swaps the cached XDocument annotation), so the
+        // converter's per-render root annotations (comment/footnote trackers, section info, field
+        // info) can never leak from one render into the next — while the formatting-part
+        // XDocuments, and the style/numbering resolution caches the converter annotates onto
+        // them, persist across renders. That persistence is the point: re-opening the shell per
+        // render paid the package open + styles/numbering parse + cache rebuild on every
+        // keystroke commit, and it dominated single-block render time.
+        var renderDoc = session.RenderShellDoc;
+        renderDoc.MainDocumentPart!.PutXDocument(
+            BuildBodyDocument(bodyContent.Cast<object>().ToArray()));
 
         var htmlElement = WmlToHtmlConverter.ConvertToHtml(renderDoc, BuildBlockConverterSettings(options));
         foreach (var e in htmlElement.Descendants())
@@ -551,10 +586,12 @@ internal static class HtmlConversionOps
 
     /// <summary>
     /// Build the reusable per-session "shell": a serialized throwaway .docx holding the copied
-    /// formatting parts and an EMPTY body. Built once (per formatting signature) and cached on the
-    /// session; <see cref="RenderTargetsFromShell"/> drops the batch's blocks into its body per
-    /// render. This front-loads the (expensive on a large style gallery) part clone+serialize so
-    /// it is paid once rather than every keystroke commit.
+    /// formatting parts and an EMPTY body. Built once (per formatting signature); the caller
+    /// opens it and keeps it OPEN on the session (<see cref="DocxSession.RenderShellDoc"/>), and
+    /// <see cref="RenderTargetsFromShell"/> replaces its main-part body document per render.
+    /// This front-loads the part clone+serialize AND the package open + formatting-part XML
+    /// parse (both expensive on a large style gallery) so they are paid once rather than on
+    /// every keystroke commit.
     /// </summary>
     private static byte[] BuildShellDocBytes(WordprocessingDocument sourceDoc)
     {

--- a/Docxodus/MarkupSimplifier.cs
+++ b/Docxodus/MarkupSimplifier.cs
@@ -104,7 +104,9 @@ namespace Docxodus
             if (part == null) return;
 
             XDocument settingsXDoc = part.GetXDocument();
-            settingsXDoc.Descendants(W.rsids).Remove();
+            var rsids = settingsXDoc.Descendants(W.rsids).ToList();
+            if (rsids.Count == 0) return; // nothing to strip — skip the part rewrite
+            rsids.ForEach(r => r.Remove());
             part.PutXDocument();
         }
 

--- a/Docxodus/WmlToMarkdownConverter.cs
+++ b/Docxodus/WmlToMarkdownConverter.cs
@@ -382,12 +382,22 @@ public static class WmlToMarkdownConverter
     /// ops resolve anchors through (<see cref="DocxSession.AnchorIndex"/>), so an edit
     /// doesn't pay a whole-document markdown render just to look up one anchor id.
     /// </summary>
+    /// <summary>
+    /// The cheap index-only rebuild <see cref="DocxSession"/> performs after every mutation.
+    /// Skips the per-part Unid flush as well as enrichment: the flush re-serializes a whole
+    /// part's XML whenever any Unid was assigned — i.e. after EVERY mutation — and nothing in
+    /// the session flow reads part STREAMS between ops (ops and renders read the cached
+    /// XDocuments; both <see cref="DocxSession.Save(bool)"/> paths flush every projected part
+    /// themselves). The full projection path keeps the flush for external callers who save a
+    /// projected document directly.
+    /// </summary>
     internal static IReadOnlyDictionary<string, AnchorTarget> BuildAnchorIndexOnly(
         WordprocessingDocument doc, WmlToMarkdownConverterSettings settings) =>
-        BuildAnchorIndex(doc, settings, enrich: false).Index;
+        BuildAnchorIndex(doc, settings, enrich: false, flushAssignedUnids: false).Index;
 
     private static (IReadOnlyDictionary<string, AnchorTarget> Index, List<ScopeInfo> Scopes, AnchorIdMap RenderMap)
-        BuildAnchorIndex(WordprocessingDocument doc, WmlToMarkdownConverterSettings settings, bool enrich = true)
+        BuildAnchorIndex(WordprocessingDocument doc, WmlToMarkdownConverterSettings settings, bool enrich = true,
+            bool flushAssignedUnids = true)
     {
         var main = doc.MainDocumentPart
             ?? throw new InvalidOperationException("Document has no MainDocumentPart.");
@@ -477,8 +487,10 @@ public static class WmlToMarkdownConverter
             // Persist newly-assigned Unids to the part. Skipped when nothing was
             // assigned — the flush is ~19 ms/part on a large document, per rebuild.
             // Content mutations no longer depend on this flush: DocxSession.Save
-            // flushes every projected part itself on BOTH its paths.
-            if (assignedAny) scope.Part.PutXDocument();
+            // flushes every projected part itself on BOTH its paths — which is why
+            // the session's per-op index-only rebuild passes flushAssignedUnids:
+            // false (see BuildAnchorIndexOnly) and skips it entirely.
+            if (assignedAny && flushAssignedUnids) scope.Part.PutXDocument();
         }
 
         // Build the AnchorIdMap based on the requested rendering mode.

--- a/docs/architecture/editor_ui_surface.md
+++ b/docs/architecture/editor_ui_surface.md
@@ -205,29 +205,47 @@ above shows `Last Updated October 2025 i` on page 1 of a section formatted `lowe
 
 ## 9. What operations cost
 
-Measured on the 346-block document above (Chromium, WASM, warm):
+Measured on a real document (`HC031-Complicated-Document.docx`, Chromium, WASM, warm) by
+`npm/tests/editor-latency-bench.spec.ts` — the standing latency instrument; run it before and
+after touching any hot path. Values are single-sample and machine-dependent; treat them as
+ratios, not contracts:
 
-| Operation | Cost | Why |
-|-----------|------|-----|
-| Open + first render | ~5–8 s | Full document conversion (one-time; M3 worker offload is the open item) |
-| Text edit (commit on blur) | ~150–220 ms | Single-block re-render + note-marker repair |
-| `setPageNumbering` | ~285 ms | Section attribute + band repaint |
-| `save()` | ~220 ms | Lossless serialize |
-| Undo / redo | ~200–360 ms | Incremental reconcile (was ~5.6 s as a full remount) |
-| Insert table / row | ~225–245 ms | Incremental reconcile (was ~6 s) |
-| Insert footnote | ~210 ms | Incremental reconcile + chrome renumber (was ~6.2 s) |
-| Delete block | ~95 ms | Incremental reconcile |
+| Operation | Cost | Before the 2026-08 latency pass | Why |
+|-----------|------|--------------------------------|-----|
+| Open + first render | ~3 s | ~3 s | Full document conversion (one-time; M3 worker offload is the open item) |
+| Text edit (commit on blur) | ~30 ms | ~100 ms | Session op + single-block re-render through the persistent shell |
+| Inline format (bold, size) | ~35–50 ms | ~90–110 ms | Same, plus selection restore |
+| Paragraph format (align) | ~40 ms | ~85 ms | Same |
+| Enter (split) | ~40 ms | ~135 ms | Both halves render in ONE batched `RenderBlocksHtml` call |
+| Backspace (merge) | ~25 ms | ~80 ms | Session op + one block render |
+| Insert table / row | ~85–130 ms | ~1.2–1.5 s (remount on real docs) | Incremental reconcile |
+| Delete block | ~25 ms | ~1.2 s (remount on real docs) | Incremental reconcile |
+| Undo / redo | ~55–125 ms | ~1.1–1.2 s (remount on real docs) | Snapshot restore + incremental reconcile |
+| `save()` | ~60–80 ms | ~60 ms | Lossless serialize |
 
-Structural operations no longer remount: `DocxEditor.reconcile()` diffs the DOM's top-level unit
+The "before" column's structural-op numbers deserve a note: the incremental reconcile existed,
+but on any document containing a block-level `w:sdt` (a TOC — i.e. most real documents) the
+render plan missed the sdt's content blocks, the plan/DOM diff read as 100 % churn, and every
+structural op silently fell back to the multi-second full remount. `ListBlocks` now flattens
+`w:sdtContent` exactly as the renderer does, so the diff actually engages.
+
+Structural operations reconcile: `DocxEditor.reconcile()` diffs the DOM's top-level unit
 sequence against the session's render plan (`ListBlocks` — LCS over `unid|contentHash` tokens),
 keeps unchanged units' DOM nodes, renders changed/created units in one batched WASM call
 (`RenderBlocksHtml`, with real sibling context and true list-marker numbers), and renumbers
-footnote/endnote marker chrome positionally from `ListNotes`. A full remount survives as the
-universal **fallback** — paginated mode, pure list-item insert/remove (sibling numbers shift
-without sibling XML changing), border-`div` regrouping (`insertHorizontalRule`, `clearBorders`,
-list toggles), or any inconsistency — so correctness never depends on the diff; the reconciled DOM
-is pinned equal to a remounted DOM by `npm/tests/editor-reconcile.spec.ts`. When an op reads
-slow in the rail, `editor['lastReconcileFallback']` says why it fell back.
+footnote/endnote marker chrome positionally from `ListNotes`. Substituted units pair by unid
+first, positionally as fallback. A full remount survives as the universal **fallback** —
+paginated mode, pure list-item insert/remove (sibling numbers shift without sibling XML
+changing), border-`div` regrouping (`insertHorizontalRule`, `clearBorders`, list toggles), or
+any inconsistency — so correctness never depends on the diff; the reconciled DOM is pinned
+equal to a remounted DOM by `npm/tests/editor-reconcile.spec.ts`. When an op reads slow in the
+rail, `editor['lastReconcileFallback']` says why it fell back.
+
+Single-block re-renders go through a **persistent render shell**: the session keeps an open
+throwaway document holding the formatting parts, and each render replaces only its body
+(`HtmlConversionOps.RenderTargetsFromShell`), so the package open, styles/numbering parse, and
+the converter's style-resolution caches are paid once per formatting-signature change instead
+of per keystroke.
 
 ---
 

--- a/docs/architecture/ir_editor_roadmap.md
+++ b/docs/architecture/ir_editor_roadmap.md
@@ -59,6 +59,26 @@ block(s), insert/remove nodes, update the `unid → fullId` map, place the caret
 restored exactly), and round-trips through save. Insert-at-doc-start and block delete/reorder
 remain follow-ups (Enter-split + Backspace-merge cover the core authoring loop).
 
+### M2.7 — Latency pass: persistent render shell + reconcile on real documents  · effort M · ✅ **DONE**
+**Problem:** interactive ops were still visibly laggy. Two causes: (1) every single-block
+re-render re-opened the render shell from bytes — package open + styles/numbering parse +
+converter style-cache rebuild on every keystroke commit (~50–100 ms of the ~55–135 ms per
+op); (2) on any document containing a block-level `w:sdt` (a TOC — most real documents),
+`ListBlocks` missed the sdt's content blocks, the plan/DOM diff read as 100 % churn, and
+M2.6's reconcile silently fell back to the multi-second remount for EVERY structural op.
+**Shipped:** the shell `WordprocessingDocument` stays open on the session and each render
+replaces only the main part's body document (annotation caches on the formatting-part
+XDocuments persist; `FormattingAssembler` caches its style indexes on the styles XDocument
+behind a style-count guard); `ListBlocks` flattens `w:sdtContent` exactly as the renderer
+does; reconcile substitutions pair by unid first; sig-less (single-block-swapped) wrapped
+paragraphs may leaf-swap in place; `SetParagraphFormat`/`SplitParagraph` no longer rebuild
+the whole anchor index per op; the per-op index-only rebuild no longer flushes parts (the
+whole-main-part XML write per keystroke that only external save paths need); Enter renders
+both split halves in one batched call. Measured (HC031, warm): text commit 102 → 30 ms,
+Enter 137 → 41 ms, bold 108 → 52 ms, insert row 1.25 s → 85 ms, delete block 1.2 s → 24 ms,
+undo/redo ~1.2 s → 124/54 ms. Standing instrument:
+`npm/tests/editor-latency-bench.spec.ts`.
+
 ### M2.6 — Incremental STRUCTURAL repaint (reconcile replaces remount)  · effort L · ✅ **DONE**
 **Problem:** every structural op (insert table/row/col, footnote/endnote, delete block,
 undo/redo) paid a full remount — ~5–6 s on a 346-block document — and the engine ops

--- a/npm/src/editor-reconcile.ts
+++ b/npm/src/editor-reconcile.ts
@@ -100,8 +100,37 @@ export function diffUnits(oldUnids: string[], newUnits: RenderUnit[]): UnitDiff 
   while (i < n) removed.push(i++);
   while (j < m) added.push(j++);
 
-  // Substitutions: an added index and a removed index with the same number of
-  // kept units before them — an in-place change of one unit.
+  // Substitutions: an added index and a removed index that are an IN-PLACE change
+  // of one unit. Paired by UNID first — a block whose content changed keeps its
+  // unid (unids are sticky in-session; only the content signature part of the
+  // token moves), so an equal-unid add/remove pair is that block re-rendering in
+  // place regardless of how many other units changed around it. Position-based
+  // (kept-count) pairing is the fallback for genuine replacements; unid pairing
+  // must run first or several same-position changes mispair, e.g. binding an
+  // edited paragraph's fresh render to a NEIGHBOR's border-wrapped node — which
+  // the DOM patcher can only resolve by bailing to a full remount.
+  const bareUnid = (token: string): string => {
+    const bar = token.indexOf("|");
+    return bar < 0 ? token : token.slice(0, bar);
+  };
+  const substituted: Array<{ oldIndex: number; newIndex: number }> = [];
+  const usedRemoved = new Set<number>();
+  const removedByUnid = new Map<string, number[]>();
+  for (const oi of removed) {
+    const u = bareUnid(oldUnids[oi]);
+    (removedByUnid.get(u) ?? removedByUnid.set(u, []).get(u)!).push(oi);
+  }
+  const unmatchedAdded: number[] = [];
+  for (const nj of added) {
+    const candidates = removedByUnid.get(bareUnid(newUnids[nj]));
+    const oi = candidates?.find((i) => !usedRemoved.has(i));
+    if (oi !== undefined) {
+      substituted.push({ oldIndex: oi, newIndex: nj });
+      usedRemoved.add(oi);
+    } else {
+      unmatchedAdded.push(nj);
+    }
+  }
   const keptBeforeOld = (oi: number): number => {
     let c = 0;
     for (const v of keep.values()) if (v < oi) c++;
@@ -112,9 +141,7 @@ export function diffUnits(oldUnids: string[], newUnits: RenderUnit[]): UnitDiff 
     for (const k of keep.keys()) if (k < nj) c++;
     return c;
   };
-  const substituted: Array<{ oldIndex: number; newIndex: number }> = [];
-  const usedRemoved = new Set<number>();
-  for (const nj of added) {
+  for (const nj of unmatchedAdded) {
     const target = keptBeforeNew(nj);
     for (const oi of removed) {
       if (usedRemoved.has(oi)) continue;

--- a/npm/src/editor.ts
+++ b/npm/src/editor.ts
@@ -1177,8 +1177,7 @@ export class DocxEditor {
       return;
     }
 
-    const firstEl = this.renderInto(first.id);
-    const secondEl = this.renderInto(second.id);
+    const [firstEl, secondEl] = this.renderTwo(first.id, second.id);
     if (!firstEl || !secondEl) return;
 
     // el is the focused block — replaceNode guards the re-entrant blur→commit and tolerates a
@@ -1315,6 +1314,40 @@ export class DocxEditor {
     );
     if (html.charCodeAt(0) === 0x7b /* error object */) return null;
     return new DOMParser().parseFromString(html, "text/html").body.firstElementChild as HTMLElement | null;
+  }
+
+  /** Render two blocks in ONE batched bridge call when the bundle carries RenderBlocksHtml —
+   *  the per-render shell/converter setup is paid once instead of twice, which matters on the
+   *  Enter path (split renders both halves synchronously under the keystroke). Falls back to
+   *  two per-block renders on older bundles. Output is renderInto-identical per block (both
+   *  routes share the same extraction). */
+  private renderTwo(a: string, b: string): [HTMLElement | null, HTMLElement | null] {
+    const bridge = this.exports.DocxSessionBridge;
+    if (typeof bridge.RenderBlocksHtml === "function") {
+      try {
+        const map = JSON.parse(
+          bridge.RenderBlocksHtml(
+            this.handle,
+            JSON.stringify([a, b]),
+            this.options.cssPrefix,
+            this.options.fabricateClasses,
+          ),
+        ) as Record<string, string | null> & { error?: string };
+        if (!map.error) {
+          const parse = (h: string | null | undefined): HTMLElement | null =>
+            h
+              ? (new DOMParser().parseFromString(h, "text/html").body
+                  .firstElementChild as HTMLElement | null)
+              : null;
+          const fa = parse(map[a]);
+          const fb = parse(map[b]);
+          if (fa && fb) return [fa, fb];
+        }
+      } catch {
+        /* fall through to per-block renders */
+      }
+    }
+    return [this.renderInto(a), this.renderInto(b)];
   }
 
   /** The editable block immediately before `el` within its own root, or null. */
@@ -2244,7 +2277,8 @@ export class DocxEditor {
       if (oldMarker !== newMarker) return this.bail("substituted li marker drift");
     }
 
-    if (!this.applyBodyDiff(oldNodes, plan.body, bodyDiff, freshBody)) return this.bail("applyBodyDiff bail");
+    const bodyApply = this.applyBodyDiff(oldNodes, plan.body, bodyDiff, freshBody);
+    if (bodyApply !== true) return this.bail(`applyBodyDiff bail: ${bodyApply}`);
     this.applyNotesDiff("footnotes", plan.footnotes, fnState, rendered);
     this.applyNotesDiff("endnotes", plan.endnotes, enState, rendered);
 
@@ -2292,21 +2326,21 @@ export class DocxEditor {
       : root.querySelector<HTMLElement>("[data-anchor]");
   }
 
-  /** Insert/remove/swap body unit nodes per the diff. Returns false to bail (parent
-   *  ambiguity, order violation, wrapper semantics) — the session is already correct,
-   *  so bailing just means a full repaint. */
+  /** Insert/remove/swap body unit nodes per the diff. Returns `true` on success or a
+   *  bail-reason string (parent ambiguity, order violation, wrapper semantics) — the
+   *  session is already correct, so bailing just means a full repaint. */
   private applyBodyDiff(
     oldNodes: HTMLElement[],
     units: RenderUnit[],
     diff: UnitDiff,
     fresh: Map<number, HTMLElement>,
-  ): boolean {
+  ): true | string {
     // Kept nodes must appear in increasing old order (no move support in v1).
     let lastOld = -1;
     for (let j = 0; j < units.length; j++) {
       const oi = diff.keep.get(j);
       if (oi === undefined) continue;
-      if (oi < lastOld) return false;
+      if (oi < lastOld) return "kept order violation";
       lastOld = oi;
     }
 
@@ -2321,8 +2355,21 @@ export class DocxEditor {
         oldWrapper.replaceWith(freshRoot); // wrapper-shaped render (table) ⇄ wrapper
       } else if (oldWrapper === oldNodes[oi]) {
         oldNodes[oi].replaceWith(freshRoot);
+      } else if (
+        !oldNodes[oi].hasAttribute("data-render-sig") &&
+        unidOf(units[nj].id) === oldNodes[oi].getAttribute("data-anchor")
+      ) {
+        // Same block, leaf render, wrapped slot, and the old node carries NO signature:
+        // a sig-less node is one a SINGLE-BLOCK swap placed (mount and reconcile both
+        // stamp signatures), and those swaps never change border grouping — every
+        // border-changing op forces a full remount. The wrapper is therefore still
+        // valid; swap the leaf inside it, exactly as the single-block path itself does
+        // for a bordered paragraph. A STAMPED wrapped slot whose content changed stays
+        // remount territory — the change could be the border itself.
+        oldNodes[oi].replaceWith(freshRoot);
       } else {
-        return false; // leaf render into a wrapped slot — border-div semantics, remount
+        // border-div semantics, remount
+        return `leaf render into wrapped slot (unit ${units[nj].id.slice(0, 24)})`;
       }
       this.wireUnit(freshRoot, units[nj]);
     }
@@ -2351,10 +2398,11 @@ export class DocxEditor {
       }
       const prevW = prev ? this.unitWrapperOf(prev) : null;
       const nextW = next ? this.unitWrapperOf(next) : null;
-      if (prevW && nextW && prevW.parentElement !== nextW.parentElement) return false;
+      if (prevW && nextW && prevW.parentElement !== nextW.parentElement)
+        return "insert neighbors in different parents";
       if (prevW) prevW.after(el);
       else if (nextW) nextW.before(el);
-      else return false; // empty container — nowhere provably correct to insert
+      else return "insert with no anchored neighbor"; // empty container — nowhere provably correct
       this.wireUnit(el, units[j]);
     }
 

--- a/npm/tests/editor-latency-bench.spec.ts
+++ b/npm/tests/editor-latency-bench.spec.ts
@@ -1,0 +1,244 @@
+import { test, expect, Page } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const TEST_FILES_DIR = path.join(__dirname, '../../TestFiles');
+
+function readTestFile(relativePath: string): Uint8Array {
+  return new Uint8Array(fs.readFileSync(path.join(TEST_FILES_DIR, relativePath)));
+}
+
+async function waitForDocxodus(page: Page) {
+  await page.waitForFunction(() => (window as any).DocxodusReady === true, { timeout: 30000 });
+}
+
+/**
+ * Editor latency benchmark — a breakdown of where each interactive editor
+ * operation spends its time, instrumented at the WASM bridge boundary.
+ *
+ * This is a MEASUREMENT harness, not a fidelity pin: assertions are minimal
+ * (ops must succeed), and the numbers go to stdout so perf work has a stable
+ * before/after instrument. Timings on CI vary; nothing here asserts absolute ms.
+ */
+test.describe('DocxEditor — operation latency benchmark', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/test-harness.html');
+    await waitForDocxodus(page);
+  });
+
+  test('per-op latency breakdown on a real document', async ({ page }) => {
+    test.setTimeout(180000);
+    const bytes = readTestFile('HC031-Complicated-Document.docx');
+    await page.evaluate((bytesArray: number[]) => {
+      (window as any).testDocxBytes = new Uint8Array(bytesArray);
+    }, Array.from(bytes));
+
+    const results = await page.evaluate(async () => {
+      const D = (window as any).Docxodus;
+      const bytes = (window as any).testDocxBytes as Uint8Array;
+
+      // ── Instrument every bridge call ──────────────────────────────────
+      const callLog: Record<string, { count: number; ms: number }> = {};
+      const wrap = (obj: any, tag: string) => {
+        const out: any = {};
+        for (const k of Object.keys(obj)) {
+          const v = obj[k];
+          if (typeof v !== 'function') { out[k] = v; continue; }
+          out[k] = (...args: any[]) => {
+            const t0 = performance.now();
+            try {
+              return v.apply(obj, args);
+            } finally {
+              const dt = performance.now() - t0;
+              const key = `${tag}.${k}`;
+              (callLog[key] ??= { count: 0, ms: 0 });
+              callLog[key].count++;
+              callLog[key].ms += dt;
+            }
+          };
+        }
+        return out;
+      };
+      const instrumented = {
+        DocxSessionBridge: wrap(D.DocxSessionBridge, 'S'),
+        DocumentConverter: wrap(D.DocumentConverter, 'C'),
+      };
+
+      const container = document.createElement('div');
+      container.id = 'bench';
+      document.body.appendChild(container);
+
+      const results: Record<string, { totalMs: number; calls: Record<string, { count: number; ms: number }>; fallback?: string | null }> = {};
+      const measure = async (name: string, fn: () => void | Promise<void>) => {
+        for (const k of Object.keys(callLog)) delete callLog[k];
+        const t0 = performance.now();
+        await fn();
+        const total = performance.now() - t0;
+        results[name] = {
+          totalMs: total,
+          calls: JSON.parse(JSON.stringify(callLog)),
+          fallback: editor ? (editor as any).lastReconcileFallback : undefined,
+        };
+      };
+
+      let editor: any;
+      await measure('open', () => {
+        editor = D.DocxEditor.open(container, bytes, instrumented, {});
+      });
+
+      const blocks = () =>
+        (Array.from(
+          container.querySelectorAll('p[data-anchor][contenteditable="true"]'),
+        ) as HTMLElement[]).filter(
+          (p) => !p.closest('table') && !p.closest('section.footnotes, section.endnotes') &&
+            (p.textContent || '').trim().length > 10,
+        );
+
+      const focusBlock = (el: HTMLElement) => {
+        el.focus();
+        const t = document.createTreeWalker(el, NodeFilter.SHOW_TEXT).nextNode();
+        if (t) {
+          const r = document.createRange();
+          r.setStart(t, 1);
+          r.collapse(true);
+          const s = window.getSelection()!;
+          s.removeAllRanges();
+          s.addRange(r);
+        }
+      };
+
+      // Warm-up: one commit so first-call JIT/lazy-init doesn't pollute op 1.
+      {
+        const b = blocks()[0];
+        focusBlock(b);
+        const t = document.createTreeWalker(b, NodeFilter.SHOW_TEXT).nextNode()!;
+        t.textContent = t.textContent + 'w';
+        b.blur();
+      }
+
+      // 1. Text commit (type + blur).
+      await measure('textCommit', () => {
+        const b = blocks()[1];
+        focusBlock(b);
+        const t = document.createTreeWalker(b, NodeFilter.SHOW_TEXT).nextNode()!;
+        t.textContent = t.textContent + 'X';
+        b.blur();
+      });
+
+      // 2. Bold on a sub-selection of one block.
+      await measure('formatBold', () => {
+        const b = blocks()[2];
+        focusBlock(b);
+        const t = document.createTreeWalker(b, NodeFilter.SHOW_TEXT).nextNode()!;
+        const r = document.createRange();
+        r.setStart(t, 0);
+        r.setEnd(t, Math.min(5, (t.textContent || '').length));
+        const s = window.getSelection()!;
+        s.removeAllRanges();
+        s.addRange(r);
+        editor.format('bold');
+      });
+
+      // 3. Font size on a sub-selection.
+      await measure('fontSize', () => {
+        const b = blocks()[3];
+        focusBlock(b);
+        const t = document.createTreeWalker(b, NodeFilter.SHOW_TEXT).nextNode()!;
+        const r = document.createRange();
+        r.setStart(t, 0);
+        r.setEnd(t, Math.min(5, (t.textContent || '').length));
+        const s = window.getSelection()!;
+        s.removeAllRanges();
+        s.addRange(r);
+        editor.setFontSize(14);
+      });
+
+      // 4. Alignment (paragraph op) on one block.
+      await measure('alignCenter', () => {
+        const b = blocks()[4];
+        focusBlock(b);
+        editor.setAlignment('center');
+      });
+
+      // 5. Enter (split at caret).
+      await measure('enterSplit', () => {
+        const b = blocks()[5];
+        focusBlock(b);
+        (editor as any).splitAtCaret(b);
+      });
+
+      // 6. Backspace merge (merge the split back).
+      await measure('backspaceMerge', () => {
+        const all = blocks();
+        const el = all[6];
+        const prev = (editor as any).previousEditable(el);
+        (editor as any).mergeWithPrevious(prev, el);
+      });
+
+      // 7. Structural: insert a table (reconcile path).
+      await measure('insertTable', () => {
+        const b = blocks()[7];
+        focusBlock(b);
+        editor.insertTable(2, 2, {});
+      });
+
+      // 8. Structural: insert a row into that table.
+      await measure('insertTableRow', () => {
+        const cellP = container.querySelector(
+          'table p[data-anchor][contenteditable="true"]',
+        ) as HTMLElement;
+        cellP.focus();
+        (editor as any).activeBlock = cellP;
+        editor.insertTableRow('below');
+      });
+
+      // 9. Structural: delete a block (reconcile path).
+      await measure('deleteBlock', () => {
+        const b = blocks()[8];
+        focusBlock(b);
+        (editor as any).activeBlock = b;
+        editor.deleteBlock();
+      });
+
+      // 10. Undo / redo (reconcile path).
+      await measure('undo', () => {
+        editor.undo();
+      });
+      await measure('redo', () => {
+        editor.redo();
+      });
+
+      // 11. Save (lossless serialize).
+      let savedLen = 0;
+      await measure('save', () => {
+        savedLen = editor.save().length;
+      });
+
+      const blockCount = container.querySelectorAll('[data-anchor]').length;
+      editor.close();
+      container.remove();
+      return { results, savedLen, blockCount };
+    });
+
+    // Emit the breakdown.
+    const fmt = (n: number) => n.toFixed(1).padStart(8);
+    console.log(`\n=== editor latency benchmark (HC031, ${results.blockCount} anchored nodes) ===`);
+    for (const [op, r] of Object.entries(results.results)) {
+      const calls = Object.entries(r.calls)
+        .sort((a, b) => b[1].ms - a[1].ms)
+        .map(([k, v]) => `${k}×${v.count} ${v.ms.toFixed(1)}ms`)
+        .join(', ');
+      const fb = r.fallback ? `  ⟲remount: ${r.fallback}` : '';
+      console.log(`${op.padEnd(16)} ${fmt(r.totalMs)}ms   [${calls}]${fb}`);
+    }
+
+    expect(results.savedLen).toBeGreaterThan(0);
+    // Every measured op must actually have hit the session bridge.
+    for (const key of ['textCommit', 'formatBold', 'enterSplit', 'undo', 'save']) {
+      expect(Object.keys(results.results[key].calls).length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Cuts the in-browser editor's interactive latency by **52–98 % per operation**, measured end-to-end on a real document (`HC031-Complicated-Document.docx`, Chromium/WASM, warm) by the new standing benchmark `npm/tests/editor-latency-bench.spec.ts`:

| Operation | Before | After | Reduction |
|---|---|---|---|
| Text commit (blur) | 102 ms | 30 ms | 71 % |
| Enter (split) | 137 ms | 41 ms | 70 % |
| Bold | 108 ms | 52 ms | 52 % |
| Font size | 88 ms | 34 ms | 62 % |
| Align | 84 ms | 41 ms | 52 % |
| Backspace (merge) | 79 ms | 25 ms | 68 % |
| Insert table | 1.49 s | 130 ms | 91 % |
| Insert row | 1.25 s | 85 ms | 93 % |
| Delete block | 1.2 s | 24 ms | 98 % |
| Undo / redo | ~1.2 s | 124 / 54 ms | 90 / 95 % |

## The five compounding fixes

1. **Persistent render shell** (`HtmlConversionOps.RenderTargetsFromShell`): the session-attached single-block render used to re-open its cached shell bytes — package open + styles/numbering XML parse — on every keystroke commit. The shell `WordprocessingDocument` now stays open on the session; each render replaces only the main part's body document (a fresh root per render, so converter root annotations can never leak between renders), while the formatting-part parses and the converter's style/numbering resolution caches persist. `FormattingAssembler` additionally caches its style indexes on the styles `XDocument` behind a style-count guard, and `MarkupSimplifier` skips the settings-part rewrite when there are no rsids to strip.

2. **`ListBlocks` mirrors the renderer for block-level content controls**: a body-level `w:sdt` (a TOC is the everyday case) now contributes its `w:sdtContent` blocks as top-level render units, matching the flattening the HTML converter performs. Before this, any document containing one diffed as 100 % churn and the incremental structural reconcile **silently fell back to the multi-second full remount on every structural op** — which is why insert row / delete block / undo / redo measured >1 s on real documents despite the M2.6 reconcile work.

3. **Reconcile substitutions pair by unid first** (positional kept-count pairing only as fallback), and a same-unid leaf render may swap into a border-wrapped slot when the old node is provably from a single-block swap (no `data-render-sig` — border-changing ops always force a remount, so the wrapper is still valid).

4. **Per-op fixed costs removed**: `SetParagraphFormat` no longer eagerly rebuilds the whole anchor index (pPr writes can't change an anchor's kind/scope/unid); `SplitParagraph` derives the new paragraph's kind locally via the projector's own `KindFor`; the block-render path resolves body anchors by a direct unid walk when the index cache is cold; the editor's Enter path renders both split halves in one batched `RenderBlocksHtml` call.

5. **The session's per-op index-only rebuild no longer flushes parts**: after every mutation, `BuildAnchorIndexOnly` re-serialized any part where a Unid was assigned — a whole main-part XML write per keystroke that nothing in the session flow reads (ops and renders read the cached XDocuments; both `DocxSession.Save` paths flush every projected part themselves). The full projection path keeps the flush for external callers.

## Verification

- Full .NET suite: **3355 passed, 0 failed** (run twice — mid-stack and after the final change).
- Full Playwright browser suite: **322 passed, 0 failed**.
- Fidelity pins that specifically guard these changes: `render-block.spec.ts` (single-block render ≡ full render, exercising many successive renders through the reused shell), `editor-reconcile.spec.ts` (reconciled DOM ≡ remounted DOM), `editor-perf-incremental.spec.ts` (RenderHtml ≡ bytes path).
- `npm/tests/editor-latency-bench.spec.ts` is committed as the standing latency instrument (prints a per-op bridge-call breakdown; asserts only that ops succeed).

## Docs

- CHANGELOG entry under `[Unreleased]`.
- `docs/architecture/editor_ui_surface.md` §9 cost table refreshed with before/after and the persistent-shell/reconcile notes.
- `docs/architecture/ir_editor_roadmap.md` gains M2.7 documenting this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FDySB3QCUig1NuwUN9J1p

---
_Generated by [Claude Code](https://claude.ai/code/session_014FDySB3QCUig1NuwUN9J1p)_