### PR TITLE
Fix an infinite loop comparing a table against a text box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ All notable changes to this project will be documented in this file.
   the CRUD rules are documented in `docs/architecture/docx_mutation_api.md`.
 
 ### Fixed
+- **`WmlComparer.Compare` no longer hangs forever comparing a document containing a table against
+  one containing a text box.** The structural walk in `DoLcsAlgorithm` groups each side into adjacent
+  runs of Word / Row / Textbox and advances a counter per side, but every branch required one side to
+  be a `Word`. Two *different non-word* kinds facing each other — a row against a text box — therefore
+  matched no branch and advanced neither counter: a loop that allocated nothing and never terminated,
+  pegging one core with flat memory until the caller gave up. The left group of such a pair is now
+  retired as a deletion, restoring the invariant that makes the walk terminate at all (every branch
+  advances at least one counter) while leaving the right group free to pair with a later group of its
+  own kind. Found by fuzzing a 1,925-document corpus: 7 of 400 random pairs hung past 600 s, every one
+  of them mixing tables with text boxes; all now complete in milliseconds. The sibling
+  table-vs-paragraph walk is unaffected — its key space is only `Table`/`Para` and all four
+  combinations already advance. Coverage: `WmlComparerRowVersusTextboxTests`.
 - **Table row/column CRUD is now grid-aware instead of cell-index-aware.** `InsertTableRow`,
   `InsertTableColumn`, `DeleteTableColumn` and `SetColumnWidths` addressed cells by their position
   in `w:tr`, which silently corrupted any table containing a merge. They now resolve cells through

--- a/Docxodus.Tests/WmlComparerRowVersusTextboxTests.cs
+++ b/Docxodus.Tests/WmlComparerRowVersusTextboxTests.cs
@@ -1,0 +1,153 @@
+#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+/// <summary>
+/// A table row aligned against a text box used to hang <see cref="WmlComparer.Compare"/> forever:
+/// every branch of the structural walk in <c>DoLcsAlgorithm</c> needed one side to be a word, so two
+/// different non-word kinds advanced neither counter.
+/// </summary>
+public class WmlComparerRowVersusTextboxTests
+{
+    private static readonly XNamespace V = "urn:schemas-microsoft-com:vml";
+
+    private static WmlDocument Doc(params XElement[] bodyChildren)
+    {
+        using var ms = new MemoryStream();
+        using (var wDoc = WordprocessingDocument.Create(ms, DocumentFormat.OpenXml.WordprocessingDocumentType.Document))
+        {
+            var main = wDoc.AddMainDocumentPart();
+            main.PutXDocument(new XDocument(
+                new XElement(W.document,
+                    new XAttribute(XNamespace.Xmlns + "w", W.w),
+                    new XAttribute(XNamespace.Xmlns + "v", V),
+                    new XElement(W.body, bodyChildren))));
+            main.AddNewPart<StyleDefinitionsPart>().PutXDocument(
+                new XDocument(new XElement(W.styles, new XAttribute(XNamespace.Xmlns + "w", W.w))));
+            main.AddNewPart<DocumentSettingsPart>().PutXDocument(
+                new XDocument(new XElement(W.settings, new XAttribute(XNamespace.Xmlns + "w", W.w))));
+        }
+        return new WmlDocument("test.docx", ms.ToArray());
+    }
+
+    private static XElement Para(string text) =>
+        new(W.p, new XElement(W.r, new XElement(W.t, text)));
+
+    private static XElement Table(params string[] cells) =>
+        new(W.tbl,
+            new XElement(W.tblPr,
+                new XElement(W.tblW, new XAttribute(W._w, "0"), new XAttribute(W.type, "auto"))),
+            new XElement(W.tblGrid,
+                cells.Select(_ => new XElement(W.gridCol, new XAttribute(W._w, "3000")))),
+            new XElement(W.tr, cells.Select(c => new XElement(W.tc, Para(c)))));
+
+    private static XElement TextboxPara(string text) =>
+        new(W.p,
+            new XElement(W.r,
+                new XElement(W.pict,
+                    new XElement(V + "shape",
+                        new XAttribute("id", "shape1"),
+                        new XAttribute("style", "width:200pt;height:50pt"),
+                        new XElement(V + "textbox",
+                            new XElement(W.txbxContent, Para(text)))))));
+
+    /// <summary>
+    /// A regression here does not fail, it hangs, so the assertion is a deadline. The comparison
+    /// takes well under a second once the walk advances.
+    /// </summary>
+    private static WmlDocument CompareWithin(WmlDocument left, WmlDocument right, int timeoutMs = 10_000)
+    {
+        WmlDocument? result = null;
+        Exception? failure = null;
+
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                result = WmlComparer.Compare(left, right,
+                    new WmlComparerSettings { DateTimeForRevisions = "2000-01-01T00:00:00Z" });
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+        })
+        { IsBackground = true };
+
+        thread.Start();
+        Assert.True(thread.Join(timeoutMs),
+            $"WmlComparer.Compare did not finish within {timeoutMs} ms - the structural walk is not advancing.");
+
+        if (failure != null)
+            throw new Xunit.Sdk.XunitException("Compare threw: " + failure);
+
+        return result!;
+    }
+
+    private static XElement Body(WmlDocument doc)
+    {
+        using var ms = new MemoryStream(doc.DocumentByteArray);
+        using var wDoc = WordprocessingDocument.Open(ms, false);
+        return wDoc.MainDocumentPart!.GetXDocument().Root!.Element(W.body)!;
+    }
+
+    /// <summary>All the text the document carries, deleted text included.</summary>
+    private static string AllText(XElement body) =>
+        string.Concat(body.Descendants()
+            .Where(d => d.Name == W.t || d.Name == W.delText)
+            .Select(d => d.Value));
+
+    /// <summary>RT001 — a table row on the left facing a text box on the right terminates.</summary>
+    [Fact]
+    public void RT001_RowAgainstTextbox_Terminates()
+    {
+        var body = Body(CompareWithin(
+            Doc(Para("Alpha"), Table("cell"), Para("Omega")),
+            Doc(Para("Alpha"), TextboxPara("boxed"), Para("Omega"))));
+
+        // Terminating is not enough - neither side's content may be dropped on the floor.
+        var text = AllText(body);
+        Assert.Contains("cell", text);
+        Assert.Contains("boxed", text);
+        Assert.Contains("Alpha", text);
+        Assert.Contains("Omega", text);
+    }
+
+    /// <summary>RT002 — and the mirror image, text box on the left facing a row on the right.</summary>
+    [Fact]
+    public void RT002_TextboxAgainstRow_Terminates()
+    {
+        var body = Body(CompareWithin(
+            Doc(Para("Alpha"), TextboxPara("boxed"), Para("Omega")),
+            Doc(Para("Alpha"), Table("cell"), Para("Omega"))));
+
+        var text = AllText(body);
+        Assert.Contains("cell", text);
+        Assert.Contains("boxed", text);
+    }
+
+    /// <summary>
+    /// RT003 — the mismatch reached with differing prose on both sides, so the walk meets it with
+    /// words in play rather than only at the structural boundary.
+    /// </summary>
+    [Fact]
+    public void RT003_RowAgainstTextboxWithDifferingProse_Terminates()
+    {
+        var body = Body(CompareWithin(
+            Doc(Para("Alpha one"), Table("cell", "second"), Para("Omega tail")),
+            Doc(Para("Alpha two"), TextboxPara("boxed text"), Para("Omega end"))));
+
+        var text = AllText(body);
+        Assert.Contains("cell", text);
+        Assert.Contains("boxed text", text);
+    }
+
+}

