### PR TITLE
Keep cross-block drag highlighting live in Firefox

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -38,7 +38,7 @@ jobs:
         run: cd npm && npm run build
 
       - name: Install Playwright browsers
-        run: cd npm && npx playwright install --with-deps chromium
+        run: cd npm && npx playwright install --with-deps chromium firefox
 
       - name: Run Playwright tests
         run: cd npm && npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Cross-block drag selection now highlights continuously in Firefox.** The browser reapplied its
+  native per-`contenteditable` selection after each `mousemove`, visually fencing the highlight to
+  the first block until mouseup even though the final range and formatting were correct. The core
+  editor now coalesces bridged range updates into the pre-paint animation frame, preserving native
+  live highlighting without overlays or surface-specific patches. The physical-drag regression is
+  exercised in both Chromium and a dedicated Firefox Playwright project while the button is held.
+
 ## [9.1.1] - 2026-08-05
 
 ### Changed

--- a/docs/architecture/editor_ui_surface.md
+++ b/docs/architecture/editor_ui_surface.md
@@ -64,8 +64,10 @@ Each document block remains an independent `contenteditable` host so edits can b
 its stable OOXML anchor without replacing the surrounding document. Browsers normally fence a
 physical mouse drag at that host boundary, so `DocxEditor` takes over only after the pointer enters
 another editable block in the same OOXML story and exposes the gesture as one normalized DOM
-`Range`. Intra-block selection remains native, and body/header/footer story boundaries remain
-uncrossable.
+`Range`. Cross-block updates are coalesced into the next animation frame, after the browser's own
+mousemove selection update but before paint; this keeps Firefox's highlight live instead of
+snapping to the complete range only on mouseup. Intra-block selection remains native, and
+body/header/footer story boundaries remain uncrossable.
 
 Size and font controls cache the last real selection, because a combobox steals focus when clicked.
 Single-block selections are bookmarked as one anchor plus a span; multi-block selections use two

