### PR TITLE
Fix a crash comparing a document whose body has no paragraphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **`WmlComparer.Compare` and `GetRevisions` no longer throw `NullReferenceException` when a document
+  body contains no paragraphs.** `MoveLastSectPrIntoLastParagraph` looked for the paragraph to move the
+  trailing `w:sectPr` into and dereferenced the result without checking it found one, so a body holding
+  only a `w:sectPr` — which Word's UI cannot produce but a generator can — crashed as either side of the
+  comparison. The section is now left as a body child, which is where the produced document puts it back
+  regardless. The same three lines added the `w:pPr` XName rather than the element just created, leaving
+  it detached, so the section appended to it was dropped and the name became a text node; that branch is
+  reached routinely but was output-neutral, since the stray node is never read and the section is
+  re-added from the original document at the end.
+
 ## [9.3.0] - 2026-08-06
 
 ### Added

--- a/Docxodus.Tests/WmlComparerEmptyBodyTests.cs
+++ b/Docxodus.Tests/WmlComparerEmptyBodyTests.cs
@@ -1,0 +1,158 @@
+#nullable enable
+
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using Docxodus;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+/// <summary>
+/// Degenerate bodies that Word's UI cannot produce but a generator can: a body with no
+/// <c>w:p</c> at all, and a last paragraph carrying no <c>w:pPr</c>. Both meet
+/// <c>MoveLastSectPrIntoLastParagraph</c>, which used to dereference a null paragraph.
+/// </summary>
+public class WmlComparerEmptyBodyTests
+{
+    private static WmlDocument Doc(params XElement[] bodyChildren)
+    {
+        using var ms = new MemoryStream();
+        using (var wDoc = WordprocessingDocument.Create(ms, DocumentFormat.OpenXml.WordprocessingDocumentType.Document))
+        {
+            var main = wDoc.AddMainDocumentPart();
+            main.PutXDocument(new XDocument(
+                new XElement(W.document,
+                    new XAttribute(XNamespace.Xmlns + "w", W.w),
+                    new XElement(W.body, bodyChildren,
+                        new XElement(W.sectPr,
+                            new XElement(W.pgSz,
+                                new XAttribute(W._w, "12240"), new XAttribute(W.h, "15840")))))));
+            main.AddNewPart<StyleDefinitionsPart>().PutXDocument(
+                new XDocument(new XElement(W.styles, new XAttribute(XNamespace.Xmlns + "w", W.w))));
+            main.AddNewPart<DocumentSettingsPart>().PutXDocument(
+                new XDocument(new XElement(W.settings, new XAttribute(XNamespace.Xmlns + "w", W.w))));
+        }
+        return new WmlDocument("t.docx", ms.ToArray());
+    }
+
+    /// <summary>A paragraph with NO w:pPr — the shape that exercises the pPr-creation branch.</summary>
+    private static XElement Para(string text) =>
+        new(W.p, new XElement(W.r, new XElement(W.t, text)));
+
+    private static WmlComparerSettings Settings() =>
+        new() { SimplifyMoveMarkup = true, DateTimeForRevisions = "2000-01-01T00:00:00Z" };
+
+    private static XElement Body(WmlDocument doc)
+    {
+        using var ms = new MemoryStream(doc.DocumentByteArray);
+        using var wDoc = WordprocessingDocument.Open(ms, false);
+        return wDoc.MainDocumentPart!.GetXDocument().Root!.Element(W.body)!;
+    }
+
+    /// <summary>
+    /// EB001 — a body stripped of every paragraph, as either side.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void EB001_BodyWithNoParagraphs_DoesNotThrow(bool emptyOnTheLeft)
+    {
+        var populated = Doc(Para("alpha"), Para("bravo"));
+        var empty = Doc();
+
+        var (left, right) = emptyOnTheLeft ? (empty, populated) : (populated, empty);
+
+        var result = WmlComparer.Compare(left, right, Settings());
+
+        // The populated side's content is accounted for, and the section stays a body child.
+        var revisions = WmlComparer.GetRevisions(result, Settings());
+        var expected = emptyOnTheLeft
+            ? WmlComparer.WmlComparerRevisionType.Inserted
+            : WmlComparer.WmlComparerRevisionType.Deleted;
+        Assert.All(revisions, r => Assert.Equal(expected, r.RevisionType));
+        Assert.Contains("alpha", string.Concat(revisions.Select(r => r.Text)));
+        Assert.Single(Body(result).Elements(W.sectPr));
+    }
+
+    /// <summary>
+    /// EB002 — both sides paragraph-less. The two packages must not be byte-identical, or
+    /// <see cref="DocxCompare"/>'s exact-no-op shortcut would return a clone without running the
+    /// comparison at all; a differing sectPr keeps the pipeline engaged.
+    /// </summary>
+    [Fact]
+    public void EB002_BothBodiesEmpty_DoNotThrow()
+    {
+        var left = Doc();
+        var right = DocWithPageWidth("12242");
+        Assert.NotEqual(left.DocumentByteArray, right.DocumentByteArray);
+
+        var result = WmlComparer.Compare(left, right, Settings());
+
+        Assert.Empty(WmlComparer.GetRevisions(result, Settings()));
+        Assert.Empty(Body(result).Elements(W.p));
+    }
+
+    private static WmlDocument DocWithPageWidth(string width)
+    {
+        using var ms = new MemoryStream();
+        using (var wDoc = WordprocessingDocument.Create(ms, DocumentFormat.OpenXml.WordprocessingDocumentType.Document))
+        {
+            var main = wDoc.AddMainDocumentPart();
+            main.PutXDocument(new XDocument(
+                new XElement(W.document,
+                    new XAttribute(XNamespace.Xmlns + "w", W.w),
+                    new XElement(W.body,
+                        new XElement(W.sectPr,
+                            new XElement(W.pgSz,
+                                new XAttribute(W._w, width), new XAttribute(W.h, "15840")))))));
+            main.AddNewPart<StyleDefinitionsPart>().PutXDocument(
+                new XDocument(new XElement(W.styles, new XAttribute(XNamespace.Xmlns + "w", W.w))));
+            main.AddNewPart<DocumentSettingsPart>().PutXDocument(
+                new XDocument(new XElement(W.settings, new XAttribute(XNamespace.Xmlns + "w", W.w))));
+        }
+        return new WmlDocument("t2.docx", ms.ToArray());
+    }
+
+    /// <summary>
+    /// EB003 — the helper directly: with a last paragraph that has no <c>w:pPr</c>, the section must end
+    /// up inside a REAL pPr element on that paragraph. Adding the XName instead left the pPr detached, so
+    /// the section went with it and the name landed as a text node.
+    /// </summary>
+    [Fact]
+    public void EB003_SectionMovesIntoACreatedPPr()
+    {
+        var body = new XElement(W.body,
+            new XElement(W.p, new XElement(W.r, new XElement(W.t, "alpha"))),
+            new XElement(W.sectPr, new XElement(W.pgSz, new XAttribute(W._w, "12240"))));
+
+        WmlComparer.MoveLastSectPrIntoLastParagraph(body);
+
+        var paragraph = Assert.Single(body.Elements(W.p));
+        var pPr = paragraph.Element(W.pPr);
+        Assert.NotNull(pPr);
+        Assert.NotNull(pPr!.Element(W.sectPr));
+        Assert.Empty(body.Elements(W.sectPr));
+        Assert.Empty(paragraph.Nodes().OfType<XText>());
+    }
+
+    /// <summary>
+    /// EB004 — a body whose only block content is a TABLE: the early return does not fire, and the
+    /// section is moved into the table's last cell paragraph rather than crashing.
+    /// </summary>
+    [Fact]
+    public void EB004_BodyWithOnlyATable_DoesNotThrow()
+    {
+        var table = new XElement(W.tbl,
+            new XElement(W.tblPr,
+                new XElement(W.tblW, new XAttribute(W._w, "0"), new XAttribute(W.type, "auto"))),
+            new XElement(W.tblGrid, new XElement(W.gridCol, new XAttribute(W._w, "3000"))),
+            new XElement(W.tr, new XElement(W.tc, Para("cell"))));
+
+        var result = WmlComparer.Compare(Doc(table), Doc(table, Para("added")), Settings());
+
+        Assert.NotNull(result);
+        Assert.Single(Body(result).Elements(W.tbl));
+    }
+}