--- a/Docxodus/WmlComparer.cs
+++ b/Docxodus/WmlComparer.cs
@@ -7482,6 +7482,20 @@ namespace Docxodus
                             ++iRight;
                         }
 
+                        // Two different non-word kinds, a row against a text box. Every branch above
+                        // needs one side to be a word, so this pair advanced neither counter and the
+                        // walk spun forever. Retire the left one only: the right group may still pair
+                        // with a later group of its own kind.
+                        else
+                        {
+                            var deletedCorrelatedSequence = new CorrelatedSequence();
+                            deletedCorrelatedSequence.ComparisonUnitArray1 = leftGrouped[iLeft].ToArray();
+                            deletedCorrelatedSequence.ComparisonUnitArray2 = null;
+                            deletedCorrelatedSequence.CorrelationStatus = CorrelationStatus.Deleted;
+                            newListOfCorrelatedSequence.Add(deletedCorrelatedSequence);
+                            ++iLeft;
+                        }
+
                         if (iLeft == leftGrouped.Length && iRight == rightGrouped.Length)
                             return newListOfCorrelatedSequence;
 


### PR DESCRIPTION
`WmlComparer.Compare` never returns when one document contains a table and the other a text box in the same position. It is not a deadlock and not an expensive search: one core runs flat out, memory stays completely flat, and the call simply never ends. Callers see it only as a timeout.

### Cause

The structural walk in `DoLcsAlgorithm` groups each side into adjacent runs keyed `Word` / `Row` / `Textbox`, then advances `iLeft` / `iRight` until both are exhausted. Every branch of the chain required one side to be a `Word`:

| left | right | branch |
|---|---|---|
| same | same | advance both |
| `Word` | `Row` | advance right |
| `Row` | `Word` | advance left |
| `Word` | non-`Word` | advance left |
| non-`Word` | `Word` | advance right |
| **`Row`** | **`Textbox`** | **none — neither advances** |

Two *different non-word* kinds match nothing, so neither counter moves and the `while (true)` spins, allocating nothing.

### Fix

A final `else` retires the left group as a deletion and advances `iLeft`. That restores the invariant which makes the walk terminate at all — every branch now advances at least one counter — while leaving the right group free to pair with a later group of its own kind (retiring both sides would render everything as a deletion plus an insertion).

The sibling table-vs-paragraph walk later in the same method was checked and is not affected: its key space is only `Table`/`Para` and all four combinations already advance.

### Evidence

Found by fuzzing a corpus of 1,925 documents, comparing 400 random pairs drawn only from files that self-compare cleanly. 7 pairs (~1.8%) hung past 600 s, every one of them mixing tables with text boxes. All 7 now complete in milliseconds.

Each pair was independently reproduced with a minimal synthetic fixture before the fix was written; the hot frame was confirmed by stack sampling rather than inspection.

### Tests

`WmlComparerRowVersusTextboxTests` (RT001–RT003) — a row against a text box, the mirror case, and the mismatch reached with differing prose on both sides. Because a regression here hangs rather than fails, each test asserts a deadline on a worker thread, and asserts that neither side's content was dropped.

All three were verified to hang with the fix reverted and to pass with it, so they are not vacuous. Full suite is unchanged otherwise.
