### PR TITLE
Add a CompareTables option to WmlComparer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **`WmlComparerSettings.CompareTables` — Word's "Tables" compare checkbox (default `true`, so
+  existing callers are unaffected).** When false, body-level tables take no part in the comparison:
+  an edited, added or removed table produces no revision, and the result carries the original
+  document's tables unmarked — so, as with any ignored scope, accept and reject no longer reproduce
+  the revised document's tables. Each of the original's body-level tables is swapped for a marker
+  paragraph before hashing so it lands back in place afterwards; the atom/LCS core is untouched, so
+  nothing changes when the option is left on. v1 scope: tables that are direct children of
+  `w:body` — one nested in a content control or a textbox is still compared. Coverage:
+  `WmlComparerCompareTablesTests`.
+
 ## [9.3.0] - 2026-08-06
 
 ### Added

--- a/Docxodus.Tests/WmlComparerCompareTablesTests.cs
+++ b/Docxodus.Tests/WmlComparerCompareTablesTests.cs
@@ -1,0 +1,468 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using Docxodus;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+/// <summary>
+/// Tests for <see cref="WmlComparerSettings.CompareTables"/> — Word's "Tables" compare option.
+/// When off, body-level tables take no part in the comparison and the result carries the left
+/// document's tables verbatim and unmarked.
+/// </summary>
+public class WmlComparerCompareTablesTests
+{
+    private static WmlDocument Doc(params XElement[] bodyChildren)
+    {
+        using var ms = new MemoryStream();
+        using (var wDoc = WordprocessingDocument.Create(ms, DocumentFormat.OpenXml.WordprocessingDocumentType.Document))
+        {
+            var main = wDoc.AddMainDocumentPart();
+            main.PutXDocument(new XDocument(
+                new XElement(W.document,
+                    new XAttribute(XNamespace.Xmlns + "w", W.w),
+                    new XElement(W.body, bodyChildren))));
+            main.AddNewPart<StyleDefinitionsPart>().PutXDocument(
+                new XDocument(new XElement(W.styles, new XAttribute(XNamespace.Xmlns + "w", W.w))));
+            main.AddNewPart<DocumentSettingsPart>().PutXDocument(
+                new XDocument(new XElement(W.settings, new XAttribute(XNamespace.Xmlns + "w", W.w))));
+        }
+        return new WmlDocument("test.docx", ms.ToArray());
+    }
+
+    private static XElement Para(string text) =>
+        new(W.p, new XElement(W.r, new XElement(W.t, text)));
+
+    private static XElement Table(params string[][] rows) =>
+        new(W.tbl,
+            new XElement(W.tblPr,
+                new XElement(W.tblW, new XAttribute(W._w, "0"), new XAttribute(W.type, "auto"))),
+            new XElement(W.tblGrid,
+                Enumerable.Range(0, rows[0].Length)
+                    .Select(_ => new XElement(W.gridCol, new XAttribute(W._w, "3000")))),
+            rows.Select(cells => new XElement(W.tr,
+                cells.Select(c => new XElement(W.tc, Para(c))))));
+
+    private static WmlComparerSettings Settings(bool compareTables) =>
+        new() { CompareTables = compareTables, DateTimeForRevisions = "2000-01-01T00:00:00Z" };
+
+    private static XElement Body(WmlDocument doc)
+    {
+        using var ms = new MemoryStream(doc.DocumentByteArray);
+        using var wDoc = WordprocessingDocument.Open(ms, false);
+        return wDoc.MainDocumentPart!.GetXDocument().Root!.Element(W.body)!;
+    }
+
+    private static int RevisionCount(WmlDocument result, WmlComparerSettings settings) =>
+        WmlComparer.GetRevisions(result, settings).Count;
+
+    /// <summary>The block sequence of the produced body: paragraph text, or "TBL" for a table.</summary>
+    private static List<string> BlockOrder(WmlDocument doc) =>
+        Body(doc).Elements()
+            .Where(e => e.Name == W.p || e.Name == W.tbl)
+            .Select(e => e.Name == W.tbl ? "TBL" : e.Value)
+            .ToList();
+
+    /// <summary>
+    /// Ignoring a scope must never produce a package Word would refuse. Also asserts no marker
+    /// paragraph leaked into the output, whatever shape the renderer gave it.
+    /// </summary>
+    private static void AssertSchemaValidAndNoPlaceholder(WmlDocument doc)
+    {
+        using var ms = new MemoryStream(doc.DocumentByteArray);
+        using var wDoc = WordprocessingDocument.Open(ms, false);
+
+        var errors = new DocumentFormat.OpenXml.Validation.OpenXmlValidator().Validate(wDoc)
+            .Where(e => e.ErrorType == DocumentFormat.OpenXml.Validation.ValidationErrorType.Schema &&
+                        !OxPt.WcTests.ExpectedErrors.Contains(e.Description))
+            .Select(e => e.Description)
+            .ToList();
+        Assert.Empty(errors);
+
+        // Match the full internal marker (prefix + 32 hex), not the bare prefix — a document may
+        // legitimately contain the prefix as ordinary prose.
+        var xml = wDoc.MainDocumentPart!.GetXDocument().ToString();
+        Assert.DoesNotMatch(@"DocxodusIgnoredTable[0-9a-f]{32}", xml);
+    }
+
+    /// <summary>
+    /// WCT001 — the reported case: a table on the left, none on the right, identical prose.
+    /// With tables off this is not a change at all.
+    /// </summary>
+    [Fact]
+    public void WCT001_TableOnlyOnTheLeft_IsIgnored()
+    {
+        var left = Doc(Table(new[] { "1", "2", "3" }), Para("Hans Christian Andersen"));
+        var right = Doc(Para("Hans Christian Andersen"));
+
+        var offSettings = Settings(compareTables: false);
+        var ignored = WmlComparer.Compare(left, right, offSettings);
+
+        Assert.Equal(0, RevisionCount(ignored, offSettings));
+        AssertSchemaValidAndNoPlaceholder(ignored);
+
+        var table = Assert.Single(Body(ignored).Elements(W.tbl));
+        Assert.Equal(3, table.Descendants(W.tc).Count());
+        Assert.Empty(table.Descendants(W.ins));
+        Assert.Empty(table.Descendants(W.del));
+
+        // Guard: with the option ON the same pair genuinely differs, so the test is not vacuous.
+        var onSettings = Settings(compareTables: true);
+        Assert.NotEqual(0, RevisionCount(WmlComparer.Compare(left, right, onSettings), onSettings));
+    }
+
+    /// <summary>
+    /// WCT002 — a row added to a table, prose identical on both sides. The added row is the only
+    /// difference, so with tables off there is nothing to report.
+    /// </summary>
+    [Fact]
+    public void WCT002_AddedTableRow_IsIgnored()
+    {
+        var threeRows = new[]
+        {
+            new[] { "1", "2", "3" }, new[] { "4", "5", "6" }, new[] { "7", "8", "9" },
+        };
+        var left = Doc(Table(threeRows), Para("Hans Christian Andersen"));
+        var right = Doc(Table(threeRows.Append(new[] { "A", "B", "C" }).ToArray()),
+            Para("Hans Christian Andersen"));
+
+        var offSettings = Settings(compareTables: false);
+        var ignored = WmlComparer.Compare(left, right, offSettings);
+
+        Assert.Equal(0, RevisionCount(ignored, offSettings));
+        AssertSchemaValidAndNoPlaceholder(ignored);
+
+        // The left table survives as three rows — the added row is not carried over.
+        var table = Assert.Single(Body(ignored).Elements(W.tbl));
+        Assert.Equal(3, table.Elements(W.tr).Count());
+
+        var onSettings = Settings(compareTables: true);
+        Assert.NotEqual(0, RevisionCount(WmlComparer.Compare(left, right, onSettings), onSettings));
+    }
+
+    /// <summary>
+    /// WCT003 — ignoring tables must not silence prose. A paragraph edit alongside a table edit is
+    /// still reported; only the table part is dropped.
+    /// </summary>
+    [Fact]
+    public void WCT003_ParagraphChangeIsStillReported_WhenTablesAreIgnored()
+    {
+        var left = Doc(Table(new[] { "1", "2", "3" }), Para("Hans Christian Andersen"));
+        var right = Doc(Table(new[] { "9", "9", "9" }), Para("Someone Else"));
+
+        var settings = Settings(compareTables: false);
+        var result = WmlComparer.Compare(left, right, settings);
+
+        AssertSchemaValidAndNoPlaceholder(result);
+        Assert.NotEmpty(WmlComparer.GetRevisions(result, settings));
+
+        var table = Assert.Single(Body(result).Elements(W.tbl));
+        Assert.Empty(table.Descendants(W.ins));
+        Assert.Empty(table.Descendants(W.del));
+        Assert.Equal("1", table.Descendants(W.t).First().Value);
+    }
+
+    /// <summary>
+    /// WCT004 — a table-only document has no paragraph anywhere, so the marker is the body's only
+    /// block; it must not survive into the result.
+    /// </summary>
+    [Fact]
+    public void WCT004_TableOnlyDocument_KeepsTheTableAndLeavesNoMarker()
+    {
+        var left = Doc(Table(new[] { "1", "2" }));
+        var right = Doc(Table(new[] { "8", "9" }));
+
+        var settings = Settings(compareTables: false);
+        var result = WmlComparer.Compare(left, right, settings);
+
+        Assert.Equal(0, RevisionCount(result, settings));
+        AssertSchemaValidAndNoPlaceholder(result);
+        Assert.Equal(new[] { "TBL" }, BlockOrder(result));
+        Assert.Equal("1", Assert.Single(Body(result).Elements(W.tbl)).Descendants(W.t).First().Value);
+    }
+
+    /// <summary>WCT005 — the default is ON, so existing callers are unaffected.</summary>
+    [Fact]
+    public void WCT005_DefaultIsCompareTablesOn()
+    {
+        Assert.True(new WmlComparerSettings().CompareTables);
+    }
+
+    /// <summary>
+    /// WCT006 — a table that is NOT the first body child keeps its place. This is the case the
+    /// original unid-anchored implementation got wrong (the table moved to the top of the body).
+    /// </summary>
+    [Fact]
+    public void WCT006_TableKeepsItsPosition_WhenNotFirstBlock()
+    {
+        var left = Doc(Para("AAA"), Table(new[] { "1", "2" }), Para("ZZZ"));
+        var right = Doc(Para("AAA"), Para("ZZZ"));
+
+        var settings = Settings(compareTables: false);
+        var result = WmlComparer.Compare(left, right, settings);
+
+        Assert.Equal(new[] { "AAA", "TBL", "ZZZ" }, BlockOrder(result));
+        Assert.Equal(0, RevisionCount(result, settings));
+        AssertSchemaValidAndNoPlaceholder(result);
+    }
+
+    /// <summary>
+    /// WCT007 — several tables at different positions each stay put, in order, and keep their own
+    /// content (no cross-assignment).
+    /// </summary>
+    [Fact]
+    public void WCT007_MultipleTables_KeepTheirPositionsAndContent()
+    {
+        // Each table needs a paragraph after it: two adjacent w:tbl elements are one table.
+        var left = Doc(
+            Para("AAA"), Table(new[] { "T1" }),
+            Para("BBB"), Table(new[] { "T2" }),
+            Para("CCC"), Table(new[] { "T3" }),
+            Para("DDD"));
+        var right = Doc(Para("AAA"), Para("BBB"), Para("CCC"), Para("DDD"));
+
+        var settings = Settings(compareTables: false);
+        var result = WmlComparer.Compare(left, right, settings);
+
+        Assert.Equal(
+            new[] { "AAA", "TBL", "BBB", "TBL", "CCC", "TBL", "DDD" },
+            BlockOrder(result));
+        Assert.Equal(
+            new[] { "T1", "T2", "T3" },
+            Body(result).Elements(W.tbl).Select(t => t.Descendants(W.t).First().Value).ToArray());
+        Assert.Equal(0, RevisionCount(result, settings));
+        AssertSchemaValidAndNoPlaceholder(result);
+    }
+
+    /// <summary>
+    /// WCT008 — a table only the RIGHT document has leaves nothing behind: there is no left table to
+    /// carry over, and the marker standing in for it must not leak.
+    /// </summary>
+    [Fact]
+    public void WCT008_TableOnlyOnTheRight_LeavesNoMarker()
+    {
+        var left = Doc(Para("AAA"), Para("ZZZ"));
+        var right = Doc(Para("AAA"), Table(new[] { "9" }), Para("ZZZ"));
+
+        var settings = Settings(compareTables: false);
+        var result = WmlComparer.Compare(left, right, settings);
+
+        Assert.Equal(new[] { "AAA", "ZZZ" }, BlockOrder(result));
+        Assert.Equal(0, RevisionCount(result, settings));
+        AssertSchemaValidAndNoPlaceholder(result);
+    }
+
+    /// <summary>
+    /// WCT009 — a footnote cited only from inside an ignored table must still resolve, otherwise Word
+    /// asks to repair the file.
+    /// </summary>
+    [Fact]
+    public void WCT009_FootnoteCitedOnlyInsideAnIgnoredTable_StillResolves()
+    {
+        var left = DocWithFootnoteInTable();
+        var right = Doc(Para("AAA"));
+
+        var settings = Settings(compareTables: false);
+        var result = WmlComparer.Compare(left, right, settings);
+
+        AssertSchemaValidAndNoPlaceholder(result);
+
+        using var ms = new MemoryStream(result.DocumentByteArray);
+        using var wDoc = WordprocessingDocument.Open(ms, false);
+        var referenced = wDoc.MainDocumentPart!.GetXDocument()
+            .Descendants(W.footnoteReference)
+            .Select(r => (string?)r.Attribute(W.id))
+            .Where(id => id != null)
+            .ToList();
+
+        Assert.NotEmpty(referenced);
+
+        var defined = wDoc.MainDocumentPart.FootnotesPart?.GetXDocument()
+            .Root!.Elements(W.footnote)
+            .Select(f => (string?)f.Attribute(W.id))
+            .ToHashSet() ?? new HashSet<string?>();
+
+        Assert.All(referenced, id => Assert.Contains(id, defined));
+    }
+
+    /// <summary>
+    /// WCT010 — the right document has MORE tables than the left. The left table must survive and the
+    /// extra right table must not become a revision.
+    /// </summary>
+    [Fact]
+    public void WCT010_RightHasMoreTables_LeftTableSurvives()
+    {
+        var left = Doc(Para("AAA"), Para("BBB"), Table(new[] { "keep" }), Para("CCC"));
+        var right = Doc(
+            Para("AAA"), Table(new[] { "new" }),
+            Para("BBB"), Table(new[] { "keep" }), Para("CCC"));
+
+        var settings = Settings(compareTables: false);
+        var result = WmlComparer.Compare(left, right, settings);
+
+        Assert.Equal(new[] { "AAA", "BBB", "TBL", "CCC" }, BlockOrder(result));
+        Assert.Equal("keep", Assert.Single(Body(result).Elements(W.tbl)).Descendants(W.t).First().Value);
+        Assert.Equal(0, RevisionCount(result, settings));
+        AssertSchemaValidAndNoPlaceholder(result);
+    }
+
+    /// <summary>
+    /// WCT011 — a table removed BEFORE other tables must not perturb how the prose matches: the
+    /// paragraphs are identical in both documents, so nothing may be reported.
+    /// </summary>
+    [Fact]
+    public void WCT011_TableRemovedBeforeOtherTables_DoesNotChurnProse()
+    {
+        var left = Doc(
+            Para("AAA"), Table(new[] { "T1" }),
+            Para("BBB"), Table(new[] { "T2" }), Para("CCC"));
+        var right = Doc(Para("AAA"), Para("BBB"), Table(new[] { "T2" }), Para("CCC"));
+
+        var settings = Settings(compareTables: false);
+        var result = WmlComparer.Compare(left, right, settings);
+
+        Assert.Equal(new[] { "AAA", "TBL", "BBB", "TBL", "CCC" }, BlockOrder(result));
+        Assert.Equal(
+            new[] { "T1", "T2" },
+            Body(result).Elements(W.tbl).Select(t => t.Descendants(W.t).First().Value).ToArray());
+        Assert.Equal(0, RevisionCount(result, settings));
+        AssertSchemaValidAndNoPlaceholder(result);
+    }
+
+    /// <summary>
+    /// WCT012 — a table moved past a paragraph is still not a change, and the prose stays quiet.
+    /// </summary>
+    [Fact]
+    public void WCT012_MovedTable_IsIgnored()
+    {
+        var left = Doc(Para("AAA"), Table(new[] { "T" }), Para("BBB"), Para("CCC"));
+        var right = Doc(Para("AAA"), Para("BBB"), Table(new[] { "T" }), Para("CCC"));
+
+        var settings = Settings(compareTables: false);
+        var result = WmlComparer.Compare(left, right, settings);
+
+        // The LEFT position wins, since the left document's tables are what is carried over.
+        Assert.Equal(new[] { "AAA", "TBL", "BBB", "CCC" }, BlockOrder(result));
+        Assert.Equal(0, RevisionCount(result, settings));
+        AssertSchemaValidAndNoPlaceholder(result);
+    }
+
+    /// <summary>
+    /// WCT013 — marker-lookalike prose present on ONE side only (the pairing that could break the
+    /// marker): the table must survive and no marker token may leak. The marker text carries no word
+    /// separator, so the LCS treats it as one indivisible word and real prose cannot alias its prefix.
+    /// </summary>
+    [Fact]
+    public void WCT013_MarkerLookalikeProseOnOneSide_DoesNotConsumeTheTable()
+    {
+        var left = Doc(Para("AAA"), Table(new[] { "T" }), Para("ZZZ"));
+        var right = Doc(Para("AAA"), Para("DocxodusIgnoredTable"), Para("ZZZ"));
+
+        var settings = Settings(compareTables: false);
+        var result = WmlComparer.Compare(left, right, settings);
+
+        // The table survives with its content, and the internal marker never leaks (the lookalike
+        // prose is preserved as ordinary right-side content, which is fine — only tables are ignored).
+        Assert.Equal("T", Assert.Single(Body(result).Elements(W.tbl)).Descendants(W.t).First().Value);
+        AssertSchemaValidAndNoPlaceholder(result);
+    }
+
+    /// <summary>
+    /// WCT014 — a right-side paragraph that carries content but NO text (a line break lives in a run
+    /// with no w:t) adjacent to an ignored table must not be swept away when its marker run is removed.
+    /// </summary>
+    [Fact]
+    public void WCT014_TextlessButRealRightParagraph_SurvivesMarkerRemoval()
+    {
+        var breakPara = new XElement(W.p, new XElement(W.r, new XElement(W.br)));
+
+        var left = Doc(Para("AAA"), Table(new[] { "T" }), Para("ZZZ"));
+        var right = Doc(Para("AAA"), breakPara, Para("ZZZ"));
+
+        var settings = Settings(compareTables: false);
+        var result = WmlComparer.Compare(left, right, settings);
+
+        var body = Body(result);
+        Assert.Single(body.Elements(W.tbl));
+        Assert.Single(body.Descendants(W.br)); // the break was not deleted with the marker run
+        AssertSchemaValidAndNoPlaceholder(result);
+    }
+
+    /// <summary>
+    /// WCT015 — Consolidate routes through the same internals: the left table must survive, the prose
+    /// revision must land, and no marker may leak.
+    /// </summary>
+    [Fact]
+    public void WCT015_Consolidate_KeepsTheTableAndTheProseRevision()
+    {
+        var original = Doc(Para("AAA"), Table(new[] { "T" }), Para("BBB"));
+        var revised = Doc(Para("AAA"), Table(new[] { "CHANGED" }), Para("BBB edited"));
+
+        var settings = Settings(compareTables: false);
+        var consolidated = WmlComparer.Consolidate(
+            original,
+            new List<WmlRevisedDocumentInfo>
+            {
+                new WmlRevisedDocumentInfo { RevisedDocument = revised, Revisor = "Rev1" },
+            },
+            settings);
+
+        // Consolidate juxtaposes revisions in its own wrapper table, so do not count tables: assert the
+        // ignored table's own content survived, the prose edit landed, and no marker or table edit leaked.
+        var body = Body(consolidated);
+        Assert.Contains(body.Descendants(W.tbl),
+            t => t.Descendants(W.t).Any(x => x.Value == "T"));
+        Assert.NotEmpty(body.Descendants(W.ins));
+        var xml = body.ToString();
+        Assert.DoesNotMatch(@"DocxodusIgnoredTable[0-9a-f]{32}", xml);
+        Assert.DoesNotContain("CHANGED", xml);
+    }
+
+    /// <summary>A document whose ONLY footnote reference sits in a body-level table cell.</summary>
+    private static WmlDocument DocWithFootnoteInTable()
+    {
+        var cell = new XElement(W.tc,
+            new XElement(W.tcPr,
+                new XElement(W.tcW, new XAttribute(W._w, "3000"), new XAttribute(W.type, "dxa"))),
+            new XElement(W.p,
+                new XElement(W.r, new XElement(W.t, "cell")),
+                new XElement(W.r, new XElement(W.footnoteReference, new XAttribute(W.id, "2")))));
+
+        var table = new XElement(W.tbl,
+            new XElement(W.tblPr,
+                new XElement(W.tblW, new XAttribute(W._w, "0"), new XAttribute(W.type, "auto"))),
+            new XElement(W.tblGrid, new XElement(W.gridCol, new XAttribute(W._w, "3000"))),
+            new XElement(W.tr, cell));
+
+        using var ms = new MemoryStream();
+        using (var wDoc = WordprocessingDocument.Create(ms, DocumentFormat.OpenXml.WordprocessingDocumentType.Document))
+        {
+            var main = wDoc.AddMainDocumentPart();
+            main.PutXDocument(new XDocument(
+                new XElement(W.document,
+                    new XAttribute(XNamespace.Xmlns + "w", W.w),
+                    new XElement(W.body, Para("AAA"), table))));
+            main.AddNewPart<StyleDefinitionsPart>().PutXDocument(
+                new XDocument(new XElement(W.styles, new XAttribute(XNamespace.Xmlns + "w", W.w))));
+            main.AddNewPart<DocumentSettingsPart>().PutXDocument(
+                new XDocument(new XElement(W.settings, new XAttribute(XNamespace.Xmlns + "w", W.w))));
+            main.AddNewPart<FootnotesPart>().PutXDocument(new XDocument(
+                new XElement(W.footnotes,
+                    new XAttribute(XNamespace.Xmlns + "w", W.w),
+                    new XElement(W.footnote, new XAttribute(W.id, "-1"),
+                        new XAttribute(W.type, "separator"),
+                        new XElement(W.p, new XElement(W.r, new XElement(W.separator)))),
+                    new XElement(W.footnote, new XAttribute(W.id, "0"),
+                        new XAttribute(W.type, "continuationSeparator"),
+                        new XElement(W.p, new XElement(W.r, new XElement(W.continuationSeparator)))),
+                    new XElement(W.footnote, new XAttribute(W.id, "2"),
+                        new XElement(W.p, new XElement(W.r, new XElement(W.t, "note text")))))));
+        }
+        return new WmlDocument("left.docx", ms.ToArray());
+    }
+}

