### PR TITLE
Add draggable editor blocks with tracked moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,59 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Draggable editor blocks with native tracked moves.** A floating drag handle reorders
+  top-level body blocks (paragraphs, headings, list items, and a whole table as one unit) in
+  the editor's continuous view, via Atlassian's Pragmatic drag-and-drop. The handle doubles as
+  a button opening an accessible move menu (up / down / to top / to bottom) with an
+  `aria-live` announcement, so pointer dragging is never the only way to move a block. Enabled
+  by default in `mountRibbon`; opt-in as `blockDrag` on `DocxEditor`. Paginated dragging is
+  deferred — the handle is not mounted there.
+- **`DocxSession.MoveBlock(sourceAnchorId, targetAnchorId, position)`** — one atomic,
+  anchor-addressed OOXML mutation per move, one undo snapshot. With tracking off it relocates
+  the existing element (descendant Unids and relationship ids untouched); with
+  `TrackedChangeMode.RenderInline` it emits a named `w:moveFrom`/`w:moveTo` pair for a
+  paragraph and Word's row insert/delete vocabulary for a table. `accept ≡ the moved order`
+  and `reject ≡ the original order` hold for both, and `ListRevisions` reports a paragraph
+  move as ONE selectable `move` revision resolving both sides. Rippled through
+  `DocxSessionOps`, the WASM bridge, npm, the stdio host, docx-scalpel and MCP.
+- **`DocxSession.ValidMoveTargets(sourceAnchorId)`** — the anchors a block may legally move
+  next to, sharing `MoveBlock`'s own guards. The drag UI registers only these as drop targets,
+  disables move-menu items with no destination, withholds the handle from a block that can
+  move nowhere, and resolves "move to top/bottom" **within the source's own region** — a
+  document with section breaks is partitioned into move regions, where targeting the document
+  ends could never succeed. WASM/npm only, like the other editor-support endpoints.
+
+### Fixed
+- **A tracked move no longer duplicates identity-bearing markers.** The destination clone's
+  bookmarks get fresh document-unique ids (both copies keep the NAME, so each survives its own
+  resolution and every `REF`/`PAGEREF` still resolves), and the move source takes a fresh
+  comment id plus a cloned definition — with fresh `w14:paraId`, entries in both threading
+  parts, and cloned replies re-pointed at cloned parents. Previously a pending redline over a
+  document with bookmarks or comments was schema-invalid (`Sem_UniqueAttributeValue`) and the
+  comment appeared twice in Word's Reviewing pane. Mirrors `IrMarkupRenderer`'s
+  `NormalizeBookmarks`/`NormalizeComments` step (B) rather than inventing a second dialect.
+- **Whole-block revisions mark content, not just structure.** `w:moveFrom` runs now carry
+  `w:delText`/`w:delInstrText` (Word's spelling, and what reject swaps back), and a tracked
+  table move marks every cell paragraph's content and mark instead of only `w:trPr` — row
+  marks alone left the moved-away table's text rendering as ordinary body text.
+- **`RevisionProcessor` keeps a coalesced paragraph's identity.** The paragraph built when a
+  deleted or moved-away paragraph mark merges two blocks was constructed without its
+  attributes, dropping `pt:Unid`; an anchor-stamped render of the resolved document then
+  emitted a block with no `data-anchor` — unaddressable, and invisible to the editor's
+  incremental reconciler, which diffs the rendered DOM against `ListBlocks`. Identity now
+  comes from the same member the paragraph properties do.
+- **Drag autoscroll is registered on the element that actually scrolls** rather than on the
+  document flow, which did nothing and logged "Auto scrolling has been attached to an element
+  that appears not to be scrollable" on every document open. A drop released outside any valid
+  target is now announced instead of failing silently, and a refused move announces an
+  outcome rather than the engine's OOXML-worded reason.
+- **The CDN embed scopes every whole-document render, not just the first.**
+  `createScopedEditorExports` wrapped `ConvertDocxToHtmlComplete` and `RenderHtml` but not the
+  new `RenderHtmlForReview`, which is what a remount prefers — so a remount inside
+  `createEditor`/`createViewer` inserted the converter's unscoped stylesheet and its `body`
+  rules restyled the host page (a host `body { margin: 7px }` became `0px`).
+
 ## [9.2.0] - 2026-08-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,16 @@ All notable changes to this project will be documented in this file.
   and `reject ≡ the original order` hold for both, and `ListRevisions` reports a paragraph
   move as ONE selectable `move` revision resolving both sides. Rippled through
   `DocxSessionOps`, the WASM bridge, npm, the stdio host, docx-scalpel and MCP.
-- **`DocxSession.ValidMoveTargets(sourceAnchorId)`** — the anchors a block may legally move
-  next to, sharing `MoveBlock`'s own guards. The drag UI registers only these as drop targets,
-  disables move-menu items with no destination, withholds the handle from a block that can
-  move nowhere, and resolves "move to top/bottom" **within the source's own region** — a
-  document with section breaks is partitioned into move regions, where targeting the document
-  ends could never succeed. WASM/npm only, like the other editor-support endpoints.
+- **`DocxSession.ValidMoveTargets(sourceAnchorId)`** — the blocks a block may legally move next
+  to **and on which side** (`MoveTarget(AnchorId, Before, After)`), sharing `MoveBlock`'s own
+  guards. The sides are separate because landing *into* a cross-block bookmark/comment range
+  changes its membership while landing outside it does not, so a target is routinely legal on
+  one side and refused on the other. The drag UI registers only valid targets, snaps a drop to
+  the legal side when only one is, disables move-menu items with no destination, withholds the
+  handle from a block that can move nowhere, and resolves "move to top/bottom" **within the
+  source's own region** — a document with section breaks is partitioned into move regions,
+  where targeting the document ends could never succeed. WASM/npm only, like the other
+  editor-support endpoints.
 
 ### Fixed
 - **A tracked move no longer duplicates identity-bearing markers.** The destination clone's

--- a/Docxodus.Tests/DocxSessionMoveBlockTests.cs
+++ b/Docxodus.Tests/DocxSessionMoveBlockTests.cs
@@ -1,0 +1,198 @@
+#nullable enable
+
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+public class DocxSessionMoveBlockTests
+{
+    private static readonly XNamespace Xml = XNamespace.Xml;
+
+    private static XElement P(string text, params object[] leading) =>
+        new(W.p, leading, new XElement(W.r,
+            new XElement(W.t, new XAttribute(Xml + "space", "preserve"), text)));
+
+    private static XElement Table(string text) =>
+        new(W.tbl,
+            new XElement(W.tblPr),
+            new XElement(W.tblGrid, new XElement(W.gridCol, new XAttribute(W.w + "w", 2000))),
+            new XElement(W.tr,
+                new XElement(W.tc,
+                    new XElement(W.tcPr),
+                    P(text))));
+
+    private static byte[] Document(params object[] bodyChildren)
+    {
+        using var stream = new MemoryStream();
+        using (var document = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document))
+        {
+            var main = document.AddMainDocumentPart();
+            main.Document = new Document(new Body());
+            main.AddNewPart<StyleDefinitionsPart>().Styles = new Styles();
+            main.AddNewPart<DocumentSettingsPart>().Settings = new Settings();
+            main.Document.Save();
+            var xdoc = main.GetXDocument();
+            xdoc.Root!.Element(W.body)!.ReplaceNodes(bodyChildren);
+            main.PutXDocument();
+        }
+        return stream.ToArray();
+    }
+
+    private static string[] ParagraphAnchors(DocxSession session) =>
+        session.FindByKind("p", "body").Select(t => t.Anchor.Id).ToArray();
+
+    private static string[] BodyLabels(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes);
+        using var document = WordprocessingDocument.Open(stream, false);
+        var body = document.MainDocumentPart!.GetXDocument().Root!.Element(W.body)!;
+        return body.Elements()
+            .Where(e => e.Name == W.p || e.Name == W.tbl)
+            .Select(e => string.Concat(e.Descendants(W.t).Select(t => t.Value)))
+            .ToArray();
+    }
+
+    private static byte[] Accept(byte[] bytes) =>
+        RevisionProcessor.AcceptRevisions(new WmlDocument("accepted.docx", bytes)).DocumentByteArray;
+
+    private static byte[] Reject(byte[] bytes) =>
+        RevisionProcessor.RejectRevisions(new WmlDocument("rejected.docx", bytes)).DocumentByteArray;
+
+    private static void AssertValid(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes);
+        using var document = WordprocessingDocument.Open(stream, false);
+        Assert.Empty(new OpenXmlValidator(FileFormatVersions.Office2019).Validate(document));
+    }
+
+    [Fact]
+    public void MoveBlock_Direct_ReordersSameElementAndUndoRedo()
+    {
+        using var session = new DocxSession(Document(P("A"), P("B"), P("C")));
+        var anchors = ParagraphAnchors(session);
+        var sourceUnid = session.FindByText("A")!.Anchor.Unid;
+
+        var result = session.MoveBlock(anchors[0], anchors[2], Position.After);
+
+        Assert.True(result.Success, result.Error?.Message);
+        Assert.Equal(sourceUnid, Assert.Single(result.Modified).Unid);
+        Assert.Equal(new[] { "B", "C", "A" }, BodyLabels(session.Save()));
+        Assert.True(session.Undo());
+        Assert.Equal(new[] { "A", "B", "C" }, BodyLabels(session.Save()));
+        Assert.True(session.Redo());
+        Assert.Equal(new[] { "B", "C", "A" }, BodyLabels(session.Save()));
+    }
+
+    [Fact]
+    public void MoveBlock_AlreadyAdjacent_IsNoOpAndConsumesNoUndo()
+    {
+        using var session = new DocxSession(Document(P("A"), P("B")));
+        var anchors = ParagraphAnchors(session);
+
+        Assert.True(session.MoveBlock(anchors[0], anchors[1], Position.Before).Success);
+        Assert.False(session.Undo());
+        Assert.Equal(new[] { "A", "B" }, BodyLabels(session.Save()));
+    }
+
+    [Fact]
+    public void MoveBlock_Direct_MovesWholeTable()
+    {
+        using var session = new DocxSession(Document(P("A"), Table("TABLE"), P("B")));
+        var table = Assert.Single(session.FindByKind("tbl", "body")).Anchor.Id;
+        var target = ParagraphAnchors(session).Last();
+
+        var result = session.MoveBlock(table, target, Position.After);
+
+        Assert.True(result.Success, result.Error?.Message);
+        Assert.Equal(new[] { "A", "B", "TABLE" }, BodyLabels(session.Save()));
+    }
+
+    [Fact]
+    public void MoveBlock_TrackedParagraph_EmitsNamedMoveAndRoundTrips()
+    {
+        using var session = new DocxSession(
+            Document(P("A"), P("B"), P("C")),
+            new DocxSessionSettings
+            {
+                TrackedChanges = TrackedChangeMode.RenderInline,
+                RevisionAuthor = "Alice",
+            });
+        var anchors = ParagraphAnchors(session);
+
+        var result = session.MoveBlock(anchors[0], anchors[2], Position.After);
+
+        Assert.True(result.Success, result.Error?.Message);
+        Assert.Single(result.Created);
+        var saved = session.Save();
+        AssertValid(saved);
+
+        using (var stream = new MemoryStream(saved))
+        using (var document = WordprocessingDocument.Open(stream, false))
+        {
+            var main = document.MainDocumentPart!.GetXDocument();
+            var from = Assert.Single(main.Descendants(W.moveFromRangeStart));
+            var to = Assert.Single(main.Descendants(W.moveToRangeStart));
+            Assert.Equal((string?)from.Attribute(W.name), (string?)to.Attribute(W.name));
+            Assert.Equal("Alice", (string?)from.Attribute(W.author));
+            Assert.NotNull(document.MainDocumentPart.DocumentSettingsPart!
+                .GetXDocument().Root!.Element(W.trackRevisions));
+        }
+
+        Assert.Equal(new[] { "B", "C", "A" }, BodyLabels(Accept(saved)));
+        Assert.Equal(new[] { "A", "B", "C" }, BodyLabels(Reject(saved)));
+        var listed = Assert.Single(session.ListRevisions().Where(r => r.Type == "move"));
+        Assert.Equal("Alice", listed.Author);
+    }
+
+    [Fact]
+    public void MoveBlock_TrackedTable_UsesDeletedAndInsertedRowsAndRoundTrips()
+    {
+        using var session = new DocxSession(
+            Document(P("A"), Table("TABLE"), P("B")),
+            new DocxSessionSettings
+            {
+                TrackedChanges = TrackedChangeMode.RenderInline,
+                RevisionAuthor = "Alice",
+            });
+        var table = Assert.Single(session.FindByKind("tbl", "body")).Anchor.Id;
+        var target = ParagraphAnchors(session).Last();
+
+        var result = session.MoveBlock(table, target, Position.After);
+
+        Assert.True(result.Success, result.Error?.Message);
+        var saved = session.Save();
+        AssertValid(saved);
+        using (var stream = new MemoryStream(saved))
+        using (var document = WordprocessingDocument.Open(stream, false))
+        {
+            var rows = document.MainDocumentPart!.GetXDocument().Descendants(W.tr).ToList();
+            Assert.Contains(rows, r => r.Element(W.trPr)?.Element(W.del) is not null);
+            Assert.Contains(rows, r => r.Element(W.trPr)?.Element(W.ins) is not null);
+        }
+        Assert.Equal(new[] { "A", "B", "TABLE" }, BodyLabels(Accept(saved)));
+        Assert.Equal(new[] { "A", "TABLE", "B" }, BodyLabels(Reject(saved)));
+    }
+
+    [Fact]
+    public void MoveBlock_RejectsCrossBlockRangeMembershipChange()
+    {
+        var start = new XElement(W.commentRangeStart, new XAttribute(W.id, 7));
+        var end = new XElement(W.commentRangeEnd, new XAttribute(W.id, 7));
+        using var session = new DocxSession(Document(
+            P("A", start), P("B"), P("C", end), P("D")));
+        var anchors = ParagraphAnchors(session);
+
+        var result = session.MoveBlock(anchors[1], anchors[3], Position.After);
+
+        Assert.False(result.Success);
+        Assert.Equal(EditErrorCode.InvalidPosition, result.Error!.Code);
+        Assert.Contains("cross-block comment range", result.Error.Message);
+    }
+}

--- a/Docxodus.Tests/DocxSessionMoveBlockTests.cs
+++ b/Docxodus.Tests/DocxSessionMoveBlockTests.cs
@@ -195,4 +195,276 @@ public class DocxSessionMoveBlockTests
         Assert.Equal(EditErrorCode.InvalidPosition, result.Error!.Code);
         Assert.Contains("cross-block comment range", result.Error.Message);
     }
+
+    // A tracked move clones the source paragraph. Every id-bearing marker in the clone is a
+    // SECOND live copy, so the ids must be made unique or the document violates the schema's
+    // id-uniqueness constraint while the revision is pending — the exact state a redline is
+    // sent out in. Mirrors IrMarkupRenderer.NormalizeBookmarks step (B): both copies keep the
+    // NAME (each survives its own resolution); only the ids are renumbered.
+    [Fact]
+    public void MoveBlock_TrackedParagraph_GivesClonedBookmarksFreshIds()
+    {
+        using var session = new DocxSession(
+            Document(
+                P("A",
+                    new XElement(W.bookmarkStart, new XAttribute(W.id, 4), new XAttribute(W.name, "_Ref1")),
+                    new XElement(W.bookmarkEnd, new XAttribute(W.id, 4))),
+                P("B"), P("C")),
+            new DocxSessionSettings
+            {
+                TrackedChanges = TrackedChangeMode.RenderInline,
+                RevisionAuthor = "Alice",
+            });
+        var anchors = ParagraphAnchors(session);
+
+        Assert.True(session.MoveBlock(anchors[0], anchors[2], Position.After).Success);
+
+        var saved = session.Save();
+        AssertValid(saved);
+        using var stream = new MemoryStream(saved);
+        using var document = WordprocessingDocument.Open(stream, false);
+        var main = document.MainDocumentPart!.GetXDocument();
+        var starts = main.Descendants(W.bookmarkStart).ToList();
+        var ends = main.Descendants(W.bookmarkEnd).ToList();
+
+        Assert.Equal(2, starts.Count);
+        Assert.Equal(2, ends.Count);
+        // Both copies keep the name; the ids are distinct and each start still pairs with an end.
+        Assert.All(starts, s => Assert.Equal("_Ref1", (string?)s.Attribute(W.name)));
+        var startIds = starts.Select(s => (string?)s.Attribute(W.id)).ToList();
+        Assert.Equal(2, startIds.Distinct().Count());
+        Assert.Equal(startIds.OrderBy(x => x), ends.Select(e => (string?)e.Attribute(W.id)).OrderBy(x => x));
+    }
+
+    // The drag UI gates its drop indicators on this, so it has to agree with MoveBlock exactly:
+    // anything listed must be accepted, and anything omitted must be refused.
+    [Fact]
+    public void ValidMoveTargets_ExcludesTargetsAcrossASectionBreak()
+    {
+        var sectionBreak = new XElement(W.pPr, new XElement(W.sectPr));
+        using var session = new DocxSession(Document(
+            P("A"), P("B"), P("BREAK", sectionBreak), P("C"), P("D")));
+        var anchors = ParagraphAnchors(session);
+
+        var valid = session.ValidMoveTargets(anchors[0]);
+
+        // A and B are on one side of the break; C and D on the other.
+        Assert.Contains(anchors[1], valid);
+        Assert.DoesNotContain(anchors[3], valid);
+        Assert.DoesNotContain(anchors[4], valid);
+
+        // Every listed target really is accepted, and an omitted one really is refused.
+        foreach (var target in valid)
+        {
+            using var probe = new DocxSession(session.Save());
+            var probeAnchors = ParagraphAnchors(probe);
+            Assert.True(probe.MoveBlock(probeAnchors[0], target, Position.After).Success);
+        }
+        Assert.False(session.MoveBlock(anchors[0], anchors[3], Position.After).Success);
+    }
+
+    // A block already carrying revision markup cannot become a TRACKED move (re-wrapping would
+    // nest revisions), but a DIRECT move relocates the element untouched and is fine. The two
+    // modes must therefore disagree — which is what makes this a test of the source-level guard
+    // rather than of the section-break span check.
+    [Fact]
+    public void ValidMoveTargets_ExcludesABlockWithExistingRevisionsOnlyWhenTracking()
+    {
+        var alreadyInserted = new XElement(W.p,
+            new XElement(W.ins,
+                new XAttribute(W.id, 1),
+                new XAttribute(W.author, "Bob"),
+                new XAttribute(W.date, "2026-01-01T00:00:00Z"),
+                new XElement(W.r, new XElement(W.t, "A"))));
+
+        using (var direct = new DocxSession(Document(alreadyInserted, P("B"), P("C"))))
+        {
+            var anchors = ParagraphAnchors(direct);
+            Assert.NotEmpty(direct.ValidMoveTargets(anchors[0]));
+        }
+
+        using var tracked = new DocxSession(
+            Document(new XElement(alreadyInserted), P("B"), P("C")),
+            new DocxSessionSettings { TrackedChanges = TrackedChangeMode.RenderInline });
+        var trackedAnchors = ParagraphAnchors(tracked);
+
+        Assert.Empty(tracked.ValidMoveTargets(trackedAnchors[0]));
+        Assert.False(tracked.MoveBlock(trackedAnchors[0], trackedAnchors[2], Position.After).Success);
+    }
+
+    // Deleted content is w:delText, not w:t — that is what Word writes, what the IR renderer's
+    // ConvertTextToDelText produces, and what RevisionProcessor's reject path swaps back. A
+    // w:moveFrom IS a deletion, so its runs must follow the same rule.
+    [Fact]
+    public void MoveBlock_TrackedParagraph_MarksMovedFromTextAsDeleted()
+    {
+        using var session = new DocxSession(
+            Document(P("A"), P("B"), P("C")),
+            new DocxSessionSettings
+            {
+                TrackedChanges = TrackedChangeMode.RenderInline,
+                RevisionAuthor = "Alice",
+            });
+        var anchors = ParagraphAnchors(session);
+
+        Assert.True(session.MoveBlock(anchors[0], anchors[2], Position.After).Success);
+
+        var saved = session.Save();
+        AssertValid(saved);
+        using (var stream = new MemoryStream(saved))
+        using (var document = WordprocessingDocument.Open(stream, false))
+        {
+            var moveFrom = document.MainDocumentPart!.GetXDocument()
+                .Descendants(W.moveFrom).Single(e => e.Elements(W.r).Any());
+            Assert.NotEmpty(moveFrom.Descendants(W.delText));
+            Assert.Empty(moveFrom.Descendants(W.t));
+        }
+
+        // …and the text still comes back intact on reject (delText → t).
+        Assert.Equal(new[] { "A", "B", "C" }, BodyLabels(Reject(saved)));
+        Assert.Equal(new[] { "B", "C", "A" }, BodyLabels(Accept(saved)));
+    }
+
+    // The design doc's whole-table lowering is "every source row AND ITS CONTENT is deleted, and
+    // every destination row and its content is inserted". Marking only w:trPr leaves the moved-away
+    // table's text rendering as ordinary body text inside a row Word believes is deleted.
+    [Fact]
+    public void MoveBlock_TrackedTable_MarksCellContentNotJustRows()
+    {
+        using var session = new DocxSession(
+            Document(P("A"), Table("CELL"), P("B")),
+            new DocxSessionSettings
+            {
+                TrackedChanges = TrackedChangeMode.RenderInline,
+                RevisionAuthor = "Alice",
+            });
+        var table = Assert.Single(session.FindByKind("tbl", "body")).Anchor.Id;
+        var target = ParagraphAnchors(session).Last();
+
+        Assert.True(session.MoveBlock(table, target, Position.After).Success);
+
+        var saved = session.Save();
+        AssertValid(saved);
+        using var stream2 = new MemoryStream(saved);
+        using var document2 = WordprocessingDocument.Open(stream2, false);
+        var tables = document2.MainDocumentPart!.GetXDocument().Descendants(W.tbl).ToList();
+        Assert.Equal(2, tables.Count);
+
+        var deleted = tables.Single(t => t.Descendants(W.trPr).Elements(W.del).Any());
+        var inserted = tables.Single(t => t.Descendants(W.trPr).Elements(W.ins).Any());
+        // The deleted table's cell text is inside w:del as w:delText…
+        Assert.NotEmpty(deleted.Descendants(W.del).SelectMany(d => d.Descendants(W.delText)));
+        Assert.Empty(deleted.Descendants(W.r).Descendants(W.t));
+        // …and the inserted table's cell text is inside w:ins.
+        Assert.NotEmpty(inserted.Descendants(W.ins).SelectMany(i => i.Descendants(W.t)));
+
+        Assert.Equal(new[] { "A", "B", "CELL" }, BodyLabels(Accept(saved)));
+        Assert.Equal(new[] { "A", "CELL", "B" }, BodyLabels(Reject(saved)));
+    }
+
+    private static (string[] Ids, int Definitions) CommentShape(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes);
+        using var document = WordprocessingDocument.Open(stream, false);
+        var main = document.MainDocumentPart!;
+        var ids = main.GetXDocument().Descendants()
+            .Where(e => e.Name == W.commentRangeStart)
+            .Select(e => (string)e.Attribute(W.id)!)
+            .ToArray();
+        var defs = main.WordprocessingCommentsPart?.GetXDocument().Root!
+            .Elements(W.comment).Count() ?? 0;
+        return (ids, defs);
+    }
+
+    private static string[] DefinedCommentIds(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes);
+        using var document = WordprocessingDocument.Open(stream, false);
+        return document.MainDocumentPart!.WordprocessingCommentsPart?.GetXDocument().Root!
+            .Elements(W.comment).Select(c => (string)c.Attribute(W.id)!).ToArray() ?? [];
+    }
+
+    // The tracked-move clone duplicates the source's comment markers. Left alone that is both a
+    // schema violation (the id is uniqueness-constrained) and a visible defect — one comment shows
+    // twice in Word's Reviewing pane, anchored to the source AND the destination. Mirrors
+    // IrMarkupRenderer.NormalizeComments step (B): the DELETED copy (the move source) gets a fresh
+    // id + a cloned definition, so accept ≡ the destination's comment and reject ≡ the source's.
+    [Fact]
+    public void MoveBlock_TrackedParagraph_ClonesCommentForTheMoveSource()
+    {
+        using var session = new DocxSession(
+            Document(P("A"), P("B"), P("C")),
+            new DocxSessionSettings { RevisionAuthor = "Alice" });
+        var anchors = ParagraphAnchors(session);
+        Assert.True(session.AddComment(anchors[0], null, "Alice", "look here").Success);
+
+        session.SetTrackedChanges(TrackedChangeMode.RenderInline);
+        Assert.True(session.MoveBlock(anchors[0], anchors[2], Position.After).Success);
+
+        var saved = session.Save();
+        AssertValid(saved);
+
+        var (ids, defs) = CommentShape(saved);
+        Assert.Equal(2, ids.Length);                 // one range on each live copy
+        Assert.Equal(2, ids.Distinct().Count());     // …with DISTINCT ids
+        Assert.Equal(2, defs);                       // …each resolving to its own definition
+
+        // Exactly one comment is anchored after each resolution, and it resolves to a definition.
+        // (The resolved-away copy's definition stays behind unreferenced — RevisionProcessor does
+        // not prune orphaned definitions for any resolved comment, and Word ignores an unanchored
+        // one. What matters is that the pane shows the comment once, not twice.)
+        foreach (var resolved in new[] { Accept(saved), Reject(saved) })
+        {
+            AssertValid(resolved);
+            var live = Assert.Single(CommentShape(resolved).Ids);
+            Assert.Contains(live, DefinedCommentIds(resolved));
+        }
+    }
+
+    /// <summary>Anchor unids stamped on the rendered top-level body blocks, in document order.</summary>
+    private static string[] RenderedBodyAnchors(int handle, bool renderTrackedChanges)
+    {
+        var html = Docxodus.Internal.DocxSessionOps.RenderHtml(
+            handle, "dx-", false, false, 1.0, renderTrackedChanges);
+        return System.Text.RegularExpressions.Regex
+            .Matches(html, "data-anchor=\"([0-9a-f]{8,})\"")
+            .Select(m => m.Groups[1].Value)
+            .ToArray();
+    }
+
+    private static string[] PlannedBodyAnchors(DocxSession session, bool renderTrackedChanges) =>
+        session.ListBlocks(renderTrackedChanges).Body
+            .Select(u => u.Id.Split(':')[^1])
+            .ToArray();
+
+    // The editor's incremental reconciler diffs the rendered DOM against ListBlocks. After a
+    // tracked move the two must still describe the SAME units in BOTH review and accepted views,
+    // or every later structural op diffs against a unit the DOM can never contain.
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void MoveBlock_TrackedParagraph_RenderPlanMatchesRenderedBlocks(bool renderTrackedChanges)
+    {
+        var handle = Docxodus.Internal.DocxSessionOps.OpenSession(
+            Document(P("A"), P("B"), P("C"), P("D")),
+            new DocxSessionSettings
+            {
+                TrackedChanges = TrackedChangeMode.RenderInline,
+                RevisionAuthor = "Alice",
+            });
+        try
+        {
+            var session = Docxodus.Internal.SessionRegistry.Get(handle);
+            var anchors = ParagraphAnchors(session);
+            Assert.True(session.MoveBlock(anchors[0], anchors[2], Position.After).Success);
+
+            Assert.Equal(
+                PlannedBodyAnchors(session, renderTrackedChanges),
+                RenderedBodyAnchors(handle, renderTrackedChanges));
+        }
+        finally
+        {
+            Docxodus.Internal.DocxSessionOps.CloseSession(handle);
+        }
+    }
 }

