### PR TITLE
Pin GitHub Pages demo to Docxodus 9.3.0

### DIFF
--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -1,7 +1,7 @@
 # GitHub Pages demo
 
 Three static pages, no application server. All three host the **same** editor
-surface — `createRibbonEditor` from the pinned `docxodus@9.2.0` embed bundle on
+surface — `createRibbonEditor` from the pinned `docxodus@9.3.0` embed bundle on
 jsDelivr — and differ only in how much of the page belongs to the editor:
 
 | Page | What it is |
@@ -20,8 +20,8 @@ it with `python tools/generate-demo-guide.py` from the repository root.
 
 ## Publish
 
-1. Publish `docxodus@9.2.0` and confirm
-   `https://cdn.jsdelivr.net/npm/docxodus@9.2.0/dist/embed.bundle.js` returns JavaScript.
+1. Publish `docxodus@9.3.0` and confirm
+   `https://cdn.jsdelivr.net/npm/docxodus@9.3.0/dist/embed.bundle.js` returns JavaScript.
 2. In GitHub **Settings → Pages**, choose **GitHub Actions** as the publishing source.
    The `Deploy static demo to GitHub Pages` workflow uploads `/docs` without
    running Jekyll.

--- a/docs/demo/app.html
+++ b/docs/demo/app.html
@@ -18,7 +18,7 @@
     page and the landing page cannot drift apart.
 
     Query overrides (used by tests and local dev):
-      ?engine=<module URL of embed bundle>   default: jsDelivr docxodus@9.2.0
+      ?engine=<module URL of embed bundle>   default: jsDelivr docxodus@9.3.0
       ?doc=<docx URL>                        default: local branded product guide
       ?blank=1                               start from a new empty document
   -->
@@ -70,7 +70,7 @@
   <script type="module">
     const params = new URLSearchParams(location.search);
     const ENGINE = params.get("engine")
-      ?? "https://cdn.jsdelivr.net/npm/docxodus@9.2.0/dist/embed.bundle.js";
+      ?? "https://cdn.jsdelivr.net/npm/docxodus@9.3.0/dist/embed.bundle.js";
     const DOC = params.get("doc") ?? "./docxodus-demo-guide.docx";
     const BLANK = params.get("blank") === "1";
 

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -308,7 +308,7 @@
   </main>
 
   <footer>Engine delivered by <a href="https://www.jsdelivr.com/package/npm/docxodus">jsDelivr</a> from
-    <a href="https://www.npmjs.com/package/docxodus">docxodus@9.2.0</a>. Everything runs client-side.</footer>
+    <a href="https://www.npmjs.com/package/docxodus">docxodus@9.3.0</a>. Everything runs client-side.</footer>
 
   <dialog id="embedDialog" aria-labelledby="embedTitle">
     <div class="embed-inner">
@@ -335,7 +335,7 @@
   <script type="module">
     const params = new URLSearchParams(location.search);
     const ENGINE = params.get("engine")
-      ?? "https://cdn.jsdelivr.net/npm/docxodus@9.2.0/dist/embed.bundle.js";
+      ?? "https://cdn.jsdelivr.net/npm/docxodus@9.3.0/dist/embed.bundle.js";
     const DOC = params.get("doc")
       ?? "./docxodus-demo-guide.docx";
 
@@ -352,7 +352,7 @@
     const moduleSnippet = `<div id="docx-editor" style="height:80vh"></div>
 <script type="module">
   import { createRibbonEditor } from
-    "https://cdn.jsdelivr.net/npm/docxodus@9.2.0/dist/embed.bundle.js";
+    "https://cdn.jsdelivr.net/npm/docxodus@9.3.0/dist/embed.bundle.js";
 
   await createRibbonEditor("#docx-editor", "/documents/example.docx");
 <\/script>`;

--- a/docs/demo/player.html
+++ b/docs/demo/player.html
@@ -20,7 +20,7 @@
     from jsDelivr and the sample document comes from this same directory.
 
     Query overrides (used by tests and local dev):
-      ?engine=<module URL of embed bundle>   default: jsDelivr docxodus@9.2.0
+      ?engine=<module URL of embed bundle>   default: jsDelivr docxodus@9.3.0
       ?doc=<docx URL>                        default: local branded product guide
   -->
   <style>
@@ -122,7 +122,7 @@
   <script type="module">
     const params = new URLSearchParams(location.search);
     const ENGINE = params.get("engine")
-      ?? "https://cdn.jsdelivr.net/npm/docxodus@9.2.0/dist/embed.bundle.js";
+      ?? "https://cdn.jsdelivr.net/npm/docxodus@9.3.0/dist/embed.bundle.js";
     const DOC = params.get("doc")
       ?? "./docxodus-demo-guide.docx";
 

--- a/npm/tests/social-demo.spec.ts
+++ b/npm/tests/social-demo.spec.ts
@@ -21,7 +21,7 @@ import { test, expect, type Page } from '@playwright/test';
  */
 
 const OVERRIDES = 'engine=./embed.bundle.js&doc=./docxodus-demo-guide.docx';
-const RELEASE_ENGINE = 'docxodus@9.2.0/dist/embed.bundle.js';
+const RELEASE_ENGINE = 'docxodus@9.3.0/dist/embed.bundle.js';
 
 async function formattingState(page: Page, anchor: string, text: string) {
   return page.evaluate(({ anchor, text }) => {


### PR DESCRIPTION
## What changed

- Pin all three GitHub Pages demo hosts to `docxodus@9.3.0`
- Update the displayed version and deployment instructions
- Update the Playwright guard that prevents the production demo pin from drifting

## Why

The Pages demo was still loading `docxodus@9.2.0` after the `v9.3.0` release. This moves the live demo forward by one minor version while retaining an immutable production CDN URL.

## Impact

After merge, the Pages workflow will deploy the demo against the published `9.3.0` bundle. No npm or .NET package metadata changes are needed because release versions are derived from git tags in this repository.

## Validation

- `npm test -- social-demo.spec.ts` — 3 passed
- `git diff --check`
- Verified jsDelivr returns HTTP 200 with `x-jsd-version: 9.3.0`