--- a/Docxodus/DocxCompare.cs
+++ b/Docxodus/DocxCompare.cs
@@ -106,7 +106,8 @@ public static class DocxCompare
 
     /// <summary>
     /// Map the option set shared by both engines from <see cref="WmlComparerSettings"/> onto a fresh
-    /// <see cref="DocxDiffSettings"/>. WmlComparer-only knobs are intentionally dropped: <c>DetailThreshold</c>
+    /// <see cref="DocxDiffSettings"/>. WmlComparer-only knobs are intentionally dropped: <c>CompareTables</c>
+    /// (DocxDiff always compares tables), <c>DetailThreshold</c>
     /// (an LCS-granularity knob with no IR equivalent), <c>SimplifyMoveMarkup</c> (DocxDiff renders moves
     /// natively), and <c>DetectFormatChanges</c> (DocxDiff uses <see cref="DocxDiffSettings.FormatComparison"/>,
     /// left at its default). DocxDiff-specific settings keep their defaults. An explicit

--- a/Docxodus/WmlComparer.cs
+++ b/Docxodus/WmlComparer.cs
@@ -100,6 +100,19 @@ namespace Docxodus
         public bool DetectFormatChanges = true;
 
         /// <summary>
+        /// Compare tables. Mirrors the "Tables" checkbox in Word's Compare Documents dialog.
+        /// Default: true.
+        /// <para>When false, body-level tables take no part in the comparison: a table that was
+        /// edited, added or removed produces no revision, and the result carries the ORIGINAL
+        /// (left) document's tables verbatim and unmarked. Consequently accept/reject do not
+        /// reproduce the revised document's tables — that is what ignoring a scope means, and it
+        /// mirrors DocxDiff's <c>CompareHeadersFooters = false</c>.</para>
+        /// <para>v1 scope: tables that are direct children of <c>w:body</c>. A table nested in a
+        /// content control or a textbox is still compared.</para>
+        /// </summary>
+        public bool CompareTables = true;
+
+        /// <summary>
         /// Optional log to collect warnings and errors during comparison.
         /// When provided, the comparison will attempt to continue past recoverable errors
         /// (like orphaned footnote references) and log them instead of throwing exceptions.