--- a/Docxodus.Tests/DocxSessionMoveBlockTests.cs
+++ b/Docxodus.Tests/DocxSessionMoveBlockTests.cs
@@ -249,18 +249,44 @@ public class DocxSessionMoveBlockTests
         var valid = session.ValidMoveTargets(anchors[0]);
 
         // A and B are on one side of the break; C and D on the other.
-        Assert.Contains(anchors[1], valid);
-        Assert.DoesNotContain(anchors[3], valid);
-        Assert.DoesNotContain(anchors[4], valid);
+        Assert.Contains(valid, t => t.AnchorId == anchors[1]);
+        Assert.DoesNotContain(valid, t => t.AnchorId == anchors[3]);
+        Assert.DoesNotContain(valid, t => t.AnchorId == anchors[4]);
 
-        // Every listed target really is accepted, and an omitted one really is refused.
+        // Every listed (target, side) pair really is accepted — a target can be reachable on one
+        // side and refused on the other, so the side is part of the claim.
         foreach (var target in valid)
         {
-            using var probe = new DocxSession(session.Save());
-            var probeAnchors = ParagraphAnchors(probe);
-            Assert.True(probe.MoveBlock(probeAnchors[0], target, Position.After).Success);
+            foreach (var (allowed, pos) in new[] { (target.Before, Position.Before), (target.After, Position.After) })
+            {
+                using var probe = new DocxSession(session.Save());
+                var probeAnchors = ParagraphAnchors(probe);
+                Assert.Equal(allowed, probe.MoveBlock(probeAnchors[0], target.AnchorId, pos).Success);
+            }
         }
         Assert.False(session.MoveBlock(anchors[0], anchors[3], Position.After).Success);
+    }
+
+    // A target can be legal on one side and refused on the other: moving a block INTO a
+    // cross-block range changes that range's membership, while landing outside it does not. A
+    // caller told only "this target is reachable" would still pick the refused side.
+    [Fact]
+    public void ValidMoveTargets_ReportsEachSideOfATargetSeparately()
+    {
+        // The bookmark spans B..C, so A may land before B but not between B and C.
+        using var session = new DocxSession(Document(
+            P("A"),
+            P("B", new XElement(W.bookmarkStart, new XAttribute(W.id, 3), new XAttribute(W.name, "_span"))),
+            P("C", new XElement(W.bookmarkEnd, new XAttribute(W.id, 3))),
+            P("D")));
+        var anchors = ParagraphAnchors(session);
+
+        var target = Assert.Single(session.ValidMoveTargets(anchors[0]).Where(t => t.AnchorId == anchors[1]));
+
+        Assert.True(target.Before);
+        Assert.False(target.After);
+        Assert.False(session.MoveBlock(anchors[0], anchors[1], Position.After).Success);
+        Assert.True(session.MoveBlock(anchors[0], anchors[1], Position.Before).Success);
     }
 
     // A block already carrying revision markup cannot become a TRACKED move (re-wrapping would

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -1016,6 +1016,13 @@ public sealed record MarkdownPatch(string ScopeAnchorId, string Markdown);
 public sealed record RenderUnit(string Id, string Kind, string? Sig = null);
 
 /// <summary>
+/// A block a move source may legally land against, and on which side. The two positions are
+/// reported separately because a cross-block range or a section break BETWEEN the blocks can
+/// make one side legal and the other not — see <see cref="DocxSession.ValidMoveTargets"/>.
+/// </summary>
+public sealed record MoveTarget(string AnchorId, bool Before, bool After);
+
+/// <summary>
 /// The ordered top-level render units per scope container — the authority for "what
 /// blocks exist, in what order" that an incremental renderer diffs its DOM against.
 /// The projection's flat <c>AnchorIndex</c> cannot express table containment (a cell
@@ -4602,13 +4609,14 @@ public sealed class DocxSession : IDisposable
     /// indicators and menu items on the result, instead of drawing an indicator over a target the
     /// engine will refuse. <see cref="MoveBlock"/> stays authoritative — this shares its guards
     /// rather than restating them, so a target listed here is one <c>MoveBlock</c> accepts.
-    /// A target is listed when EITHER <see cref="Position.Before"/> or <see cref="Position.After"/>
-    /// is legal; the two differ only where a section break sits between the blocks.
+    /// Each entry reports the two positions SEPARATELY: a cross-block range or a section break
+    /// between the blocks can make one side legal and the other not, so a caller that knows only
+    /// "this target is reachable" can still pick the refused side.
     /// </remarks>
-    public IReadOnlyList<string> ValidMoveTargets(string sourceAnchorId)
+    public IReadOnlyList<MoveTarget> ValidMoveTargets(string sourceAnchorId)
     {
         ThrowIfDisposed();
-        var empty = Array.Empty<string>();
+        var empty = Array.Empty<MoveTarget>();
 
         var sourceTarget = FindAnchor(sourceAnchorId);
         if (sourceTarget is null || sourceTarget.Anchor.Kind is not ("p" or "h" or "li" or "tbl"))
@@ -4619,7 +4627,7 @@ public sealed class DocxSession : IDisposable
         if (!IsEditorBodyBlock(source, parent) || MoveSourceRejection(source) is not null)
             return empty;
 
-        var targets = new List<string>();
+        var targets = new List<MoveTarget>();
         foreach (var candidate in parent.Elements().Where(e => e.Name == W.p || e.Name == W.tbl))
         {
             if (ReferenceEquals(candidate, source) || !IsEditorBodyBlock(candidate, parent))
@@ -4629,9 +4637,10 @@ public sealed class DocxSession : IDisposable
             var kind = candidate.Name == W.tbl ? "tbl" : WmlToMarkdownConverter.KindFor(candidate);
             if (kind is null) continue;
 
-            if (BlockMoveSafetyError(parent, source, candidate, Position.Before) is null ||
-                BlockMoveSafetyError(parent, source, candidate, Position.After) is null)
-                targets.Add($"{kind}:{sourceTarget.Anchor.Scope}:{unid}");
+            bool before = BlockMoveSafetyError(parent, source, candidate, Position.Before) is null;
+            bool after = BlockMoveSafetyError(parent, source, candidate, Position.After) is null;
+            if (before || after)
+                targets.Add(new MoveTarget($"{kind}:{sourceTarget.Anchor.Scope}:{unid}", before, after));
         }
         return targets;
     }

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -1478,7 +1478,7 @@ public sealed class DocxSession : IDisposable
     /// paragraphs are ALWAYS listed — the plan mirrors the rendered DOM, which contains
     /// every block regardless of <see cref="EmptyParagraphMode"/>.
     /// </summary>
-    public RenderPlan ListBlocks()
+    public RenderPlan ListBlocks(bool renderTrackedChanges = true)
     {
         ThrowIfDisposed();
         _ = AnchorIndex(); // guarantees Unids are assigned on every projected part
@@ -1505,6 +1505,8 @@ public sealed class DocxSession : IDisposable
                     string? kind =
                         el.Name == W.tbl ? "tbl" :
                         el.Name == W.p ? WmlToMarkdownConverter.KindFor(el) : null;
+                    if (!renderTrackedChanges && IsRemovedInAcceptedRevisionView(el))
+                        continue;
                     var unid = (string?)el.Attribute(PtOpenXml.Unid);
                     if (kind is null || unid is null) continue;
                     body.Add(new RenderUnit($"{kind}:body:{unid}", kind, UnidHelper.ContentHash(el)));
@@ -1550,6 +1552,21 @@ public sealed class DocxSession : IDisposable
             body,
             Notes(main?.FootnotesPart?.GetXDocument().Root, W.footnote, endnotes: false, "fn"),
             Notes(main?.EndnotesPart?.GetXDocument().Root, W.endnote, endnotes: true, "en"));
+    }
+
+    private static bool IsRemovedInAcceptedRevisionView(XElement block)
+    {
+        if (block.Name == W.p)
+        {
+            var mark = block.Element(W.pPr)?.Element(W.rPr);
+            return mark?.Element(W.del) is not null || mark?.Element(W.moveFrom) is not null;
+        }
+        if (block.Name == W.tbl)
+        {
+            var rows = block.Elements(W.tr).ToList();
+            return rows.Count > 0 && rows.All(r => r.Element(W.trPr)?.Element(W.del) is not null);
+        }
+        return false;
     }
 
     /// <summary>
@@ -4426,6 +4443,293 @@ public sealed class DocxSession : IDisposable
     }
 
     // ─── Tier B: structural ops ──────────────────────────────────────────
+
+    /// <summary>
+    /// Reorder one top-level body block relative to another. Paragraphs, headings,
+    /// list items, and whole tables are supported. A direct edit moves the existing
+    /// XML element; <see cref="TrackedChangeMode.RenderInline"/> emits a native named
+    /// paragraph move or a Word-native deleted/inserted table pair.
+    /// </summary>
+    public EditResult MoveBlock(string sourceAnchorId, string targetAnchorId, Position pos)
+    {
+        if (_disposed) return EditResult.Fail(EditErrorCode.SessionDisposed, "session disposed");
+
+        var sourceTarget = FindAnchor(sourceAnchorId);
+        if (sourceTarget is null)
+            return EditResult.Fail(EditErrorCode.AnchorNotFound,
+                $"source anchor not found: {sourceAnchorId}", sourceAnchorId);
+        var targetTarget = FindAnchor(targetAnchorId);
+        if (targetTarget is null)
+            return EditResult.Fail(EditErrorCode.AnchorNotFound,
+                $"target anchor not found: {targetAnchorId}", targetAnchorId);
+
+        if (sourceTarget.Anchor.Kind is not ("p" or "h" or "li" or "tbl"))
+            return EditResult.Fail(EditErrorCode.AnchorWrongKind,
+                $"MoveBlock requires a paragraph/heading/list/table source; got kind={sourceTarget.Anchor.Kind}",
+                sourceAnchorId);
+        if (targetTarget.Anchor.Kind is not ("p" or "h" or "li" or "tbl"))
+            return EditResult.Fail(EditErrorCode.AnchorWrongKind,
+                $"MoveBlock requires a paragraph/heading/list/table target; got kind={targetTarget.Anchor.Kind}",
+                targetAnchorId);
+        if (sourceTarget.Anchor.Scope != targetTarget.Anchor.Scope)
+            return EditResult.Fail(EditErrorCode.InvalidPosition,
+                "MoveBlock source and target must be in the same package part", sourceAnchorId);
+
+        var source = sourceTarget.Resolve(_doc!);
+        var target = targetTarget.Resolve(_doc!);
+        if (source is null || target is null)
+            return EditResult.Fail(EditErrorCode.AnchorNotFound, "source or target element resolved null", sourceAnchorId);
+        if (ReferenceEquals(source, target))
+            return new EditResult { Success = true };
+        if (!ReferenceEquals(source.Parent, target.Parent) || source.Parent is not { } parent)
+            return EditResult.Fail(EditErrorCode.InvalidPosition,
+                "MoveBlock source and target must share a direct XML parent", sourceAnchorId);
+        if (!IsEditorBodyBlock(source, parent) || !IsEditorBodyBlock(target, parent))
+            return EditResult.Fail(EditErrorCode.AnchorWrongKind,
+                "MoveBlock only supports top-level body blocks (including flattened body content controls)",
+                sourceAnchorId);
+
+        // A source already in the requested slot is a true no-op: do not consume undo.
+        if ((pos == Position.Before && ReferenceEquals(source.NextNode, target)) ||
+            (pos == Position.After && ReferenceEquals(target.NextNode, source)))
+            return new EditResult { Success = true };
+
+        if (source.Name == W.p && source.Element(W.pPr)?.Element(W.sectPr) is not null)
+            return EditResult.Fail(EditErrorCode.InvalidPosition,
+                "cannot move a paragraph that owns a section break", sourceAnchorId);
+
+        if (BlockMoveSafetyError(parent, source, target, pos) is { } safetyError)
+            return EditResult.Fail(EditErrorCode.InvalidPosition, safetyError, sourceAnchorId);
+
+        // Re-wrapping an existing revision can create illegal nested move markup. Direct
+        // mode can carry ordinary ins/del content safely, but an existing named move range
+        // is tied to its current document-order location and is intentionally immovable.
+        if (source.DescendantsAndSelf().Any(e =>
+                e.Name == W.moveFromRangeStart || e.Name == W.moveFromRangeEnd ||
+                e.Name == W.moveToRangeStart || e.Name == W.moveToRangeEnd))
+            return EditResult.Fail(EditErrorCode.InvalidPosition,
+                "cannot move a block that is already part of a native move range", sourceAnchorId);
+        if (_trackedChanges == TrackedChangeMode.RenderInline &&
+            source.DescendantsAndSelf().Any(e =>
+                e.Name == W.ins || e.Name == W.del || e.Name == W.moveFrom || e.Name == W.moveTo))
+            return EditResult.Fail(EditErrorCode.InvalidPosition,
+                "cannot create a tracked move around a block that already contains revisions",
+                sourceAnchorId);
+
+        _history.RecordPreOp(TakeSnapshot());
+        try
+        {
+            if (_trackedChanges != TrackedChangeMode.RenderInline)
+            {
+                source.Remove();
+                if (pos == Position.Before) target.AddBeforeSelf(source);
+                else target.AddAfterSelf(source);
+
+                InvalidateProjectionCache();
+                return new EditResult
+                {
+                    Success = true,
+                    Modified = new[] { sourceTarget.Anchor },
+                    Patch = PatchFor(sourceTarget),
+                };
+            }
+
+            var destination = new XElement(source);
+            foreach (var el in destination.DescendantsAndSelf())
+                el.Attributes(PtOpenXml.Unid).Remove();
+
+            var author = _revisionAuthor ?? "docxodus";
+            var date = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
+            if (source.Name == W.p)
+            {
+                var moveName = $"move{NextRevisionId()}";
+                MarkParagraphAsTrackedMove(source, from: true, moveName, author, date);
+                MarkParagraphAsTrackedMove(destination, from: false, moveName, author, date);
+            }
+            else
+            {
+                MarkTableRowsAsTrackedRevision(source, inserted: false, author, date);
+                MarkTableRowsAsTrackedRevision(destination, inserted: true, author, date);
+            }
+
+            UnidHelper.AssignToSelfAndDescendants(destination);
+            if (pos == Position.Before) target.AddBeforeSelf(destination);
+            else target.AddAfterSelf(destination);
+
+            var destinationUnid = (string)destination.Attribute(PtOpenXml.Unid)!;
+            var destinationAnchor = new Anchor(
+                $"{sourceTarget.Anchor.Kind}:{sourceTarget.Anchor.Scope}:{destinationUnid}",
+                sourceTarget.Anchor.Kind, sourceTarget.Anchor.Scope, destinationUnid);
+
+            InvalidateProjectionCache();
+            return new EditResult
+            {
+                Success = true,
+                Modified = new[] { sourceTarget.Anchor },
+                Created = new[] { destinationAnchor },
+                Patch = PatchFor(sourceTarget),
+            };
+        }
+        catch (Exception ex)
+        {
+            LastInternalError = ex;
+            var preOp = _history.PopForUndo();
+            if (preOp.ok) RestoreSnapshot(preOp.snapshot);
+            return EditResult.Fail(EditErrorCode.InternalError, ex.Message, sourceAnchorId);
+        }
+    }
+
+    private static bool IsEditorBodyBlock(XElement block, XElement parent)
+    {
+        if (block.Name != W.p && block.Name != W.tbl) return false;
+        if (parent.Name == W.body) return true;
+        if (parent.Name != W.sdtContent) return false;
+        // The renderer flattens a body-level content control. A content control inside
+        // a table cell/text box is not one of the editor's top-level body units.
+        return parent.Ancestors(W.body).Any() &&
+               !parent.Ancestors(W.tc).Any() &&
+               !parent.Ancestors(W.txbxContent).Any();
+    }
+
+    /// <summary>Reject a move when it would change the membership/order of a cross-block
+    /// comment, bookmark, permission, or native-move range, or cross a section break.</summary>
+    private static string? BlockMoveSafetyError(
+        XElement parent, XElement source, XElement target, Position pos)
+    {
+        var blocks = parent.Elements().Where(e => e.Name == W.p || e.Name == W.tbl).ToList();
+        int sourceIndex = blocks.IndexOf(source);
+        int targetIndex = blocks.IndexOf(target);
+        if (sourceIndex < 0 || targetIndex < 0) return "source or target is not a body render unit";
+
+        var reordered = blocks.ToList();
+        reordered.RemoveAt(sourceIndex);
+        int targetAfterRemoval = reordered.IndexOf(target);
+        int insertAt = pos == Position.Before ? targetAfterRemoval : targetAfterRemoval + 1;
+        reordered.Insert(insertAt, source);
+
+        int lo = Math.Min(sourceIndex, targetIndex);
+        int hi = Math.Max(sourceIndex, targetIndex);
+        if (blocks.Skip(lo).Take(hi - lo + 1)
+            .Any(e => e.Name == W.p && e.Element(W.pPr)?.Element(W.sectPr) is not null))
+            return "cannot move a block across a section-break paragraph";
+
+        var pairs = new (XName Start, XName End, string Label)[]
+        {
+            (W.commentRangeStart, W.commentRangeEnd, "comment"),
+            (W.bookmarkStart, W.bookmarkEnd, "bookmark"),
+            (W.permStart, W.permEnd, "permission"),
+            (W.moveFromRangeStart, W.moveFromRangeEnd, "move-source"),
+            (W.moveToRangeStart, W.moveToRangeEnd, "move-destination"),
+        };
+
+        foreach (var (startName, endName, label) in pairs)
+        {
+            var starts = parent.Descendants(startName)
+                .GroupBy(e => (string?)e.Attribute(W.id) ?? "")
+                .ToDictionary(g => g.Key, g => g.First());
+            foreach (var end in parent.Descendants(endName))
+            {
+                var id = (string?)end.Attribute(W.id) ?? "";
+                if (!starts.TryGetValue(id, out var start)) continue;
+                var startBlock = TopLevelOwner(start, parent);
+                var endBlock = TopLevelOwner(end, parent);
+                if (startBlock is null || endBlock is null || ReferenceEquals(startBlock, endBlock))
+                    continue;
+
+                var before = RangeMembers(blocks, startBlock, endBlock);
+                var after = RangeMembers(reordered, startBlock, endBlock);
+                if (before is null || after is null || !before.SetEquals(after))
+                    return $"move would change or invert a cross-block {label} range";
+            }
+        }
+        return null;
+    }
+
+    private static XElement? TopLevelOwner(XElement marker, XElement parent) =>
+        marker.Ancestors().FirstOrDefault(e => ReferenceEquals(e.Parent, parent) &&
+            (e.Name == W.p || e.Name == W.tbl));
+
+    private static HashSet<XElement>? RangeMembers(
+        IReadOnlyList<XElement> order, XElement start, XElement end)
+    {
+        int a = -1;
+        int b = -1;
+        for (int i = 0; i < order.Count; i++)
+        {
+            if (ReferenceEquals(order[i], start)) a = i;
+            if (ReferenceEquals(order[i], end)) b = i;
+        }
+        if (a < 0 || b < a) return null;
+        return order.Skip(a).Take(b - a + 1).ToHashSet();
+    }
+
+    private void MarkParagraphAsTrackedMove(
+        XElement paragraph, bool from, string moveName, string author, string date)
+    {
+        EnsureTrackRevisionsEnabled();
+        var wrapperName = from ? W.moveFrom : W.moveTo;
+
+        // Keep hyperlink/SDT/field containers in place and revision-wrap their runs.
+        // This is the schema-safe shape (w:hyperlink > w:moveFrom|moveTo > w:r).
+        foreach (var run in paragraph.Descendants(W.r).ToList())
+        {
+            if (run.Ancestors().Any(e =>
+                    e.Name == W.ins || e.Name == W.del ||
+                    e.Name == W.moveFrom || e.Name == W.moveTo))
+                continue;
+            var envelope = CreateRevisionEnvelope(wrapperName, author, date);
+            run.ReplaceWith(envelope);
+            envelope.Add(run);
+        }
+
+        // Revise the paragraph mark as well as its runs. Without this mark, accepting
+        // the move leaves an empty source paragraph and rejecting it leaves an empty
+        // destination paragraph. RevisionOps associates the mark with the named range.
+        var pPr = paragraph.Element(W.pPr);
+        if (pPr is null)
+        {
+            pPr = new XElement(W.pPr);
+            paragraph.AddFirst(pPr);
+        }
+        var rPr = pPr.Element(W.rPr);
+        if (rPr is null)
+        {
+            rPr = new XElement(W.rPr);
+            var sectPr = pPr.Element(W.sectPr);
+            var pPrChange = pPr.Element(W.pPrChange);
+            if (sectPr is not null) sectPr.AddBeforeSelf(rPr);
+            else if (pPrChange is not null) pPrChange.AddBeforeSelf(rPr);
+            else pPr.Add(rPr);
+        }
+        rPr.AddFirst(CreateRevisionEnvelope(wrapperName, author, date));
+
+        int rangeId = NextRevisionId();
+        var start = new XElement(from ? W.moveFromRangeStart : W.moveToRangeStart,
+            new XAttribute(W.id, rangeId),
+            new XAttribute(W.name, moveName),
+            new XAttribute(W.author, author),
+            new XAttribute(W.date, date));
+        var end = new XElement(from ? W.moveFromRangeEnd : W.moveToRangeEnd,
+            new XAttribute(W.id, rangeId));
+        pPr.AddAfterSelf(start);
+        paragraph.Add(end);
+    }
+
+    private void MarkTableRowsAsTrackedRevision(
+        XElement table, bool inserted, string author, string date)
+    {
+        EnsureTrackRevisionsEnabled();
+        foreach (var row in table.Descendants(W.tr))
+        {
+            var trPr = row.Element(W.trPr);
+            if (trPr is null)
+            {
+                trPr = new XElement(W.trPr);
+                row.AddFirst(trPr);
+            }
+            trPr.Add(CreateRevisionEnvelope(inserted ? W.ins : W.del, author, date));
+        }
+    }
 
     public EditResult InsertParagraph(string anchorId, Position pos, string markdownPayload)
     {

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -4494,27 +4494,10 @@ public sealed class DocxSession : IDisposable
             (pos == Position.After && ReferenceEquals(target.NextNode, source)))
             return new EditResult { Success = true };
 
-        if (source.Name == W.p && source.Element(W.pPr)?.Element(W.sectPr) is not null)
-            return EditResult.Fail(EditErrorCode.InvalidPosition,
-                "cannot move a paragraph that owns a section break", sourceAnchorId);
-
+        if (MoveSourceRejection(source) is { } sourceRejection)
+            return EditResult.Fail(EditErrorCode.InvalidPosition, sourceRejection, sourceAnchorId);
         if (BlockMoveSafetyError(parent, source, target, pos) is { } safetyError)
             return EditResult.Fail(EditErrorCode.InvalidPosition, safetyError, sourceAnchorId);
-
-        // Re-wrapping an existing revision can create illegal nested move markup. Direct
-        // mode can carry ordinary ins/del content safely, but an existing named move range
-        // is tied to its current document-order location and is intentionally immovable.
-        if (source.DescendantsAndSelf().Any(e =>
-                e.Name == W.moveFromRangeStart || e.Name == W.moveFromRangeEnd ||
-                e.Name == W.moveToRangeStart || e.Name == W.moveToRangeEnd))
-            return EditResult.Fail(EditErrorCode.InvalidPosition,
-                "cannot move a block that is already part of a native move range", sourceAnchorId);
-        if (_trackedChanges == TrackedChangeMode.RenderInline &&
-            source.DescendantsAndSelf().Any(e =>
-                e.Name == W.ins || e.Name == W.del || e.Name == W.moveFrom || e.Name == W.moveTo))
-            return EditResult.Fail(EditErrorCode.InvalidPosition,
-                "cannot create a tracked move around a block that already contains revisions",
-                sourceAnchorId);
 
         _history.RecordPreOp(TakeSnapshot());
         try
@@ -4537,6 +4520,13 @@ public sealed class DocxSession : IDisposable
             var destination = new XElement(source);
             foreach (var el in destination.DescendantsAndSelf())
                 el.Attributes(PtOpenXml.Unid).Remove();
+            RenumberClonedBookmarks(destination);
+
+            // Both copies are live while the revision is pending, so the shared comment ids have to
+            // be split. The move SOURCE takes the clones (see CloneCommentsForMoveSource), leaving
+            // the destination wired to the original comments and their threads.
+            if (_doc!.MainDocumentPart is { } commentHost)
+                Internal.CommentOps.CloneCommentsForMoveSource(commentHost, source);
 
             var author = _revisionAuthor ?? "docxodus";
             var date = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
@@ -4577,6 +4567,73 @@ public sealed class DocxSession : IDisposable
             if (preOp.ok) RestoreSnapshot(preOp.snapshot);
             return EditResult.Fail(EditErrorCode.InternalError, ex.Message, sourceAnchorId);
         }