--- a/Docxodus/WmlComparer.cs
+++ b/Docxodus/WmlComparer.cs
@@ -8973,7 +8973,7 @@ namespace Docxodus
             return reconstructedElement;
         }
 
-        private static void MoveLastSectPrIntoLastParagraph(XElement contentParent)
+        internal static void MoveLastSectPrIntoLastParagraph(XElement contentParent)
         {
             var lastSectPrList = contentParent.Elements(W.sectPr).ToList();
             if (lastSectPrList.Count() > 1)
@@ -8984,11 +8984,18 @@ namespace Docxodus
                 var lastParagraph = contentParent.Elements(W.p).LastOrDefault();
                 if (lastParagraph == null)
                     lastParagraph = contentParent.Descendants(W.p).LastOrDefault();
+
+                // A generated document can have a body with no paragraph at all. There is nowhere to move
+                // the section to; leave it as a body child, which is where the produced document puts it
+                // back anyway.
+                if (lastParagraph == null)
+                    return;
+
                 var pPr = lastParagraph.Element(W.pPr);
                 if (pPr == null)
                 {
                     pPr = new XElement(W.pPr);
-                    lastParagraph.AddFirst(W.pPr);
+                    lastParagraph.AddFirst(pPr);
                 }
                 pPr.Add(lastSectPr);
                 contentParent.Elements(W.sectPr).Remove();


### PR DESCRIPTION
`WmlComparer.Compare` and `GetRevisions` throw `NullReferenceException` when one side's `w:body` contains no `w:p` elements — only a `w:sectPr`.

```
System.NullReferenceException
   at Docxodus.WmlComparer.MoveLastSectPrIntoLastParagraph(XElement contentParent)
   at Docxodus.WmlComparer.CreateComparisonUnitAtomList(...)
   at Docxodus.WmlComparer.ProduceDocumentWithTrackedRevisions(...)
   at Docxodus.WmlComparer.Compare(...)
```

## Reproduction

Take any `.docx`, remove every `<w:p>…</w:p>` from `word/document.xml` leaving the trailing `<w:sectPr>`, and compare it against the original. Direction does not matter — an empty body as either side throws. Word's UI always keeps at least one paragraph, so this is only reachable with programmatically generated input.

## Cause and fix

`MoveLastSectPrIntoLastParagraph` looks for the paragraph to move the trailing `w:sectPr` into and dereferences the result without checking it found one. The fix returns early, leaving the section as a body child — which is where the produced document puts it back regardless, so nothing is duplicated, lost or misplaced.

The same three lines also called `lastParagraph.AddFirst(W.pPr)`, adding the XName rather than the `pPr` element just created. That left the element detached, so the `w:sectPr` appended to it was dropped and the name was added as a text node. That branch is reached routinely — a last paragraph with no `w:pPr` is ordinary — but it was output-neutral: the stray text node is never read (the atom walk enumerates elements only) and the section is re-added unconditionally from the original document at the end of `ProduceDocumentWithTrackedRevisions`.

## Tests

`Docxodus.Tests/WmlComparerEmptyBodyTests.cs`: the paragraph-less body as either side and as both, the helper's created-`pPr` behaviour asserted directly, and a body whose only block content is a table (the one shape where the early return deliberately does not fire, and the section moves into a cell paragraph). Each test was confirmed to fail without its corresponding fix.