@@ -297,6 +310,70 @@ namespace Docxodus
                 }
 
                 return producedDocument;
+            }
+        }
+
+        // Only the LEFT tables get a marker paragraph; the right's are dropped. Marking both sides
+        // would let a table count difference perturb how the surrounding prose matches.
+        // Letters and digits only: any WordSeparator (e.g. '-') would split the marker into several
+        // comparison words whose prefix could match real prose. Guid "N" is 32 hex chars, no separators.
+        private static string NewTableMarker() => "DocxodusIgnoredTable" + Guid.NewGuid().ToString("N");
+
+        private static List<XElement> TakeBodyTables(XElement body, string marker)
+        {
+            var tables = new List<XElement>();
+            foreach (var tbl in body.Elements(W.tbl).ToList())
+            {
+                tables.Add(new XElement(tbl));
+                if (marker == null)
+                    tbl.Remove();
+                else
+                    tbl.ReplaceWith(new XElement(W.p, new XElement(W.r, new XElement(W.t, marker))));
+            }
+
+            // A table that was the body's only block-level content leaves nothing to align.
+            if (tables.Count > 0 && !body.Elements().Any(e => e.Name == W.p || e.Name == W.tbl))
+                body.Add(new XElement(W.p));
+
+            return tables;
+        }
+
+        private static void RestoreIgnoredTables(
+            XDocument newXDoc, List<XElement> leftTables, string marker, WmlComparerSettings settings)
+        {
+            if (leftTables == null)
+                return;
+
+            var body = newXDoc.Root.Element(W.body);
+            var restored = 0;
+
+            // Work per marker RUN, not per paragraph: the comparer can pair a marker paragraph with a
+            // real one, leaving the marker's text sitting beside prose in a single paragraph.
+            foreach (var markerText in body.Descendants()
+                .Where(e => (e.Name == W.t || e.Name == W.delText) && e.Value == marker)
+                .ToList())
+            {
+                var block = markerText.AncestorsAndSelf().FirstOrDefault(a => a.Parent == body);
+                var run = markerText.Ancestors(W.r).FirstOrDefault();
+
+                if (block != null && restored < leftTables.Count)
+                    block.AddBeforeSelf(leftTables[restored++]);
+
+                var wrapper = run?.Parent;
+                run?.Remove();
+                if (wrapper != null && wrapper != block && !wrapper.HasElements)
+                    wrapper.Remove();
+
+                // Drop the paragraph only if the marker run was all it held: a drawing or a break on
+                // a paired right paragraph is content, and it lives in a run with no w:t.
+                if (block != null && block.Name == W.p && !block.Descendants(W.r).Any())
+                    block.Remove();
+            }
+
+            if (restored != leftTables.Count)
+            {
+                settings.Log?.AddWarning("CompareTables",
+                    $"Restored {restored} of {leftTables.Count} ignored tables.");
             }
         }
 
