### PR TITLE
Add Word-style table Tab navigation

### DIFF
--- a/npm/src/editor.ts
+++ b/npm/src/editor.ts
@@ -1168,9 +1168,9 @@ export class DocxEditor {
     if (!EDITABLE_TAGS.has(el.tagName)) return;
     const unid = el.getAttribute("data-anchor");
     // Only blocks the markdown projection addresses are editable via the text path. This INCLUDES
-    // table-cell paragraphs (the projection indexes them), so cell text IS editable — but structural
-    // keys are kept inert inside a cell (see onKeydown / GAP3) so single-block editing can't corrupt
-    // table structure. Anything the projection does not index (unstamped content) stays read-only.
+    // table-cell paragraphs (the projection indexes them), so cell text IS editable. Table-aware
+    // key handling keeps structural edits safe while still providing Word-style cell navigation
+    // (see onKeydown). Anything the projection does not index (unstamped content) stays read-only.
     // A band block is authoritative via its stamped `data-hf-anchor` even when the unid map
     // resolves that unid to a different part (content-addressed unids collide across parts).
     if (!unid || !this.anchorIdOf(el)) return;
@@ -1297,19 +1297,21 @@ export class DocxEditor {
       if (k === "z") { ev.preventDefault(); ev.shiftKey ? this.redo() : this.undo(); return; }
       if (k === "y") { ev.preventDefault(); this.redo(); return; }
     }
-    // Inside a table cell, structural ops that change the TABLE GRID (cross-cell merge,
-    // list-nest, focus-jumping Tab) stay INERT — the single-block model can't give them
-    // whole-table context. Tab is swallowed (no focus escape / literal tab); Backspace at
-    // the cell's start does not merge across the cell boundary (mid-text Backspace still
-    // deletes normally). Enter, however, splits the cell paragraph into two paragraphs
-    // WITHIN the same cell — the engine keeps the new w:p in the w:tc, the grid is
-    // unchanged, so it's safe (it's how a cell holds stacked lines: value over a smaller
-    // label, multi-line addresses). (GAP3.)
+    // Inside a table cell, Backspace at the cell's start does not merge across the cell
+    // boundary (mid-text Backspace still deletes normally). Enter splits the cell paragraph
+    // WITHIN the same cell — the engine keeps the new w:p in the w:tc, so the grid is unchanged.
+    // Tab navigation is handled explicitly below; at the final cell it uses the existing safe
+    // whole-table row insertion path to match Word's add-a-row behavior.
     const inTableCell = !!el.closest("table");
 
-    // Tab / Shift+Tab on a list item nests / un-nests it (changes list level).
-    if (ev.key === "Tab") {
-      if (inTableCell) { ev.preventDefault(); return; }
+    // Plain Tab / Shift+Tab moves between table cells. Outside tables it retains list
+    // nest/un-nest behavior. Modified Tab chords remain available to the browser/platform.
+    if (ev.key === "Tab" && !ev.ctrlKey && !ev.metaKey && !ev.altKey && !ev.isComposing) {
+      if (inTableCell) {
+        ev.preventDefault();
+        this.navigateTableCell(el, ev.shiftKey);
+        return;
+      }
       if (isListBlock(el)) {
         ev.preventDefault();
         this.activeBlock = el;
@@ -1340,6 +1342,50 @@ export class DocxEditor {
         }
       }
     }
+  }
+
+  /** Editable cells in visual document order, excluding cells from any nested table. */
+  private tableCellsFor(el: HTMLElement): { cells: HTMLElement[]; index: number } | null {
+    const cell = el.closest<HTMLElement>("td, th");
+    const table = cell?.closest<HTMLTableElement>("table");
+    if (!cell || !table) return null;
+    const cells = Array.from(table.querySelectorAll<HTMLElement>("td, th"))
+      .filter((candidate) => candidate.closest("table") === table);
+    const index = cells.indexOf(cell);
+    return index >= 0 ? { cells, index } : null;
+  }
+
+  /** First addressable paragraph in a cell, fenced against nested-table descendants. */
+  private editableInCell(cell: HTMLElement): HTMLElement | null {
+    return Array.from(
+      cell.querySelectorAll<HTMLElement>('[data-anchor][contenteditable="true"]'),
+    ).find((block) => block.closest("td, th") === cell) ?? null;
+  }
+
+  /** Word-style cell navigation: Shift+Tab goes back, Tab goes forward, and Tab at the
+   *  final cell appends a row before entering its first cell. The first cell is a hard
+   *  boundary for Shift+Tab so focus never leaks out of the editor table. */
+  private navigateTableCell(el: HTMLElement, backwards: boolean): void {
+    const state = this.tableCellsFor(el);
+    if (!state) return;
+    const adjacent = state.cells[state.index + (backwards ? -1 : 1)];
+    if (adjacent) {
+      const target = this.editableInCell(adjacent);
+      if (target) placeCaretAtOffset(target, 0);
+      return;
+    }
+    if (backwards) return;
+
+    // The current block may contain uncommitted typing. insertTableRow flushes it before the
+    // structural edit, then reconcile/remount restores focus by block index. Resolve the new
+    // adjacent cell from that fresh DOM rather than retaining a node from the replaced table.
+    this.activeBlock = el;
+    this.insertTableRow("below");
+    const fresh = this.activeBlock ? this.tableCellsFor(this.activeBlock) : null;
+    if (!fresh) return;
+    const target = fresh.cells[fresh.index + 1];
+    const block = target ? this.editableInCell(target) : null;
+    if (block) placeCaretAtOffset(block, 0);
   }
 
   /** Shift+Enter: insert an intra-paragraph line break at the caret. Delegates to the

--- a/npm/tests/editor-gaps.spec.ts
+++ b/npm/tests/editor-gaps.spec.ts
@@ -107,10 +107,10 @@ test.describe('DocxEditor — smoke-test gap regressions', () => {
 
   // GAP 3: table cells are editable for TEXT and Enter now SPLITS the cell paragraph into two
   // paragraphs within the SAME cell (the engine keeps the new w:p in the w:tc — the grid is
-  // unchanged), so a cell can hold stacked lines. Grid-changing ops (cross-cell Backspace-merge,
-  // Tab focus-jump / list-nest) still need whole-table context the single-block model lacks, so
-  // they stay inert.
-  test('GAP3: Enter splits within a cell (grid unchanged); Tab stays inert; text editing works', async ({ page }) => {
+  // unchanged), so a cell can hold stacked lines. Cross-cell Backspace-merge stays inert. Tab now
+  // performs cell navigation without changing the grid except for its separately tested
+  // Word-style behavior at the final cell.
+  test('GAP3: Enter splits within a cell; Tab navigates without reshaping; text editing works', async ({ page }) => {
     const errors: string[] = [];
     page.on('pageerror', (e) => errors.push(String(e)));
 
@@ -167,7 +167,7 @@ test.describe('DocxEditor — smoke-test gap regressions', () => {
     await page.keyboard.press('Enter');
     const afterEnter = await tableStats();
 
-    // Tab must be inert (no list nesting / marker, no focus jump that re-shapes the table).
+    // Tab must not nest a list or reshape the table while another cell follows.
     await caretToEndOfCell();
     await page.keyboard.press('Tab');
     const afterTab = await tableStats();
@@ -186,7 +186,7 @@ test.describe('DocxEditor — smoke-test gap regressions', () => {
     expect(afterEnter.tableParagraphs).toBe(before.tableParagraphs + 1);
     expect(afterEnter.tableCells).toBe(before.tableCells);
     expect(afterEnter.listMarkers).toBe(before.listMarkers);
-    // Tab stays inert: nothing changes from the post-Enter state.
+    // Tab navigation leaves the post-Enter table structure unchanged.
     expect(afterTab.tableParagraphs).toBe(afterEnter.tableParagraphs);
     expect(afterTab.tableCells).toBe(before.tableCells);
     expect(afterTab.listMarkers).toBe(before.listMarkers);

--- a/npm/tests/editor-table-tab-navigation.spec.ts
+++ b/npm/tests/editor-table-tab-navigation.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect, Page } from '@playwright/test';
+
+async function waitForDocxodus(page: Page) {
+  await page.waitForFunction(() => (window as any).DocxodusReady === true, { timeout: 30000 });
+}
+
+test.describe('DocxEditor — table Tab navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/test-harness.html');
+    await waitForDocxodus(page);
+  });
+
+  test('Tab and Shift+Tab move by cell, preserve edits, and append a final row', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (error) => errors.push(String(error)));
+
+    await page.evaluate(() => {
+      const D = (window as any).Docxodus;
+      const container = document.createElement('div');
+      container.id = 'table-tab-editor';
+      document.body.appendChild(container);
+      const editor = D.DocxEditor.open(container, D.DocxSessionBridge.CreateBlankDocx(), D, {});
+      (window as any).__tableTab = { container, editor, D };
+
+      const body = container.querySelector('p[data-anchor][contenteditable="true"]') as HTMLElement;
+      body.focus();
+      editor.insertTable(2, 2, {
+        borderless: true,
+        cellContents: ['one', 'two', 'three', 'four'],
+      });
+    });
+
+    const focusCell = async (index: number, atEnd = false) => {
+      await page.evaluate(({ index, atEnd }) => {
+        const container = (window as any).__tableTab.container as HTMLElement;
+        const table = container.querySelector('table') as HTMLTableElement;
+        const cells = Array.from(table.querySelectorAll<HTMLElement>('td, th'))
+          .filter((cell) => cell.closest('table') === table);
+        const block = Array.from(
+          cells[index].querySelectorAll<HTMLElement>('[data-anchor][contenteditable="true"]'),
+        ).find((candidate) => candidate.closest('td, th') === cells[index])!;
+        block.focus();
+        const range = document.createRange();
+        range.selectNodeContents(block);
+        range.collapse(!atEnd);
+        const selection = getSelection()!;
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }, { index, atEnd });
+    };
+
+    const state = () => page.evaluate(() => {
+      const container = (window as any).__tableTab.container as HTMLElement;
+      const active = document.activeElement as HTMLElement | null;
+      const block = active?.closest<HTMLElement>('[data-anchor][contenteditable="true"]') ?? null;
+      const cell = block?.closest<HTMLElement>('td, th') ?? null;
+      const table = cell?.closest<HTMLTableElement>('table') ?? null;
+      const cells = table
+        ? Array.from(table.querySelectorAll<HTMLElement>('td, th'))
+            .filter((candidate) => candidate.closest('table') === table)
+        : [];
+      const selection = getSelection();
+      let caretAtStart = false;
+      if (block && selection?.rangeCount && selection.isCollapsed) {
+        const before = document.createRange();
+        before.selectNodeContents(block);
+        before.setEnd(selection.anchorNode!, selection.anchorOffset);
+        caretAtStart = before.toString().length === 0;
+      }
+      return {
+        cellIndex: cell ? cells.indexOf(cell) : -1,
+        cellCount: cells.length,
+        rowCount: table?.querySelectorAll('tr').length ?? 0,
+        caretAtStart,
+      };
+    });
+
+    // A dirty edit commits during the focus move, and Tab lands at the start of the next cell.
+    await focusCell(0, true);
+    await page.keyboard.type('!');
+    await page.keyboard.press('Tab');
+    expect(await state()).toEqual({ cellIndex: 1, cellCount: 4, rowCount: 2, caretAtStart: true });
+
+    // Shift+Tab reverses the move and clamps at the first cell instead of escaping the table.
+    await page.keyboard.press('Shift+Tab');
+    expect(await state()).toEqual({ cellIndex: 0, cellCount: 4, rowCount: 2, caretAtStart: true });
+    await page.keyboard.press('Shift+Tab');
+    expect(await state()).toEqual({ cellIndex: 0, cellCount: 4, rowCount: 2, caretAtStart: true });
+
+    // Like Word, Tab from the final cell appends a matching row and enters its first cell.
+    await focusCell(3, true);
+    await page.keyboard.type('!');
+    await page.keyboard.press('Tab');
+    expect(await state()).toEqual({ cellIndex: 4, cellCount: 6, rowCount: 3, caretAtStart: true });
+    await page.keyboard.press('Shift+Tab');
+    expect(await state()).toEqual({ cellIndex: 3, cellCount: 6, rowCount: 3, caretAtStart: true });
+
+    const persisted = await page.evaluate(() => {
+      const { container, editor, D } = (window as any).__tableTab;
+      (document.activeElement as HTMLElement | null)?.blur();
+      const saved: Uint8Array = editor.save();
+      const reopenedContainer = document.createElement('div');
+      document.body.appendChild(reopenedContainer);
+      const reopened = D.DocxEditor.open(reopenedContainer, saved, D, {});
+      const texts = Array.from(reopenedContainer.querySelectorAll('td, th'))
+        .map((cell) => (cell.textContent ?? '').trim());
+      const rows = reopenedContainer.querySelectorAll('table tr').length;
+      reopened.close();
+      reopenedContainer.remove();
+      return { texts, rows };
+    });
+
+    expect(persisted.texts[0]).toBe('one!');
+    expect(persisted.texts[3]).toBe('four!');
+    expect(persisted.rows).toBe(3);
+    expect(errors, `uncaught errors:\n${errors.join('\n')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What changed

- Make `Tab` move to the next editable table cell and `Shift+Tab` move to the previous cell.
- Keep `Shift+Tab` contained at the first cell.
- Match Word at the final cell by appending a row and moving into its first cell.
- Preserve pending cell edits across both focus navigation and the row-insertion/remount path.
- Fence cell discovery from nested tables and leave modified Tab chords to the browser/platform.

## Why

The editor previously swallowed Tab inside tables, so keyboard users could not navigate the grid. The existing single-block editing model already had safe text commits and table-row insertion primitives; this change composes those paths into table-aware keyboard behavior.

## Validation

- `npm run typecheck`
- `npm test -- tests/editor-table-tab-navigation.spec.ts tests/editor-gaps.spec.ts` (7 passed)
- `npm test -- tests/editor-table-tab-navigation.spec.ts` after strengthening dirty-final-cell coverage (1 passed)