+    }
+
+    /// <summary>Reject reasons that depend only on the SOURCE block — if one applies, the block
+    /// cannot be moved anywhere, so <see cref="ValidMoveTargets"/> can answer with an empty set
+    /// without testing a single target. Shared with <see cref="MoveBlock"/> so the drag UI and the
+    /// engine can never disagree about what is movable.</summary>
+    private string? MoveSourceRejection(XElement source)
+    {
+        if (source.Name == W.p && source.Element(W.pPr)?.Element(W.sectPr) is not null)
+            return "cannot move a paragraph that owns a section break";
+
+        // Re-wrapping an existing revision can create illegal nested move markup. Direct
+        // mode can carry ordinary ins/del content safely, but an existing named move range
+        // is tied to its current document-order location and is intentionally immovable.
+        if (source.DescendantsAndSelf().Any(e =>
+                e.Name == W.moveFromRangeStart || e.Name == W.moveFromRangeEnd ||
+                e.Name == W.moveToRangeStart || e.Name == W.moveToRangeEnd))
+            return "cannot move a block that is already part of a native move range";
+        if (_trackedChanges == TrackedChangeMode.RenderInline &&
+            source.DescendantsAndSelf().Any(e =>
+                e.Name == W.ins || e.Name == W.del || e.Name == W.moveFrom || e.Name == W.moveTo))
+            return "cannot create a tracked move around a block that already contains revisions";
+        return null;
+    }
+
+    /// <summary>
+    /// The anchors this block may legally be moved next to, in document order — the drop targets a
+    /// drag UI should offer. Empty when the block cannot move at all (it owns a section break, or
+    /// it already carries revision markup a move would have to re-wrap).
+    /// </summary>
+    /// <remarks>
+    /// One query answers a whole drag: the UI asks on drag start / menu open and gates its drop
+    /// indicators and menu items on the result, instead of drawing an indicator over a target the
+    /// engine will refuse. <see cref="MoveBlock"/> stays authoritative — this shares its guards
+    /// rather than restating them, so a target listed here is one <c>MoveBlock</c> accepts.
+    /// A target is listed when EITHER <see cref="Position.Before"/> or <see cref="Position.After"/>
+    /// is legal; the two differ only where a section break sits between the blocks.
+    /// </remarks>
+    public IReadOnlyList<string> ValidMoveTargets(string sourceAnchorId)
+    {
+        ThrowIfDisposed();
+        var empty = Array.Empty<string>();
+
+        var sourceTarget = FindAnchor(sourceAnchorId);
+        if (sourceTarget is null || sourceTarget.Anchor.Kind is not ("p" or "h" or "li" or "tbl"))
+            return empty;
+        var source = sourceTarget.Resolve(_doc!);
+        if (source?.Parent is not { } parent)
+            return empty;
+        if (!IsEditorBodyBlock(source, parent) || MoveSourceRejection(source) is not null)
+            return empty;
+
+        var targets = new List<string>();
+        foreach (var candidate in parent.Elements().Where(e => e.Name == W.p || e.Name == W.tbl))
+        {
+            if (ReferenceEquals(candidate, source) || !IsEditorBodyBlock(candidate, parent))
+                continue;
+            var unid = (string?)candidate.Attribute(PtOpenXml.Unid);
+            if (unid is null) continue;
+            var kind = candidate.Name == W.tbl ? "tbl" : WmlToMarkdownConverter.KindFor(candidate);
+            if (kind is null) continue;
+
+            if (BlockMoveSafetyError(parent, source, candidate, Position.Before) is null ||
+                BlockMoveSafetyError(parent, source, candidate, Position.After) is null)
+                targets.Add($"{kind}:{sourceTarget.Anchor.Scope}:{unid}");
+        }
+        return targets;
     }
 
     private static bool IsEditorBodyBlock(XElement block, XElement parent)
@@ -4663,11 +4720,87 @@ public sealed class DocxSession : IDisposable
         return order.Skip(a).Take(b - a + 1).ToHashSet();
     }
 
-    private void MarkParagraphAsTrackedMove(
-        XElement paragraph, bool from, string moveName, string author, string date)
+    /// <summary>
+    /// Give a tracked-move destination clone's bookmarks fresh, document-unique ids, preserving
+    /// each start↔end pairing and both copies' NAME.
+    /// </summary>
+    /// <remarks>
+    /// A tracked move keeps the source and the destination live at the same time, so every
+    /// id-bearing marker in the clone is a second copy. <c>w:bookmarkStart/@w:id</c> is
+    /// uniqueness-constrained, so leaving the clone's ids alone makes the document schema-invalid
+    /// for as long as the revision is pending — the state a redline is sent out in.
+    /// <para>
+    /// The NAME is deliberately duplicated: this mirrors
+    /// <c>IrMarkupRenderer.NormalizeBookmarks</c> step (B), whose rule for a whole-block-revised
+    /// paragraph is that the del copy and the ins copy each carry the name into their own
+    /// resolution. Accepting keeps the destination's bookmark, rejecting keeps the source's, so
+    /// every <c>REF</c>/<c>PAGEREF</c>/<c>HYPERLINK \l</c> still resolves either way.
+    /// </para>
+    /// </remarks>
+    private void RenumberClonedBookmarks(XElement destination)
     {
-        EnsureTrackRevisionsEnabled();
-        var wrapperName = from ? W.moveFrom : W.moveTo;
+        var starts = destination.DescendantsAndSelf(W.bookmarkStart).ToList();
+        var ends = destination.DescendantsAndSelf(W.bookmarkEnd).ToList();
+        if (starts.Count == 0 && ends.Count == 0)
+            return;
+
+        int next = GlobalMaxBookmarkId() + 1;
+        foreach (var start in starts)
+        {
+            var oldId = (string?)start.Attribute(W.id);
+            var fresh = (next++).ToString();
+            start.SetAttributeValue(W.id, fresh);
+            // Re-pair: the matching end is the clone's own end with the same original id.
+            foreach (var end in ends.Where(e => (string?)e.Attribute(W.id) == oldId).Take(1))
+                end.SetAttributeValue(W.id, fresh);
+        }
+    }
+
+    /// <summary>Highest <c>w:bookmarkStart</c>/<c>w:bookmarkEnd</c> id across every story in the
+    /// package, so a fresh id collides with nothing. Mirrors
+    /// <c>IrMarkupRenderer.GlobalMaxBookmarkId</c>.</summary>
+    private int GlobalMaxBookmarkId()
+    {
+        int max = 0;
+        var main = _doc!.MainDocumentPart;
+        if (main is null)
+            return max;
+
+        void Scan(XElement? root)
+        {
+            if (root is null) return;
+            foreach (var m in root.DescendantsAndSelf()
+                         .Where(e => e.Name == W.bookmarkStart || e.Name == W.bookmarkEnd))
+                if (int.TryParse((string?)m.Attribute(W.id), out var v) && v > max)
+                    max = v;
+        }
+
+        Scan(main.GetXDocument().Root);
+        foreach (var header in main.HeaderParts) Scan(header.GetXDocument().Root);
+        foreach (var footer in main.FooterParts) Scan(footer.GetXDocument().Root);
+        if (main.FootnotesPart is not null) Scan(main.FootnotesPart.GetXDocument().Root);
+        if (main.EndnotesPart is not null) Scan(main.EndnotesPart.GetXDocument().Root);
+        return max;
+    }
+
+    /// <summary>
+    /// Wrap every not-already-revised run of <paramref name="paragraph"/> in a
+    /// <paramref name="wrapperName"/> revision envelope and mark the paragraph mark to match.
+    /// </summary>
+    /// <remarks>
+    /// The single owner of "this whole paragraph is one revision" for <see cref="MoveBlock"/> —
+    /// used for a paragraph move (<c>w:moveFrom</c>/<c>w:moveTo</c>) and for the cell paragraphs
+    /// of a moved table (<c>w:del</c>/<c>w:ins</c>). A DELETING wrapper also converts
+    /// <c>w:t</c>→<c>w:delText</c> (and <c>w:instrText</c>→<c>w:delInstrText</c>), which is what
+    /// Word writes, what <c>IrMarkupRenderer.ConvertTextToDelText</c> produces, and what
+    /// <see cref="RevisionProcessor"/>'s reject path swaps back. Without the paragraph mark,
+    /// accepting the move leaves an empty source paragraph and rejecting leaves an empty
+    /// destination one; <c>RevisionOps</c> associates the mark with the named range.
+    /// </remarks>
+    private XElement MarkParagraphContentAndMark(
+        XElement paragraph, XName wrapperName, string author, string date)
+    {
+        bool deleting = wrapperName == W.del || wrapperName == W.moveFrom;
 
         // Keep hyperlink/SDT/field containers in place and revision-wrap their runs.
         // This is the schema-safe shape (w:hyperlink > w:moveFrom|moveTo > w:r).
@@ -4680,11 +4813,9 @@ public sealed class DocxSession : IDisposable
             var envelope = CreateRevisionEnvelope(wrapperName, author, date);
             run.ReplaceWith(envelope);
             envelope.Add(run);
+            if (deleting) ConvertTextToDeletedText(run);
         }
 
-        // Revise the paragraph mark as well as its runs. Without this mark, accepting
-        // the move leaves an empty source paragraph and rejecting it leaves an empty
-        // destination paragraph. RevisionOps associates the mark with the named range.
         var pPr = paragraph.Element(W.pPr);
         if (pPr is null)
         {
@@ -4702,6 +4833,25 @@ public sealed class DocxSession : IDisposable
             else pPr.Add(rPr);
         }
         rPr.AddFirst(CreateRevisionEnvelope(wrapperName, author, date));
+        return pPr;
+    }
+
+    /// <summary>Convert a deleted run-level element's text to its deleted spelling in place.
+    /// Mirrors <c>IrMarkupRenderer.ConvertTextToDelText</c>.</summary>
+    private static void ConvertTextToDeletedText(XElement runLevel)
+    {
+        foreach (var t in runLevel.DescendantsAndSelf(W.t).ToList())
+            t.Name = W.delText;
+        foreach (var instr in runLevel.DescendantsAndSelf(W.instrText).ToList())
+            instr.Name = W.delInstrText;
+    }
+
+    private void MarkParagraphAsTrackedMove(
+        XElement paragraph, bool from, string moveName, string author, string date)
+    {
+        EnsureTrackRevisionsEnabled();
+        var pPr = MarkParagraphContentAndMark(
+            paragraph, from ? W.moveFrom : W.moveTo, author, date);
 
         int rangeId = NextRevisionId();
         var start = new XElement(from ? W.moveFromRangeStart : W.moveToRangeStart,
@@ -4715,11 +4865,18 @@ public sealed class DocxSession : IDisposable
         paragraph.Add(end);
     }
 
+    /// <summary>
+    /// Mark a whole table as inserted or deleted: the row-existence revision on every
+    /// <c>w:trPr</c> AND the cell content, matching the design's whole-table lowering ("every
+    /// source row <em>and its content</em> is deleted"). Row marks alone leave the moved-away
+    /// table's text rendering as ordinary body text inside a row Word believes is deleted.
+    /// </summary>
     private void MarkTableRowsAsTrackedRevision(
         XElement table, bool inserted, string author, string date)
     {
         EnsureTrackRevisionsEnabled();
-        foreach (var row in table.Descendants(W.tr))
+        var wrapperName = inserted ? W.ins : W.del;
+        foreach (var row in table.Descendants(W.tr).ToList())
         {
             var trPr = row.Element(W.trPr);
             if (trPr is null)
@@ -4727,7 +4884,9 @@ public sealed class DocxSession : IDisposable
                 trPr = new XElement(W.trPr);
                 row.AddFirst(trPr);
             }
-            trPr.Add(CreateRevisionEnvelope(inserted ? W.ins : W.del, author, date));
+            trPr.Add(CreateRevisionEnvelope(wrapperName, author, date));
+            foreach (var paragraph in row.Descendants(W.p).ToList())
+                MarkParagraphContentAndMark(paragraph, wrapperName, author, date);
         }
     }
 

--- a/Docxodus/Internal/CommentOps.cs
+++ b/Docxodus/Internal/CommentOps.cs
@@ -366,6 +366,96 @@ internal static class CommentOps
     }
 
     /// <summary>
+    /// Re-home the comment markers inside a tracked-move SOURCE block onto freshly cloned comment
+    /// definitions, so the source copy and the destination clone no longer share comment ids.
+    /// </summary>
+    /// <remarks>
+    /// A tracked move leaves two live copies of the block. Copying the markers verbatim would give
+    /// one comment two ranges and two references — a schema violation (<c>w:id</c> is
+    /// uniqueness-constrained) and a visible defect: the comment shows twice in the Reviewing
+    /// pane. This mirrors <c>IrMarkupRenderer.NormalizeComments</c> step (B): the DELETED copy —
+    /// here the <c>w:moveFrom</c> source — takes the fresh id and a cloned definition, so
+    /// accepting keeps the destination's original comment (with its thread intact) and rejecting
+    /// keeps the source's clone.
+    /// <para>
+    /// Every comment referenced from the block is cloned, so a whole thread (a root plus the
+    /// replies whose references live in the same paragraph) is cloned together and the clones'
+    /// <c>w15:paraIdParent</c> links are re-pointed at the cloned parents rather than at the
+    /// originals.
+    /// </para>
+    /// </remarks>
+    internal static void CloneCommentsForMoveSource(MainDocumentPart main, XElement source)
+    {
+        static bool IsMarker(XElement e) =>
+            e.Name == W.commentRangeStart || e.Name == W.commentRangeEnd || e.Name == W.commentReference;
+
+        var markers = source.DescendantsAndSelf().Where(IsMarker).ToList();
+        if (markers.Count == 0) return;
+
+        var commentsRoot = main.WordprocessingCommentsPart?.GetXDocument().Root;
+        if (commentsRoot is null) return;
+
+        var oldIds = markers.Select(m => (string?)m.Attribute(W.id))
+            .Where(id => id is not null).Distinct().ToList();
+
+        // Original last-paragraph paraId → the clone's, so cloned replies re-point at cloned parents.
+        var paraIdMap = new Dictionary<string, string>();
+        var clonedParents = new List<(XElement Clone, string OldParentParaId)>();
+        var exRoot = main.WordprocessingCommentsExPart?.GetXDocument().Root;
+
+        foreach (var oldId in oldIds)
+        {
+            var definition = commentsRoot.Elements(W.comment)
+                .FirstOrDefault(c => (string?)c.Attribute(W.id) == oldId);
+            if (definition is null) continue; // dangling marker: nothing to clone, id stays put
+
+            var oldParaId = (string?)definition.Elements(W.p).LastOrDefault()?.Attribute(W14.paraId);
+            var oldEx = oldParaId is null || exRoot is null
+                ? null
+                : exRoot.Elements(W15 + "commentEx")
+                    .FirstOrDefault(e => (string?)e.Attribute(W15 + "paraId") == oldParaId);
+
+            var clone = new XElement(definition);
+            clone.SetAttributeValue(W.id, NextCommentId(main).ToString(CultureInfo.InvariantCulture));
+            // Strip the identities the clone must not share: paraId keys the threading parts and
+            // Unid keys the projection index. EnsureThreadingMetadata mints a fresh paraId below.
+            foreach (var el in clone.DescendantsAndSelf())
+            {
+                el.Attributes(W14.paraId).Remove();
+                el.Attributes(PtOpenXml.Unid).Remove();
+            }
+            commentsRoot.Add(clone);
+
+            var newId = (string)clone.Attribute(W.id)!;
+            foreach (var marker in markers.Where(m => (string?)m.Attribute(W.id) == oldId))
+                marker.SetAttributeValue(W.id, newId);
+
+            var newParaId = EnsureThreadingMetadata(
+                main, clone, resolved: ParseDone((string?)oldEx?.Attribute(W15 + "done")));
+            if (oldParaId is not null) paraIdMap[oldParaId] = newParaId;
+            if ((string?)oldEx?.Attribute(W15 + "paraIdParent") is { } oldParent)
+                clonedParents.Add((clone, oldParent));
+        }
+
+        // Re-point cloned replies at their cloned parent. A parent outside the moved block was not
+        // cloned — the reply then becomes top-level rather than dangling, matching the teardown
+        // policy in PruneThreadingMetadata.
+        foreach (var (clone, oldParent) in clonedParents)
+        {
+            var paraId = (string?)clone.Elements(W.p).LastOrDefault()?.Attribute(W14.paraId);
+            var entry = paraId is null ? null : main.WordprocessingCommentsExPart?.GetXDocument().Root?
+                .Elements(W15 + "commentEx")
+                .FirstOrDefault(e => (string?)e.Attribute(W15 + "paraId") == paraId);
+            if (entry is null) continue;
+            if (paraIdMap.TryGetValue(oldParent, out var newParent))
+                entry.SetAttributeValue(W15 + "paraIdParent", newParent);
+            else
+                entry.Attributes(W15 + "paraIdParent").Remove();
+        }
+        main.WordprocessingCommentsExPart?.PutXDocument();
+    }
+
+    /// <summary>
     /// Prune Word's comment-threading metadata for removed comment definitions:
     /// <c>commentsExtended.xml</c> (<c>w15:commentEx</c>) and <c>commentsIds.xml</c>
     /// (<c>w16cid:commentId</c>) entries key on a definition paragraph's <c>w14:paraId</c>, so a

--- a/Docxodus/Internal/DocxSessionJson.cs
+++ b/Docxodus/Internal/DocxSessionJson.cs
@@ -695,6 +695,20 @@ internal static class DocxSessionJson
         return sb.ToString();
     }
 
+    /// <summary>A bare JSON array of anchor ids — the wire shape for
+    /// <see cref="DocxSession.ValidMoveTargets"/>.</summary>
+    public static string SerializeAnchorIds(IReadOnlyList<string> anchorIds)
+    {
+        var sb = new StringBuilder(2 + anchorIds.Count * 48);
+        sb.Append('[');
+        for (int i = 0; i < anchorIds.Count; i++)
+        {
+            if (i > 0) sb.Append(',');
+            sb.Append(JsonString(anchorIds[i]));
+        }
+        return sb.Append(']').ToString();
+    }
+
     /// <summary>
     /// The projection's anchor index WITHOUT the markdown payload — the shape the
     /// editor's anchor-map refresh needs. Emits the same <c>{"anchorIndex":{…}}</c>

--- a/Docxodus/Internal/DocxSessionJson.cs
+++ b/Docxodus/Internal/DocxSessionJson.cs
@@ -695,16 +695,19 @@ internal static class DocxSessionJson
         return sb.ToString();
     }
 
-    /// <summary>A bare JSON array of anchor ids — the wire shape for
-    /// <see cref="DocxSession.ValidMoveTargets"/>.</summary>
-    public static string SerializeAnchorIds(IReadOnlyList<string> anchorIds)
+    /// <summary>The wire shape for <see cref="DocxSession.ValidMoveTargets"/>:
+    /// <c>[{"anchorId":…,"before":true,"after":false}]</c>.</summary>
+    public static string SerializeMoveTargets(IReadOnlyList<MoveTarget> targets)
     {
-        var sb = new StringBuilder(2 + anchorIds.Count * 48);
+        var sb = new StringBuilder(2 + targets.Count * 72);
         sb.Append('[');
-        for (int i = 0; i < anchorIds.Count; i++)
+        for (int i = 0; i < targets.Count; i++)
         {
             if (i > 0) sb.Append(',');
-            sb.Append(JsonString(anchorIds[i]));
+            sb.Append("{\"anchorId\":").Append(JsonString(targets[i].AnchorId))
+              .Append(",\"before\":").Append(targets[i].Before ? "true" : "false")
+              .Append(",\"after\":").Append(targets[i].After ? "true" : "false")
+              .Append('}');
         }
         return sb.Append(']').ToString();
     }

--- a/Docxodus/Internal/DocxSessionOps.cs
+++ b/Docxodus/Internal/DocxSessionOps.cs
@@ -54,6 +54,10 @@ internal static class DocxSessionOps
     public static string ListBlocks(int handle) =>
         DocxSessionJson.SerializeRenderPlan(SessionRegistry.Get(handle).ListBlocks());
 
+    public static string ListRenderedBlocks(int handle, bool renderTrackedChanges) =>
+        DocxSessionJson.SerializeRenderPlan(
+            SessionRegistry.Get(handle).ListBlocks(renderTrackedChanges));
+
     /// <summary>Citation-ordered footnotes/endnotes — the id↔ordinal authority a client
     /// renumbering rendered note chrome walks. See <see cref="NoteListEntry"/>.</summary>
     public static string ListNotes(int handle, bool endnotes) =>
@@ -255,6 +259,11 @@ internal static class DocxSessionOps
     }
 
     // ─── Tier B: structural ─────────────────────────────────────────────
+
+    public static string MoveBlock(int handle, string sourceAnchorId, string targetAnchorId,
+        Position position) =>
+        DocxSessionJson.Serialize(
+            SessionRegistry.Get(handle).MoveBlock(sourceAnchorId, targetAnchorId, position));
 
     public static string InsertParagraph(int handle, string anchorId, Position position, string markdown) =>
         DocxSessionJson.Serialize(SessionRegistry.Get(handle).InsertParagraph(anchorId, position, markdown));

--- a/Docxodus/Internal/DocxSessionOps.cs
+++ b/Docxodus/Internal/DocxSessionOps.cs
@@ -265,10 +265,11 @@ internal static class DocxSessionOps
         DocxSessionJson.Serialize(
             SessionRegistry.Get(handle).MoveBlock(sourceAnchorId, targetAnchorId, position));
 
-    /// <summary>The anchors <paramref name="sourceAnchorId"/> may legally move next to — what a
-    /// drag UI gates its drop targets on, so it never offers a drop the engine will refuse.</summary>
+    /// <summary>The blocks <paramref name="sourceAnchorId"/> may legally move next to, and on which
+    /// side — what a drag UI gates its drop targets on, so it never offers a drop the engine
+    /// will refuse.</summary>
     public static string ValidMoveTargets(int handle, string sourceAnchorId) =>
-        DocxSessionJson.SerializeAnchorIds(
+        DocxSessionJson.SerializeMoveTargets(
             SessionRegistry.Get(handle).ValidMoveTargets(sourceAnchorId));
 
     public static string InsertParagraph(int handle, string anchorId, Position position, string markdown) =>

--- a/Docxodus/Internal/DocxSessionOps.cs
+++ b/Docxodus/Internal/DocxSessionOps.cs
@@ -265,6 +265,12 @@ internal static class DocxSessionOps
         DocxSessionJson.Serialize(
             SessionRegistry.Get(handle).MoveBlock(sourceAnchorId, targetAnchorId, position));
 
+    /// <summary>The anchors <paramref name="sourceAnchorId"/> may legally move next to — what a
+    /// drag UI gates its drop targets on, so it never offers a drop the engine will refuse.</summary>
+    public static string ValidMoveTargets(int handle, string sourceAnchorId) =>
+        DocxSessionJson.SerializeAnchorIds(
+            SessionRegistry.Get(handle).ValidMoveTargets(sourceAnchorId));
+
     public static string InsertParagraph(int handle, string anchorId, Position position, string markdown) =>
         DocxSessionJson.Serialize(SessionRegistry.Get(handle).InsertParagraph(anchorId, position, markdown));
 

--- a/Docxodus/Internal/RevisionOps.cs
+++ b/Docxodus/Internal/RevisionOps.cs
@@ -326,6 +326,16 @@ internal static class RevisionOps
         string? moveName = null;
         if (n == W.moveFrom && ctx.MoveFromStack.Count > 0) moveName = ctx.MoveFromStack[^1].Name;
         else if (n == W.moveTo && ctx.MoveToStack.Count > 0) moveName = ctx.MoveToStack[^1].Name;
+        else if (kind == UnitKind.ParaMark && paragraph is not null &&
+                 (n == W.moveFrom || n == W.moveTo))
+        {
+            // Whole-paragraph moves revise the paragraph mark in pPr/rPr. The named
+            // range lives in the paragraph body and its stack has closed by the time
+            // WalkParagraph emits this final pilcrow unit, so recover the name from
+            // the sibling range start and keep the whole move one selectable revision.
+            var startName = n == W.moveFrom ? W.moveFromRangeStart : W.moveToRangeStart;
+            moveName = (string?)paragraph.Elements(startName).FirstOrDefault()?.Attribute(W.name);
+        }
         return new RevisionUnit
         {
             Element = el,

--- a/Docxodus/RevisionProcessor.cs
+++ b/Docxodus/RevisionProcessor.cs
@@ -2611,6 +2611,12 @@ namespace Docxodus
                                     // in the sequence of coalesced paragraph.  It is possible that we should take Last when accepting revisions, but First when rejecting revisions.
                                     g.First().BlockLevelContent.ThisBlockContentElement.Elements(W.pPr),
 #endif
+                                    // Identity comes from the SAME member the properties do. Building the
+                                    // coalesced paragraph without its attributes dropped pt:Unid, so an
+                                    // anchor-stamped render of the resolved document emitted a block with no
+                                    // data-anchor — unaddressable, and invisible to the editor's reconciler,
+                                    // which diffs the rendered DOM against ListBlocks.
+                                    paragraphMembers.Last().BlockLevelContent.ThisBlockContentElement.Attributes(),
                                     paragraphMembers.Last().BlockLevelContent.ThisBlockContentElement.Elements(W.pPr),
                                     paragraphMembers.Select(z => CollapseParagraphTransform(z.BlockLevelContent.ThisBlockContentElement)));
 

--- a/docs/architecture/docx_mutation_api.md
+++ b/docs/architecture/docx_mutation_api.md
@@ -226,7 +226,7 @@ What am I editing?
 
 ```csharp
 EditResult MoveBlock(string sourceAnchorId, string targetAnchorId, Position pos);
-IReadOnlyList<string> ValidMoveTargets(string sourceAnchorId);
+IReadOnlyList<MoveTarget> ValidMoveTargets(string sourceAnchorId);  // record(AnchorId, Before, After)
 ```
 
 `MoveBlock` reorders ONE top-level body block relative to another — the model half of the
@@ -265,13 +265,25 @@ the whole table instead).
 
 ### `ValidMoveTargets` — ask before offering
 
-Returns the anchors `sourceAnchorId` may legally move next to, in document order; empty when
-the block cannot move at all. It shares `MoveBlock`'s guards rather than restating them, so a
-listed target is one `MoveBlock` accepts. A drag UI calls it once per drag source instead of
-drawing a drop indicator over a target the engine will refuse — and because a section break
-partitions the body into regions, "move to top/bottom" means the ends of the source's own
-region. `MoveBlock` stays authoritative: the gate is advisory, and a caller that bypasses it
-still gets the typed error. WASM/npm only, like the other editor-support endpoints.
+Returns the blocks `sourceAnchorId` may legally move next to, in document order; empty when the
+block cannot move at all. It shares `MoveBlock`'s guards rather than restating them, so a listed
+`(target, side)` pair is one `MoveBlock` accepts.
+
+**The two sides are reported separately, and that distinction is load-bearing.** Landing *into* a
+cross-block bookmark/comment/permission range changes its membership while landing outside it does
+not, so a target is routinely legal `Before` and refused `After` (or the reverse) — a caller that
+knows only "this target is reachable" will pick the refused side half the time. The editor gates
+its drop indicator on the side, snaps a drop to the legal side when only one is, and resolves each
+move-menu command against `(target, side)` pairs. Because a section break partitions the body,
+"move to top/bottom" means the ends of the source's own region.
+
+Note the practical consequence on real documents: a heavily cross-referenced contract can restrict
+moves far more than its section breaks alone would suggest, because most blocks sit inside some
+range. That is the confirmed v1 safety policy (reject rather than silently re-scope a range), not a
+defect — and it is why the UI must ask rather than offer everything and fail on drop.
+
+`MoveBlock` stays authoritative: the gate is advisory, and a caller that bypasses it still gets the
+typed error. WASM/npm only, like the other editor-support endpoints.
 
 ## Bulk block removal — `DeleteRange` and `DeleteSection`
 