@@ -1739,8 +1816,18 @@ namespace Docxodus
                 .Element(W.sectPr);
 
             var contentParent1 = wDoc1.MainDocumentPart.GetXDocument().Root.Element(W.body);
-            AddSha1HashToBlockLevelContent(wDoc1.MainDocumentPart, contentParent1, settings);
             var contentParent2 = wDoc2.MainDocumentPart.GetXDocument().Root.Element(W.body);
+
+            List<XElement> ignoredTables = null;
+            string tableMarker = null;
+            if (!settings.CompareTables)
+            {
+                tableMarker = NewTableMarker();
+                ignoredTables = TakeBodyTables(contentParent1, tableMarker);
+                TakeBodyTables(contentParent2, null);
+            }
+
+            AddSha1HashToBlockLevelContent(wDoc1.MainDocumentPart, contentParent1, settings);
             AddSha1HashToBlockLevelContent(wDoc2.MainDocumentPart, contentParent2, settings);
 
             var cal1 = WmlComparer.CreateComparisonUnitAtomList(wDoc1.MainDocumentPart, wDoc1.MainDocumentPart.GetXDocument().Root.Element(W.body), settings);
@@ -1877,6 +1964,8 @@ namespace Docxodus
                     MarkContentAsDeletedOrInserted(newXDoc, settings);
                     CoalesceAdjacentRunsWithIdenticalFormatting(newXDoc);
                     IgnorePt14Namespace(newXDoc.Root);