--- a/npm/playwright.config.ts
+++ b/npm/playwright.config.ts
@@ -26,6 +26,13 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
+    {
+      // Firefox is the canary for cross-contenteditable drag feedback: its native selection
+      // update runs after mousemove dispatch and used to erase the bridged Range until mouseup.
+      name: 'firefox-cross-block-selection',
+      testMatch: /editor-multiblock-format\.spec\.ts/,
+      use: { ...devices['Desktop Firefox'] },
+    },
   ],
   webServer: [
     {

--- a/npm/src/editor.ts
+++ b/npm/src/editor.ts
@@ -280,6 +280,14 @@ interface CrossBlockSelectionBookmark {
   endOffset: number;
 }
 
+interface CrossBlockDragSelection {
+  anchor: DomSelectionPoint;
+  origin: HTMLElement;
+  crossedBlockBoundary: boolean;
+  focus: DomSelectionPoint | null;
+  frame: number | null;
+}
+
 /** True if `block` renders as a list item (has a generated marker as its first child). */
 function isListBlock(block: HTMLElement): boolean {
   return !!block.querySelector(":scope > [data-list-marker]");
@@ -711,11 +719,7 @@ export class DocxEditor {
   private lastCrossBlockSelection: CrossBlockSelectionBookmark | null = null;
 
   /** State for the mouse-selection bridge between independent contenteditable block hosts. */
-  private dragSelection: {
-    anchor: DomSelectionPoint;
-    origin: HTMLElement;
-    crossedBlockBoundary: boolean;
-  } | null = null;
+  private dragSelection: CrossBlockDragSelection | null = null;
 
   /** The docked header/footer bands, when `options.headerFooter` is on. */
   private region: HeaderFooterRegion | null = null;
@@ -790,8 +794,46 @@ export class DocxEditor {
     if (!origin || isInMarker(target)) return;
     const anchor = caretPointFromClient(document, event.clientX, event.clientY);
     if (!anchor || this.editableBlockOf(anchor.node) !== origin) return;
-    this.dragSelection = { anchor, origin, crossedBlockBoundary: false };
+    this.clearDragSelection();
+    this.dragSelection = {
+      anchor,
+      origin,
+      crossedBlockBoundary: false,
+      focus: null,
+      frame: null,
+    };
   };
+
+  /**
+   * Apply the latest cross-block endpoint after the browser finishes its native mousemove
+   * selection update. Firefox rewrites Selection back into the originating contenteditable after
+   * event dispatch even when mousemove is cancelled; writing in requestAnimationFrame wins that
+   * race and happens before paint. Coalescing also avoids rebuilding a Range for every raw pointer
+   * event when the mouse is moving faster than the display can refresh.
+   */
+  private queueDragSelection(drag: CrossBlockDragSelection, focus: DomSelectionPoint): void {
+    drag.focus = focus;
+    if (drag.frame !== null) return;
+    const view = this.container.ownerDocument.defaultView;
+    if (!view) {
+      setSelectionBetween(drag.anchor, focus);
+      return;
+    }
+    drag.frame = view.requestAnimationFrame(() => {
+      drag.frame = null;
+      if (this.dragSelection !== drag || !drag.focus) return;
+      setSelectionBetween(drag.anchor, drag.focus);
+    });
+  }
+
+  /** Cancel a queued repaint and discard the current gesture. */
+  private clearDragSelection(): void {
+    const drag = this.dragSelection;
+    if (drag && drag.frame !== null) {
+      this.container.ownerDocument.defaultView?.cancelAnimationFrame(drag.frame);
+    }
+    this.dragSelection = null;
+  }
 
   /**
    * Browsers fence native mouse selection at a contenteditable host boundary. Once a drag reaches
@@ -803,7 +845,7 @@ export class DocxEditor {
     const drag = this.dragSelection;
     if (!drag) return;
     if ((event.buttons & 1) === 0) {
-      this.dragSelection = null;
+      this.clearDragSelection();
       return;
     }
     const focus = caretPointFromClient(document, event.clientX, event.clientY);
@@ -813,7 +855,7 @@ export class DocxEditor {
     if (focusBlock !== drag.origin) drag.crossedBlockBoundary = true;
     if (!drag.crossedBlockBoundary) return;
     event.preventDefault();
-    setSelectionBetween(drag.anchor, focus);
+    this.queueDragSelection(drag, focus);
   };
 
   /** Commit the final cross-block endpoint before releasing the gesture state. */
@@ -828,7 +870,7 @@ export class DocxEditor {
         setSelectionBetween(drag.anchor, focus);
       }
     }
-    this.dragSelection = null;
+    this.clearDragSelection();
   };
 
   /** The editable block (contenteditable [data-anchor]) containing `node`, if any, within this editor.
@@ -937,7 +979,7 @@ export class DocxEditor {
       document.removeEventListener("mousemove", this.onMouseMove, true);
       document.removeEventListener("mouseup", this.onMouseUp, true);
     }
-    this.dragSelection = null;
+    this.clearDragSelection();
     this.exports.DocxSessionBridge.CloseSession(this.handle);
   }
 

--- a/npm/tests/editor-multiblock-format.spec.ts
+++ b/npm/tests/editor-multiblock-format.spec.ts
@@ -19,13 +19,13 @@ async function textPoint(block: Locator, fraction: number) {
   }, fraction);
 }
 
-async function mouseDragAcross(page: Page, first: Locator, last: Locator) {
+async function mouseDragAcross(page: Page, first: Locator, last: Locator, release = true) {
   const start = await textPoint(first, 0.2);
   const end = await textPoint(last, 0.8);
   await page.mouse.move(start.x, start.y);
   await page.mouse.down();
   await page.mouse.move(end.x, end.y, { steps: 24 });
-  await page.mouse.up();
+  if (release) await page.mouse.up();
 }
 
 // Issue 7 — multi-block formatting. A selection spanning multiple paragraphs applies
@@ -155,7 +155,13 @@ test.describe('DocxEditor — multi-block formatting', () => {
     const blocks = page.locator('#editor p[data-anchor][contenteditable="true"]');
     const first = blocks.filter({ hasText: 'AAA' }).first();
     const last = blocks.filter({ hasText: 'CCC' }).first();
-    await mouseDragAcross(page, first, last);
+    // Assert while the primary button is still held. Firefox's native selection machinery used to
+    // reset the Range to the first contenteditable after every mousemove, so the correct larger
+    // selection appeared only on mouseup even though commands ultimately affected all blocks.
+    await mouseDragAcross(page, first, last, false);
+    await page.evaluate(() => new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+    ));
 
     const selection = await page.evaluate(() => {
       const current = window.getSelection()!;
@@ -173,6 +179,7 @@ test.describe('DocxEditor — multi-block formatting', () => {
     });
     expect(selection.anchorBlock).not.toBe(selection.focusBlock);
     expect(selection.text).toContain('BBB');
+    await page.mouse.up();
 
     // The real ribbon button retains and formats the cross-block selection.
     await page.locator('#ribbon button[data-cmd="bold"]').click();


### PR DESCRIPTION
## What changed

- coalesce cross-block drag endpoints into the next animation frame
- apply the bridged DOM Range after the browser's native mousemove selection update and before paint
- retain the synchronous mouseup finalization and stable multi-block formatting bookmark
- run the held-button multi-block selection spec in a dedicated Firefox Playwright project
- install Firefox in the browser CI job and document the behavior

## Why

Firefox reapplies its native per-`contenteditable` selection after mousemove dispatch. The editor's correct cross-block Range was therefore overwritten back to the originating paragraph while the mouse button remained held. On mouseup the editor's final Range won, making a much larger selection appear suddenly; formatting worked, but the drag feedback looked broken.

The animation-frame update wins that browser ordering race without fake CSS highlights, DOM overlays, surface-specific code, or changes to independent per-anchor commit boundaries. Updates are coalesced to one Range rebuild per display frame.

## User impact

Dragging across document blocks now highlights the full live selection continuously in Firefox, matching the final range and formatting behavior already present in both editor surfaces.

## Validation

- `npm run typecheck`
- `npm test -- editor-multiblock-format.spec.ts` — 4 passed across Chromium and Firefox; the assertion runs before mouseup
- `npm test -- social-demo.spec.ts` — 2 passed
- visual Firefox capture while the primary button remained held confirmed both endpoint blocks painted as selected