--- a/docs/architecture/docx_mutation_api.md
+++ b/docs/architecture/docx_mutation_api.md
@@ -222,6 +222,57 @@ What am I editing?
           session.Undo() restores prior state.
 ```
 
+## Block reordering — `MoveBlock` and `ValidMoveTargets`
+
+```csharp
+EditResult MoveBlock(string sourceAnchorId, string targetAnchorId, Position pos);
+IReadOnlyList<string> ValidMoveTargets(string sourceAnchorId);
+```
+
+`MoveBlock` reorders ONE top-level body block relative to another — the model half of the
+editor's drag handle. Source and target must be block kinds (`p`, `h`, `li`, `tbl`), live in
+the same part, and share a direct XML parent (so a block-level `w:sdt` boundary is never
+crossed: that would change content-control membership). Moving a block to where it already
+is succeeds as a no-op **and records no undo snapshot**.
+
+| Tracking | Behaviour |
+|---|---|
+| Off (`Accept`) | Detaches and re-inserts the EXISTING element. Descendant Unids, hyperlink/image/comment/note relationship ids all stay valid — v1 only moves within one part. |
+| `RenderInline` | Keeps a revision-marked source and adds a revision-marked destination. A paragraph-like block uses one named `w:moveFrom`/`w:moveTo` pair (`ListRevisions` reports it as a single `move` revision that resolves both sides); a table lowers to Word's row delete + insert, which Word may present as two revisions. `EditResult.Created` carries the destination anchor so focus can follow the moved block. |
+
+`accept ≡ the requested order` and `reject ≡ the original order` hold for both shapes.
+
+**Two live copies, so ids must be split.** A tracked move duplicates the block, and the clone's
+id-bearing markers would otherwise collide:
+
+- bookmarks — the destination clone takes fresh document-unique ids; **both copies keep the
+  NAME**, so each survives its own resolution and cross-references resolve either way;
+- comments — the move SOURCE takes a fresh comment id and a cloned definition (fresh
+  `w14:paraId`, entries in both threading parts, cloned replies re-pointed at cloned parents),
+  leaving the destination on the original comment and its thread;
+- footnote/endnote references — deliberately duplicated: a note cited at both the old and new
+  position is a faithful pending move, and exactly one citation survives either resolution.
+
+### Refusals
+
+`InvalidPosition` for: a different parent or part; a source owning an inline `w:pPr/w:sectPr`
+(a section boundary, not an ordinary visual block); a move that would change or invert a
+cross-block comment, bookmark, permission or native-move range; a move whose span crosses a
+section-break paragraph; a source already inside a native move range; and — in tracked mode
+only — a source that already contains revision markup a move would have to re-wrap.
+`AnchorWrongKind` for a non-block kind or a non-top-level block (a table cell paragraph: move
+the whole table instead).
+
+### `ValidMoveTargets` — ask before offering
+
+Returns the anchors `sourceAnchorId` may legally move next to, in document order; empty when
+the block cannot move at all. It shares `MoveBlock`'s guards rather than restating them, so a
+listed target is one `MoveBlock` accepts. A drag UI calls it once per drag source instead of
+drawing a drop indicator over a target the engine will refuse — and because a section break
+partitions the body into regions, "move to top/bottom" means the ends of the source's own
+region. `MoveBlock` stays authoritative: the gate is advisory, and a caller that bypasses it
+still gets the typed error. WASM/npm only, like the other editor-support endpoints.
+
 ## Bulk block removal — `DeleteRange` and `DeleteSection`
 
 ### `DeleteRange` — bulk sibling removal

--- a/docs/architecture/editor_block_drag_handles.md
+++ b/docs/architecture/editor_block_drag_handles.md
@@ -1,0 +1,459 @@
+# Editor block drag handles — feasibility and implementation plan
+
+Status: **investigation / design; product direction confirmed** (no feature
+implementation yet).
+
+Investigation branch: `investigate/block-drag-handles`, based on `origin/main`
+`f290c23` (2026-08-05).
+
+## Verdict
+
+Adding an Atlassian-style handle for reordering editor blocks is feasible without
+changing the editor's model-of-record. The UI half is a contained addition to
+`DocxEditor`; the missing prerequisite is an **atomic, anchor-addressed `MoveBlock`
+mutation on `DocxSession`**. Because moves must produce native Word revisions when track
+changes is enabled, the editor's currently accepted-only render/reconcile path also needs
+to become revision-view-aware.
+
+The feature must not reorder only the DOM. The DOM is a projection; `save()` serializes
+the live OOXML session, so a DOM-only move would disappear on save and undo. The correct
+flow is:
+
+```text
+handle drag / accessible move command
+  -> source anchor + target anchor + before|after
+  -> DocxSession.MoveBlock (one OOXML mutation, one undo snapshot)
+  -> ordered-unit reconcile (or paginated/list fallback remount)
+  -> focus restored to the moved block
+```
+
+This is a medium-sized editor feature rather than a rewrite. Recommended scope and
+effort:
+
+| Deliverable | Scope | Estimate |
+|---|---|---:|
+| Interaction spike | Pointer-only, continuous view, paragraphs, remount after drop | 1–2 engineering days |
+| Direct-move foundation | Paragraphs/headings/list items + whole tables, continuous view, keyboard/menu alternative, undo/redo, autoscroll, incremental reorder, tests | 5–8 engineering days |
+| Native-revision integration | Review-aware editor projection, named paragraph moves, tracked whole-table relocation, author/date, accept/reject and save/reopen tests | +4–7 engineering days |
+| Confirmed production scope | Direct moves plus native revisions in continuous view | **9–15 engineering days total** |
+| Paginated hardening | Cross-page targeting, scroll, full reflow/remount, focus restoration | +2–4 engineering days |
+
+The estimates assume one engineer familiar with this repository and include the required
+bridge/client ripple and browser tests. Cross-block OOXML ranges may add time if v1 must
+preserve their exact membership rather than rejecting unsafe moves (see “OOXML safety”).
+
+## Confirmed v1 direction
+
+1. Reorder **top-level body render units only**: `p`, `h`, `li`, and a whole `tbl`.
+   Never expose a separate handle for a table-cell paragraph; hovering/focusing inside a
+   table targets the table unit.
+2. Ship **continuous view first**. Paginated dragging is follow-up scope and should do a
+   full session-attached remount after drop until scoped repagination exists (roadmap M4).
+3. Follow Word editing semantics: with track changes off, directly reorder the existing
+   element; with track changes on, emit native Word revision markup with the configured
+   author/date. Paragraph-like blocks use a named `w:moveFrom`/`w:moveTo` pair. A whole
+   table uses Word's table-row insertion/deletion revision vocabulary unless a Word-made
+   fixture demonstrates a conformant named whole-table move shape (details below).
+4. Keep the framework-agnostic `DocxEditor` backward compatible with a new option such as
+   `blockDrag?: boolean` (default `false`); the full `mountRibbon` surface can default it
+   to `true`.
+5. Use the handle as both a drag source and a button. Click/keyboard opens a small move
+   menu (`Move before…`, `Move after…`, `Move to top`, `Move to bottom`) and completion is
+   announced through an `aria-live` region. Pointer dragging is not an accessible
+   substitute for those commands.
+6. Use Atlassian's Pragmatic drag-and-drop runtime plus its optional autoscroll package;
+   Docxodus continues to own the handle, drop indicator, menu, and live-region UI.
+7. Reject moves that would change or invert pre-existing cross-block comment, bookmark,
+   permission, or native-move ranges. Invalid targets should not display a drop indicator.
+8. For whole tables in track-changes mode, accept Word-native source deletion plus
+   destination insertion even when Word presents them as separate revisions rather than
+   one named “Moved” revision.
+
+## What already exists
+
+The current architecture supplies most of the feature:
+
+- Every rendered paragraph/heading/list item/table has `data-anchor`; `DocxEditor` maps it
+  to the session's full `kind:scope:unid` address.
+- `DocxSession` owns lossless OOXML mutation, bounded undo/redo, and transactional
+  pre-operation snapshots.
+- `ListBlocks` already returns body units in document order, flattening block-level
+  content controls to mirror the renderer.
+- `DocxEditor.reconcile()` already diffs the DOM's ordered units against `ListBlocks`,
+  batch-renders changed units, and preserves untouched DOM nodes.
+- `bodyUnitNodes()` already collapses cell paragraphs into one table unit—the exact list
+  the drag UI needs.
+- Continuous mode can patch structurally; paginated mode already falls back to a full
+  remount, which is correct for cross-page reflow.
+- The editor already owns document-level mouse handlers for cross-contenteditable text
+  selection. A handle outside the editable block avoids conflicting with that path.
+
+The notable gaps are:
+
+- no `DocxSession.MoveBlock` / bridge command;
+- the unit diff classifies a pure reorder as remove+add/substitution, and
+  `applyBodyDiff()` explicitly rejects kept nodes appearing in a different order;
+- no handle/drop-indicator UI, drag lifecycle, autoscroll, or accessible alternative;
+- no move-specific OOXML safety policy;
+- `DocxEditor` hard-codes an accepted revision view while `ListBlocks()` enumerates raw
+  XML blocks. A tracked move creates source and destination blocks, so the HTML and render
+  plan would diverge after the first move unless both become revision-view-aware.
+
+## Model mutation
+
+Add this primitive at the core, then expose the same operation through every session
+transport:
+
+```csharp
+public EditResult MoveBlock(
+    string sourceAnchorId,
+    string targetAnchorId,
+    Position position); // Before | After
+```
+
+### Contract
+
+- Source and target must resolve, be block-level kinds (`p`, `h`, `li`, `tbl`), live in
+  the same package part, and share a direct XML parent.
+- Moving a source relative to itself, or to the position it already occupies, is a
+  successful no-op and records no undo snapshot.
+- A real move records exactly one pre-op snapshot. In accepted/direct mode it detaches
+  the existing `XElement` and inserts that same element before/after the target. It must
+  not clone/reparse XML in this mode.
+- In direct mode, the existing element and all descendant Unids remain unchanged.
+  Hyperlink, image, comment, note, and other relationship IDs remain valid because v1
+  only moves within one part.
+- In tracked mode, preserve a revision-marked source at the old location and add a
+  revision-marked destination at the new location. The two live elements need distinct
+  anchor identities while both revisions are visible; `EditResult` must return the
+  destination anchor so focus follows the logical moved block.
+- Invalidate the projection/index cache and return the current source and target anchors
+  in `EditResult.Modified`. Returning both lets the client recognize list/contextual
+  repaint requirements.
+- On failure, restore the snapshot and return the existing typed error envelope.
+- A paragraph carrying an inline `pPr/sectPr` should be rejected in v1. It represents a
+  section boundary, not an ordinary visual block; moving it has surprising header,
+  footer, margin, and page-numbering effects.
+
+The same-parent rule intentionally rejects a move into/out of a block-level `w:sdt` even
+though the HTML renderer visually flattens its contents. Moving across that boundary
+would change content-control semantics. The UI can initially surface the core error; a
+polished version should add container identity/movability to `ListBlocks` so it never
+draws an invalid drop target.
+
+### Required layer ripple
+
+Per the repository's single-owner session architecture, the operation should be added to:
+
+1. `Docxodus/DocxSession.cs` and `Docxodus.Tests/DocxSessionTests.cs`.
+2. `Docxodus/Internal/DocxSessionOps.cs`.
+3. `wasm/DocxodusWasm/DocxSessionBridge.cs`.
+4. `tools/python-host/Dispatcher.cs`.
+5. `npm/src/types.ts`, `npm/src/session.ts`, and `npm/src/editor.ts`'s narrow bridge type.
+6. `python/src/docx_scalpel/session.py`.
+7. `tools/mcp-server/ToolCatalog.cs` and `tools/mcp-server/Dispatcher.cs` if the generic
+   agent edit surface is intended to keep parity (recommended).
+8. `docs/architecture/docx_mutation_api.md` and the public npm/Python API docs.
+
+No new response type is required; the existing `EditResult` wire shape is sufficient.
+
+## Native Word revision semantics
+
+`DocxSession` already has most of the revision plumbing this operation needs:
+
+- mutable `TrackedChangeMode` and revision-author session settings;
+- monotonic revision IDs and author/date envelopes;
+- automatic `w:trackRevisions` document setting;
+- native paragraph move emission in `IrMarkupRenderer`;
+- grouped accept/reject behavior for named `moveFrom`/`moveTo` pairs; and
+- whole-table insert/delete marking that round-trips through accept/reject.
+
+The new mutation should reuse or extract those helpers rather than create a second OOXML
+revision dialect.
+
+### Paragraphs, headings, and list items
+
+When `TrackedChangeMode.RenderInline` is active, retain a move-source paragraph at the old
+position and create a move-destination paragraph at the requested position. Use one named
+move group with paired `w:moveFromRangeStart`/`End` and
+`w:moveToRangeStart`/`End`; mark both run content and paragraph marks as moved. This is the
+same native shape the existing IR diff renderer emits and lets selective accept/reject
+resolve the pair as one logical move.
+
+The OOXML definition is explicitly paragraph/run based: Microsoft's SDK documentation
+calls `w:moveFrom` in paragraph properties a “Move Source Paragraph,” and the move-range
+documentation describes the moved pieces as inline content and paragraphs:
+
+- [MoveFrom (Move Source Paragraph)](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.movefrom?view=openxml-3.0.1)
+- [MoveToRangeStart (named move destination container)](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.movetorangestart?view=openxml-3.0.1)
+
+### Whole tables
+
+WordprocessingML has row/cell insertion and deletion revisions, but no corresponding
+table-existence `moveFrom`/`moveTo` marker. The existing `IrMarkupRenderer` therefore
+deliberately lowers a non-paragraph `MoveBlock` to a whole-block delete plus insert:
+every source row and its content is deleted, and every destination row and its content is
+inserted. Accept keeps the destination and removes the source; reject does the inverse.
+This is native, conformant Word revision markup, but Word may present it as a deletion and
+an insertion rather than one named “Moved” revision.
+
+That lowering is the recommended v1 behavior for a dragged table. Do not invent a named
+whole-table move by merely bracketing a `w:tbl`: although move range markers are legal in
+several table containers, a range marker alone does not revision-track the existence of
+the table or its rows. A different representation should only ship after capturing a
+whole-table move made by desktop Word and pinning Word/Open XML validation plus
+accept/reject golden tests. Relevant schema semantics:
+
+- [Table (`w:tbl`) content model](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.table?view=openxml-2.20.0)
+- [Inserted table row (`w:trPr/w:ins`)](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.inserted?view=openxml-3.0.1)
+
+### Review-aware editor projection
+
+This is the largest addition caused by the confirmed track-changes requirement:
+
+1. Add editor options for the mutation mode and revision author, and expose the existing
+   `SetTrackedChanges`/`SetRevisionAuthor` bridge methods through `DocxEditor`'s narrow
+   bridge type. Track-changes-off remains the backward-compatible default.
+2. In inline-review mode, pass `renderTrackedChanges: true`,
+   `showDeletedContent: true`, and `renderMoveOperations: true` consistently through
+   first paint, `RenderHtml`, `RenderBlocksHtml`, and fallback rendering. The converter
+   already knows how to render move sources/destinations and inserted/deleted table rows.
+3. Make `ListBlocks` follow the selected render view. Today it lists raw `w:p`/`w:tbl`
+   siblings even when the accepted HTML renderer removes deleted/move-source content.
+   Either add a render-view parameter or expose a separate `ListRenderedBlocks` plan so
+   the plan and DOM always contain the same units.
+4. Treat source and destination as separate visible units in inline-review mode. Reconcile
+   can render both; focus and the post-drop flash follow the destination. In accepted view
+   only the destination belongs in the render plan.
+5. Pin changing modes with pre-existing revisions: switching mutation mode does not
+   accept/reject old revisions, so render view and mutation mode should be separate editor
+   concepts even if the first UI toggles them together.
+
+## Ordered-unit reconcile
+
+`diffUnits()` should represent exact-token reorders explicitly:
+
+```ts
+interface UnitDiff {
+  keep: Map<number, number>;
+  removed: number[];
+  added: number[];
+  substituted: Array<{ oldIndex: number; newIndex: number }>;
+  moved: Array<{ oldIndex: number; newIndex: number }>;
+}
+```
+
+Pair identical `unid|contentSignature` entries found in both `removed` and `added` as
+`moved` before the existing same-Unid substitution pass. A substitution means “same slot,
+fresh HTML”; a move means “same live DOM node, new slot.” Keeping those concepts separate
+is necessary for undo/redo as well as drag-and-drop.
+
+`applyBodyDiff()` can then relocate the existing unit wrapper in new-plan order, subject
+to the same conservative guards used today:
+
+- move the wrapper returned by `unitWrapperOf()` so table alignment wrappers stay intact;
+- require source and insertion neighbors to share a provable parent;
+- fall back to a full remount for multi-child border groups or any ambiguous wrapper;
+- remount when a moved/source/target unit is a list item, because numbering is
+  position-derived and sibling markers may all change;
+- keep the churn threshold and universal exception fallback.
+
+The drag UI may optimistically move an unambiguous wrapper on drop, but the session op
+must run immediately and reconcile remains authoritative. If the model rejects the move,
+put the DOM node back (or remount) and announce the error.
+
+## Interaction design
+
+### Handle ownership
+
+Use **one floating handle** owned by `DocxEditor`, positioned beside the current top-level
+unit on pointer hover or focus. Do not inject a control into every converted block.
+
+Why:
+
+- wrapping blocks changes converter layout, margins, contextual spacing, and border
+  grouping;
+- a child inside `contenteditable` can enter text serialization and offset calculations;
+- a child inside a paginated page is clipped by the page box's `overflow:hidden`;
+- single-block re-render and reconcile replace nodes, requiring per-node control cleanup;
+- one overlay is cheaper on a 346-block document and works for tables without touching
+  their internal DOM.
+
+The handle should be at least 24×24 CSS pixels for touch, use a six-dot/grip affordance,
+show on hover/focus in continuous mode, remain visible while focused/dragging, and expose
+an accessible name containing a short block preview.
+
+### Drag lifecycle
+
+1. Resolve the hovered/focused node through `bodyUnitNodes()`; a descendant cell resolves
+   to its containing table.
+2. On drag start, commit any dirty active block, capture source anchor/index and focus,
+   dim the source to roughly 40%, and create a compact drag preview.
+3. Register top-level compatible units as drop targets. Pointer position relative to the
+   target midpoint selects `before` or `after`.
+4. Draw a 2px insertion line in an editor-owned overlay so page/table overflow cannot
+   clip it. Ignore self/adjacent no-op placements.
+5. Autoscroll the nearest editor scroll container near its top/bottom edge.
+6. On drop, call `MoveBlock`, reconcile/remount as required, flash the moved unit, restore
+   focus, call `onMove`/`onEdit`, and announce old/new position.
+7. On cancel/error/close/remount, remove transient styles, indicators, registrations, and
+   pending animation frames.
+
+The handle must be the only draggable element. Marking the entire paragraph `draggable`
+would prevent normal text selection, which is the editor's primary interaction.
+
+### Dependency choice
+
+Recommended: Atlassian's framework-agnostic **Pragmatic drag and drop** core, with only
+the optional pieces actually needed (autoscroll is the most useful). It is headless,
+incremental, works with native DOM rather than React, and is designed around a separate
+drag handle/drop targets. Docxodus would render its own handle, indicator, menu, and live
+region so no Atlassian design-system or React dependencies are pulled in.
+
+This will be the npm package's first ordinary runtime dependency. Keep it narrowly scoped
+to Pragmatic drag-and-drop core and the optional autoscroll package; do not pull in React
+or Atlassian design-system components. Docxodus remains responsible for its own visual
+and accessible UI.
+
+Relevant first-party guidance:
+
+- [Pragmatic drag and drop repository](https://github.com/atlassian/pragmatic-drag-and-drop)
+- [Atlassian drag-and-drop design guidelines](https://atlassian.design/components/pragmatic-drag-and-drop/design-guidelines/)
+- [Atlassian accessibility guidelines](https://atlassian.design/components/pragmatic-drag-and-drop/accessibility-guidelines)
+- [Autoscroll package](https://atlassian.design/components/pragmatic-drag-and-drop/optional-packages/auto-scroll)
+
+## Continuous vs paginated view
+
+### Continuous
+
+This is the straightforward path. Body units appear as one ordered flow. Most plain
+direct-mode paragraph/table moves can preserve the existing DOM node and finish in the
+same latency class as the current structural reconciler. Tracked moves add separately
+rendered source/destination units; lists and border groups can remount conservatively.
+
+### Paginated
+
+Blocks live under different page-content parents, page boxes clip overflow, and changing
+order can move every following block to a different page. The model operation is still
+correct, but the visible projection needs repagination.
+
+For the follow-up paginated hardening:
+
+- place the handle/indicator outside page boxes;
+- allow autoscroll across pages;
+- call `MoveBlock` using document-order anchors;
+- perform the existing full session-attached paginated remount after a successful drop;
+- restore focus by moved anchor (preferred) or new document index after remount.
+
+Do not optimistically transplant a block between page-content elements and treat that as
+finished; it leaves page heights and every subsequent page stale. Scoped repagination
+from the earliest affected page is a later optimization shared with roadmap M4.
+
+## OOXML safety and edge cases
+
+Moving the existing element within one XML part is lossless for the block itself, but
+document order carries semantics beyond visible text:
+
+| Case | Recommended v1 behavior |
+|---|---|
+| Paragraph / heading | Supported |
+| List item | Supported with full remount so markers recalculate |
+| Whole table | Supported as one unit; direct reorder when tracking is off, tracked delete+insert when on |
+| Table cell paragraph / row | No handle; target the whole table |
+| Header/footer/note/comment story | Not in v1; body only |
+| Inline section-break paragraph (`pPr/sectPr`) | Reject / no handle |
+| Trailing body `sectPr` | Not addressable/rendered; never a source |
+| Block inside `w:sdt` | Only reorder against a sibling with the same XML parent |
+| Floating drawing/image relationships | Safe within the same part; relationship IDs stay valid |
+| Footnote/endnote citations | Block move is safe; note ordering/chrome must reconcile |
+| Bookmarks/comments/permissions spanning blocks | Needs an explicit policy and tests |
+| Existing tracked revisions | Preserve or reject unsafe nesting; test both accepted and inline-review views |
+| Tracked paragraph-like move | Named `moveFrom`/`moveTo` pair with one accept/reject group |
+| Tracked whole-table move | Native whole-table delete+insert; see the presentation caveat above |
+
+The hardest fidelity edge is a range whose start and end markers are in different blocks.
+A literal sibling move can move content into/out of that range or move one endpoint past
+the other. The confirmed v1 policy is the safe restriction:
+
+- detect cross-block range membership and reject moves that would change or invert it;
+- hide invalid target indicators rather than allowing a doomed drop; and
+- return a typed core error if a caller bypasses the UI restriction.
+
+At minimum cover comment ranges, bookmarks, permission ranges, and native move ranges.
+
+## Test plan
+
+### .NET session tests
+
+- move first/middle/last paragraph before and after another paragraph;
+- same-source/target and already-adjacent no-ops do not consume undo;
+- one undo restores the old order; redo reapplies it;
+- direct-mode source and descendant Unids remain unchanged;
+- save/reopen retains order and content;
+- whole table move preserves cell anchors, relationships, and validation;
+- tracked paragraph/heading/list move emits paired named ranges with unique revision IDs,
+  configured author/date, and `w:trackRevisions` enabled;
+- tracked whole-table move emits source row/content deletions and destination
+  row/content insertions with no duplicate anchors;
+- accept tracked move yields the requested order exactly once; reject restores the
+  original order exactly once, for both paragraph-like and table units;
+- selective accept/reject treats a named paragraph move as one group; document-wide
+  accept/reject handles the lowered table pair cleanly;
+- list item move preserves `numPr` and produces correct projection order;
+- reject cross-part, different-parent/content-control, cell paragraph, and section-break
+  cases;
+- failure restores the exact pre-op document;
+- policy tests for cross-block range markers and existing revisions.
+
+### Pure TypeScript reconcile tests
+
+- exact-token reorder is `moved`, not `substituted`;
+- forward/backward moves preserve node identity;
+- duplicate-content/unid collision cases remain deterministic;
+- wrapper ambiguity and list moves request remount;
+- mixed move + insertion/deletion produces the requested final order;
+- accepted and inline revision-view plans exactly match their rendered DOM units.
+
+### Playwright editor tests
+
+- real mouse drag uses only the handle and persists through save/reopen;
+- dragging paragraph text still selects text and never starts block dragging;
+- whole-table drag; no cell-level handle;
+- track changes off produces no revision markup; track changes on shows a moved-from and
+  moved-to paragraph and persists native markup through save/reopen;
+- tracked whole-table drag shows deleted/inserted table rows, then Word-compatible
+  accept/reject yields the destination/original respectively;
+- undo/redo after move, including untouched-node identity in continuous view;
+- autoscroll in a long document;
+- accessible menu move, focus restoration, and live-region announcement;
+- cancel/Escape/outside drop leaves model and DOM unchanged;
+- list numbering and footnote chrome after move;
+- content-control/section-break invalid targets;
+- compact ribbon and multiple editors on one page;
+- paginated cross-page move remounts into the correct order;
+- Chromium plus targeted Firefox coverage for the interaction lifecycle.
+
+Add move timing to `npm/tests/editor-latency-bench.spec.ts`; a continuous plain-paragraph
+drop should target sub-150ms model+reconcile time on the standing HC031 fixture, excluding
+the human drag duration.
+
+## Suggested implementation sequence
+
+1. Land direct-mode `DocxSession.MoveBlock` + full transport/client ripple and .NET tests.
+2. Add tracked paragraph/table emission by extracting the existing revision helpers;
+   pin validation and accept/reject before wiring the editor.
+3. Make full/block rendering and `ListBlocks` use one explicit revision view.
+4. Teach `diffUnits` / `applyBodyDiff` about moves; pin undo/redo and node identity.
+5. Add `DocxEditor.moveBlock()` and accessible non-pointer commands before drag UI.
+6. Add the floating handle, drop indicator, pointer drag, and cleanup lifecycle in
+   continuous mode.
+7. Add list/table/content-control/range safety and browser coverage.
+8. Enable paginated-mode full-remount behavior and cross-page autoscroll.
+9. Update `editor_ui_surface.md`, README/API docs, CHANGELOG, and screenshots when the
+   feature—not this investigation—ships.
+
+## Product decisions
+
+All investigation-stage decisions are resolved. Production v1 is whole-table capable,
+continuous-view first, emits native Word revisions when track changes is active, uses
+Pragmatic drag-and-drop plus autoscroll, and rejects unsafe cross-block range moves.

--- a/docs/architecture/editor_block_drag_handles.md
+++ b/docs/architecture/editor_block_drag_handles.md
@@ -1,10 +1,12 @@
-# Editor block drag handles — feasibility and implementation plan
+# Editor block drag handles — design and shipped behaviour
 
-Status: **investigation / design; product direction confirmed** (no feature
-implementation yet).
+Status: **shipped** — direct and tracked moves in continuous view, with the
+accessible move menu. Paginated dragging remains deferred.
 
-Investigation branch: `investigate/block-drag-handles`, based on `origin/main`
-`f290c23` (2026-08-05).
+Branch: `investigate/block-drag-handles`, based on `origin/main` `f290c23`
+(2026-08-05). The sections below are the design as built; "Shipped deviations
+and follow-ups" at the end records where the implementation went further than,
+or stopped short of, this plan.
 
 ## Verdict
 
@@ -457,3 +459,68 @@ the human drag duration.
 All investigation-stage decisions are resolved. Production v1 is whole-table capable,
 continuous-view first, emits native Word revisions when track changes is active, uses
 Pragmatic drag-and-drop plus autoscroll, and rejects unsafe cross-block range moves.
+
+## Shipped deviations and follow-ups
+
+Found by smoke-testing the shipped surface against the NVCA Model Certificate of
+Incorporation (234 body blocks, 392 bookmarks, 94 footnotes, 3 inline section breaks)
+and fixed on this branch.
+
+### Identity-bearing markers in the tracked clone
+
+A tracked move keeps the source and the destination live simultaneously, so every
+id-bearing marker the clone copies is a second live copy:
+
+| Marker | Policy | Owner |
+|---|---|---|
+| `w:bookmarkStart`/`w:bookmarkEnd` | Destination clone gets fresh document-unique ids; **both copies keep the NAME**, so each survives its own resolution and every `REF`/`PAGEREF`/`HYPERLINK \l` still resolves | `DocxSession.RenumberClonedBookmarks`, mirroring `IrMarkupRenderer.NormalizeBookmarks` (B) |
+| `w:commentRangeStart`/`End`/`Reference` | The **move source** takes a fresh comment id + a cloned definition (fresh `w14:paraId`, threading entries in both metadata parts, cloned replies re-pointed at cloned parents), leaving the destination on the original comment and its thread | `CommentOps.CloneCommentsForMoveSource`, mirroring `IrMarkupRenderer.NormalizeComments` (B) |
+| `w:footnoteReference`/`w:endnoteReference` | **Deliberately duplicated.** A note cited at both the old and the new position is a faithful depiction of a pending move, it is not uniqueness-constrained, and exactly one citation survives either resolution | — |
+
+Without the first two the pending redline is schema-invalid (`Sem_UniqueAttributeValue`)
+and the comment shows twice in Word's Reviewing pane. Both resolve to a valid single-copy
+document on accept and on reject. One residue is accepted: the resolved-away copy's comment
+*definition* stays in `comments.xml` unreferenced — `RevisionProcessor` prunes no orphaned
+definition, for any resolved comment, and Word ignores an unanchored one.
+
+### Whole-block revisions mark content, not just structure
+
+`w:moveFrom` is a deletion, so its runs carry `w:delText`/`w:delInstrText` — as Word writes
+them and as `RevisionProcessor`'s reject path swaps back. The whole-table lowering marks
+**every cell paragraph's content and mark**, not only `w:trPr`; row marks alone left a
+moved-away table's text rendering as ordinary body text inside a row Word believes is
+deleted. Both go through one owner, `DocxSession.MarkParagraphContentAndMark`.
+
+### Move validity is a query, not a failed attempt
+
+`DocxSession.ValidMoveTargets(sourceAnchorId)` returns the anchors a block may legally move
+next to, sharing `MoveBlock`'s own guards (`MoveSourceRejection` + `BlockMoveSafetyError`)
+so the UI and the engine cannot disagree. The editor asks once per drag source and once per
+menu open, and uses the answer to:
+
+- register only valid blocks as drop targets, so no indicator is drawn over a doomed drop
+  (confirmed direction #7);
+- disable move-menu items with no destination;
+- withhold the handle entirely from a block that can move nowhere (a section-break paragraph);
+- resolve **"move to top/bottom" within the source's own region**. On a document with N
+  section breaks the body is partitioned into N+1 move regions; targeting the document ends
+  meant those two commands could never succeed anywhere but the first and last region.
+
+The engine remains authoritative — the UI gate is advisory, and a caller bypassing it still
+gets the typed error.
+
+### Editor projection
+
+`ListBlocks(renderTrackedChanges)` mirrors the rendered DOM in both views. The accepted view
+previously disagreed by one unit after a tracked move: `RevisionProcessor` built the
+paragraph it coalesces for a deleted/moved-away paragraph mark **without its attributes**, so
+the surviving block lost its `pt:Unid` and rendered with no `data-anchor` — unaddressable,
+and invisible to the reconciler. Identity now comes from the same member the properties do.
+
+### Still open
+
+- Paginated dragging (handle is not mounted in paginated mode).
+- Tracked moves repaint via full remount (~5–6 s on the NVCA charter) where a direct move
+  reconciles incrementally (~0.8 s).
+- No ribbon control toggles track changes; `trackedChanges`/`revisionAuthor` are mount-time
+  options on `DocxEditor`/`mountRibbon`.

--- a/docs/architecture/editor_block_drag_handles.md
+++ b/docs/architecture/editor_block_drag_handles.md
@@ -493,13 +493,20 @@ deleted. Both go through one owner, `DocxSession.MarkParagraphContentAndMark`.
 
 ### Move validity is a query, not a failed attempt
 
-`DocxSession.ValidMoveTargets(sourceAnchorId)` returns the anchors a block may legally move
-next to, sharing `MoveBlock`'s own guards (`MoveSourceRejection` + `BlockMoveSafetyError`)
-so the UI and the engine cannot disagree. The editor asks once per drag source and once per
-menu open, and uses the answer to:
+`DocxSession.ValidMoveTargets(sourceAnchorId)` returns the blocks a block may legally move next
+to **and on which side** (`MoveTarget(AnchorId, Before, After)`), sharing `MoveBlock`'s own guards
+(`MoveSourceRejection` + `BlockMoveSafetyError`) so the UI and the engine cannot disagree.
+
+The two sides are reported separately because landing *into* a cross-block range changes its
+membership while landing outside it does not — the asymmetry is the common case, not an edge one.
+Measured on the NVCA charter, a mid-document block had three reachable targets and **two of them
+were legal on only one side** (`before:false/after:true` and `before:true/after:false`). A UI told
+only "this target is reachable" picks the refused side about half the time.
+
+The editor asks once per drag source and once per menu open, and uses the answer to:
 
 - register only valid blocks as drop targets, so no indicator is drawn over a doomed drop
-  (confirmed direction #7);
+  (confirmed direction #7), snapping a drop to the legal side when only one is;
 - disable move-menu items with no destination;
 - withhold the handle entirely from a block that can move nowhere (a section-break paragraph);
 - resolve **"move to top/bottom" within the source's own region**. On a document with N
@@ -508,6 +515,13 @@ menu open, and uses the answer to:
 
 The engine remains authoritative — the UI gate is advisory, and a caller bypassing it still
 gets the typed error.
+
+Worth stating plainly for anyone measuring the feature on a real contract: a heavily
+cross-referenced document restricts moves far more than its section breaks alone suggest, because
+most blocks sit inside some bookmark range. On the NVCA charter a mid-document block could reach
+only its immediate neighbours. That is the confirmed v1 safety policy (reject rather than silently
+re-scope a range) doing its job — and it is precisely why the UI has to ask rather than offer
+everything and fail on drop.
 
 ### Editor projection
 

--- a/docs/architecture/ir_editor_roadmap.md
+++ b/docs/architecture/ir_editor_roadmap.md
@@ -61,6 +61,21 @@ block(s), insert/remove nodes, update the `unid → fullId` map, place the caret
 restored exactly), and round-trips through save. Insert-at-doc-start and block delete/reorder
 remain follow-ups (Enter-split + Backspace-merge cover the core authoring loop).
 
+### M2.8 — Block drag handles / reorder  · effort L · ○ **DESIGNED**
+**Problem:** blocks can be split, merged, inserted, and deleted, but the session has no atomic
+move primitive and the editor has no direct manipulation affordance for reordering them.
+**Plan:** add one undoable `DocxSession.MoveBlock(source, target, before|after)` operation,
+ripple it through the session transports, teach the ordered-unit reconciler to relocate an
+existing node, and add a floating (non-contenteditable) drag handle plus accessible move menu.
+Confirmed product scope is whole-table support, continuous view first, and native Word revisions
+when track changes is active. Paragraph-like blocks use named `moveFrom`/`moveTo` pairs; whole
+tables use Word-native row/content deletion plus insertion unless a desktop-Word fixture proves a
+conformant named whole-table move representation. This also requires revision-view-aware rendering
+and render plans. Pragmatic drag-and-drop core plus autoscroll is approved. Content controls and
+section breaks remain immovable; moves that would disrupt cross-block ranges are rejected. Full
+investigation and test matrix:
+[`editor_block_drag_handles.md`](editor_block_drag_handles.md).
+
 ### M2.7 — Latency pass: persistent render shell + reconcile on real documents  · effort M · ✅ **DONE**
 **Problem:** interactive ops were still visibly laggy. Two causes: (1) every single-block
 re-render re-opened the render shell from bytes — package open + styles/numbering parse +

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -8,6 +8,10 @@
       "name": "docxodus",
       "version": "0.0.0",
       "license": "MIT",
+      "dependencies": {
+        "@atlaskit/pragmatic-drag-and-drop": "^2.0.2",
+        "@atlaskit/pragmatic-drag-and-drop-auto-scroll": "^3.0.0"
+      },
       "devDependencies": {
         "@playwright/test": "^1.57.0",
         "@types/node": "^20.10.0",
@@ -22,6 +26,36 @@
         "react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@atlaskit/pragmatic-drag-and-drop": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop/-/pragmatic-drag-and-drop-2.0.2.tgz",
+      "integrity": "sha512-ou1j+lBqutK7p2S80lMresJeKu9qAL1zr1K+N0OyCTzbMpD6pXRHray8VkRoHgJICI7Wp1fk5ScJh6EctyAuPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "bind-event-listener": "^3.0.0",
+        "raf-schd": "^4.0.3"
+      }
+    },
+    "node_modules/@atlaskit/pragmatic-drag-and-drop-auto-scroll": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop-auto-scroll/-/pragmatic-drag-and-drop-auto-scroll-3.0.0.tgz",
+      "integrity": "sha512-8TlkMi417zIPrTnCpbNV0Ce63JTKBn3dGkqiadkGQROvzDAox7Y9TYRHpvbQiEdtPoHWnmyRBi+RsGDxXsQxgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/pragmatic-drag-and-drop": "^2.0.0",
+        "@babel/runtime": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -502,6 +536,12 @@
         "csstype": "^3.2.2"
       }
     },
+    "node_modules/bind-event-listener": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bind-event-listener/-/bind-event-listener-3.0.0.tgz",
+      "integrity": "sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==",
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -597,6 +637,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/npm/package.json
+++ b/npm/package.json
@@ -99,5 +99,9 @@
     "@types/react": "^19.2.7",
     "esbuild": "^0.28.1",
     "typescript": "^5.3.0"
+  },
+  "dependencies": {
+    "@atlaskit/pragmatic-drag-and-drop": "^2.0.2",
+    "@atlaskit/pragmatic-drag-and-drop-auto-scroll": "^3.0.0"
   }
 }

--- a/npm/src/editor-reconcile.ts
+++ b/npm/src/editor-reconcile.ts
@@ -51,6 +51,8 @@ export interface UnitDiff {
    * siblings and may reconcile where a pure li insert/remove may not.
    */
   substituted: Array<{ oldIndex: number; newIndex: number }>;
+  /** Exact-token units whose existing DOM node moves to a new document slot. */
+  moved: Array<{ oldIndex: number; newIndex: number }>;
 }
 
 /** unid ("a1b2…") from a full anchor id ("p:body:a1b2…"). */
@@ -113,15 +115,36 @@ export function diffUnits(oldUnids: string[], newUnits: RenderUnit[]): UnitDiff 
     const bar = token.indexOf("|");
     return bar < 0 ? token : token.slice(0, bar);
   };
-  const substituted: Array<{ oldIndex: number; newIndex: number }> = [];
+  const moved: Array<{ oldIndex: number; newIndex: number }> = [];
   const usedRemoved = new Set<number>();
+  const usedAdded = new Set<number>();
+
+  // An exact token on both sides is a relocation, not a replacement. Pair these
+  // before same-unid substitutions so a pure reorder preserves its live DOM node.
+  const removedByToken = new Map<string, number[]>();
+  for (const oi of removed) {
+    (removedByToken.get(oldUnids[oi]) ?? removedByToken.set(oldUnids[oi], []).get(oldUnids[oi])!).push(oi);
+  }
+  for (const nj of added) {
+    const candidates = removedByToken.get(newUnids[nj]);
+    const oi = candidates?.find((i) => !usedRemoved.has(i));
+    if (oi !== undefined) {
+      moved.push({ oldIndex: oi, newIndex: nj });
+      usedRemoved.add(oi);
+      usedAdded.add(nj);
+    }
+  }
+
+  const substituted: Array<{ oldIndex: number; newIndex: number }> = [];
   const removedByUnid = new Map<string, number[]>();
   for (const oi of removed) {
+    if (usedRemoved.has(oi)) continue;
     const u = bareUnid(oldUnids[oi]);
     (removedByUnid.get(u) ?? removedByUnid.set(u, []).get(u)!).push(oi);
   }
   const unmatchedAdded: number[] = [];
   for (const nj of added) {
+    if (usedAdded.has(nj)) continue;
     const candidates = removedByUnid.get(bareUnid(newUnids[nj]));
     const oi = candidates?.find((i) => !usedRemoved.has(i));
     if (oi !== undefined) {
@@ -153,7 +176,7 @@ export function diffUnits(oldUnids: string[], newUnits: RenderUnit[]): UnitDiff 
     }
   }
 
-  return { keep, removed, added, substituted };
+  return { keep, removed, added, substituted, moved };
 }
 
 /**

--- a/npm/src/editor.ts
+++ b/npm/src/editor.ts
@@ -53,6 +53,9 @@ export interface DocxEditorExports {
     MergeParagraphs: (handle: number, first: string, second: string) => string;
     DeleteBlock: (handle: number, anchor: string) => string;
     MoveBlock?: (handle: number, sourceAnchor: string, targetAnchor: string, pos: string) => string;
+    /** JSON `string[]`: the anchors a block may legally move next to. Optional — without it the
+     *  drag UI offers every block and lets the engine refuse, as it did before. */
+    ValidMoveTargets?: (handle: number, sourceAnchor: string) => string;
     InsertHorizontalRule: (handle: number, anchor: string, pos: string, ruleJson: string) => string;
     InsertTable: (
       handle: number,
@@ -798,6 +801,11 @@ export class DocxEditor {
   private blockDragTargetCleanup: Array<() => void> = [];
   private blockDragging = false;
   private blockDragPointerDown = false;
+  /** Anchors the current drag source may legally move next to, per the engine's own rules.
+   *  Null when the bridge predates ValidMoveTargets — then every block is offered, as before. */
+  private blockMoveTargets: Set<string> | null = null;
+  /** Why the last move was refused, verbatim from the engine — diagnostics, not announcement copy. */
+  lastMoveError: string | null = null;
 
   /**
    * The last real (non-collapsed) text selection inside an editable block. A toolbar control that
@@ -1135,7 +1143,10 @@ export class DocxEditor {
       bridge.MoveBlock(this.handle, sourceAnchorId, targetAnchorId, position),
     );
     if (!res.success) {
-      this.announceBlockMove(res.error?.message ?? "This block cannot be moved there.");
+      // The engine's message names an OOXML construct ("a section-break paragraph"); the live
+      // region is read aloud, so announce the outcome and keep the raw reason for debugging.
+      this.lastMoveError = res.error?.message ?? null;
+      this.announceBlockMove("This block cannot be moved there.");
       return false;
     }
     if (
@@ -1214,6 +1225,14 @@ export class DocxEditor {
     if (!handle || !this.isMovableBlockUnit(unit)) return;
     const changed = unit !== this.blockDragSource;
     this.blockDragSource = unit;
+    if (changed) this.refreshBlockMoveTargets(unit);
+    // A block the engine will not move anywhere — one owning a section break, or already carrying
+    // revision markup a tracked move would have to re-wrap — gets no handle rather than a handle
+    // that always fails.
+    if (this.blockMoveTargets?.size === 0) {
+      handle.style.display = "none";
+      return;
+    }
     const rect = unit.getBoundingClientRect();
     handle.style.display = "flex";
     handle.style.left = `${Math.max(4, rect.left - 32)}px`;
@@ -1254,14 +1273,45 @@ export class DocxEditor {
     this.container.ownerDocument.defaultView?.setTimeout(() => { live.textContent = message; }, 0);
   }
 
+  /**
+   * Ask the engine which anchors the current source may move next to. One call per drag source,
+   * so the UI offers only drops MoveBlock will accept — a document with section breaks is
+   * partitioned into regions, and drawing an indicator across one only to fail the drop was the
+   * behaviour this replaces. Null (no bridge support) keeps the previous offer-everything path.
+   */
+  private refreshBlockMoveTargets(source: HTMLElement | null): void {
+    const bridge = this.exports.DocxSessionBridge;
+    const sourceId = source ? this.anchorIdOf(source) : null;
+    if (!sourceId || typeof bridge.ValidMoveTargets !== "function") {
+      this.blockMoveTargets = null;
+      return;
+    }
+    try {
+      const ids = JSON.parse(bridge.ValidMoveTargets(this.handle, sourceId)) as string[];
+      this.blockMoveTargets = new Set(ids);
+    } catch {
+      this.blockMoveTargets = null;
+    }
+  }
+
+  /** Whether `unit` is a legal destination for the current drag source. */
+  private isValidMoveTarget(unit: HTMLElement): boolean {
+    if (!this.blockMoveTargets) return true; // no bridge support: engine stays the only gate
+    const id = this.anchorIdOf(unit);
+    return !!id && this.blockMoveTargets.has(id);
+  }
+
   private refreshBlockDropTargets(): void {
     for (const cleanup of this.blockDragTargetCleanup.splice(0)) cleanup();
     if (!this.blockDragHandle || this.options.paginated) return;
     for (const unit of this.bodyUnitNodes().filter((el) => this.isMovableBlockUnit(el))) {
       this.blockDragTargetCleanup.push(dropTargetForElements({
         element: unit,
+        // A target the engine would refuse is not a drop target at all, so Pragmatic never
+        // fires onDragEnter for it and no indicator is drawn over it.
         canDrop: ({ source }) =>
-          source.data.type === BLOCK_DRAG_TYPE && source.data.sourceAnchorId !== this.anchorIdOf(unit),
+          source.data.type === BLOCK_DRAG_TYPE && source.data.sourceAnchorId !== this.anchorIdOf(unit) &&
+          this.isValidMoveTarget(unit),
         getData: ({ input }) => ({
           type: BLOCK_DRAG_TYPE,
           targetAnchorId: this.anchorIdOf(unit),
@@ -1296,13 +1346,9 @@ export class DocxEditor {
     const handle = this.blockDragHandle;
     const source = this.currentBlockDragSource();
     if (!menu || !handle || !source) return;
-    const units = this.bodyUnitNodes().filter((el) => this.isMovableBlockUnit(el));
-    const index = units.indexOf(source);
+    this.refreshBlockMoveTargets(source);
     menu.querySelectorAll<HTMLButtonElement>("button[data-move]").forEach((button) => {
-      const action = button.dataset.move;
-      button.disabled = index < 0 ||
-        ((action === "up" || action === "top") && index === 0) ||
-        ((action === "down" || action === "bottom") && index === units.length - 1);
+      button.disabled = !this.blockMoveDestination(source, button.dataset.move ?? "");
     });
     const rect = handle.getBoundingClientRect();
     menu.style.display = "block";
@@ -1313,23 +1359,51 @@ export class DocxEditor {
     menu.querySelector<HTMLButtonElement>("button:not(:disabled)")?.focus({ preventScroll: true });
   }
 
+  /**
+   * Resolve a move-menu action to the block it should land against, considering only destinations
+   * the engine accepts. "Top"/"bottom" therefore mean the ends of the source's own movable region
+   * — on a document with section breaks that is the section, not the document, which is what makes
+   * the commands work at all there instead of always failing.
+   */
+  private blockMoveDestination(
+    source: HTMLElement,
+    action: string,
+  ): { target: HTMLElement; position: "before" | "after" } | null {
+    const units = this.bodyUnitNodes().filter((el) => this.isMovableBlockUnit(el));
+    const index = units.indexOf(source);
+    if (index < 0) return null;
+    const valid = units.filter((el) => el !== source && this.isValidMoveTarget(el));
+    if (valid.length === 0) return null;
+
+    const before = valid.filter((el) => units.indexOf(el) < index);
+    const after = valid.filter((el) => units.indexOf(el) > index);
+    if (action === "up") return before.length ? { target: before[before.length - 1], position: "before" } : null;
+    if (action === "down") return after.length ? { target: after[0], position: "after" } : null;
+    if (action === "top") return before.length ? { target: before[0], position: "before" } : null;
+    if (action === "bottom") return after.length ? { target: after[after.length - 1], position: "after" } : null;
+    return null;
+  }
+
   private runBlockMoveMenuAction(action: string): void {
     const source = this.currentBlockDragSource();
     if (!source) return;
-    const units = this.bodyUnitNodes().filter((el) => this.isMovableBlockUnit(el));
-    const index = units.indexOf(source);
-    if (index < 0) return;
-    let target: HTMLElement | undefined;
-    let position: "before" | "after" = "before";
-    if (action === "up") target = units[index - 1];
-    else if (action === "down") { target = units[index + 1]; position = "after"; }
-    else if (action === "top") target = units[0];
-    else if (action === "bottom") { target = units[units.length - 1]; position = "after"; }
-    if (!target || target === source) return;
-    const sourceId = this.anchorIdOf(source);
-    const targetId = this.anchorIdOf(target);
+    const destination = this.blockMoveDestination(source, action);
     this.closeBlockMoveMenu();
-    if (sourceId && targetId) this.moveBlock(sourceId, targetId, position);
+    if (!destination) return;
+    const sourceId = this.anchorIdOf(source);
+    const targetId = this.anchorIdOf(destination.target);
+    if (sourceId && targetId) this.moveBlock(sourceId, targetId, destination.position);
+  }
+
+  /** The nearest ancestor that actually scrolls the document flow, for drag autoscroll. */
+  private scrollContainer(): HTMLElement | null {
+    const view = this.container.ownerDocument.defaultView;
+    for (let el: HTMLElement | null = this.editRoot; el; el = el.parentElement) {
+      const overflowY = view?.getComputedStyle(el).overflowY ?? "visible";
+      if ((overflowY === "auto" || overflowY === "scroll") && el.scrollHeight > el.clientHeight)
+        return el;
+    }
+    return null;
   }
 
   /** Mount one floating handle; PDD owns pointer dragging while the menu owns keyboard moves. */
@@ -1446,6 +1520,7 @@ export class DocxEditor {
         this.blockDragging = true;
         handle.classList.add("docx-block-dragging");
         this.closeBlockMoveMenu();
+        this.refreshBlockMoveTargets(this.currentBlockDragSource());
         this.refreshBlockDropTargets();
       },
       onDrop: () => {
@@ -1465,13 +1540,23 @@ export class DocxEditor {
         const position = drop?.position === "after" ? "after" : "before";
         if (typeof sourceId === "string" && typeof targetId === "string")
           this.moveBlock(sourceId, targetId, position);
+        else
+          // Released outside any valid target. Say so — a silent no-op reads as a broken drag.
+          this.announceBlockMove("Move cancelled — the block was not dropped on a valid position.");
       },
     }));
-    this.blockDragCleanup.push(autoScrollForElements({
-      element: this.editRoot,
-      canScroll: ({ source }) => source.data.type === BLOCK_DRAG_TYPE,
-      getAllowedAxis: () => "vertical",
-    }));
+    // Register on the element that actually scrolls. editRoot is the document flow — in the
+    // ribbon surface the scroller is an ancestor of it, and registering the flow made Pragmatic
+    // log "attached to an element that appears not to be scrollable" on every document open
+    // while doing nothing.
+    const scroller = this.scrollContainer();
+    if (scroller) {
+      this.blockDragCleanup.push(autoScrollForElements({
+        element: scroller,
+        canScroll: ({ source }) => source.data.type === BLOCK_DRAG_TYPE,
+        getAllowedAxis: () => "vertical",
+      }));
+    }
     this.blockDragCleanup.push(autoScrollWindowForElements({
       canScroll: ({ source }) => source.data.type === BLOCK_DRAG_TYPE,
       getAllowedAxis: () => "vertical",

--- a/npm/src/editor.ts
+++ b/npm/src/editor.ts
@@ -53,8 +53,8 @@ export interface DocxEditorExports {
     MergeParagraphs: (handle: number, first: string, second: string) => string;
     DeleteBlock: (handle: number, anchor: string) => string;
     MoveBlock?: (handle: number, sourceAnchor: string, targetAnchor: string, pos: string) => string;
-    /** JSON `string[]`: the anchors a block may legally move next to. Optional — without it the
-     *  drag UI offers every block and lets the engine refuse, as it did before. */
+    /** JSON `{anchorId, before, after}[]`: where a block may legally move, per side. Optional —
+     *  without it the drag UI offers every block and lets the engine refuse, as it did before. */
     ValidMoveTargets?: (handle: number, sourceAnchor: string) => string;
     InsertHorizontalRule: (handle: number, anchor: string, pos: string, ruleJson: string) => string;
     InsertTable: (
@@ -803,7 +803,7 @@ export class DocxEditor {
   private blockDragPointerDown = false;
   /** Anchors the current drag source may legally move next to, per the engine's own rules.
    *  Null when the bridge predates ValidMoveTargets — then every block is offered, as before. */
-  private blockMoveTargets: Set<string> | null = null;
+  private blockMoveTargets: Map<string, { before: boolean; after: boolean }> | null = null;
   /** Why the last move was refused, verbatim from the engine — diagnostics, not announcement copy. */
   lastMoveError: string | null = null;
 
@@ -1287,18 +1287,42 @@ export class DocxEditor {
       return;
     }
     try {
-      const ids = JSON.parse(bridge.ValidMoveTargets(this.handle, sourceId)) as string[];
-      this.blockMoveTargets = new Set(ids);
+      const targets = JSON.parse(bridge.ValidMoveTargets(this.handle, sourceId)) as Array<
+        { anchorId: string; before: boolean; after: boolean }
+      >;
+      this.blockMoveTargets = new Map(
+        targets.map((t) => [t.anchorId, { before: t.before, after: t.after }]),
+      );
     } catch {
       this.blockMoveTargets = null;
     }
   }
 
-  /** Whether `unit` is a legal destination for the current drag source. */
-  private isValidMoveTarget(unit: HTMLElement): boolean {
+  /**
+   * Whether `unit` is a legal destination for the current drag source — for a SPECIFIC side when
+   * one is given. A cross-block range or a section break between the blocks can make one side
+   * legal and the other not, so "this target is reachable" is not enough to pick a position.
+   */
+  private isValidMoveTarget(unit: HTMLElement, position?: "before" | "after"): boolean {
     if (!this.blockMoveTargets) return true; // no bridge support: engine stays the only gate
     const id = this.anchorIdOf(unit);
-    return !!id && this.blockMoveTargets.has(id);
+    const sides = id ? this.blockMoveTargets.get(id) : undefined;
+    if (!sides) return false;
+    return position ? sides[position] : sides.before || sides.after;
+  }
+
+  /**
+   * The side of `unit` a drop at `clientY` should land on: the half the pointer is in, snapped to
+   * the other side when only that one is legal. Snapping rather than refusing keeps a reachable
+   * target usable — the illegal side is usually illegal only because a section break or a
+   * cross-block range sits between the two blocks on that side.
+   */
+  private dropPositionFor(unit: HTMLElement, clientY: number): "before" | "after" {
+    const rect = unit.getBoundingClientRect();
+    const preferred = clientY < rect.top + rect.height / 2 ? "before" : "after";
+    if (this.isValidMoveTarget(unit, preferred)) return preferred;
+    const other = preferred === "before" ? "after" : "before";
+    return this.isValidMoveTarget(unit, other) ? other : preferred;
   }
 
   private refreshBlockDropTargets(): void {
@@ -1315,9 +1339,7 @@ export class DocxEditor {
         getData: ({ input }) => ({
           type: BLOCK_DRAG_TYPE,
           targetAnchorId: this.anchorIdOf(unit),
-          position: input.clientY < unit.getBoundingClientRect().top + unit.getBoundingClientRect().height / 2
-            ? "before"
-            : "after",
+          position: this.dropPositionFor(unit, input.clientY),
           targetElement: unit,
         }),
         onDragEnter: ({ self }) => {
@@ -1372,15 +1394,21 @@ export class DocxEditor {
     const units = this.bodyUnitNodes().filter((el) => this.isMovableBlockUnit(el));
     const index = units.indexOf(source);
     if (index < 0) return null;
-    const valid = units.filter((el) => el !== source && this.isValidMoveTarget(el));
-    if (valid.length === 0) return null;
 
-    const before = valid.filter((el) => units.indexOf(el) < index);
-    const after = valid.filter((el) => units.indexOf(el) > index);
-    if (action === "up") return before.length ? { target: before[before.length - 1], position: "before" } : null;
-    if (action === "down") return after.length ? { target: after[0], position: "after" } : null;
-    if (action === "top") return before.length ? { target: before[0], position: "before" } : null;
-    if (action === "bottom") return after.length ? { target: after[after.length - 1], position: "after" } : null;
+    // Only pairs the engine accepts: a target can be reachable on one side and refused on the
+    // other, so the SIDE is part of what makes a candidate valid.
+    const position: "before" | "after" = action === "up" || action === "top" ? "before" : "after";
+    const candidates = units
+      .filter((el) => el !== source && this.isValidMoveTarget(el, position))
+      .filter((el) => (position === "before"
+        ? units.indexOf(el) < index
+        : units.indexOf(el) > index));
+    if (candidates.length === 0) return null;
+
+    if (action === "up") return { target: candidates[candidates.length - 1], position };
+    if (action === "down") return { target: candidates[0], position };
+    if (action === "top") return { target: candidates[0], position };
+    if (action === "bottom") return { target: candidates[candidates.length - 1], position };
     return null;
   }
 

--- a/npm/src/editor.ts
+++ b/npm/src/editor.ts
@@ -20,6 +20,16 @@
 import { paginateHtml } from "./pagination.js";
 import { HeaderFooterRegion } from "./editor-headerfooter.js";
 import type { BandWhich } from "./editor-headerfooter.js";
+import {
+  draggable,
+  dropTargetForElements,
+  monitorForElements,
+} from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import {
+  autoScrollForElements,
+  autoScrollWindowForElements,
+} from "@atlaskit/pragmatic-drag-and-drop-auto-scroll/element";
+import { TrackedChangeMode } from "./types.js";
 import type { HeaderFooterKind, NumberFormat } from "./types.js";
 import { diffUnits, needsRemount, tokenOf, unidOf } from "./editor-reconcile.js";
 import type { RenderPlan, RenderUnit, UnitDiff } from "./editor-reconcile.js";
@@ -42,6 +52,7 @@ export interface DocxEditorExports {
     SplitParagraph: (handle: number, anchor: string, offset: number) => string;
     MergeParagraphs: (handle: number, first: string, second: string) => string;
     DeleteBlock: (handle: number, anchor: string) => string;
+    MoveBlock?: (handle: number, sourceAnchor: string, targetAnchor: string, pos: string) => string;
     InsertHorizontalRule: (handle: number, anchor: string, pos: string, ruleJson: string) => string;
     InsertTable: (
       handle: number,
@@ -67,6 +78,13 @@ export interface DocxEditorExports {
       cssPrefix: string,
       fabricateClasses: boolean,
     ) => string;
+    RenderBlockHtmlForReview?: (
+      handle: number,
+      anchorId: string,
+      cssPrefix: string,
+      fabricateClasses: boolean,
+      renderTrackedChanges: boolean,
+    ) => string;
     /** Session-attached full-document render (optional: older WASM bundles lack it). */
     RenderHtml?: (
       handle: number,
@@ -74,6 +92,14 @@ export interface DocxEditorExports {
       fabricateClasses: boolean,
       paginated: boolean,
       scale: number,
+    ) => string;
+    RenderHtmlForReview?: (
+      handle: number,
+      cssPrefix: string,
+      fabricateClasses: boolean,
+      paginated: boolean,
+      scale: number,
+      renderTrackedChanges: boolean,
     ) => string;
     Save: (handle: number) => Uint8Array;
     /** Save keeping the projector's Unid bookkeeping — remount only, never a user download.
@@ -105,6 +131,7 @@ export interface DocxEditorExports {
     /** Incremental-reconcile endpoints (optional: older WASM bundles predate them;
      *  the editor falls back to full remounts / full projections without them). */
     ListBlocks?: (handle: number) => string;
+    ListRenderedBlocks?: (handle: number, renderTrackedChanges: boolean) => string;
     ListNotes?: (handle: number, endnotes: boolean) => string;
     ListAnchors?: (handle: number) => string;
     RenderBlocksHtml?: (
@@ -112,6 +139,13 @@ export interface DocxEditorExports {
       anchorIdsJson: string,
       cssPrefix: string,
       fabricateClasses: boolean,
+    ) => string;
+    RenderBlocksHtmlForReview?: (
+      handle: number,
+      anchorIdsJson: string,
+      cssPrefix: string,
+      fabricateClasses: boolean,
+      renderTrackedChanges: boolean,
     ) => string;
   };
   DocumentConverter: {
@@ -142,8 +176,16 @@ export interface DocxEditorOptions {
    * of the body's block list (which indexes remount focus).
    */
   headerFooter?: boolean;
+  /** Enable the editor-owned block drag handle. Default false (the ribbon defaults it to true). */
+  blockDrag?: boolean;
+  /** How editor mutations are recorded. RenderInline enables native Word revisions. */
+  trackedChanges?: TrackedChangeMode;
+  /** Author stamped on native Word revisions. Default "docxodus". */
+  revisionAuthor?: string;
   /** Called after a block edit commits (with the affected anchor). */
   onEdit?: (info: { anchorId: string; unid: string }) => void;
+  /** Called after a successful block move. */
+  onMove?: (info: { sourceAnchorId: string; destinationAnchorId: string }) => void;
 }
 
 interface AnchorTargetLite {
@@ -154,6 +196,49 @@ interface AnchorTargetLite {
 }
 
 const EDITABLE_TAGS = new Set(["P", "H1", "H2", "H3", "H4", "H5", "H6"]);
+
+const BLOCK_DRAG_TYPE = "docxodus-block";
+const blockDragStyledDocuments = new WeakSet<Document>();
+
+function ensureBlockDragStyles(doc: Document): void {
+  if (blockDragStyledDocuments.has(doc)) return;
+  blockDragStyledDocuments.add(doc);
+  const style = doc.createElement("style");
+  style.dataset.docxodusBlockDrag = "true";
+  style.textContent = `
+.docx-block-handle {
+  position: fixed; z-index: 2147483000; display: none; width: 26px; height: 28px;
+  align-items: center; justify-content: center; padding: 0; border: 1px solid #d0d5dd;
+  border-radius: 6px; background: #fff; color: #667085; box-shadow: 0 1px 3px rgba(16,24,40,.12);
+  cursor: grab; font: 700 17px/1 system-ui, sans-serif; user-select: none; touch-action: none;
+}
+.docx-block-handle:hover, .docx-block-handle:focus-visible { color: #344054; border-color: #98a2b3; outline: none; }
+.docx-block-handle[aria-pressed="true"] { color: #175cd3; border-color: #84adff; background: #eff8ff; }
+.docx-block-handle.docx-block-dragging { cursor: grabbing; opacity: .78; }
+.docx-block-drop-indicator {
+  position: fixed; z-index: 2147482999; display: none; height: 3px; pointer-events: none;
+  border-radius: 999px; background: #2e90fa; box-shadow: 0 0 0 1px rgba(255,255,255,.85);
+}
+.docx-block-move-menu {
+  position: fixed; z-index: 2147483001; display: none; min-width: 150px; padding: 5px;
+  border: 1px solid #d0d5dd; border-radius: 8px; background: #fff;
+  box-shadow: 0 8px 24px rgba(16,24,40,.18); font: 13px/1.35 system-ui, sans-serif;
+}
+.docx-block-move-menu button { display: block; width: 100%; padding: 7px 9px; border: 0; border-radius: 5px; background: transparent; color: #344054; text-align: left; }
+.docx-block-move-menu button:hover, .docx-block-move-menu button:focus-visible { background: #f2f4f7; outline: none; }
+.docx-block-move-menu button:disabled { color: #98a2b3; background: transparent; }
+.docx-block-move-flash { animation: docx-block-move-flash 800ms ease-out; }
+@keyframes docx-block-move-flash { from { box-shadow: 0 0 0 3px rgba(46,144,250,.55); } to { box-shadow: none; } }
+.docx-block-live-region { position: fixed; width: 1px; height: 1px; overflow: hidden; clip-path: inset(50%); white-space: nowrap; }
+`;
+  (doc.head ?? doc.documentElement).appendChild(style);
+}
+
+function trackedChangeWireName(mode: TrackedChangeMode): "accept" | "render_inline" | "strip_deletions" {
+  if (mode === TrackedChangeMode.RenderInline) return "render_inline";
+  if (mode === TrackedChangeMode.StripDeletions) return "strip_deletions";
+  return "accept";
+}
 
 // ─── M1: inline HTML → markdown (preserve formatting on edit) ───────────────
 
@@ -668,6 +753,7 @@ function completeArgs(
   fabricate: boolean,
   paginated: boolean,
   scale: number,
+  renderTrackedChanges: boolean,
 ): any[] {
   return [
     bytes, "Document", cssPrefix, fabricate, "", -1, "comment-",
@@ -677,7 +763,7 @@ function completeArgs(
     // paragraphs editable. Must stay in step with DocxSessionOps.RenderHtml (the remount path),
     // whose output has to match this first paint byte-for-byte.
     /* renderFootnotesAndEndnotes */ true, /* renderHeadersAndFooters */ paginated,
-    false, true, true, false, null, /* stampAnchors */ true,
+    renderTrackedChanges, true, true, false, null, /* stampAnchors */ true,
   ];
 }
 
@@ -685,7 +771,8 @@ export class DocxEditor {
   private readonly exports: DocxEditorExports;
   private readonly container: HTMLElement;
   private readonly handle: number;
-  private readonly options: Required<Omit<DocxEditorOptions, "onEdit">> & Pick<DocxEditorOptions, "onEdit">;
+  private readonly options: Required<Omit<DocxEditorOptions, "onEdit" | "onMove">> &
+    Pick<DocxEditorOptions, "onEdit" | "onMove">;
   /** Map a block's current bare unid → its full kind:scope:unid (DocxSession anchor). */
   private readonly unidToFullId = new Map<string, string>();
   /** The element whose [data-anchor] descendants are the editable blocks (container or page container). */
@@ -700,6 +787,17 @@ export class DocxEditor {
    * structural edit (split/merge/format) is lost. While this flag is set, commitBlock no-ops.
    */
   private replacing = false;
+
+  /** Editor-owned block-move chrome. It is deliberately outside the rendered unit tree. */
+  private blockDragHandle: HTMLElement | null = null;
+  private blockDropIndicator: HTMLElement | null = null;
+  private blockMoveMenu: HTMLElement | null = null;
+  private blockMoveLive: HTMLElement | null = null;
+  private blockDragSource: HTMLElement | null = null;
+  private blockDragCleanup: Array<() => void> = [];
+  private blockDragTargetCleanup: Array<() => void> = [];
+  private blockDragging = false;
+  private blockDragPointerDown = false;
 
   /**
    * The last real (non-collapsed) text selection inside an editable block. A toolbar control that
@@ -929,7 +1027,11 @@ export class DocxEditor {
       paginated: options.paginated ?? false,
       scale: options.scale ?? 1,
       headerFooter: options.headerFooter ?? false,
+      blockDrag: options.blockDrag ?? false,
+      trackedChanges: options.trackedChanges ?? TrackedChangeMode.Accept,
+      revisionAuthor: options.revisionAuthor ?? "docxodus",
       onEdit: options.onEdit,
+      onMove: options.onMove,
     };
     // NOT persistAnchorIds: that setting applies to every Save on the session, so it put the
     // projector's Unid bookkeeping into the bytes the USER downloads — ~6x the file size for
@@ -937,16 +1039,24 @@ export class DocxEditor {
     // save/re-render hop, and it asks for that per call via SaveWithAnchorIds.
     // emitMarkdownPatch off: the editor re-renders from HTML, never from markdown patches,
     // so paying a whole-document re-projection per op would be dead weight.
-    const handle = exports.DocxSessionBridge.OpenSession(bytes, '{"emitMarkdownPatch":false}');
+    const handle = exports.DocxSessionBridge.OpenSession(bytes, JSON.stringify({
+      emitMarkdownPatch: false,
+      trackedChanges: trackedChangeWireName(opts.trackedChanges),
+      revisionAuthor: opts.revisionAuthor,
+    }));
     const editor = new DocxEditor(container, exports, handle, opts);
     editor.refreshAnchorMap();
     if (opts.headerFooter) editor.createRegion();
     const fullHtml = exports.DocumentConverter.ConvertDocxToHtmlComplete(
-      ...completeArgs(bytes, opts.cssPrefix, opts.fabricateClasses, opts.paginated, opts.scale),
+      ...completeArgs(
+        bytes, opts.cssPrefix, opts.fabricateClasses, opts.paginated, opts.scale,
+        opts.trackedChanges === TrackedChangeMode.RenderInline,
+      ),
     );
     if (opts.paginated) editor.mountPaginated(fullHtml);
     else editor.mountHtml(fullHtml);
     editor.syncRegionToBody();
+    editor.setupBlockDrag();
     return editor;
   }
 
@@ -980,6 +1090,7 @@ export class DocxEditor {
       document.removeEventListener("mouseup", this.onMouseUp, true);
     }
     this.clearDragSelection();
+    this.teardownBlockDrag();
     this.exports.DocxSessionBridge.CloseSession(this.handle);
   }
 
@@ -1009,6 +1120,379 @@ export class DocxEditor {
    */
   get sessionHandle(): number {
     return this.handle;
+  }
+
+  /** Move one top-level body block relative to another and repaint from the live session. */
+  moveBlock(
+    sourceAnchorId: string,
+    targetAnchorId: string,
+    position: "before" | "after",
+  ): boolean {
+    this.assertOpen();
+    const bridge = this.exports.DocxSessionBridge;
+    if (typeof bridge.MoveBlock !== "function") return false;
+    const res = this.parseEdit(
+      bridge.MoveBlock(this.handle, sourceAnchorId, targetAnchorId, position),
+    );
+    if (!res.success) {
+      this.announceBlockMove(res.error?.message ?? "This block cannot be moved there.");
+      return false;
+    }
+    if (
+      (res.created?.length ?? 0) === 0 &&
+      (res.modified?.length ?? 0) === 0 &&
+      (res.removed?.length ?? 0) === 0
+    ) {
+      this.announceBlockMove("The block is already in that position.");
+      return true;
+    }
+
+    const destination = res.created?.[0] ?? res.modified?.[0];
+    // Review rendering creates a visible move-from and move-to pair. A full remount keeps
+    // their revision wrappers and table-row styling canonical; direct moves use the ordered
+    // incremental reconciler and retain the exact existing DOM node.
+    if (this.renderTrackedChanges) this.remount();
+    else this.reconcile();
+
+    const moved = destination
+      ? this.bodyUnitNodes().find((el) => el.getAttribute("data-anchor") === destination.unid)
+      : null;
+    if (moved) {
+      moved.classList.add("docx-block-move-flash");
+      moved.addEventListener("animationend", () => moved.classList.remove("docx-block-move-flash"), {
+        once: true,
+      });
+      const focusTarget = EDITABLE_TAGS.has(moved.tagName)
+        ? moved
+        : moved.querySelector<HTMLElement>('[data-anchor][contenteditable="true"]');
+      if (focusTarget) {
+        this.activeBlock = focusTarget;
+        focusTarget.focus({ preventScroll: true });
+      }
+    }
+    this.options.onMove?.({
+      sourceAnchorId,
+      destinationAnchorId: destination?.id ?? sourceAnchorId,
+    });
+    this.announceBlockMove("Block moved.");
+    return true;
+  }
+
+  /** Resolve any rendered descendant to its top-level body move unit (tables stay whole). */
+  private blockUnitOf(target: EventTarget | Node | null): HTMLElement | null {
+    const node = target instanceof Node ? target : null;
+    const el = node?.nodeType === Node.ELEMENT_NODE
+      ? node as HTMLElement
+      : node?.parentElement;
+    if (!el || !this.editRoot.contains(el)) return null;
+    return this.bodyUnitNodes().find((unit) => unit === el || unit.contains(el)) ?? null;
+  }
+
+  private isMovableBlockUnit(unit: HTMLElement | null): unit is HTMLElement {
+    if (!unit || !this.anchorIdOf(unit)) return false;
+    // A source representation of an existing tracked move/deletion is evidence, not a new
+    // editable block. Its accepted counterpart remains draggable.
+    if (unit.matches("[class$='row-del'], [class*='row-del ']") ||
+        unit.querySelector("tr[class$='row-del'], tr[class*='row-del '], del[class$='move-from'], del[class*='move-from ']")
+    ) return false;
+    return unit.tagName === "TABLE" || EDITABLE_TAGS.has(unit.tagName);
+  }
+
+  private currentBlockDragSource(): HTMLElement | null {
+    if (this.isMovableBlockUnit(this.blockDragSource) && this.blockDragSource.isConnected)
+      return this.blockDragSource;
+    const fromActive = this.blockUnitOf(this.activeBlock);
+    if (this.isMovableBlockUnit(fromActive)) {
+      this.blockDragSource = fromActive;
+      return fromActive;
+    }
+    return null;
+  }
+
+  private showBlockHandle(unit: HTMLElement): void {
+    const handle = this.blockDragHandle;
+    if (!handle || !this.isMovableBlockUnit(unit)) return;
+    const changed = unit !== this.blockDragSource;
+    this.blockDragSource = unit;
+    const rect = unit.getBoundingClientRect();
+    handle.style.display = "flex";
+    handle.style.left = `${Math.max(4, rect.left - 32)}px`;
+    handle.style.top = `${Math.max(4, rect.top + (unit.tagName === "TABLE" ? 6 : Math.max(0, (rect.height - 28) / 2)))}px`;
+    const preview = (unit.textContent ?? "").trim().replace(/\s+/g, " ").slice(0, 48);
+    handle.setAttribute("aria-label", preview ? `Move block: ${preview}` : "Move block");
+    if (changed) this.refreshBlockDropTargets();
+  }
+
+  private hideBlockHandle(): void {
+    if (this.blockDragging || this.blockMoveMenu?.style.display === "block") return;
+    if (this.blockDragHandle) this.blockDragHandle.style.display = "none";
+  }
+
+  private positionBlockHandle(): void {
+    const source = this.currentBlockDragSource();
+    if (source && this.blockDragHandle?.style.display !== "none") this.showBlockHandle(source);
+  }
+
+  private showDropIndicator(target: HTMLElement, position: "before" | "after"): void {
+    const indicator = this.blockDropIndicator;
+    if (!indicator) return;
+    const rect = this.unitWrapperOf(target).getBoundingClientRect();
+    indicator.style.display = "block";
+    indicator.style.left = `${rect.left}px`;
+    indicator.style.top = `${position === "before" ? rect.top - 1 : rect.bottom - 1}px`;
+    indicator.style.width = `${Math.max(24, rect.width)}px`;
+  }
+
+  private hideDropIndicator(): void {
+    if (this.blockDropIndicator) this.blockDropIndicator.style.display = "none";
+  }
+
+  private announceBlockMove(message: string): void {
+    const live = this.blockMoveLive;
+    if (!live) return;
+    live.textContent = "";
+    this.container.ownerDocument.defaultView?.setTimeout(() => { live.textContent = message; }, 0);
+  }
+
+  private refreshBlockDropTargets(): void {
+    for (const cleanup of this.blockDragTargetCleanup.splice(0)) cleanup();
+    if (!this.blockDragHandle || this.options.paginated) return;
+    for (const unit of this.bodyUnitNodes().filter((el) => this.isMovableBlockUnit(el))) {
+      this.blockDragTargetCleanup.push(dropTargetForElements({
+        element: unit,
+        canDrop: ({ source }) =>
+          source.data.type === BLOCK_DRAG_TYPE && source.data.sourceAnchorId !== this.anchorIdOf(unit),
+        getData: ({ input }) => ({
+          type: BLOCK_DRAG_TYPE,
+          targetAnchorId: this.anchorIdOf(unit),
+          position: input.clientY < unit.getBoundingClientRect().top + unit.getBoundingClientRect().height / 2
+            ? "before"
+            : "after",
+          targetElement: unit,
+        }),
+        onDragEnter: ({ self }) => {
+          const pos = self.data.position === "after" ? "after" : "before";
+          this.showDropIndicator(unit, pos);
+        },
+        onDrag: ({ self }) => {
+          const pos = self.data.position === "after" ? "after" : "before";
+          this.showDropIndicator(unit, pos);
+        },
+        onDragLeave: () => this.hideDropIndicator(),
+      }));
+    }
+  }
+
+  private closeBlockMoveMenu(restoreFocus = false): void {
+    if (!this.blockMoveMenu || !this.blockDragHandle) return;
+    this.blockMoveMenu.style.display = "none";
+    this.blockDragHandle.setAttribute("aria-expanded", "false");
+    this.blockDragHandle.setAttribute("aria-pressed", "false");
+    if (restoreFocus) this.blockDragHandle.focus({ preventScroll: true });
+  }
+
+  private openBlockMoveMenu(): void {
+    const menu = this.blockMoveMenu;
+    const handle = this.blockDragHandle;
+    const source = this.currentBlockDragSource();
+    if (!menu || !handle || !source) return;
+    const units = this.bodyUnitNodes().filter((el) => this.isMovableBlockUnit(el));
+    const index = units.indexOf(source);
+    menu.querySelectorAll<HTMLButtonElement>("button[data-move]").forEach((button) => {
+      const action = button.dataset.move;
+      button.disabled = index < 0 ||
+        ((action === "up" || action === "top") && index === 0) ||
+        ((action === "down" || action === "bottom") && index === units.length - 1);
+    });
+    const rect = handle.getBoundingClientRect();
+    menu.style.display = "block";
+    menu.style.left = `${Math.max(4, rect.right + 6)}px`;
+    menu.style.top = `${Math.max(4, rect.top)}px`;
+    handle.setAttribute("aria-expanded", "true");
+    handle.setAttribute("aria-pressed", "true");
+    menu.querySelector<HTMLButtonElement>("button:not(:disabled)")?.focus({ preventScroll: true });
+  }
+
+  private runBlockMoveMenuAction(action: string): void {
+    const source = this.currentBlockDragSource();
+    if (!source) return;
+    const units = this.bodyUnitNodes().filter((el) => this.isMovableBlockUnit(el));
+    const index = units.indexOf(source);
+    if (index < 0) return;
+    let target: HTMLElement | undefined;
+    let position: "before" | "after" = "before";
+    if (action === "up") target = units[index - 1];
+    else if (action === "down") { target = units[index + 1]; position = "after"; }
+    else if (action === "top") target = units[0];
+    else if (action === "bottom") { target = units[units.length - 1]; position = "after"; }
+    if (!target || target === source) return;
+    const sourceId = this.anchorIdOf(source);
+    const targetId = this.anchorIdOf(target);
+    this.closeBlockMoveMenu();
+    if (sourceId && targetId) this.moveBlock(sourceId, targetId, position);
+  }
+
+  /** Mount one floating handle; PDD owns pointer dragging while the menu owns keyboard moves. */
+  private setupBlockDrag(): void {
+    if (!this.options.blockDrag || this.options.paginated || this.closed || this.blockDragHandle)
+      return;
+    const doc = this.container.ownerDocument;
+    ensureBlockDragStyles(doc);
+
+    const handle = doc.createElement("div");
+    handle.className = "docx-block-handle";
+    handle.textContent = "⠿";
+    handle.tabIndex = 0;
+    handle.setAttribute("role", "button");
+    handle.setAttribute("contenteditable", "false");
+    handle.setAttribute("aria-haspopup", "menu");
+    handle.setAttribute("aria-expanded", "false");
+    handle.setAttribute("aria-pressed", "false");
+
+    const indicator = doc.createElement("div");
+    indicator.className = "docx-block-drop-indicator";
+    const menu = doc.createElement("div");
+    menu.className = "docx-block-move-menu";
+    menu.setAttribute("role", "menu");
+    menu.innerHTML = `
+      <button type="button" role="menuitem" data-move="up">Move up</button>
+      <button type="button" role="menuitem" data-move="down">Move down</button>
+      <button type="button" role="menuitem" data-move="top">Move to top</button>
+      <button type="button" role="menuitem" data-move="bottom">Move to bottom</button>`;
+    const live = doc.createElement("div");
+    live.className = "docx-block-live-region";
+    live.setAttribute("role", "status");
+    live.setAttribute("aria-live", "polite");
+    this.container.append(handle, indicator, menu, live);
+    this.blockDragHandle = handle;
+    this.blockDropIndicator = indicator;
+    this.blockMoveMenu = menu;
+    this.blockMoveLive = live;
+
+    const onPointerMove = (event: PointerEvent): void => {
+      // Keep the floating draggable stationary between pointerdown and native dragstart.
+      // Repositioning it under the pointer during the browser's drag threshold cancels
+      // drag initiation before PDD can receive dragstart.
+      if (this.blockDragging || this.blockDragPointerDown) return;
+      const unit = this.blockUnitOf(event.target);
+      if (this.isMovableBlockUnit(unit)) this.showBlockHandle(unit);
+    };
+    const onFocusIn = (event: FocusEvent): void => {
+      const unit = this.blockUnitOf(event.target);
+      if (this.isMovableBlockUnit(unit)) this.showBlockHandle(unit);
+    };
+    const onPointerLeave = (event: PointerEvent): void => {
+      const next = event.relatedTarget instanceof Node ? event.relatedTarget : null;
+      if (next && (handle.contains(next) || menu.contains(next))) return;
+      this.hideBlockHandle();
+    };
+    const onViewportChange = (): void => this.positionBlockHandle();
+    this.container.addEventListener("pointermove", onPointerMove);
+    this.container.addEventListener("focusin", onFocusIn);
+    this.container.addEventListener("pointerleave", onPointerLeave);
+    doc.addEventListener("scroll", onViewportChange, true);
+    doc.defaultView?.addEventListener("resize", onViewportChange);
+    this.blockDragCleanup.push(
+      () => this.container.removeEventListener("pointermove", onPointerMove),
+      () => this.container.removeEventListener("focusin", onFocusIn),
+      () => this.container.removeEventListener("pointerleave", onPointerLeave),
+      () => doc.removeEventListener("scroll", onViewportChange, true),
+      () => doc.defaultView?.removeEventListener("resize", onViewportChange),
+    );
+
+    const onHandleClick = (): void => {
+      if (menu.style.display === "block") this.closeBlockMoveMenu();
+      else this.openBlockMoveMenu();
+    };
+    const onHandlePointerDown = (): void => { this.blockDragPointerDown = true; };
+    const onPointerUp = (): void => { this.blockDragPointerDown = false; };
+    const onHandleKeydown = (event: KeyboardEvent): void => {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      onHandleClick();
+    };
+    const onMenuClick = (event: MouseEvent): void => {
+      const button = (event.target as Element | null)?.closest<HTMLButtonElement>("button[data-move]");
+      if (button && !button.disabled) this.runBlockMoveMenuAction(button.dataset.move ?? "");
+    };
+    const onMenuKeydown = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") { event.preventDefault(); this.closeBlockMoveMenu(true); }
+    };
+    handle.addEventListener("click", onHandleClick);
+    handle.addEventListener("pointerdown", onHandlePointerDown);
+    handle.addEventListener("keydown", onHandleKeydown);
+    menu.addEventListener("click", onMenuClick);
+    menu.addEventListener("keydown", onMenuKeydown);
+    doc.addEventListener("pointerup", onPointerUp, true);
+    doc.addEventListener("pointercancel", onPointerUp, true);
+    this.blockDragCleanup.push(
+      () => handle.removeEventListener("click", onHandleClick),
+      () => handle.removeEventListener("pointerdown", onHandlePointerDown),
+      () => handle.removeEventListener("keydown", onHandleKeydown),
+      () => menu.removeEventListener("click", onMenuClick),
+      () => menu.removeEventListener("keydown", onMenuKeydown),
+      () => doc.removeEventListener("pointerup", onPointerUp, true),
+      () => doc.removeEventListener("pointercancel", onPointerUp, true),
+    );
+
+    this.blockDragCleanup.push(draggable({
+      element: handle,
+      canDrag: () => !!this.currentBlockDragSource(),
+      getInitialData: () => {
+        const source = this.currentBlockDragSource();
+        return { type: BLOCK_DRAG_TYPE, sourceAnchorId: source ? this.anchorIdOf(source) : undefined };
+      },
+      onDragStart: () => {
+        this.blockDragging = true;
+        handle.classList.add("docx-block-dragging");
+        this.closeBlockMoveMenu();
+        this.refreshBlockDropTargets();
+      },
+      onDrop: () => {
+        this.blockDragging = false;
+        this.blockDragPointerDown = false;
+        handle.classList.remove("docx-block-dragging");
+        this.hideDropIndicator();
+      },
+    }));
+    this.blockDragCleanup.push(monitorForElements({
+      canMonitor: ({ source }) => source.data.type === BLOCK_DRAG_TYPE,
+      onDrop: ({ source, location }) => {
+        this.hideDropIndicator();
+        const drop = location.current.dropTargets[0]?.data;
+        const sourceId = source.data.sourceAnchorId;
+        const targetId = drop?.targetAnchorId;
+        const position = drop?.position === "after" ? "after" : "before";
+        if (typeof sourceId === "string" && typeof targetId === "string")
+          this.moveBlock(sourceId, targetId, position);
+      },
+    }));
+    this.blockDragCleanup.push(autoScrollForElements({
+      element: this.editRoot,
+      canScroll: ({ source }) => source.data.type === BLOCK_DRAG_TYPE,
+      getAllowedAxis: () => "vertical",
+    }));
+    this.blockDragCleanup.push(autoScrollWindowForElements({
+      canScroll: ({ source }) => source.data.type === BLOCK_DRAG_TYPE,
+      getAllowedAxis: () => "vertical",
+    }));
+    this.refreshBlockDropTargets();
+  }
+
+  private teardownBlockDrag(): void {
+    for (const cleanup of this.blockDragTargetCleanup.splice(0)) cleanup();
+    for (const cleanup of this.blockDragCleanup.splice(0)) cleanup();
+    this.blockDragHandle?.remove();
+    this.blockDropIndicator?.remove();
+    this.blockMoveMenu?.remove();
+    this.blockMoveLive?.remove();
+    this.blockDragHandle = null;
+    this.blockDropIndicator = null;
+    this.blockMoveMenu = null;
+    this.blockMoveLive = null;
+    this.blockDragSource = null;
+    this.blockDragging = false;
+    this.blockDragPointerDown = false;
   }
 
   // ─── internals ───────────────────────────────────────────────────────
@@ -1166,6 +1650,13 @@ export class DocxEditor {
 
   private wireBlock(el: HTMLElement): void {
     if (!EDITABLE_TAGS.has(el.tagName)) return;
+    if (
+      el.closest("tr[class$='row-del'], tr[class*='row-del ']") ||
+      el.querySelector(":scope > del[class$='move-from'], :scope > del[class*='move-from ']")
+    ) {
+      el.setAttribute("contenteditable", "false");
+      return;
+    }
     const unid = el.getAttribute("data-anchor");
     // Only blocks the markdown projection addresses are editable via the text path. This INCLUDES
     // table-cell paragraphs (the projection indexes them), so cell text IS editable. Table-aware
@@ -1257,12 +1748,7 @@ export class DocxEditor {
 
     // Plain block: re-render ONLY this block from the live session for canonical HTML. Swapping the
     // just-blurred node here is safe (verified — focus stays on the newly-clicked block).
-    const html = this.exports.DocxSessionBridge.RenderBlockHtml(
-      this.handle,
-      newAnchor,
-      this.options.cssPrefix,
-      this.options.fabricateClasses,
-    );
+    const html = this.renderBlockHtml(newAnchor);
     if (html.charCodeAt(0) !== 0x7b /* not an error object */) {
       const fresh = new DOMParser().parseFromString(html, "text/html").body.firstElementChild as HTMLElement | null;
       const inBand = this.isBandBlock(el);
@@ -1559,14 +2045,33 @@ export class DocxEditor {
 
   /** Render a block by anchor and parse it into a detached element (null on error). */
   private renderInto(anchorId: string): HTMLElement | null {
-    const html = this.exports.DocxSessionBridge.RenderBlockHtml(
-      this.handle,
-      anchorId,
-      this.options.cssPrefix,
-      this.options.fabricateClasses,
-    );
+    const html = this.renderBlockHtml(anchorId);
     if (html.charCodeAt(0) === 0x7b /* error object */) return null;
     return new DOMParser().parseFromString(html, "text/html").body.firstElementChild as HTMLElement | null;
+  }
+
+  private get renderTrackedChanges(): boolean {
+    return this.options.trackedChanges === TrackedChangeMode.RenderInline;
+  }
+
+  private renderBlockHtml(anchorId: string): string {
+    const bridge = this.exports.DocxSessionBridge;
+    if (typeof bridge.RenderBlockHtmlForReview === "function") {
+      return bridge.RenderBlockHtmlForReview(
+        this.handle, anchorId, this.options.cssPrefix, this.options.fabricateClasses,
+        this.renderTrackedChanges,
+      );
+    }
+    return bridge.RenderBlockHtml(
+      this.handle, anchorId, this.options.cssPrefix, this.options.fabricateClasses,
+    );
+  }
+
+  private renderPlanJson(): string {
+    const bridge = this.exports.DocxSessionBridge;
+    return typeof bridge.ListRenderedBlocks === "function"
+      ? bridge.ListRenderedBlocks(this.handle, this.renderTrackedChanges)
+      : bridge.ListBlocks!(this.handle);
   }
 
   /** Render two blocks in ONE batched bridge call when the bundle carries RenderBlocksHtml —
@@ -1578,14 +2083,19 @@ export class DocxEditor {
     const bridge = this.exports.DocxSessionBridge;
     if (typeof bridge.RenderBlocksHtml === "function") {
       try {
-        const map = JSON.parse(
-          bridge.RenderBlocksHtml(
+        const idsJson = JSON.stringify([a, b]);
+        const json = typeof bridge.RenderBlocksHtmlForReview === "function"
+          ? bridge.RenderBlocksHtmlForReview(
+              this.handle, idsJson, this.options.cssPrefix, this.options.fabricateClasses,
+              this.renderTrackedChanges,
+            )
+          : bridge.RenderBlocksHtml(
             this.handle,
-            JSON.stringify([a, b]),
+            idsJson,
             this.options.cssPrefix,
             this.options.fabricateClasses,
-          ),
-        ) as Record<string, string | null> & { error?: string };
+          );
+        const map = JSON.parse(json) as Record<string, string | null> & { error?: string };
         if (!map.error) {
           const parse = (h: string | null | undefined): HTMLElement | null =>
             h
@@ -2363,6 +2873,17 @@ export class DocxEditor {
    */
   private renderFullHtml(): string {
     const bridge = this.exports.DocxSessionBridge;
+    if (typeof bridge.RenderHtmlForReview === "function") {
+      const html = bridge.RenderHtmlForReview(
+        this.handle,
+        this.options.cssPrefix,
+        this.options.fabricateClasses,
+        this.options.paginated,
+        this.options.scale,
+        this.renderTrackedChanges,
+      );
+      if (html.charCodeAt(0) !== 0x7b) return html;
+    }
     if (typeof bridge.RenderHtml === "function") {
       const html = bridge.RenderHtml(
         this.handle,
@@ -2382,7 +2903,10 @@ export class DocxEditor {
         ? bridge.SaveWithAnchorIds(this.handle)
         : bridge.Save(this.handle);
     return this.exports.DocumentConverter.ConvertDocxToHtmlComplete(
-      ...completeArgs(bytes, this.options.cssPrefix, this.options.fabricateClasses, this.options.paginated, this.options.scale),
+      ...completeArgs(
+        bytes, this.options.cssPrefix, this.options.fabricateClasses,
+        this.options.paginated, this.options.scale, this.renderTrackedChanges,
+      ),
     );
   }
 
@@ -2494,7 +3018,7 @@ export class DocxEditor {
     // Refresh the unid → anchor map FIRST: wiring freshly rendered nodes (wireBlock)
     // resolves through it, and the map must reflect the post-op session.
     this.refreshAnchorMap();
-    const plan = JSON.parse(bridge.ListBlocks!(this.handle)) as RenderPlan & { error?: string };
+    const plan = JSON.parse(this.renderPlanJson()) as RenderPlan & { error?: string };
     if (plan.error) return this.bail(`plan error: ${plan.error}`);
 
     const oldNodes = this.bodyUnitNodes();
@@ -2508,21 +3032,26 @@ export class DocxEditor {
     if (fnState === null || enState === null) return this.bail("notes container unstampable/missing");
 
     // One batch render for everything that needs fresh HTML.
-    const addedBodyIds = bodyDiff.added.map((j) => plan.body[j].id);
+    const movedBodyNew = new Set(bodyDiff.moved.map((m) => m.newIndex));
+    const addedBodyIds = bodyDiff.added
+      .filter((j) => !movedBodyNew.has(j))
+      .map((j) => plan.body[j].id);
     const addedNoteIds = fnState.diff.added
       .map((j) => plan.footnotes[j].id)
       .concat(enState.diff.added.map((j) => plan.endnotes[j].id));
     const allIds = addedBodyIds.concat(addedNoteIds);
     let rendered: Record<string, string | null> = {};
     if (allIds.length > 0) {
-      rendered = JSON.parse(
-        bridge.RenderBlocksHtml!(
-          this.handle,
-          JSON.stringify(allIds),
-          this.options.cssPrefix,
-          this.options.fabricateClasses,
-        ),
-      );
+      const idsJson = JSON.stringify(allIds);
+      const renderedJson = typeof bridge.RenderBlocksHtmlForReview === "function"
+        ? bridge.RenderBlocksHtmlForReview(
+            this.handle, idsJson, this.options.cssPrefix, this.options.fabricateClasses,
+            this.renderTrackedChanges,
+          )
+        : bridge.RenderBlocksHtml!(
+            this.handle, idsJson, this.options.cssPrefix, this.options.fabricateClasses,
+          );
+      rendered = JSON.parse(renderedJson);
       if ((rendered as { error?: string }).error) return this.bail(`render error: ${(rendered as { error?: string }).error}`);
       for (const id of allIds) if (!rendered[id]) return this.bail(`unrenderable: ${id}`);
     }
@@ -2539,7 +3068,7 @@ export class DocxEditor {
       return el;
     };
     const freshBody = new Map<number, HTMLElement>();
-    for (const j of bodyDiff.added) {
+    for (const j of bodyDiff.added.filter((j) => !movedBodyNew.has(j))) {
       const el = parse(rendered[plan.body[j].id]!);
       if (!el) return this.bail(`unparseable render: ${plan.body[j].id}`);
       freshBody.set(j, el);
@@ -2611,15 +3140,6 @@ export class DocxEditor {
     diff: UnitDiff,
     fresh: Map<number, HTMLElement>,
   ): true | string {
-    // Kept nodes must appear in increasing old order (no move support in v1).
-    let lastOld = -1;
-    for (let j = 0; j < units.length; j++) {
-      const oi = diff.keep.get(j);
-      if (oi === undefined) continue;
-      if (oi < lastOld) return "kept order violation";
-      lastOld = oi;
-    }
-
     // In-place substitutions first: replace at WRAPPER level so a table swaps with its
     // alignment div. A LEAF render replacing a wrapped node would break the wrapper's
     // semantics (border <div> grouping) — that is remount territory.
@@ -2650,42 +3170,72 @@ export class DocxEditor {
       this.wireUnit(freshRoot, units[nj]);
     }
 
-    // Pure inserts against kept/substituted neighbors (at wrapper level).
-    const pureAdded = diff.added.filter((j) => !subOldByNew.has(j));
+    const movedOldByNew = new Map(diff.moved.map((m) => [m.newIndex, m.oldIndex]));
+    const movedNew = new Set(diff.moved.map((m) => m.newIndex));
+    const movedOld = new Set(diff.moved.map((m) => m.oldIndex));
+    const pureAdded = diff.added.filter((j) => !subOldByNew.has(j) && !movedNew.has(j));
     const pureRemoved = diff.removed.filter(
-      (i) => !diff.substituted.some((s) => s.oldIndex === i),
+      (i) => !diff.substituted.some((s) => s.oldIndex === i) && !movedOld.has(i),
     );
     const nodeAt = (j: number): HTMLElement | null => {
       const oi = diff.keep.get(j);
       if (oi !== undefined) return oldNodes[oi];
+      const movedOi = movedOldByNew.get(j);
+      if (movedOi !== undefined) return oldNodes[movedOi];
       if (subOldByNew.has(j)) return fresh.get(j)!;
       const f = fresh.get(j);
       return f && f.isConnected ? f : null;
     };
+
+    // Preserve the established incremental insertion path: body render output may
+    // legitimately use several wrapper parents (for example border groups), so it is
+    // not valid to normalize the whole body against one common parent.
     for (const j of pureAdded) {
       const el = fresh.get(j)!;
       let prev: HTMLElement | null = null;
       for (let k = j - 1; k >= 0 && !prev; k--) prev = nodeAt(k);
       let next: HTMLElement | null = null;
-      for (let k = j + 1; k < units.length && !next; k++) {
-        const oi = diff.keep.get(k);
-        if (oi !== undefined) next = oldNodes[oi];
-        else if (subOldByNew.has(k)) next = fresh.get(k)!;
-      }
+      for (let k = j + 1; k < units.length && !next; k++) next = nodeAt(k);
       const prevW = prev ? this.unitWrapperOf(prev) : null;
       const nextW = next ? this.unitWrapperOf(next) : null;
       if (prevW && nextW && prevW.parentElement !== nextW.parentElement)
         return "insert neighbors in different parents";
       if (prevW) prevW.after(el);
       else if (nextW) nextW.before(el);
-      else return "insert with no anchored neighbor"; // empty container — nowhere provably correct
+      else return "insert with no anchored neighbor";
       this.wireUnit(el, units[j]);
     }
 
-    // Pure removals last, taking now-empty generated wrappers with them.
+    // Pure removals take their now-empty generated wrappers with them. Exact-token
+    // move sources remain live even though the LCS also reports them as removed.
     for (const i of pureRemoved) {
-      const wrapper = this.unitWrapperOf(oldNodes[i]);
-      wrapper.remove();
+      this.unitWrapperOf(oldNodes[i]).remove();
+    }
+
+    // A block move changes one exact-token unit's slot. Move only that existing
+    // wrapper beside its final neighbor; this preserves identity without disturbing
+    // unrelated nodes or assuming every rendered unit shares one DOM parent.
+    for (const { newIndex } of [...diff.moved].sort((a, b) => a.newIndex - b.newIndex)) {
+      const moving = nodeAt(newIndex);
+      if (!moving?.isConnected) return "move source is not connected";
+      const movingW = this.unitWrapperOf(moving);
+      let prevW: HTMLElement | null = null;
+      for (let k = newIndex - 1; k >= 0 && !prevW; k--) {
+        const n = nodeAt(k);
+        if (n?.isConnected) prevW = this.unitWrapperOf(n);
+      }
+      let nextW: HTMLElement | null = null;
+      for (let k = newIndex + 1; k < units.length && !nextW; k++) {
+        const n = nodeAt(k);
+        if (n?.isConnected) nextW = this.unitWrapperOf(n);
+      }
+      if (prevW && prevW !== movingW && prevW.parentElement === movingW.parentElement) {
+        prevW.after(movingW);
+      } else if (nextW && nextW !== movingW && nextW.parentElement === movingW.parentElement) {
+        nextW.before(movingW);
+      } else {
+        return "move neighbors in different parents";
+      }
     }
     return true;
   }
@@ -2830,7 +3380,7 @@ export class DocxEditor {
     const bridge = this.exports.DocxSessionBridge;
     if (typeof bridge.ListBlocks !== "function") return;
     try {
-      const plan = JSON.parse(bridge.ListBlocks(this.handle)) as RenderPlan & { error?: string };
+      const plan = JSON.parse(this.renderPlanJson()) as RenderPlan & { error?: string };
       if (plan.error) return;
       // Positional pairing: a fresh full mount renders exactly the plan's units in
       // order (verified invariant). On any mismatch, leave unstamped — an unstamped
@@ -2864,6 +3414,7 @@ export class DocxEditor {
    * block's content-hashed unid changes across the save/reproject a remount performs.
    */
   private remount(focusIndex = -1, caretAtEnd = false): void {
+    this.teardownBlockDrag();
     this.refreshAnchorMap();
     const fullHtml = this.renderFullHtml();
     this.activeBlock = null;
@@ -2880,5 +3431,6 @@ export class DocxEditor {
     // A remount rebuilds the body from the live session; re-resolve the section so undo/redo of a
     // section-affecting edit (or a pagination toggle) leaves the bands describing the right one.
     this.syncRegionToBody(this.activeBlock ?? undefined);
+    this.setupBlockDrag();
   }
 }

--- a/npm/src/embed.ts
+++ b/npm/src/embed.ts
@@ -273,9 +273,18 @@ function createScopedEditorExports(
 ): DocxEditorExports {
   const convert = exports.DocumentConverter.ConvertDocxToHtmlComplete;
   const bridge = { ...exports.DocxSessionBridge };
+  // EVERY whole-document render has to be scoped, not just the first one the editor happened to
+  // use: the converter's stylesheet contains `body`/`span` rules, so one unwrapped path is enough
+  // to restyle the host page. `RenderHtmlForReview` is the revision-view twin of `RenderHtml` and
+  // is what remount prefers when it exists.
   const renderHtml = bridge.RenderHtml;
   if (renderHtml) {
     bridge.RenderHtml = (...args) => scopeDocumentStyles(renderHtml(...args), rootSelector);
+  }
+  const renderHtmlForReview = bridge.RenderHtmlForReview;
+  if (renderHtmlForReview) {
+    bridge.RenderHtmlForReview = (...args) =>
+      scopeDocumentStyles(renderHtmlForReview(...args), rootSelector);
   }
   return {
     DocxSessionBridge: bridge,

--- a/npm/src/ribbon.ts
+++ b/npm/src/ribbon.ts
@@ -480,8 +480,12 @@ class RibbonSurface implements RibbonEditor {
       editable: this.options.editable,
       scale: this.options.scale,
       onEdit: this.options.onEdit,
+      onMove: this.options.onMove,
       paginated,
       headerFooter: this.headerFooter,
+      blockDrag: this.options.blockDrag ?? true,
+      trackedChanges: this.options.trackedChanges,
+      revisionAuthor: this.options.revisionAuthor,
     });
     this.require<HTMLButtonElement>("save").disabled = false;
     this.require("ribbon").setAttribute("aria-disabled", "false");

--- a/npm/src/session.ts
+++ b/npm/src/session.ts
@@ -126,6 +126,13 @@ export class DocxSession {
     return JSON.parse(this.wasm.DeleteBlock(this.handle, anchorId)) as EditResult;
   }
 
+  /** Reorder one top-level paragraph/heading/list/table block relative to another. */
+  moveBlock(sourceAnchorId: string, targetAnchorId: string, position: "before" | "after"): EditResult {
+    return JSON.parse(
+      this.wasm.MoveBlock(this.handle, sourceAnchorId, targetAnchorId, position),
+    ) as EditResult;
+  }
+
   /**
    * Delete every top-level block-level sibling between `fromAnchorId` (inclusive)
    * and `toAnchorIdExclusive` (exclusive). Both anchors must share a direct

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -1112,8 +1112,10 @@ export interface DocxodusWasmExports {
     ReplaceText: (handle: number, anchor: string, md: string) => string;
     DeleteBlock: (handle: number, anchor: string) => string;
     MoveBlock: (handle: number, sourceAnchor: string, targetAnchor: string, pos: string) => string;
-    /** JSON `string[]` of the anchors a block may legally be moved next to — what a drag UI
-     *  gates its drop targets on. Optional: absent on older WASM bundles. */
+    /** JSON `{anchorId, before, after}[]` — the blocks a block may legally be moved next to and
+     *  on which side, which is what a drag UI gates its drop targets on. The two sides are
+     *  reported separately because a cross-block range or a section break between the blocks can
+     *  make one legal and the other not. Optional: absent on older WASM bundles. */
     ValidMoveTargets?: (handle: number, sourceAnchor: string) => string;
     DeleteRange: (handle: number, fromAnchorId: string, toAnchorIdExclusive: string) => string;
     DeleteSection: (handle: number, headingAnchorId: string) => string;

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -1054,6 +1054,7 @@ export interface DocxodusWasmExports {
      *  what the editor's incremental reconciler diffs its DOM against. Optional:
      *  absent on older WASM bundles. */
     ListBlocks?: (handle: number) => string;
+    ListRenderedBlocks?: (handle: number, renderTrackedChanges: boolean) => string;
     /** Citation-ordered footnotes/endnotes (JSON {@link NoteListEntry}[]) — the
      *  id↔ordinal authority for renumbering rendered note chrome. Optional:
      *  absent on older WASM bundles. */
@@ -1073,11 +1074,25 @@ export interface DocxodusWasmExports {
       cssPrefix: string,
       fabricateClasses: boolean
     ) => string;
+    RenderBlocksHtmlForReview?: (
+      handle: number,
+      anchorIdsJson: string,
+      cssPrefix: string,
+      fabricateClasses: boolean,
+      renderTrackedChanges: boolean
+    ) => string;
     RenderBlockHtml: (
       handle: number,
       anchorId: string,
       cssPrefix: string,
       fabricateClasses: boolean
+    ) => string;
+    RenderBlockHtmlForReview?: (
+      handle: number,
+      anchorId: string,
+      cssPrefix: string,
+      fabricateClasses: boolean,
+      renderTrackedChanges: boolean
     ) => string;
     RenderHtml: (
       handle: number,
@@ -1086,8 +1101,17 @@ export interface DocxodusWasmExports {
       paginated: boolean,
       scale: number
     ) => string;
+    RenderHtmlForReview?: (
+      handle: number,
+      cssPrefix: string,
+      fabricateClasses: boolean,
+      paginated: boolean,
+      scale: number,
+      renderTrackedChanges: boolean
+    ) => string;
     ReplaceText: (handle: number, anchor: string, md: string) => string;
     DeleteBlock: (handle: number, anchor: string) => string;
+    MoveBlock: (handle: number, sourceAnchor: string, targetAnchor: string, pos: string) => string;
     DeleteRange: (handle: number, fromAnchorId: string, toAnchorIdExclusive: string) => string;
     DeleteSection: (handle: number, headingAnchorId: string) => string;
     InsertParagraph: (handle: number, anchor: string, pos: string, md: string) => string;

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -1112,6 +1112,9 @@ export interface DocxodusWasmExports {
     ReplaceText: (handle: number, anchor: string, md: string) => string;
     DeleteBlock: (handle: number, anchor: string) => string;
     MoveBlock: (handle: number, sourceAnchor: string, targetAnchor: string, pos: string) => string;
+    /** JSON `string[]` of the anchors a block may legally be moved next to — what a drag UI
+     *  gates its drop targets on. Optional: absent on older WASM bundles. */
+    ValidMoveTargets?: (handle: number, sourceAnchor: string) => string;
     DeleteRange: (handle: number, fromAnchorId: string, toAnchorIdExclusive: string) => string;
     DeleteSection: (handle: number, headingAnchorId: string) => string;
     InsertParagraph: (handle: number, anchor: string, pos: string, md: string) => string;

--- a/npm/tests/editor-block-drag.spec.ts
+++ b/npm/tests/editor-block-drag.spec.ts
@@ -106,6 +106,69 @@ test.describe('DocxEditor — block drag handle', () => {
     expect(units.filter((x) => x.tag === 'TABLE')).toHaveLength(1);
   });
 
+  // A section break partitions the body into regions a block cannot move between. The engine has
+  // always refused those moves; the UI used to draw a drop indicator over them anyway and only
+  // fail on release, and "move to top/bottom" always targeted the document ends — so on a document
+  // with section breaks those commands could never succeed.
+  test('a section break partitions the document into move regions', async ({ page }) => {
+    await openParagraphDocument(page, ['Alpha', 'Beta', 'Gamma']);
+    await page.evaluate(() => {
+      const D = (window as any).Docxodus;
+      const { editor } = (window as any).__drag;
+      const units = editor['bodyUnitNodes']() as HTMLElement[];
+      const afterBeta = editor['anchorIdOf'](units[1]);
+      D.DocxSessionBridge.RawInsertXml(editor.sessionHandle, afterBeta, 'after',
+        '<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' +
+        '<w:pPr><w:sectPr/></w:pPr></w:p>');
+      editor['remount']();
+    });
+
+    // The section-break paragraph itself can never be moved, so it gets no handle at all.
+    const state = await page.evaluate(() => {
+      const { editor } = (window as any).__drag;
+      const units = editor['bodyUnitNodes']() as HTMLElement[];
+      const breakUnit = units.find((el) => (el.textContent ?? '').trim() === '')!;
+      editor['showBlockHandle'](breakUnit);
+      const handleHidden = document.querySelector<HTMLElement>('.docx-block-handle')!.style.display === 'none';
+      // Alpha may reach Beta (same region) but not Gamma (across the break).
+      const alpha = units.find((el) => el.textContent?.includes('Alpha'))!;
+      editor['refreshBlockMoveTargets'](alpha);
+      const targets: Set<string> = editor['blockMoveTargets'];
+      const idOf = (text: string) =>
+        editor['anchorIdOf'](units.find((el: HTMLElement) => el.textContent?.includes(text))!);
+      return {
+        handleHidden,
+        canReachBeta: targets.has(idOf('Beta')),
+        canReachGamma: targets.has(idOf('Gamma')),
+      };
+    });
+    expect(state).toEqual({ handleHidden: true, canReachBeta: true, canReachGamma: false });
+
+    // Dragging Alpha onto Gamma must not even offer a drop: no indicator, no reorder.
+    const alpha = page.locator('#block-drag-host p[data-anchor]').filter({ hasText: 'Alpha' });
+    const gamma = page.locator('#block-drag-host p[data-anchor]').filter({ hasText: 'Gamma' });
+    await alpha.hover();
+    await page.evaluate(() => {
+      const indicator = document.querySelector<HTMLElement>('.docx-block-drop-indicator')!;
+      (window as any).__shown = [];
+      new MutationObserver(() => {
+        if (indicator.style.display === 'block') (window as any).__shown.push(1);
+      }).observe(indicator, { attributes: true, attributeFilter: ['style'] });
+    });
+    const gammaBox = (await gamma.boundingBox())!;
+    await page.locator('.docx-block-handle').dragTo(gamma, {
+      targetPosition: { x: gammaBox.width / 2, y: gammaBox.height - 2 },
+    });
+    expect(await page.evaluate(() => (window as any).__shown.length)).toBe(0);
+    expect((await unitState(page)).map((x) => x.text).filter(Boolean)).toEqual(['Alpha', 'Beta', 'Gamma']);
+
+    // "Move to bottom" means the end of Alpha's OWN region — Beta — not the document end.
+    await alpha.hover();
+    await page.locator('.docx-block-handle').click();
+    await page.getByRole('menuitem', { name: 'Move to bottom' }).click();
+    expect((await unitState(page)).map((x) => x.text).filter(Boolean)).toEqual(['Beta', 'Alpha', 'Gamma']);
+  });
+
   test('review mode renders a native move pair and keeps the source read-only', async ({ page }) => {
     await openParagraphDocument(page, ['North', 'Middle', 'South']);
     await page.evaluate(() => {

--- a/npm/tests/editor-block-drag.spec.ts
+++ b/npm/tests/editor-block-drag.spec.ts
@@ -133,7 +133,7 @@ test.describe('DocxEditor — block drag handle', () => {
       // Alpha may reach Beta (same region) but not Gamma (across the break).
       const alpha = units.find((el) => el.textContent?.includes('Alpha'))!;
       editor['refreshBlockMoveTargets'](alpha);
-      const targets: Set<string> = editor['blockMoveTargets'];
+      const targets: Map<string, { before: boolean; after: boolean }> = editor['blockMoveTargets'];
       const idOf = (text: string) =>
         editor['anchorIdOf'](units.find((el: HTMLElement) => el.textContent?.includes(text))!);
       return {

--- a/npm/tests/editor-block-drag.spec.ts
+++ b/npm/tests/editor-block-drag.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect, Page } from '@playwright/test';
+
+async function waitForDocxodus(page: Page) {
+  await page.waitForFunction(() => (window as any).DocxodusReady === true, { timeout: 30000 });
+}
+
+async function openParagraphDocument(page: Page, names: string[], options: Record<string, unknown> = {}) {
+  await page.evaluate((options) => {
+    const D = (window as any).Docxodus;
+    const container = document.createElement('div');
+    container.id = 'block-drag-host';
+    container.style.cssText = 'width:700px;margin:40px auto;padding:32px;background:white';
+    document.body.appendChild(container);
+    const moves: unknown[] = [];
+    const editor = D.DocxEditor.open(container, D.DocxSessionBridge.CreateBlankDocx(), D, {
+      blockDrag: true,
+      onMove: (info: unknown) => moves.push(info),
+      ...options,
+    });
+    (window as any).__drag = { editor, container, moves };
+    (container.querySelector('p[data-anchor][contenteditable="true"]') as HTMLElement).focus();
+  }, options);
+  for (let i = 0; i < names.length; i++) {
+    if (i > 0) await page.keyboard.press('Enter');
+    await page.keyboard.type(names[i]);
+  }
+  await page.evaluate(() => {
+    (document.activeElement as HTMLElement)?.blur();
+    // Canonical full paint gives every unit a signature and recreates the drag targets.
+    (window as any).__drag.editor['remount']();
+  });
+}
+
+const unitState = (page: Page) => page.evaluate(() => {
+  const { editor } = (window as any).__drag;
+  return (editor['bodyUnitNodes']() as HTMLElement[]).map((el) => ({
+    tag: el.tagName,
+    text: (el.textContent ?? '').replace(/\s+/g, ' ').trim(),
+    editable: el.getAttribute('contenteditable'),
+  }));
+});
+
+test.describe('DocxEditor — block drag handle', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/test-harness.html');
+    await waitForDocxodus(page);
+  });
+
+  test('click menu moves a block accessibly and preserves its DOM node', async ({ page }) => {
+    await openParagraphDocument(page, ['Alpha', 'Beta', 'Gamma']);
+    await page.evaluate(() => {
+      const beta = Array.from(document.querySelectorAll<HTMLElement>('#block-drag-host p[data-anchor]'))
+        .find((el) => el.textContent?.includes('Beta'))!;
+      (beta as any).__identity = 'same-node';
+    });
+
+    const beta = page.locator('#block-drag-host p[data-anchor]').filter({ hasText: 'Beta' });
+    await beta.hover();
+    const handle = page.locator('.docx-block-handle');
+    await expect(handle).toBeVisible();
+    await expect(handle).toHaveAttribute('aria-haspopup', 'menu');
+    await handle.click();
+    await expect(page.getByRole('menuitem', { name: 'Move to top' })).toBeVisible();
+    await page.getByRole('menuitem', { name: 'Move to top' }).click();
+
+    expect((await unitState(page)).map((x) => x.text)).toEqual(['Beta', 'Alpha', 'Gamma']);
+    const result = await page.evaluate(() => {
+      const { moves } = (window as any).__drag;
+      const beta = Array.from(document.querySelectorAll<HTMLElement>('#block-drag-host p[data-anchor]'))
+        .find((el) => el.textContent?.includes('Beta'))!;
+      return { sameNode: (beta as any).__identity, moves: moves.length };
+    });
+    expect(result).toEqual({ sameNode: 'same-node', moves: 1 });
+  });
+
+  test('dragging uses before/after drop zones and reorders the live session', async ({ page }) => {
+    await openParagraphDocument(page, ['One', 'Two', 'Three']);
+    const one = page.locator('#block-drag-host p[data-anchor]').filter({ hasText: 'One' });
+    const three = page.locator('#block-drag-host p[data-anchor]').filter({ hasText: 'Three' });
+    await one.hover();
+    const handle = page.locator('.docx-block-handle');
+    const handleBox = await handle.boundingBox();
+    const targetBox = await three.boundingBox();
+    expect(handleBox).not.toBeNull();
+    expect(targetBox).not.toBeNull();
+    await handle.dragTo(three, {
+      targetPosition: { x: targetBox!.width / 2, y: targetBox!.height - 2 },
+    });
+    expect((await unitState(page)).map((x) => x.text)).toEqual(['Two', 'Three', 'One']);
+  });
+
+  test('a cell hover selects and moves its whole table', async ({ page }) => {
+    await openParagraphDocument(page, ['Before', 'After']);
+    await page.evaluate(() => {
+      const { editor } = (window as any).__drag;
+      const first = editor['editableList']()[0] as HTMLElement;
+      first.focus();
+      editor.insertTable(2, 2);
+    });
+    const cell = page.locator('#block-drag-host table td p[contenteditable="true"]').first();
+    await cell.hover();
+    await page.locator('.docx-block-handle').click();
+    await page.getByRole('menuitem', { name: 'Move to bottom' }).click();
+    const units = await unitState(page);
+    expect(units.at(-1)?.tag).toBe('TABLE');
+    expect(units.filter((x) => x.tag === 'TABLE')).toHaveLength(1);
+  });
+
+  test('review mode renders a native move pair and keeps the source read-only', async ({ page }) => {
+    await openParagraphDocument(page, ['North', 'Middle', 'South']);
+    await page.evaluate(() => {
+      const D = (window as any).Docxodus;
+      const state = (window as any).__drag;
+      const saved = state.editor.save();
+      state.editor.close();
+      state.container.replaceChildren();
+      const editor = D.DocxEditor.open(state.container, saved, D, {
+        blockDrag: true,
+        trackedChanges: 1, // TrackedChangeMode.RenderInline
+        revisionAuthor: 'Drag Tester',
+      });
+      (window as any).__drag.editor = editor;
+      const units = editor['bodyUnitNodes']() as HTMLElement[];
+      editor.moveBlock(editor['anchorIdOf'](units[0]), editor['anchorIdOf'](units[2]), 'after');
+    });
+    const review = await page.evaluate(() => {
+      const host = document.querySelector('#block-drag-host')!;
+      const from = host.querySelector<HTMLElement>("del[class$='move-from'], del[class*='move-from ']");
+      const to = host.querySelector<HTMLElement>("ins[class$='move-to'], ins[class*='move-to ']");
+      return {
+        from: from?.textContent,
+        to: to?.textContent,
+        sourceEditable: from?.closest('[data-anchor]')?.getAttribute('contenteditable'),
+      };
+    });
+    expect(review.from).toContain('North');
+    expect(review.to).toContain('North');
+    expect(review.sourceEditable).toBe('false');
+  });
+});

--- a/npm/tests/editor-reconcile-unit.spec.ts
+++ b/npm/tests/editor-reconcile-unit.spec.ts
@@ -32,6 +32,30 @@ test.describe("editor-reconcile unit diff", () => {
     expect(d.keep.size).toBe(2);
   });
 
+  test("exact-token reorder is a move, not a substitution", () => {
+    const d = diffUnits(U("a b c"), P("b c a"));
+    expect(d.moved).toEqual([{ oldIndex: 0, newIndex: 2 }]);
+    expect(d.substituted).toEqual([]);
+  });
+
+  test("backward exact-token reorder preserves the moved identity", () => {
+    const d = diffUnits(U("a b c d"), P("a d b c"));
+    expect(d.moved).toEqual([{ oldIndex: 3, newIndex: 1 }]);
+    expect(d.substituted).toEqual([]);
+  });
+
+  test("moving a list item requests remount so numbering can recalculate", () => {
+    const old = U("a b c");
+    const next: RenderUnit[] = [
+      { id: "li:body:b", kind: "li" },
+      { id: "li:body:c", kind: "li" },
+      { id: "li:body:a", kind: "li" },
+    ];
+    const d = diffUnits(old, next);
+    expect(d.moved).toEqual([{ oldIndex: 0, newIndex: 2 }]);
+    expect(needsRemount(d, next, ["li", "li", "li"])).toBe(true);
+  });
+
   test("duplicate unids treated positionally", () => {
     const d = diffUnits(U("a x x b"), P("a x b"));
     expect(d.removed.length).toBe(1);

--- a/python/src/docx_scalpel/session.py
+++ b/python/src/docx_scalpel/session.py
@@ -879,6 +879,24 @@ class DocxSession:
     def delete_block(self, anchor_id: str) -> EditResult:
         return EditResult._from_wire(self._call("delete_block", {"anchorId": anchor_id}))
 
+    def move_block(
+        self,
+        source_anchor_id: str,
+        target_anchor_id: str,
+        position: Position,
+    ) -> EditResult:
+        """Move one top-level paragraph/list/table block before or after another."""
+        return EditResult._from_wire(
+            self._call(
+                "move_block",
+                {
+                    "sourceAnchorId": source_anchor_id,
+                    "targetAnchorId": target_anchor_id,
+                    "position": position.value,
+                },
+            )
+        )
+
     def delete_range(self, from_anchor_id: str, to_anchor_id_exclusive: str) -> EditResult:
         return EditResult._from_wire(
             self._call(

--- a/tools/mcp-server/Dispatcher.cs
+++ b/tools/mcp-server/Dispatcher.cs
@@ -274,6 +274,8 @@ internal static class Dispatcher
             session.Handle, Str(args, "anchorId"), Str(args, "find"), Str(args, "replace"),
             new ReplaceOptions { IgnoreCase = !BoolOpt(args, "caseSensitive", false) }),
         "delete_block" => DocxSessionOps.DeleteBlock(session.Handle, Str(args, "anchorId")),
+        "move_block" => DocxSessionOps.MoveBlock(
+            session.Handle, Str(args, "sourceAnchorId"), Str(args, "targetAnchorId"), ParsePos(args)),
         "delete_range" => DocxSessionOps.DeleteRange(
             session.Handle, Str(args, "fromAnchorId"), Str(args, "toAnchorIdExclusive")),
         "delete_section" => DocxSessionOps.DeleteSection(session.Handle, Str(args, "headingAnchorId")),

--- a/tools/mcp-server/ToolCatalog.cs
+++ b/tools/mcp-server/ToolCatalog.cs
@@ -102,15 +102,15 @@ internal static class ToolCatalog
             """),
         new ToolDefinition(
             "docxodus_edit",
-            "Insert, replace, delete, or undo/redo text and blocks, addressed by anchor id.",
+            "Insert, replace, move, delete, or undo/redo text and blocks, addressed by anchor id.",
             """
             {
               "type": "object",
               "properties": {
                 "sessionId": { "type": "string" },
-                "action": { "type": "string", "enum": ["insert_paragraph", "replace_text", "replace_text_range", "delete_block", "delete_range", "delete_section", "split_paragraph", "merge_paragraphs", "undo", "redo"] },
+                "action": { "type": "string", "enum": ["insert_paragraph", "replace_text", "replace_text_range", "delete_block", "move_block", "delete_range", "delete_section", "split_paragraph", "merge_paragraphs", "undo", "redo"] },
                 "anchorId": { "type": "string", "description": "Target block. Required for every action except delete_range, delete_section, undo, redo." },
-                "position": { "type": "string", "enum": ["before", "after"], "description": "insert_paragraph only." },
+                "position": { "type": "string", "enum": ["before", "after"], "description": "insert_paragraph/move_block only." },
                 "markdown": { "type": "string", "description": "insert_paragraph/replace_text payload, in the supported markdown subset (headings, bullet/ordered lists, bold/italic/code/strike, links, hard breaks)." },
                 "find": { "type": "string", "description": "replace_text_range: literal text to find within the block." },
                 "replace": { "type": "string", "description": "replace_text_range: replacement text." },
@@ -119,7 +119,9 @@ internal static class ToolCatalog
                 "fromAnchorId": { "type": "string", "description": "delete_range: start boundary (use anchorId as the field name for the start would be ambiguous with toAnchorIdExclusive; both are required together)." },
                 "headingAnchorId": { "type": "string", "description": "delete_section: heading whose section (heading + everything until the next same-or-higher heading) should be removed." },
                 "characterOffset": { "type": "integer", "description": "split_paragraph: character offset to split at." },
-                "secondAnchorId": { "type": "string", "description": "merge_paragraphs: the paragraph absorbed into anchorId." }
+                "secondAnchorId": { "type": "string", "description": "merge_paragraphs: the paragraph absorbed into anchorId." },
+                "sourceAnchorId": { "type": "string", "description": "move_block: block to relocate." },
+                "targetAnchorId": { "type": "string", "description": "move_block: reference block used with position." }
               },
               "required": ["sessionId", "action"]
             }

--- a/tools/python-host/Dispatcher.cs
+++ b/tools/python-host/Dispatcher.cs
@@ -47,6 +47,9 @@ internal static class Dispatcher
 
         "replace_text" => DocxSessionOps.ReplaceText(Handle(args), Str(args, "anchorId"), Str(args, "markdown")),
         "delete_block" => DocxSessionOps.DeleteBlock(Handle(args), Str(args, "anchorId")),
+        "move_block" => DocxSessionOps.MoveBlock(
+            Handle(args), Str(args, "sourceAnchorId"), Str(args, "targetAnchorId"),
+            DocxSessionJson.ParsePos(Str(args, "position"))),
         "delete_range" => DocxSessionOps.DeleteRange(
             Handle(args), Str(args, "fromAnchorId"), Str(args, "toAnchorIdExclusive")),
         "delete_section" => DocxSessionOps.DeleteSection(

--- a/wasm/DocxodusWasm/DocxSessionBridge.cs
+++ b/wasm/DocxodusWasm/DocxSessionBridge.cs
@@ -184,6 +184,15 @@ public static partial class DocxSessionBridge
         DocxSessionOps.MoveBlock(h, sourceAnchor, targetAnchor, DocxSessionJson.ParsePos(posStr));
 
     /// <summary>
+    /// Bridge for <see cref="DocxSession.ValidMoveTargets"/>. Returns a JSON array of the anchor
+    /// ids <paramref name="sourceAnchor"/> may legally be moved next to, so the editor's drag UI
+    /// can gate its drop indicators and move-menu items on the engine's own rules.
+    /// </summary>
+    [JSExport]
+    public static string ValidMoveTargets(int h, string sourceAnchor) =>
+        DocxSessionOps.ValidMoveTargets(h, sourceAnchor);
+
+    /// <summary>
     /// Bridge for <see cref="DocxSession.DeleteRange"/>. Deletes every top-level
     /// block-level sibling between <paramref name="fromAnchorId"/> (inclusive) and
     /// <paramref name="toAnchorIdExclusive"/> (exclusive). Both anchors must share a

--- a/wasm/DocxodusWasm/DocxSessionBridge.cs
+++ b/wasm/DocxodusWasm/DocxSessionBridge.cs
@@ -46,6 +46,11 @@ public static partial class DocxSessionBridge
     [JSExport]
     public static string ListBlocks(int handle) => DocxSessionOps.ListBlocks(handle);
 
+    /// <summary>Render-plan variant whose units match the requested revision view.</summary>
+    [JSExport]
+    public static string ListRenderedBlocks(int handle, bool renderTrackedChanges) =>
+        DocxSessionOps.ListRenderedBlocks(handle, renderTrackedChanges);
+
     /// <summary>
     /// Citation-ordered footnotes (or endnotes) as JSON
     /// <c>[{"id","defAnchorId","ordinal"},…]</c> — the id↔ordinal authority the
@@ -79,6 +84,22 @@ public static partial class DocxSessionBridge
         catch (System.Exception ex) { return $"{{\"error\":\"{JsonEncodedText.Encode(ex.Message ?? string.Empty)}\"}}"; }
     }
 
+    [JSExport]
+    public static string RenderBlocksHtmlForReview(
+        int handle, string anchorIdsJson, string cssPrefix, bool fabricateClasses,
+        bool renderTrackedChanges)
+    {
+        try
+        {
+            return DocxSessionOps.RenderBlocksHtml(
+                handle, anchorIdsJson, cssPrefix, fabricateClasses, renderTrackedChanges);
+        }
+        catch (System.Exception ex)
+        {
+            return $"{{\"error\":\"{JsonEncodedText.Encode(ex.Message ?? string.Empty)}\"}}";
+        }
+    }
+
     /// <summary>
     /// Bridge for <see cref="DocxSession.ProjectAnchor"/>. <paramref name="depth"/>
     /// uses the numeric layout of <see cref="ProjectionDepth"/> (SelfOnly=0,
@@ -105,6 +126,22 @@ public static partial class DocxSessionBridge
         catch (System.Exception ex) { return $"{{\"error\":\"{JsonEncodedText.Encode(ex.Message ?? string.Empty)}\"}}"; }
     }
 
+    [JSExport]
+    public static string RenderBlockHtmlForReview(
+        int h, string anchorId, string cssPrefix, bool fabricateClasses,
+        bool renderTrackedChanges)
+    {
+        try
+        {
+            return DocxSessionOps.RenderBlockHtml(
+                h, anchorId, cssPrefix, fabricateClasses, renderTrackedChanges);
+        }
+        catch (System.Exception ex)
+        {
+            return $"{{\"error\":\"{JsonEncodedText.Encode(ex.Message ?? string.Empty)}\"}}";
+        }
+    }
+
     /// <summary>
     /// Render the live session's current state to a complete anchor-stamped HTML document —
     /// the editor's full re-render (remount) without marshaling the saved bytes out to JS
@@ -119,12 +156,32 @@ public static partial class DocxSessionBridge
     }
 
     [JSExport]
+    public static string RenderHtmlForReview(
+        int h, string cssPrefix, bool fabricateClasses, bool paginated, double scale,
+        bool renderTrackedChanges)
+    {
+        try
+        {
+            return DocxSessionOps.RenderHtml(
+                h, cssPrefix, fabricateClasses, paginated, scale, renderTrackedChanges);
+        }
+        catch (System.Exception ex)
+        {
+            return $"{{\"error\":\"{JsonEncodedText.Encode(ex.Message ?? string.Empty)}\"}}";
+        }
+    }
+
+    [JSExport]
     public static string ReplaceText(int h, string anchor, string md) =>
         DocxSessionOps.ReplaceText(h, anchor, md);
 
     [JSExport]
     public static string DeleteBlock(int h, string anchor) =>
         DocxSessionOps.DeleteBlock(h, anchor);
+
+    [JSExport]
+    public static string MoveBlock(int h, string sourceAnchor, string targetAnchor, string posStr) =>
+        DocxSessionOps.MoveBlock(h, sourceAnchor, targetAnchor, DocxSessionJson.ParsePos(posStr));
 
     /// <summary>
     /// Bridge for <see cref="DocxSession.DeleteRange"/>. Deletes every top-level


### PR DESCRIPTION
## Summary

- add a floating drag handle and accessible move menu for editor body blocks in continuous view
- treat tables as single draggable units, including when the pointer enters through a table cell
- preserve live DOM nodes during direct moves and add drop indicators plus auto-scroll through Atlassian Pragmatic Drag and Drop
- emit native Word tracked changes: `moveFrom`/`moveTo` for paragraphs and tracked row deletion/insertion for whole tables
- expose block moves through the core session, WASM bridge, TypeScript, Python, Python host, and MCP
- document the design, supported scope, safety rules, and follow-up work

## Why

Block-level drag and drop makes restructuring longer documents substantially faster than cut/paste while keeping the DOCX session, undo history, anchors, and tracked-change semantics authoritative.

## Behavior and safety

- enabled by default in the ribbon editor; opt-in through the lower-level editor API
- initial support targets continuous view and top-level body blocks
- rejects moves across section boundaries, protected cross-block ranges, nested table/textbox contexts, or ambiguous existing revisions
- keyboard users can move blocks up, down, to the top, or to the bottom
- paginated drag behavior remains deferred

## Validation

- 51 focused .NET move/revision regression tests passed
- 26 Playwright drag/reconciliation tests passed
- TypeScript typecheck passed
- production WASM build passed
- `git diff --check` passed