+
+                    RestoreIgnoredTables(newXDoc, ignoredTables, tableMarker, settings);
 
                     ProcessFootnoteEndnote(settings,
                         listOfComparisonUnitAtoms,

--- a/docs/architecture/wml_comparer_gaps.md
+++ b/docs/architecture/wml_comparer_gaps.md
@@ -78,6 +78,33 @@ Add a `FormatChange` revision type that captures:
 - The old formatting properties
 - The new formatting properties
 
+## 3b. Scope toggles — Tables ✅ IMPLEMENTED
+
+Word's Compare dialog can exclude whole categories of content. `WmlComparerSettings.CompareTables`
+(default `true`) mirrors its **Tables** checkbox: set it false and body-level tables take no part in
+the comparison — an edited, added or removed table yields no revision and the result keeps the left
+document's tables unmarked (with their own pre-existing tracked changes accepted, as the comparer
+does throughout).
+
+Mechanics: each LEFT body-level table is replaced by a marker paragraph before hashing, so the marker
+is aligned by the ordinary LCS and the table is laid back into its place afterwards (before footnote
+rectification and the docPr/shape id fixups). The right document's tables are dropped, because an
+ignored table is never carried over and marking both sides would let a table count difference disturb
+how the surrounding prose matches.
+
+Consequences worth knowing:
+
+- Ignoring a scope necessarily breaks the round trip for it: `accept` no longer reproduces the revised
+  document's tables. This mirrors `DocxDiffSettings.CompareHeadersFooters = false`.
+- v1 covers tables that are direct children of `w:body`. A table nested inside a content control or a
+  textbox is still compared.
+- WmlComparer-only: `DocxCompare` drops the knob on the `ComparisonEngine.DocxDiff` branch, and the
+  WASM/npm bridges do not expose it (nor do they expose `DetectFormatChanges`).
+
+Word's remaining Compare categories (Formatting is `DetectFormatChanges`; Moves is `DetectMoves`;
+Comments, Fields, Footnotes/endnotes, Headers/footers, Textboxes, Case changes, White space have no
+`WmlComparer` equivalent) are still unimplemented as scope toggles.
+
 ## 4. Revision Metadata Limitations
 
 **Location:** `WmlComparerRevision` class


### PR DESCRIPTION
Adds `WmlComparerSettings.CompareTables`, mirroring the **Tables** checkbox in Word's Compare Documents dialog.

Default is `true`, so existing callers are unaffected and output is byte-identical to before.

## Behaviour when off

Body-level tables take no part in the comparison: an edited, added or removed table produces no revision, and the result carries the original document's tables unmarked. As with any ignored scope, accept and reject therefore no longer reproduce the revised document's tables.

## How

Each of the original document's body-level tables is swapped for a marker paragraph before hashing, so the marker rides through the LCS in the table's place and the real table is laid back over it afterwards. The revised document's tables are dropped: an ignored table is never carried over, and marking both sides would let a table count difference perturb how the surrounding prose matches.

The marker token is generated per comparison, so document text cannot impersonate it. Restoration happens before footnote rectification and the docPr/shape id fixups, so a note cited only inside an ignored table still resolves and ids stay unique. The atom/LCS core is untouched.

## Scope

Tables that are direct children of `w:body`. A table nested in a content control or a textbox is still compared.

`DocxCompare` drops the option on the `DocxDiff` branch (that engine has no ignore-tables mode), and it is not surfaced on WASM/npm — matching the sibling `DetectFormatChanges`.

## Tests

`Docxodus.Tests/WmlComparerCompareTablesTests.cs`, 15 cases: block-position preservation, several tables, differing non-zero table counts on the two sides, a table removed or moved ahead of other tables, a right-only table, a table-only document, marker-lookalike prose, `Consolidate`, and a footnote cited only inside an ignored table. Every case asserts a schema-valid package with no marker left behind.
