### PR TITLE
Add paragraph-level format change tracking to WmlComparer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **`WmlComparerSettings.DetectParagraphFormatChanges` — paragraph-level format tracking as native
+  `w:pPrChange` markup (default `false`, so existing callers are unaffected).** Covers alignment,
+  indentation, spacing, paragraph style and list membership (`w:numPr`), and is independent of
+  `DetectFormatChanges`, which stays run-level (`w:rPrChange`) and stays on.
+  What it fixes is a silent loss rather than a missing feature: a paragraph mark hashes as its element
+  name plus its text value, and every `w:pPr` child is attribute-only, so a paragraph whose formatting
+  alone changed hashes identically on both sides, correlates as Equal, and is rebuilt from the RIGHT
+  document. The revised formatting was therefore already being applied to the result, the original's
+  discarded, and nothing reported — leaving reject unable to restore it. Detection mirrors the
+  run-level pass; `ReduceToParagraphPropertiesChange` produces both the comparison key and the archived
+  copy, so what is compared is exactly what is stored. It drops what a `w:pPrChange` may not carry —
+  its inner `w:pPr` is a CT_PPrBase, so the mark's own `w:rPr` and an inline `w:sectPr` are excluded —
+  and strips revision-save ids and internal bookkeeping at every level so they neither trip a false
+  positive nor leak into the archive. Accept/reject needed no new code: `RevisionProcessor` already
+  handles `w:pPrChange`. Adding the emission branch also closed a crash reachable without this option:
+  run-level detection can stamp `FormatChanged` on a paragraph mark inside a text box (a paragraph
+  there hangs off the run carrying the drawing, so unlike an ordinary paragraph mark it has a run
+  ancestor whose properties the run pass reads), and the paragraph-properties transform had no branch
+  for that status, throwing `Internal error - unknown status: FormatChanged` on text-box documents
+  under the default settings. `GetRevisions()` reports these as `FormatChanged` alongside run changes,
+  carrying the paragraph's text; the revision type enum is unchanged, and reporting is not gated by the
+  setting — a document that already contains a `w:pPrChange` is reported either way, exactly as
+  `w:rPrChange` already was. Lists ride the same path for free, though renumbering caused by editing
+  `numbering.xml` is not a `w:pPr` change and is not tracked (nor is it by Word). Body scope only: no
+  formatting change inside a footnote or endnote is detected, a pre-existing limitation the run-level
+  pass shares exactly. CLI: `redline --detect-paragraph-format-changes`. Coverage:
+  `WmlComparerParagraphFormatTests`.
+  Two rode-along fixes on the default-on run-level path, both pre-existing: archived properties are
+  serialized into an internal attribute and parsed back, and without an explicit namespace declaration
+  XLinq wrote them as a default-namespace `<rPr xmlns="…">` that re-declared the namespace on every
+  child and survived into the produced document; and a property with no `w:val` is compared by its
+  serialized form when reporting changed property names, so an untouched `w:rFonts` counted as changed
+  whenever the two copies carried different internal ids.
 - **Table cell merge/unmerge — `DocxSession.MergeCells`/`UnmergeCells` (issue #340, the
   deferred Stage B of post-insert table editing).** `MergeCells(cellAnchor, rowSpan, colSpan,
   TableMergeOptions?)` writes native `w:gridSpan` for the horizontal extent and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,7 +243,8 @@ DocumentBuilder.BuildDocument(sources, outputPath);
 - `SimplifyMoveMarkup` - Convert move markup to del/ins (default: false)
 - `MoveSimilarityThreshold` - Jaccard similarity threshold for moves (default: 0.8)
 - `MoveMinimumWordCount` - Minimum words for move detection (default: 3)
-- `DetectFormatChanges` - Enable format change detection (default: true)
+- `DetectFormatChanges` - Enable run-level (`w:rPrChange`) format change detection (default: true)
+- `DetectParagraphFormatChanges` - Enable paragraph-level (`w:pPrChange`) format change detection — alignment, indent, spacing, style, list membership (default: **false**)
 
 Move detection produces **native Word move markup** (`w:moveFrom`/`w:moveTo`) when `DetectMoves` is enabled:
 - The comparer analyzes deleted/inserted content blocks for similarity after LCS comparison
@@ -260,6 +261,14 @@ Format change detection produces **native Word format change markup** (`w:rPrCha
 - The output document contains `w:rPrChange` elements inside `w:rPr` with the old formatting properties
 - `GetRevisions()` recognizes this native markup and returns `WmlComparerRevisionType.FormatChanged` revisions
 - `WmlComparerRevision.FormatChange` contains details about what changed (old/new properties, changed property names)
+
+Paragraph-level format change detection (`DetectParagraphFormatChanges`, default **false**) mirrors that pass on the paragraph mark, emitting `w:pPrChange`:
+- A paragraph mark hashes as element name + text value, and every `w:pPr` child is attribute-only — so a format-only change correlates as Equal and the result is rebuilt from the right document. Without this option the revised formatting is applied silently and the original is lost, so reject cannot restore it
+- `ReduceToParagraphPropertiesChange` produces both the comparison key and the archived copy. It excludes what `w:pPrChange`'s CT_PPrBase forbids (the mark's `w:rPr`, an inline `w:sectPr`) and strips rsids/`pt14:` bookkeeping at every level
+- Lists come free — `w:numPr` is an ordinary `w:pPr` child. Editing `numbering.xml` is not a `w:pPr` change and is not tracked
+- Accept/reject needed no new code; `RevisionProcessor` already handles `w:pPrChange`. `GetRevisions()` reports these as `FormatChanged` (enum unchanged), with the paragraph's text
+- Body scope only — no format change inside a footnote/endnote is detected. Pre-existing and shared with the run-level pass (a *text* change in the same note IS detected); pinned by `PF022`
+- Not on the WASM/npm bridges (same as `DetectFormatChanges`). CLI: `redline --detect-paragraph-format-changes`
 
 **DocxCompare.cs** - The shared comparison-engine selector (M-B). One public `enum ComparisonEngine { WmlComparer = 0, DocxDiff = 1 }` + `DocxCompare.Compare(left, right, engine, WmlComparerSettings)` — the single `WmlComparer`-vs-`DocxDiff` dispatch owner that the CLI (`tools/redline` `--engine=`), the WASM bridge (`DocumentComparer`'s four primary redline methods, via a trailing `engine` int), and — transitively — the npm wrappers (`CompareOptions.engine`) all route through (mirrors the `DocxDiffOps`/`HtmlConversionOps` single-owner pattern). Takes the incumbent `WmlComparerSettings` and maps the common option set to `DocxDiffSettings` on the `DocxDiff` branch via `ToDocxDiffSettings` (drops the WmlComparer-only knobs `DetailThreshold`/`SimplifyMoveMarkup`/`DetectFormatChanges`). **Seeded to `WmlComparer` — the default is NOT flipped** (that remains gated on decision D4); omitting the selector reproduces today's behavior exactly. `DocxCompare.TryParseEngine` is the CLI name↔enum mapper. Note: python-host/docx-scalpel are out of M-B scope.
 

--- a/Docxodus.Tests/WmlComparerFormatChangeTests.cs
+++ b/Docxodus.Tests/WmlComparerFormatChangeTests.cs
@@ -568,6 +568,44 @@ namespace OxPt
             Assert.NotEmpty(textRevisions);
         }
 
+        /// <summary>
+        /// Only the run properties that actually differ are reported. A property with no w:val is
+        /// compared by its serialized form, so an untouched w:rFonts must not read as changed just
+        /// because the two copies carry different internal ids.
+        /// </summary>
+        [Fact]
+        public void GetRevisions_FormatChange_ShouldReportOnlyThePropertiesThatDiffer()
+        {
+            static WmlDocument Build(bool bold)
+            {
+                using var stream = new MemoryStream();
+                using (var doc = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document))
+                {
+                    var mainPart = doc.AddMainDocumentPart();
+                    var runProperties = new RunProperties(
+                        new RunFonts { Ascii = "Georgia", HighAnsi = "Georgia" });
+                    if (bold)
+                        runProperties.AppendChild(new Bold());
+
+                    mainPart.Document = new Document(new Body(
+                        new Paragraph(new Run(runProperties, new Text("Hello")))));
+                    mainPart.AddNewPart<StyleDefinitionsPart>().Styles = new Styles();
+                    mainPart.AddNewPart<DocumentSettingsPart>().Settings = new Settings();
+                }
+                return new WmlDocument("test.docx", stream.ToArray());
+            }
+
+            var settings = new WmlComparerSettings { DateTimeForRevisions = "2000-01-01T00:00:00Z" };
+            var compared = WmlComparer.Compare(Build(false), Build(true), settings);
+
+            var formatRevisions = WmlComparer.GetRevisions(compared, settings)
+                .Where(r => r.RevisionType == WmlComparerRevisionType.FormatChanged)
+                .ToList();
+
+            var revision = Assert.Single(formatRevisions);
+            Assert.Equal(new[] { "bold" }, revision.FormatChange.ChangedPropertyNames);
+        }
+
         #endregion
     }
 }

--- a/Docxodus.Tests/WmlComparerParagraphFormatTests.cs
+++ b/Docxodus.Tests/WmlComparerParagraphFormatTests.cs
@@ -1,0 +1,785 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using Docxodus;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+/// <summary>
+/// Tests for <see cref="WmlComparerSettings.DetectParagraphFormatChanges"/> — paragraph-level
+/// format tracking (alignment, indent, spacing, style, list membership) as native
+/// <c>w:pPrChange</c> markup.
+/// </summary>
+public class WmlComparerParagraphFormatTests
+{
+    private static WmlDocument Doc(params XElement[] bodyChildren)
+    {
+        using var ms = new MemoryStream();
+        using (var wDoc = WordprocessingDocument.Create(ms, DocumentFormat.OpenXml.WordprocessingDocumentType.Document))
+        {
+            var main = wDoc.AddMainDocumentPart();
+            main.PutXDocument(new XDocument(
+                new XElement(W.document,
+                    new XAttribute(XNamespace.Xmlns + "w", W.w),
+                    new XElement(W.body, bodyChildren))));
+
+            main.AddNewPart<StyleDefinitionsPart>().PutXDocument(
+                new XDocument(
+                    new XElement(W.styles,
+                        new XAttribute(XNamespace.Xmlns + "w", W.w),
+                        Style("Heading1", "heading 1"),
+                        Style("Quote", "Quote"))));
+
+            main.AddNewPart<NumberingDefinitionsPart>().PutXDocument(
+                new XDocument(
+                    new XElement(W.numbering,
+                        new XAttribute(XNamespace.Xmlns + "w", W.w),
+                        AbstractNum(1, "bullet"),
+                        AbstractNum(2, "decimal"),
+                        Num(1, 1),
+                        Num(2, 2))));
+
+            main.AddNewPart<DocumentSettingsPart>().PutXDocument(
+                new XDocument(new XElement(W.settings, new XAttribute(XNamespace.Xmlns + "w", W.w))));
+        }
+        return new WmlDocument("test.docx", ms.ToArray());
+    }
+
+    private static XElement Style(string id, string name) =>
+        new(W.style,
+            new XAttribute(W.type, "paragraph"),
+            new XAttribute(W.styleId, id),
+            new XElement(W.name, new XAttribute(W.val, name)));
+
+    private static XElement AbstractNum(int id, string format) =>
+        new(W.abstractNum,
+            new XAttribute(W.abstractNumId, id),
+            Enumerable.Range(0, 3).Select(lvl => new XElement(W.lvl,
+                new XAttribute(W.ilvl, lvl),
+                new XElement(W.start, new XAttribute(W.val, "1")),
+                new XElement(W.numFmt, new XAttribute(W.val, format)),
+                new XElement(W.lvlText, new XAttribute(W.val, format == "bullet" ? "·" : "%1.")),
+                new XElement(W.lvlJc, new XAttribute(W.val, "left")))));
+
+    private static XElement Num(int numId, int abstractNumId) =>
+        new(W.num,
+            new XAttribute(W.numId, numId),
+            new XElement(W.abstractNumId, new XAttribute(W.val, abstractNumId)));
+
+    private static XElement Para(string text, XElement? pPr = null) =>
+        pPr == null
+            ? new XElement(W.p, new XElement(W.r, new XElement(W.t, text)))
+            : new XElement(W.p, pPr, new XElement(W.r, new XElement(W.t, text)));
+
+    private static XElement PPr(params XElement[] children) => new(W.pPr, children);
+
+    private static XElement Jc(string val) => new(W.jc, new XAttribute(W.val, val));
+
+    private static XElement PStyle(string id) => new(W.pStyle, new XAttribute(W.val, id));
+
+    private static XElement NumPr(int numId, int ilvl) =>
+        new(W.numPr,
+            new XElement(W.ilvl, new XAttribute(W.val, ilvl)),
+            new XElement(W.numId, new XAttribute(W.val, numId)));
+
+    private static XElement SectPr() =>
+        new(W.sectPr,
+            new XElement(W.pgSz, new XAttribute(W._w, "12240"), new XAttribute(W.h, "15840")));
+
+    private static WmlComparerSettings Settings(bool detectParagraphFormat) => new()
+    {
+        DetectParagraphFormatChanges = detectParagraphFormat,
+        DateTimeForRevisions = "2000-01-01T00:00:00Z",
+    };
+
+    private static XElement Body(WmlDocument doc)
+    {
+        using var ms = new MemoryStream(doc.DocumentByteArray);
+        using var wDoc = WordprocessingDocument.Open(ms, false);
+        return wDoc.MainDocumentPart!.GetXDocument().Root!.Element(W.body)!;
+    }
+
+    /// <summary>The result of comparing left against right with paragraph format tracking on.</summary>
+    private static WmlDocument CompareOn(WmlDocument left, WmlDocument right)
+    {
+        var result = WmlComparer.Compare(left, right, Settings(true));
+        AssertSchemaValid(result);
+        return result;
+    }
+
+    private static void AssertSchemaValid(WmlDocument doc)
+    {
+        using var ms = new MemoryStream(doc.DocumentByteArray);
+        using var wDoc = WordprocessingDocument.Open(ms, false);
+
+        var errors = new DocumentFormat.OpenXml.Validation.OpenXmlValidator().Validate(wDoc)
+            .Where(e => e.ErrorType == DocumentFormat.OpenXml.Validation.ValidationErrorType.Schema &&
+                        !OxPt.WcTests.ExpectedErrors.Contains(e.Description))
+            .Select(e => e.Description)
+            .ToList();
+        Assert.Empty(errors);
+    }
+
+    private static List<XElement> PPrChanges(WmlDocument doc) =>
+        Body(doc).Descendants(W.pPrChange).ToList();
+
+    /// <summary>The properties a pPrChange archives, as local names in document order.</summary>
+    private static List<string> ArchivedProps(XElement pPrChange) =>
+        pPrChange.Element(W.pPr)!.Elements().Select(e => e.Name.LocalName).ToList();
+
+    /// <summary>The live properties of the paragraph owning a pPrChange, excluding the marker.</summary>
+    private static List<string> LiveProps(XElement pPrChange) =>
+        pPrChange.Parent!.Elements()
+            .Where(e => e.Name != W.pPrChange)
+            .Select(e => e.Name.LocalName)
+            .ToList();
+
+    // ---------------------------------------------------------------------------------------
+    // Detection
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>PF001 — alignment change is tracked, and does not become a delete/insert.</summary>
+    [Fact]
+    public void PF001_AlignmentChange_EmitsPPrChange()
+    {
+        var result = CompareOn(
+            Doc(Para("Hello")),
+            Doc(Para("Hello", PPr(Jc("center")))));
+
+        var change = Assert.Single(PPrChanges(result));
+        Assert.Equal(new[] { "jc" }, LiveProps(change));
+        Assert.Empty(ArchivedProps(change));
+
+        var body = Body(result);
+        Assert.Empty(body.Descendants(W.ins));
+        Assert.Empty(body.Descendants(W.del));
+    }
+
+    /// <summary>
+    /// PF002 — the guard that matters most: off by default, so an existing caller who upgrades
+    /// sees byte-for-byte what they saw before.
+    /// </summary>
+    [Fact]
+    public void PF002_OffByDefault_EmitsNothing()
+    {
+        Assert.False(new WmlComparerSettings().DetectParagraphFormatChanges);
+
+        var left = Doc(Para("Hello"));
+        var right = Doc(Para("Hello", PPr(Jc("center"))));
+
+        var off = WmlComparer.Compare(left, right, Settings(false));
+        Assert.Empty(PPrChanges(off));
+        Assert.Equal(0, WmlComparer.GetRevisions(off, Settings(false)).Count);
+
+        // Not vacuous: the same pair does produce a change with the option on.
+        Assert.Single(PPrChanges(CompareOn(left, right)));
+    }
+
+    /// <summary>PF003 — a paragraph style change.</summary>
+    [Fact]
+    public void PF003_StyleChange_EmitsPPrChange()
+    {
+        var result = CompareOn(
+            Doc(Para("Hello", PPr(PStyle("Quote")))),
+            Doc(Para("Hello", PPr(PStyle("Heading1")))));
+
+        var change = Assert.Single(PPrChanges(result));
+        Assert.Equal("Heading1", (string)change.Parent!.Element(W.pStyle)!.Attribute(W.val)!);
+        Assert.Equal("Quote", (string)change.Element(W.pPr)!.Element(W.pStyle)!.Attribute(W.val)!);
+    }
+
+    /// <summary>PF004 — indent and spacing, the other two common paragraph properties.</summary>
+    [Fact]
+    public void PF004_IndentAndSpacingChange_EmitsPPrChange()
+    {
+        var result = CompareOn(
+            Doc(Para("Hello")),
+            Doc(Para("Hello", PPr(
+                new XElement(W.ind, new XAttribute(W.left, "720")),
+                new XElement(W.spacing, new XAttribute(W.before, "240"))))));
+
+        // CT_PPrBase order, which the comparer restores: w:spacing precedes w:ind.
+        var change = Assert.Single(PPrChanges(result));
+        Assert.Equal(new[] { "spacing", "ind" }, LiveProps(change));
+    }
+
+    /// <summary>
+    /// PF004b — a source paragraph whose properties are stored out of schema order. The archived
+    /// copy must come out ordered, or Word rejects the w:pPrChange.
+    /// </summary>
+    [Fact]
+    public void PF004b_OutOfOrderSourceProperties_AreArchivedInSchemaOrder()
+    {
+        var result = CompareOn(
+            Doc(Para("Hello", PPr(
+                new XElement(W.ind, new XAttribute(W.left, "720")),
+                new XElement(W.spacing, new XAttribute(W.before, "240")),
+                PStyle("Quote")))),
+            Doc(Para("Hello", PPr(Jc("center")))));
+
+        var change = Assert.Single(PPrChanges(result));
+        Assert.Equal(new[] { "pStyle", "spacing", "ind" }, ArchivedProps(change));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Lists — w:numPr is an ordinary pPr child, so list changes ride the same path
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>PF005 — a paragraph made into a list item.</summary>
+    [Fact]
+    public void PF005_ListMembershipAdded_EmitsPPrChange()
+    {
+        var result = CompareOn(
+            Doc(Para("Hello")),
+            Doc(Para("Hello", PPr(NumPr(1, 0)))));
+
+        var change = Assert.Single(PPrChanges(result));
+        Assert.Equal(new[] { "numPr" }, LiveProps(change));
+        Assert.Empty(ArchivedProps(change));
+    }
+
+    /// <summary>PF006 — a list item demoted to plain text: the archive holds the old numbering.</summary>
+    [Fact]
+    public void PF006_ListMembershipRemoved_ArchivesOldNumbering()
+    {
+        var result = CompareOn(
+            Doc(Para("Hello", PPr(NumPr(1, 0)))),
+            Doc(Para("Hello")));
+
+        var change = Assert.Single(PPrChanges(result));
+        Assert.Empty(LiveProps(change));
+        Assert.Equal(new[] { "numPr" }, ArchivedProps(change));
+        Assert.Equal("1", (string)change.Descendants(W.numId).Single().Attribute(W.val)!);
+    }
+
+    /// <summary>PF007 — bullet list to numbered list, and an indent-level change.</summary>
+    [Theory]
+    [InlineData(1, 0, 2, 0)] // bullet -> decimal
+    [InlineData(1, 0, 1, 1)] // level 0 -> level 1
+    public void PF007_ListFormatAndLevelChanges_AreTracked(int leftNum, int leftLvl, int rightNum, int rightLvl)
+    {
+        var result = CompareOn(
+            Doc(Para("Hello", PPr(NumPr(leftNum, leftLvl)))),
+            Doc(Para("Hello", PPr(NumPr(rightNum, rightLvl)))));
+
+        var change = Assert.Single(PPrChanges(result));
+        Assert.Equal(leftNum.ToString(), (string)change.Element(W.pPr)!.Descendants(W.numId).Single().Attribute(W.val)!);
+        Assert.Equal(leftLvl.ToString(), (string)change.Element(W.pPr)!.Descendants(W.ilvl).Single().Attribute(W.val)!);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // False-positive guards — these carry more weight than the positive cases
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>PF008 — identical documents produce nothing.</summary>
+    [Fact]
+    public void PF008_IdenticalDocuments_ProduceNoChange()
+    {
+        var result = CompareOn(
+            Doc(Para("Hello", PPr(Jc("center"), NumPr(1, 0)))),
+            Doc(Para("Hello", PPr(Jc("center"), NumPr(1, 0)))));
+
+        Assert.Empty(PPrChanges(result));
+        Assert.Equal(0, WmlComparer.GetRevisions(result, Settings(true)).Count);
+    }
+
+    /// <summary>
+    /// PF008b — the same properties written in a different source order are not a change.
+    /// <see cref="XNode.DeepEquals"/> is order-sensitive, so the reduction has to sort.
+    /// </summary>
+    [Fact]
+    public void PF008b_SamePropertiesInADifferentOrder_ProduceNoChange()
+    {
+        XElement Ind() => new(W.ind, new XAttribute(W.left, "720"));
+        XElement Spacing() => new(W.spacing, new XAttribute(W.before, "240"));
+
+        var result = CompareOn(
+            Doc(Para("Hello", PPr(Ind(), Spacing()))),
+            Doc(Para("Hello", PPr(Spacing(), Ind()))));
+
+        Assert.Empty(PPrChanges(result));
+    }
+
+    /// <summary>
+    /// PF008c — the same applies inside a property: a w:numPr holding w:numId before w:ilvl is the
+    /// same numbering, so the sort reaches every level.
+    /// <para>The fixture is deliberately malformed — CT_NumPr is a sequence, so only a non-Word
+    /// generator writes it this way, and unlike a top-level w:pPr the writer's element ordering does
+    /// not reach inside w:numPr, leaving the output as invalid as the input. Hence no schema
+    /// assertion here: what is pinned is that malformed input yields no phantom revision.</para>
+    /// </summary>
+    [Fact]
+    public void PF008c_SameNumberingInADifferentChildOrder_ProducesNoChange()
+    {
+        XElement Ilvl() => new(W.ilvl, new XAttribute(W.val, "0"));
+        XElement NumId() => new(W.numId, new XAttribute(W.val, "1"));
+
+        var result = WmlComparer.Compare(
+            Doc(Para("Hello", PPr(new XElement(W.numPr, Ilvl(), NumId())))),
+            Doc(Para("Hello", PPr(new XElement(W.numPr, NumId(), Ilvl())))),
+            Settings(true));
+
+        Assert.Empty(PPrChanges(result));
+    }
+
+    /// <summary>
+    /// PF009 — revision-save ids differ between two saves of the same paragraph. They are not a
+    /// formatting change and must not be reported as one.
+    /// </summary>
+    [Fact]
+    public void PF009_RsidOnlyDifference_ProducesNoChange()
+    {
+        var left = Doc(new XElement(W.p,
+            new XAttribute(W.rsidR, "00AA00AA"),
+            new XElement(W.pPr, new XAttribute(W.rsidRDefault, "00AA00AA"), Jc("center")),
+            new XElement(W.r, new XElement(W.t, "Hello"))));
+        var right = Doc(new XElement(W.p,
+            new XAttribute(W.rsidR, "00BB00BB"),
+            new XElement(W.pPr, new XAttribute(W.rsidRDefault, "00BB00BB"), Jc("center")),
+            new XElement(W.r, new XElement(W.t, "Hello"))));
+
+        Assert.Empty(PPrChanges(CompareOn(left, right)));
+    }
+
+    /// <summary>
+    /// PF010 — a changed section is a section change (w:sectPrChange), explicitly out of scope. It
+    /// must not masquerade as a paragraph format change.
+    /// <para>Note this passes for a second reason as well: WmlComparer discards a mid-document
+    /// inline w:sectPr altogether, with or without this option. That is pre-existing behaviour, not
+    /// something the option introduces — see PF012, which tests the exclusion directly because this
+    /// route cannot reach it.</para>
+    /// </summary>
+    [Fact]
+    public void PF010_SectionOnlyDifference_ProducesNoParagraphChange()
+    {
+        var left = Doc(
+            Para("First", PPr(SectPr())), Para("Second"),
+            new XElement(W.sectPr, new XElement(W.pgSz,
+                new XAttribute(W._w, "12240"), new XAttribute(W.h, "15840"))));
+        var right = Doc(
+            Para("First", PPr(new XElement(W.sectPr, new XElement(W.pgSz,
+                new XAttribute(W._w, "15840"), new XAttribute(W.h, "12240"))))),
+            Para("Second"),
+            new XElement(W.sectPr, new XElement(W.pgSz,
+                new XAttribute(W._w, "12240"), new XAttribute(W.h, "15840"))));
+
+        Assert.Empty(PPrChanges(CompareOn(left, right)));
+    }
+
+    /// <summary>
+    /// PF011 — the paragraph mark's own run properties are out of scope (Word tracks those as
+    /// w:pPr/w:rPr/w:rPrChange). Documented, not accidental.
+    /// </summary>
+    [Fact]
+    public void PF011_ParagraphMarkRunPropertiesChange_IsNotTracked()
+    {
+        var left = Doc(Para("Hello", PPr(new XElement(W.rPr, new XElement(W.b)))));
+        var right = Doc(Para("Hello", PPr(new XElement(W.rPr, new XElement(W.i)))));
+
+        Assert.Empty(PPrChanges(CompareOn(left, right)));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The sectPr trap: w:pPrChange stores a CT_PPrBase, which excludes w:sectPr and w:rPr
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// PF012 — what a w:pPrChange may archive, tested on the reduction directly.
+    /// <para>A w:pPrChange stores a CT_PPrBase, which excludes w:sectPr, w:rPr and a nested
+    /// w:pPrChange; including any of them produces a file Word refuses. This is asserted against
+    /// the reduction rather than through Compare because the comparer discards an inline w:sectPr
+    /// before the comparison sees it (PF010), so no document pair can drive this path — the guard
+    /// exists so that stays true if the comparer ever starts preserving inline sections.</para>
+    /// </summary>
+    [Fact]
+    public void PF012_ArchivedProperties_ExcludeWhatCtPPrBaseForbids()
+    {
+        var pPr = PPr(
+            PStyle("Quote"),
+            new XElement(W.rPr, new XElement(W.b)),
+            SectPr(),
+            new XElement(W.pPrChange,
+                new XAttribute(W.id, "9"),
+                new XAttribute(W.author, "Someone"),
+                new XAttribute(W.date, "1999-01-01T00:00:00Z"),
+                PPr(Jc("left"))));
+
+        var reduced = WmlComparer.ReduceToParagraphPropertiesChange(pPr);
+
+        Assert.Equal(new[] { "pStyle" }, reduced.Elements().Select(e => e.Name.LocalName));
+    }
+
+    /// <summary>
+    /// PF012b — the reduction ignores revision-save ids and internal bookkeeping at every level, so
+    /// they neither cause a false positive nor leak into the archive.
+    /// </summary>
+    [Fact]
+    public void PF012b_ArchivedProperties_StripBookkeepingAtEveryLevel()
+    {
+        var pPr = PPr(NumPr(1, 0));
+        pPr.SetAttributeValue(W.rsidRDefault, "00AA00AA");
+        pPr.Element(W.numPr)!.SetAttributeValue(PtOpenXml.Unid, "deadbeef");
+        pPr.Element(W.numPr)!.Element(W.numId)!.SetAttributeValue(PtOpenXml.Unid, "cafebabe");
+
+        var reduced = WmlComparer.ReduceToParagraphPropertiesChange(pPr);
+
+        Assert.Empty(reduced.DescendantsAndSelf().Attributes()
+            .Where(a => a.Name.Namespace == PtOpenXml.pt ||
+                        a.Name.LocalName.StartsWith("rsid", System.StringComparison.OrdinalIgnoreCase)));
+        Assert.Equal("1", (string)reduced.Descendants(W.numId).Single().Attribute(W.val)!);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Round trip
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// PF013 — the contract: accepting reproduces the revised document's properties, rejecting
+    /// restores the original's. Rejecting is what the feature buys — today the original is lost.
+    /// </summary>
+    [Fact]
+    public void PF013_AcceptAndReject_RoundTripParagraphProperties()
+    {
+        var result = CompareOn(
+            Doc(Para("Hello", PPr(Jc("both")))),
+            Doc(Para("Hello", PPr(Jc("center"), NumPr(2, 0)))));
+
+        var accepted = Body(RevisionProcessor.AcceptRevisions(result)).Descendants(W.p).First();
+        Assert.Equal("center", (string)accepted.Element(W.pPr)!.Element(W.jc)!.Attribute(W.val)!);
+        Assert.NotNull(accepted.Element(W.pPr)!.Element(W.numPr));
+        Assert.Empty(accepted.Descendants(W.pPrChange));
+
+        var rejected = Body(RevisionProcessor.RejectRevisions(result)).Descendants(W.p).First();
+        Assert.Equal("both", (string)rejected.Element(W.pPr)!.Element(W.jc)!.Attribute(W.val)!);
+        Assert.Null(rejected.Element(W.pPr)!.Element(W.numPr));
+        Assert.Empty(rejected.Descendants(W.pPrChange));
+    }
+
+    /// <summary>
+    /// PF014 — a format change on the last paragraph of a document with a trailing section. The
+    /// section survives both the comparison and the reject.
+    /// </summary>
+    [Fact]
+    public void PF014_TrailingSection_SurvivesCompareAndReject()
+    {
+        var trailing = new XElement(W.sectPr,
+            new XElement(W.pgSz, new XAttribute(W._w, "12240"), new XAttribute(W.h, "15840")));
+
+        var result = CompareOn(
+            Doc(Para("Only"), new XElement(trailing)),
+            Doc(Para("Only", PPr(Jc("center"))), new XElement(trailing)));
+
+        Assert.Single(PPrChanges(result));
+        Assert.NotNull(Body(result).Element(W.sectPr));
+
+        var rejected = Body(RevisionProcessor.RejectRevisions(result));
+        Assert.Null(rejected.Elements(W.p).First().Element(W.pPr)?.Element(W.jc));
+        Assert.NotNull(rejected.Element(W.sectPr));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // GetRevisions
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>PF015 — a paragraph format change is reported, with the paragraph's text.</summary>
+    [Fact]
+    public void PF015_GetRevisions_ReportsParagraphFormatChange()
+    {
+        var settings = Settings(true);
+        var result = CompareOn(
+            Doc(Para("Alpha"), Para("Beta")),
+            Doc(Para("Alpha"), Para("Beta", PPr(Jc("center")))));
+
+        var revision = Assert.Single(WmlComparer.GetRevisions(result, settings));
+        Assert.Equal(WmlComparer.WmlComparerRevisionType.FormatChanged, revision.RevisionType);
+        Assert.Equal("Beta", revision.Text);
+        Assert.Equal(settings.AuthorForRevisions, revision.Author);
+        Assert.Equal(new[] { "alignment" }, revision.FormatChange!.ChangedPropertyNames);
+    }
+
+    /// <summary>
+    /// PF015b — only the properties that actually differ are reported. A property with no w:val is
+    /// compared by its serialized form, so an unrelated w:ind must not read as changed just because
+    /// the two copies carry different internal ids.
+    /// </summary>
+    [Fact]
+    public void PF015b_GetRevisions_ReportsOnlyThePropertiesThatDiffer()
+    {
+        XElement Ind() => new(W.ind, new XAttribute(W.left, "720"));
+
+        var settings = Settings(true);
+        var result = CompareOn(
+            Doc(Para("Hello", PPr(Ind()))),
+            Doc(Para("Hello", PPr(Ind(), Jc("center")))));
+
+        var revision = Assert.Single(WmlComparer.GetRevisions(result, settings));
+        Assert.Equal(new[] { "alignment" }, revision.FormatChange!.ChangedPropertyNames);
+    }
+
+    /// <summary>
+    /// PF015c — reporting is not gated by the setting. `GetRevisions` reads the markup, so a
+    /// document that already carries a w:pPrChange — written by Word, not by us — is reported even
+    /// with paragraph detection off, exactly as w:rPrChange already was. That keeps a document
+    /// produced WITH the option from going silent when read back with default settings.
+    /// </summary>
+    [Fact]
+    public void PF015c_GetRevisions_ReportsExistingParagraphFormatMarkup_RegardlessOfTheSetting()
+    {
+        var doc = Doc(new XElement(W.p,
+            PPr(Jc("center"),
+                new XElement(W.pPrChange,
+                    new XAttribute(W.id, "1"),
+                    new XAttribute(W.author, "Word"),
+                    new XAttribute(W.date, "2000-01-01T00:00:00Z"),
+                    PPr())),
+            new XElement(W.r, new XElement(W.t, "Hello"))));
+
+        var revision = Assert.Single(WmlComparer.GetRevisions(doc, Settings(false)));
+        Assert.Equal(WmlComparer.WmlComparerRevisionType.FormatChanged, revision.RevisionType);
+        Assert.Equal("Word", revision.Author);
+    }
+
+    /// <summary>
+    /// PF023 — the archived properties keep the w: prefix. Serializing them for their trip through
+    /// a bookkeeping attribute used to emit a default-namespace element that re-declared the
+    /// namespace on every child. Covers the run-level w:rPrChange too, which shares the round trip
+    /// and is on by default.
+    /// </summary>
+    [Fact]
+    public void PF023_ArchivedPropertiesKeepThePrefix_ForBothScopes()
+    {
+        var paragraph = CompareOn(
+            Doc(Para("Hello", PPr(PStyle("Quote")))),
+            Doc(Para("Hello", PPr(PStyle("Heading1")))));
+
+        var runs = WmlComparer.Compare(
+            Doc(new XElement(W.p,
+                new XElement(W.r, new XElement(W.rPr, new XElement(W.b)), new XElement(W.t, "Hello")))),
+            Doc(new XElement(W.p,
+                new XElement(W.r, new XElement(W.rPr, new XElement(W.i)), new XElement(W.t, "Hello")))),
+            Settings(true));
+        AssertSchemaValid(runs);
+
+        foreach (var archived in PPrChanges(paragraph).Select(c => c.Element(W.pPr)!)
+                     .Concat(Body(runs).Descendants(W.rPrChange).Select(c => c.Element(W.rPr)!)))
+        {
+            Assert.NotEmpty(archived.Elements());
+            Assert.DoesNotContain(archived.DescendantsAndSelf().Attributes(), a => a.IsNamespaceDeclaration);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Interaction with the existing run-level detection
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// PF016 — the two detectors are independent: turning paragraph tracking on does not disturb
+    /// run tracking, and both can fire on one paragraph.
+    /// </summary>
+    [Fact]
+    public void PF016_RunAndParagraphFormatChanges_Coexist()
+    {
+        var result = CompareOn(
+            Doc(Para("Hello")),
+            Doc(new XElement(W.p,
+                PPr(Jc("center")),
+                new XElement(W.r, new XElement(W.rPr, new XElement(W.b)), new XElement(W.t, "Hello")))));
+
+        var body = Body(result);
+        Assert.Single(body.Descendants(W.pPrChange));
+        Assert.Single(body.Descendants(W.rPrChange));
+        Assert.Equal(2, WmlComparer.GetRevisions(result, Settings(true)).Count);
+    }
+
+    /// <summary>
+    /// PF017 — run format detection still works with paragraph detection off, and vice versa. The
+    /// two settings gate only their own pass.
+    /// </summary>
+    [Fact]
+    public void PF017_SettingsGateOnlyTheirOwnPass()
+    {
+        var left = Doc(Para("Hello"));
+        var right = Doc(new XElement(W.p,
+            PPr(Jc("center")),
+            new XElement(W.r, new XElement(W.rPr, new XElement(W.b)), new XElement(W.t, "Hello"))));
+
+        var runOnly = WmlComparer.Compare(left, right,
+            new WmlComparerSettings { DetectFormatChanges = true, DetectParagraphFormatChanges = false });
+        Assert.Empty(Body(runOnly).Descendants(W.pPrChange));
+        Assert.Single(Body(runOnly).Descendants(W.rPrChange));
+
+        var paragraphOnly = WmlComparer.Compare(left, right,
+            new WmlComparerSettings { DetectFormatChanges = false, DetectParagraphFormatChanges = true });
+        Assert.Single(Body(paragraphOnly).Descendants(W.pPrChange));
+        Assert.Empty(Body(paragraphOnly).Descendants(W.rPrChange));
+    }
+
+    /// <summary>
+    /// PF018 — a paragraph that is both reformatted and edited. The text edit is a real
+    /// insert/delete; the format change rides alongside it.
+    /// </summary>
+    [Fact]
+    public void PF018_TextEditAndFormatChange_OnTheSameParagraph()
+    {
+        var result = CompareOn(
+            Doc(Para("Hello world")),
+            Doc(Para("Hello there", PPr(Jc("center")))));
+
+        var body = Body(result);
+
+        // One paragraph, not two: marking the paragraph mark FormatChanged must not stop it taking
+        // the left document's ancestor unids, or its runs and its mark regroup separately.
+        Assert.Single(body.Elements(W.p));
+        Assert.Single(body.Descendants(W.pPrChange));
+        Assert.NotEmpty(body.Descendants(W.ins));
+        Assert.NotEmpty(body.Descendants(W.del));
+        Assert.Equal("Hello there", body.Descendants(W.t).Select(t => t.Value).StringConcatenate());
+    }
+
+    /// <summary>
+    /// PF019 — only the reformatted paragraph is touched; its neighbours stay clean.
+    /// </summary>
+    [Fact]
+    public void PF019_OnlyTheChangedParagraphIsMarked()
+    {
+        var result = CompareOn(
+            Doc(Para("Alpha"), Para("Beta"), Para("Gamma")),
+            Doc(Para("Alpha"), Para("Beta", PPr(Jc("center"))), Para("Gamma")));
+
+        var paragraphs = Body(result).Elements(W.p).ToList();
+        Assert.Equal(3, paragraphs.Count);
+        Assert.Empty(paragraphs[0].Descendants(W.pPrChange));
+        Assert.Single(paragraphs[1].Descendants(W.pPrChange));
+        Assert.Empty(paragraphs[2].Descendants(W.pPrChange));
+    }
+
+    /// <summary>
+    /// PF020 — the serialized old properties do not ride into the output as an attribute. The live
+    /// w:pPr and its children still carry the converter's own pt14 unids, as everywhere else in a
+    /// produced document; only the OldPPr hand-off attribute must be gone.
+    /// </summary>
+    [Fact]
+    public void PF020_TheSerializedOldPropertiesDoNotLeakIntoOutput()
+    {
+        var result = CompareOn(
+            Doc(Para("Hello")),
+            Doc(Para("Hello", PPr(Jc("center"), NumPr(1, 0)))));
+
+        var change = Assert.Single(PPrChanges(result));
+        Assert.DoesNotContain(change.Parent!.Attributes(),
+            a => a.Name == PtOpenXml.pt + "OldPPr" || a.Name == PtOpenXml.Status);
+        Assert.DoesNotContain(Body(result).DescendantsAndSelf().Attributes(),
+            a => a.Name == PtOpenXml.pt + "OldPPr");
+    }
+
+    /// <summary>
+    /// PF022 — pins a PRE-EXISTING limitation, not a property of this option: WmlComparer detects no
+    /// formatting change inside a footnote, at either granularity. A text change in the same note IS
+    /// detected, so notes are compared — it is the format passes that do not reach them. The
+    /// run-level pass (<see cref="WmlComparerSettings.DetectFormatChanges"/>, on by default) behaves
+    /// identically, which is why this is asserted for both.
+    /// <para>If a future change makes note-scope format detection work, this test fails and should
+    /// be rewritten to assert the markup rather than its absence.</para>
+    /// </summary>
+    [Fact]
+    public void PF022_FormatChangesInsideAFootnote_AreNotDetected_PreExistingLimitation()
+    {
+        var settings = Settings(true);
+
+        var paragraphChange = WmlComparer.Compare(
+            WithFootnote("Body text", "Note text"),
+            MutateNoteParagraph(WithFootnote("Body text", "Note text"), p =>
+            {
+                var pPr = p.Element(W.pPr)!;
+                pPr.Add(Jc("center"));
+            }),
+            settings);
+
+        var runChange = WmlComparer.Compare(
+            WithFootnote("Body text", "Note text"),
+            MutateNoteParagraph(WithFootnote("Body text", "Note text"), p =>
+            {
+                foreach (var run in p.Elements(W.r).Where(r => r.Elements(W.t).Any()))
+                    run.AddFirst(new XElement(W.rPr, new XElement(W.b)));
+            }),
+            settings);
+
+        Assert.Empty(NoteMarkup(paragraphChange, W.pPrChange));
+        Assert.Empty(NoteMarkup(runChange, W.rPrChange));
+
+        // Not vacuous: the note itself is compared, so the absence above is about formatting only.
+        var textChange = WmlComparer.Compare(
+            WithFootnote("Body text", "Note text"),
+            MutateNoteParagraph(WithFootnote("Body text", "Note text"), p =>
+            {
+                foreach (var t in p.Descendants(W.t))
+                    t.Value = "Different";
+            }),
+            settings);
+
+        Assert.NotEmpty(NoteMarkup(textChange, W.ins));
+        Assert.NotEmpty(NoteMarkup(textChange, W.del));
+    }
+
+    private static List<XElement> NoteMarkup(WmlDocument doc, XName name)
+    {
+        using var ms = new MemoryStream(doc.DocumentByteArray);
+        using var wDoc = WordprocessingDocument.Open(ms, false);
+        return wDoc.MainDocumentPart!.FootnotesPart!.GetXDocument().Descendants(name).ToList();
+    }
+
+    /// <summary>A document with one real footnote, built through the session API's scaffold.</summary>
+    private static WmlDocument WithFootnote(string bodyText, string noteText)
+    {
+        var session = new DocxSession(DocxSession.CreateBlankDocxBytes());
+        var body = session.ListBlocks().Body.First(b => b.Kind == "p");
+
+        session.ReplaceText(body.Id, bodyText);
+        var inserted = session.InsertFootnote(body.Id, bodyText.Length, noteText);
+        Assert.True(inserted.Success, inserted.Error?.Message);
+
+        return new WmlDocument("note.docx", session.Save());
+    }
+
+    /// <summary>Edits the real footnote's paragraph, changing nothing else in the document.</summary>
+    private static WmlDocument MutateNoteParagraph(WmlDocument doc, System.Action<XElement> mutate)
+    {
+        using var ms = new MemoryStream();
+        ms.Write(doc.DocumentByteArray, 0, doc.DocumentByteArray.Length);
+        using (var wDoc = WordprocessingDocument.Open(ms, true))
+        {
+            var notePara = wDoc.MainDocumentPart!.FootnotesPart!.GetXDocument()
+                .Root!.Elements(W.footnote)
+                .Where(f => (string)f.Attribute(W.type) == null)   // skip the reserved separators
+                .Descendants(W.p)
+                .First();
+
+            mutate(notePara);
+            wDoc.MainDocumentPart.FootnotesPart.PutXDocument();
+        }
+        return new WmlDocument("note.docx", ms.ToArray());
+    }
+
+    /// <summary>PF021 — a change inside a table cell is tracked like any other paragraph.</summary>
+    [Fact]
+    public void PF021_ParagraphInsideTableCell_IsTracked()
+    {
+        XElement Table(XElement cellPara) =>
+            new(W.tbl,
+                new XElement(W.tblPr, new XElement(W.tblW, new XAttribute(W._w, "0"), new XAttribute(W.type, "auto"))),
+                new XElement(W.tblGrid, new XElement(W.gridCol, new XAttribute(W._w, "3000"))),
+                new XElement(W.tr, new XElement(W.tc, cellPara)));
+
+        var result = CompareOn(
+            Doc(Table(Para("Cell")), Para("After")),
+            Doc(Table(Para("Cell", PPr(Jc("center")))), Para("After")));
+
+        var change = Assert.Single(PPrChanges(result));
+        Assert.NotNull(change.Ancestors(W.tc).FirstOrDefault());
+    }
+}

--- a/Docxodus/DocxCompare.cs
+++ b/Docxodus/DocxCompare.cs
@@ -108,8 +108,10 @@ public static class DocxCompare
     /// Map the option set shared by both engines from <see cref="WmlComparerSettings"/> onto a fresh
     /// <see cref="DocxDiffSettings"/>. WmlComparer-only knobs are intentionally dropped: <c>DetailThreshold</c>
     /// (an LCS-granularity knob with no IR equivalent), <c>SimplifyMoveMarkup</c> (DocxDiff renders moves
-    /// natively), and <c>DetectFormatChanges</c> (DocxDiff uses <see cref="DocxDiffSettings.FormatComparison"/>,
-    /// left at its default). DocxDiff-specific settings keep their defaults. An explicit
+    /// natively), <c>DetectFormatChanges</c> (DocxDiff uses <see cref="DocxDiffSettings.FormatComparison"/>,
+    /// left at its default), and <c>DetectParagraphFormatChanges</c> (DocxDiff tracks the whole
+    /// block-format-change family under <see cref="DocxDiffSettings.TrackBlockFormatChanges"/>, on by
+    /// default and far wider in scope). DocxDiff-specific settings keep their defaults. An explicit
     /// <c>DateTimeForRevisions</c> is carried through and wins over <see cref="DocxDiffSettings.Deterministic"/>.
     /// </summary>
     internal static DocxDiffSettings ToDocxDiffSettings(WmlComparerSettings settings) => new()

--- a/Docxodus/WmlComparer.cs
+++ b/Docxodus/WmlComparer.cs
@@ -100,6 +100,23 @@ namespace Docxodus
         public bool DetectFormatChanges = true;
 
         /// <summary>
+        /// Enable detection of paragraph-level formatting changes: alignment, indentation, spacing,
+        /// paragraph style, and list membership (<c>w:numPr</c>). When enabled, an Equal paragraph
+        /// mark whose <c>w:pPr</c> differs between the two documents is marked as FormatChanged and
+        /// emits native <c>w:pPrChange</c> markup.
+        /// Default: false.
+        /// <para>Off by default because enabling it changes the output of comparisons that produce
+        /// none today: without it the revised document's paragraph properties are applied to the
+        /// result silently and the original's are lost, so reject cannot restore them.</para>
+        /// <para>Independent of <see cref="DetectFormatChanges"/>, which covers run properties
+        /// (<c>w:rPr</c>) only.</para>
+        /// <para>Out of scope: an inline <c>w:sectPr</c> (a section change is <c>w:sectPrChange</c>,
+        /// and <c>w:sectPr</c> is not permitted inside <c>w:pPrChange</c>, whose stored <c>w:pPr</c>
+        /// is a CT_PPrBase) and the paragraph mark's own run properties (<c>w:pPr/w:rPr</c>).</para>
+        /// </summary>
+        public bool DetectParagraphFormatChanges = false;
+
+        /// <summary>
         /// Optional log to collect warnings and errors during comparison.
         /// When provided, the comparison will attempt to continue past recoverable errors
         /// (like orphaned footnote references) and log them instead of throwing exceptions.
@@ -2879,22 +2896,9 @@ namespace Docxodus
                         }
 
                         // Add w:rPrChange with the old properties
-                        XElement oldRPr = null;
-                        if (oldRPrAttr != null)
-                        {
-                            try
-                            {
-                                oldRPr = XElement.Parse((string)oldRPrAttr);
-                            }
-                            catch
-                            {
-                                oldRPr = new XElement(W.rPr);
-                            }
-                        }
-                        else
-                        {
-                            oldRPr = new XElement(W.rPr);
-                        }
+                        var oldRPr = oldRPrAttr != null
+                            ? ParseArchivedProperties((string)oldRPrAttr, W.rPr)
+                            : new XElement(W.rPr);
 
                         rPr.Add(new XElement(W.rPrChange,
                             new XAttribute(W.id, s_MaxId++),
@@ -2945,6 +2949,23 @@ namespace Docxodus
                         else
                             pPr.AddFirst(rPr);
                     }
+                    else if (status == "FormatChanged")
+                    {
+                        var oldPPrAttr = pPr.Attribute(PtOpenXml.pt + "OldPPr");
+                        var oldPPr = oldPPrAttr != null
+                            ? ParseArchivedProperties((string)oldPPrAttr, W.pPr)
+                            : new XElement(W.pPr);
+
+                        // The archived copy is a whole serialized element; leaving the hand-off
+                        // attribute behind would bloat every reformatted paragraph.
+                        pPr.Attributes().Where(a => a.Name.Namespace == PtOpenXml.pt).Remove();
+
+                        pPr.Add(new XElement(W.pPrChange,
+                            new XAttribute(W.id, s_MaxId++),
+                            new XAttribute(W.author, settings.AuthorForRevisions),
+                            new XAttribute(W.date, settings.DateTimeForRevisions),
+                            oldPPr));
+                    }
                     else
                         throw new DocxodusException("Internal error - unknown status: " + status);
                     return pPr;
@@ -2962,7 +2983,7 @@ namespace Docxodus
             // Include move elements and format change elements in revision ID tracking
             var revisionElements = new[] { W.ins, W.del, W.moveFrom, W.moveTo,
                 W.moveFromRangeStart, W.moveFromRangeEnd, W.moveToRangeStart, W.moveToRangeEnd,
-                W.rPrChange };
+                W.rPrChange, W.pPrChange };
 
             IEnumerable<XElement> footnoteRevisions = Enumerable.Empty<XElement>();
             if (wDocWithRevisions.MainDocumentPart.FootnotesPart != null)
@@ -3701,7 +3722,11 @@ namespace Docxodus
                 {
                     if (cua.AncestorElements.Any(ae => ae.Name == W.txbxContent))
                         doSet = true;
-                    if (cua.CorrelationStatus == CorrelationStatus.Equal)
+
+                    // FormatChanged is Equal with differing properties — the paragraph is present on
+                    // both sides either way, so it must still take the before document's unids.
+                    if (cua.CorrelationStatus == CorrelationStatus.Equal ||
+                        cua.CorrelationStatus == CorrelationStatus.FormatChanged)
                         doSet = true;
                 }
                 if (doSet)
@@ -4078,6 +4103,13 @@ namespace Docxodus
             /// List of property names that changed (e.g., "bold", "italic", "fontSize").
             /// </summary>
             public List<string> ChangedProperties { get; set; } = new List<string>();
+
+            /// <summary>
+            /// Paragraph properties from the original document, already reduced to what a
+            /// <c>w:pPrChange</c> may carry. Set instead of <see cref="OldRunProperties"/> when the
+            /// changed atom is a paragraph mark.
+            /// </summary>
+            public XElement OldParagraphProperties { get; set; }
         }
 
         /// <summary>
@@ -4338,77 +4370,43 @@ namespace Docxodus
         }
 
         /// <summary>
-        /// Extracts format change revisions from w:rPrChange elements in the document.
+        /// Extracts format change revisions from the w:rPrChange (run properties) and w:pPrChange
+        /// (paragraph properties) elements in the document. Both report as
+        /// <see cref="WmlComparerRevisionType.FormatChanged"/>.
         /// </summary>
         private static IEnumerable<WmlComparerRevision> GetFormatChangeRevisions(WordprocessingDocument wDoc)
         {
-            var revisions = new List<WmlComparerRevision>();
-
-            // Get all rPrChange elements from the main document part
-            var mainXDoc = wDoc.MainDocumentPart.GetXDocument();
-            var rPrChanges = mainXDoc.Descendants(W.rPrChange);
-
-            foreach (var rPrChange in rPrChanges)
+            var parts = new[]
             {
-                var revision = new WmlComparerRevision
-                {
-                    RevisionType = WmlComparerRevisionType.FormatChanged,
-                    Author = (string)rPrChange.Attribute(W.author) ?? "",
-                    Date = (string)rPrChange.Attribute(W.date) ?? "",
-                    RevisionXElement = rPrChange,
-                    PartUri = wDoc.MainDocumentPart.Uri,
-                    PartContentType = wDoc.MainDocumentPart.ContentType,
-                    Text = GetTextFromAncestorRun(rPrChange),
-                    FormatChange = ExtractFormatChangeDetails(rPrChange)
-                };
-                revisions.Add(revision);
-            }
+                (OpenXmlPart)wDoc.MainDocumentPart,
+                wDoc.MainDocumentPart.FootnotesPart,
+                wDoc.MainDocumentPart.EndnotesPart,
+            };
 
-            // Get rPrChange elements from footnotes
-            if (wDoc.MainDocumentPart.FootnotesPart != null)
-            {
-                var fnXDoc = wDoc.MainDocumentPart.FootnotesPart.GetXDocument();
-                var fnRPrChanges = fnXDoc.Descendants(W.rPrChange);
-                foreach (var rPrChange in fnRPrChanges)
-                {
-                    var revision = new WmlComparerRevision
+            return parts
+                .Where(part => part != null)
+                .SelectMany(part => part
+                    .GetXDocument()
+                    .Descendants()
+                    .Where(d => d.Name == W.rPrChange || d.Name == W.pPrChange)
+                    .Select(change =>
                     {
-                        RevisionType = WmlComparerRevisionType.FormatChanged,
-                        Author = (string)rPrChange.Attribute(W.author) ?? "",
-                        Date = (string)rPrChange.Attribute(W.date) ?? "",
-                        RevisionXElement = rPrChange,
-                        PartUri = wDoc.MainDocumentPart.FootnotesPart.Uri,
-                        PartContentType = wDoc.MainDocumentPart.FootnotesPart.ContentType,
-                        Text = GetTextFromAncestorRun(rPrChange),
-                        FormatChange = ExtractFormatChangeDetails(rPrChange)
-                    };
-                    revisions.Add(revision);
-                }
-            }
-
-            // Get rPrChange elements from endnotes
-            if (wDoc.MainDocumentPart.EndnotesPart != null)
-            {
-                var enXDoc = wDoc.MainDocumentPart.EndnotesPart.GetXDocument();
-                var enRPrChanges = enXDoc.Descendants(W.rPrChange);
-                foreach (var rPrChange in enRPrChanges)
-                {
-                    var revision = new WmlComparerRevision
-                    {
-                        RevisionType = WmlComparerRevisionType.FormatChanged,
-                        Author = (string)rPrChange.Attribute(W.author) ?? "",
-                        Date = (string)rPrChange.Attribute(W.date) ?? "",
-                        RevisionXElement = rPrChange,
-                        PartUri = wDoc.MainDocumentPart.EndnotesPart.Uri,
-                        PartContentType = wDoc.MainDocumentPart.EndnotesPart.ContentType,
-                        Text = GetTextFromAncestorRun(rPrChange),
-                        FormatChange = ExtractFormatChangeDetails(rPrChange)
-                    };
-                    revisions.Add(revision);
-                }
-            }
-
-            return revisions;
+                        var isParagraph = change.Name == W.pPrChange;
+                        return new WmlComparerRevision
+                        {
+                            RevisionType = WmlComparerRevisionType.FormatChanged,
+                            Author = (string)change.Attribute(W.author) ?? "",
+                            Date = (string)change.Attribute(W.date) ?? "",
+                            RevisionXElement = change,
+                            PartUri = part.Uri,
+                            PartContentType = part.ContentType,
+                            Text = isParagraph
+                                ? GetTextFromAncestorParagraph(change)
+                                : GetTextFromAncestorRun(change),
+                            FormatChange = ExtractFormatChangeDetails(change, isParagraph ? W.pPr : W.rPr),
+                        };
+                    }))
+                .ToList();
         }
 
         /// <summary>
@@ -4426,17 +4424,34 @@ namespace Docxodus
         }
 
         /// <summary>
-        /// Extracts format change details from an rPrChange element.
+        /// Gets the text of the paragraph a pPrChange belongs to. A paragraph-properties change has
+        /// no run of its own, so the paragraph's text is what identifies it to a caller.
         /// </summary>
-        private static FormatChangeDetails ExtractFormatChangeDetails(XElement rPrChange)
+        private static string GetTextFromAncestorParagraph(XElement pPrChange)
         {
-            var oldRPr = rPrChange.Element(W.rPr);
-            var newRPr = rPrChange.Parent; // The parent is w:rPr which contains the new properties
+            var para = pPrChange.Ancestors(W.p).FirstOrDefault();
+            if (para == null)
+                return "";
+
+            return para.Descendants(W.t)
+                .Select(t => t.Value)
+                .StringConcatenate();
+        }
+
+        /// <summary>
+        /// Extracts format change details from an rPrChange or pPrChange element.
+        /// <paramref name="innerName"/> is the properties element the change archives — w:rPr or
+        /// w:pPr — which is also the name of the live element the change hangs off.
+        /// </summary>
+        private static FormatChangeDetails ExtractFormatChangeDetails(XElement change, XName innerName)
+        {
+            var oldProperties = change.Element(innerName);
+            var newProperties = change.Parent; // The parent is the live properties element
 
             var details = new FormatChangeDetails
             {
-                OldProperties = ExtractPropertyDictionary(oldRPr),
-                NewProperties = ExtractPropertyDictionary(newRPr),
+                OldProperties = ExtractPropertyDictionary(oldProperties),
+                NewProperties = ExtractPropertyDictionary(newProperties),
                 ChangedPropertyNames = new List<string>()
             };
 
@@ -4457,22 +4472,30 @@ namespace Docxodus
         }
 
         /// <summary>
-        /// Extracts a dictionary of property names and values from an rPr element.
+        /// Extracts a dictionary of property names and values from a w:rPr or w:pPr element.
         /// </summary>
-        private static Dictionary<string, string> ExtractPropertyDictionary(XElement rPr)
+        private static Dictionary<string, string> ExtractPropertyDictionary(XElement properties)
         {
             var dict = new Dictionary<string, string>();
-            if (rPr == null)
+            if (properties == null)
                 return dict;
 
-            foreach (var elem in rPr.Elements())
+            var paragraphScope = properties.Name == W.pPr;
+
+            foreach (var elem in properties.Elements())
             {
-                // Skip the rPrChange element itself
-                if (elem.Name == W.rPrChange)
+                // Skip the change element itself, and — reading a live w:pPr — the parts a
+                // w:pPrChange cannot describe.
+                if (elem.Name == W.rPrChange || elem.Name == W.pPrChange)
+                    continue;
+                if (paragraphScope && (elem.Name == W.rPr || elem.Name == W.sectPr))
                     continue;
 
-                var propName = GetFriendlyPropertyName(elem.Name);
-                var propValue = GetPropertyValue(elem);
+                // A property with no w:val is compared by its serialized form, so revision-save ids
+                // and this library's bookkeeping attributes have to go first — two identical w:ind
+                // carrying different unids are not a formatting change.
+                var propName = GetFriendlyPropertyName(elem.Name, paragraphScope);
+                var propValue = GetPropertyValue((XElement)CleanPartTransform(elem));
                 dict[propName] = propValue;
             }
 
@@ -4752,12 +4775,12 @@ namespace Docxodus
 
         /// <summary>
         /// Analyzes Equal atoms for formatting differences.
-        /// Converts atoms with different rPr to FormatChanged status.
-        /// Called after move detection but before markup emission.
+        /// Converts atoms with different rPr — or, for a paragraph mark, a different pPr — to
+        /// FormatChanged status. Called after move detection but before markup emission.
         /// </summary>
         private static void DetectFormatChangesInAtomList(List<ComparisonUnitAtom> atoms, WmlComparerSettings settings)
         {
-            if (!settings.DetectFormatChanges)
+            if (!settings.DetectFormatChanges && !settings.DetectParagraphFormatChanges)
                 return;
 
             foreach (var atom in atoms)
@@ -4766,6 +4789,28 @@ namespace Docxodus
                 if (atom.CorrelationStatus != CorrelationStatus.Equal)
                     continue;
                 if (atom.ComparisonUnitAtomBefore == null)
+                    continue;
+
+                if (atom.ContentElement.Name == W.pPr)
+                {
+                    if (!settings.DetectParagraphFormatChanges)
+                        continue;
+
+                    var oldPPr = ReduceToParagraphPropertiesChange(atom.ComparisonUnitAtomBefore.ContentElement);
+                    var newPPr = ReduceToParagraphPropertiesChange(atom.ContentElement);
+
+                    if (!XNode.DeepEquals(oldPPr, newPPr))
+                    {
+                        atom.CorrelationStatus = CorrelationStatus.FormatChanged;
+                        atom.FormatChange = new FormatChangeInfo
+                        {
+                            OldParagraphProperties = oldPPr,
+                        };
+                    }
+                    continue;
+                }
+
+                if (!settings.DetectFormatChanges)
                     continue;
 
                 // Extract rPr from both documents
@@ -4841,6 +4886,68 @@ namespace Docxodus
         }
 
         /// <summary>
+        /// Reduces a <c>w:pPr</c> to the form a <c>w:pPrChange</c> may carry, which is also the form
+        /// the two sides are compared in — so what is compared is exactly what is archived.
+        /// <para>Dropped: <c>w:rPr</c> (the paragraph mark's run properties, tracked separately by
+        /// Word), <c>w:sectPr</c> (excluded from CT_PPrBase; a section change is
+        /// <c>w:sectPrChange</c>), and any pre-existing <c>w:pPrChange</c>.</para>
+        /// <para>Sorted at every level so that the same properties written in a different source
+        /// order compare equal — <see cref="XNode.DeepEquals"/> is order-sensitive, and a
+        /// <c>w:numPr</c> holding <c>w:numId</c> before <c>w:ilvl</c> is the same numbering. The
+        /// sort is not the schema sequence; the writer's element ordering puts the archived
+        /// properties back into it (pinned by PF004b).</para>
+        /// </summary>
+        internal static XElement ReduceToParagraphPropertiesChange(XElement pPr)
+        {
+            if (pPr == null)
+                return new XElement(W.pPr);
+
+            return SortPropertyTree(new XElement(W.pPr,
+                pPr.Elements()
+                   .Where(e => e.Name != W.rPr && e.Name != W.sectPr && e.Name != W.pPrChange)
+                   .Select(e => (XElement)CleanPartTransform(e))));
+        }
+
+        /// <summary>Orders an element's descendants by name. Stable, so repeated siblings such as
+        /// <c>w:tab</c> keep their relative order, which is significant.</summary>
+        private static XElement SortPropertyTree(XElement element) =>
+            new XElement(element.Name,
+                element.Attributes(),
+                element.Elements().OrderBy(e => e.Name.LocalName).Select(SortPropertyTree));
+
+        /// <summary>
+        /// Serializes archived properties for their round trip through a bookkeeping attribute. The
+        /// namespace declaration is written explicitly: without it XLinq emits a bare
+        /// <c>&lt;pPr xmlns="..."&gt;</c> and re-declares the namespace on every child, which
+        /// survives into the produced document.
+        /// </summary>
+        private static string SerializeArchivedProperties(XElement properties)
+        {
+            var copy = new XElement(properties);
+            copy.SetAttributeValue(XNamespace.Xmlns + "w", W.w.NamespaceName);
+            return copy.ToString(SaveOptions.DisableFormatting);
+        }
+
+        /// <summary>
+        /// Reads back what <see cref="SerializeArchivedProperties"/> wrote, dropping the namespace
+        /// declaration it carried so the element inherits the prefix already in scope where it lands.
+        /// Falls back to empty properties rather than failing the comparison.
+        /// </summary>
+        private static XElement ParseArchivedProperties(string xml, XName fallbackName)
+        {
+            try
+            {
+                var parsed = XElement.Parse(xml);
+                parsed.Attributes().Where(a => a.IsNamespaceDeclaration).Remove();
+                return parsed;
+            }
+            catch
+            {
+                return new XElement(fallbackName);
+            }
+        }
+
+        /// <summary>
         /// Returns a list of property names that differ between two rPr elements.
         /// </summary>
         private static List<string> GetChangedPropertyNames(XElement oldRPr, XElement newRPr)
@@ -4885,10 +4992,27 @@ namespace Docxodus
         }
 
         /// <summary>
-        /// Converts OpenXML property names to friendly display names.
+        /// Converts OpenXML property names to friendly display names. A handful of local names mean
+        /// different things in a w:pPr than in a w:rPr, so <paramref name="paragraphScope"/> selects
+        /// the paragraph reading — notably w:spacing, which is character spacing in a run and line
+        /// spacing in a paragraph.
         /// </summary>
-        private static string GetFriendlyPropertyName(XName propName)
+        private static string GetFriendlyPropertyName(XName propName, bool paragraphScope = false)
         {
+            if (paragraphScope)
+            {
+                return propName.LocalName switch
+                {
+                    "jc" => "alignment",
+                    "ind" => "indent",
+                    "spacing" => "paragraphSpacing",
+                    "pStyle" => "style",
+                    "numPr" => "numbering",
+                    "shd" => "shading",
+                    _ => propName.LocalName
+                };
+            }
+
             return propName.LocalName switch
             {
                 "b" => "bold",
@@ -6036,10 +6160,18 @@ namespace Docxodus
                                         else if (spl[1] == "FormatChanged")
                                         {
                                             dup.Add(new XAttribute(PtOpenXml.Status, "FormatChanged"));
-                                            if (gcc.FormatChange?.OldRunProperties != null)
+                                            if (gcc.ContentElement.Name == W.pPr)
+                                            {
+                                                if (gcc.FormatChange?.OldParagraphProperties != null)
+                                                {
+                                                    dup.Add(new XAttribute(PtOpenXml.pt + "OldPPr",
+                                                        SerializeArchivedProperties(gcc.FormatChange.OldParagraphProperties)));
+                                                }
+                                            }
+                                            else if (gcc.FormatChange?.OldRunProperties != null)
                                             {
                                                 dup.Add(new XAttribute(PtOpenXml.pt + "OldRPr",
-                                                    gcc.FormatChange.OldRunProperties.ToString(SaveOptions.DisableFormatting)));
+                                                    SerializeArchivedProperties(gcc.FormatChange.OldRunProperties)));
                                             }
                                         }
                                         return dup;
@@ -6097,7 +6229,7 @@ namespace Docxodus
                                             if (gcc.FormatChange?.OldRunProperties != null)
                                             {
                                                 dup.Add(new XAttribute(PtOpenXml.pt + "OldRPr",
-                                                    gcc.FormatChange.OldRunProperties.ToString(SaveOptions.DisableFormatting)));
+                                                    SerializeArchivedProperties(gcc.FormatChange.OldRunProperties)));
                                             }
                                         }
                                         return dup;
@@ -6173,7 +6305,7 @@ namespace Docxodus
                                     if (firstAtom.FormatChange?.OldRunProperties != null)
                                     {
                                         elem.Add(new XAttribute(PtOpenXml.pt + "OldRPr",
-                                            firstAtom.FormatChange.OldRunProperties.ToString(SaveOptions.DisableFormatting)));
+                                            SerializeArchivedProperties(firstAtom.FormatChange.OldRunProperties)));
                                     }
                                     return (object)elem;
                                 }

--- a/docs/architecture/format_change_detection.md
+++ b/docs/architecture/format_change_detection.md
@@ -2,7 +2,11 @@
 
 > **Status: IMPLEMENTED** (November 2025)
 >
-> **Scope note.** This document describes format-change detection in the **`WmlComparer`** engine, where it is run-level only (`w:rPrChange`). The IR diff engine (`DocxDiff`) tracks the full **block-format-change family** — `w:pPrChange`/`w:tcPrChange`/`w:trPrChange`/`w:tblPrChange`/`w:tblGridChange`/`w:sectPrChange` in addition to `w:rPrChange` — see the "Paragraph-and-above formatting changes" section of [`ir_diff_engine.md`](ir_diff_engine.md). The paragraph/section/table extension sketched at the end of this document was NOT implemented in `WmlComparer`; it was implemented in `DocxDiff` instead.
+> **Scope note.** This document describes run-level format-change detection (`w:rPrChange`, `DetectFormatChanges`, default true) in the **`WmlComparer`** engine.
+>
+> `WmlComparer` now also tracks **paragraph** properties as `w:pPrChange` via `DetectParagraphFormatChanges` (default **false**) — alignment, indent, spacing, style and list membership. That pass mirrors the algorithm below on the paragraph mark; see the "Paragraph properties" section of [`wml_comparer_gaps.md`](wml_comparer_gaps.md) for its mechanics and limits. The table/section part of the extension sketched at the end of this document remains unimplemented in `WmlComparer`.
+>
+> The IR diff engine (`DocxDiff`) tracks the full **block-format-change family** — `w:pPrChange`/`w:tcPrChange`/`w:trPrChange`/`w:tblPrChange`/`w:tblGridChange`/`w:sectPrChange` in addition to `w:rPrChange` — see the "Paragraph-and-above formatting changes" section of [`ir_diff_engine.md`](ir_diff_engine.md).
 
 ## Overview
 

--- a/docs/architecture/wml_comparer_gaps.md
+++ b/docs/architecture/wml_comparer_gaps.md
@@ -65,18 +65,62 @@ The implementation uses word-level Jaccard similarity to match deletions with in
 
 **Status (corrected, v6.x):** Implemented. Earlier revisions called this a gap; **that is stale.** `WmlComparer` exposes a `FormatChanged` revision type with `DetectFormatChanges` (default true): when text is identical but modeled run formatting differs, it produces native `w:rPrChange` markup and `GetRevisions()` returns a `FormatChanged` revision whose `FormatChange` carries old/new properties and changed names (see CLAUDE.md "WmlComparer.cs" and `docs/architecture/format_change_detection.md`). The new `DocxDiff` IR engine surfaces the same via `DocxDiffRevisionType.FormatChanged` + `DocxDiffFormatChange`, with a `FormatComparison` (ModeledOnly | Full) policy ([`ir_diff_engine.md`](./ir_diff_engine.md)).
 
-The original (now-closed) description follows for history. Word documents can track formatting changes via:
-- `w:rPrChange` - Run property changes (font, size, bold, etc.)
-- `w:pPrChange` - Paragraph property changes (alignment, spacing, etc.)
-- `w:sectPrChange` - Section property changes
-- `w:tblPrChange` - Table property changes
+Word documents can track formatting changes via:
 
-### Recommendation
+| Markup | Scope | WmlComparer |
+|--------|-------|-------------|
+| `w:rPrChange` | run properties | ✅ `DetectFormatChanges` (default **true**) |
+| `w:pPrChange` | paragraph properties — alignment, indent, spacing, style, numbering | ✅ `DetectParagraphFormatChanges` (default **false**) |
+| `w:sectPrChange` | section properties | ✗ |
+| `w:tblPrChange` | table properties | ✗ |
 
-Add a `FormatChange` revision type that captures:
-- The element affected
-- The old formatting properties
-- The new formatting properties
+### 3a. Paragraph properties ✅ IMPLEMENTED
+
+`WmlComparerSettings.DetectParagraphFormatChanges` extends the run-level pass to the paragraph mark.
+Off by default: enabling it changes the output of comparisons that produce no revision today.
+
+Why it is worth having on: without it a paragraph-format-only change is *silently lossy*. The
+paragraph mark hashes as `"pPr"` regardless of its contents (the hash is element name + text value,
+and every `w:pPr` child is attribute-only), so such a paragraph correlates as Equal and the result
+is rebuilt from the RIGHT side. The revised formatting is therefore already applied to the output,
+the original's is discarded, and nothing is reported — so reject cannot put it back.
+
+Mechanics, mirroring the run-level pass exactly:
+
+- `DetectFormatChangesInAtomList` branches on a `w:pPr` atom and compares the two sides through
+  `ReduceToParagraphPropertiesChange`, which also produces the archived copy — what is compared is
+  precisely what is stored.
+- The reduction drops what a `w:pPrChange` may not carry: its inner `w:pPr` is a **CT_PPrBase**, so
+  `w:rPr` (the mark's own run properties, which Word tracks separately) and `w:sectPr` are excluded,
+  along with any pre-existing `w:pPrChange`. Revision-save ids and `pt14:` bookkeeping are stripped
+  at every level, so they can neither cause a false positive nor leak into the archive.
+- The reduction sorts properties at every level, so the same properties written in a different
+  source order — including a `w:numPr` holding `w:numId` before `w:ilvl` — do not read as a change;
+  `XNode.DeepEquals` is order-sensitive. That sort is not the schema sequence, but the writer's
+  element ordering restores it in the emitted archive (pinned by `PF004b`).
+- Accept/reject needed no new code — `RevisionProcessor` already handles `w:pPrChange`, including
+  carrying an inline `w:sectPr` across a reject.
+
+**Lists come free.** `w:numPr` is an ordinary `w:pPr` child, so list membership, level and format
+changes are tracked by the same path. Renumbering caused by editing `numbering.xml` — changing what
+a `numId` *means* rather than which one a paragraph points at — is not a `w:pPr` change and is not
+tracked. Word does not track that either.
+
+Known limits:
+
+- The paragraph mark's own run properties (`w:pPr/w:rPr`) are not tracked, and neither is a section
+  change.
+- **Body scope only.** No formatting change inside a footnote or endnote is detected — and this is
+  pre-existing, not a property of the new option: the run-level pass misses note-scope `w:rPr`
+  changes in exactly the same way, while a *text* change in the same note is detected normally, so
+  notes are compared and it is the format passes that do not reach them. `GetFormatChangeRevisions`
+  scans the note parts, so the reporting side is ready if detection is ever extended. Pinned by
+  `PF022`, which fails if that changes.
+- WmlComparer discards a mid-document inline `w:sectPr` altogether — again pre-existing and
+  unrelated to this option, and the reason the CT_PPrBase exclusion is covered by a direct unit test
+  rather than through `Compare`.
+
+Coverage: `WmlComparerParagraphFormatTests`. CLI: `redline --detect-paragraph-format-changes`.
 
 ## 4. Revision Metadata Limitations
 

--- a/tools/redline/Program.cs
+++ b/tools/redline/Program.cs
@@ -140,6 +140,10 @@ class Program
             {
                 settings.DetectFormatChanges = false;
             }
+            else if (flag == "--detect-paragraph-format-changes")
+            {
+                settings.DetectParagraphFormatChanges = true;
+            }
             else if (flag == "--no-conflate-spaces")
             {
                 settings.ConflateBreakingAndNonbreakingSpaces = false;
@@ -224,7 +228,8 @@ class Program
         Console.WriteLine("  --simplify-move-markup             Convert moves to del/ins for Word compatibility");
         Console.WriteLine("  --move-similarity-threshold=<val>  Jaccard threshold for move matching (default: 0.8)");
         Console.WriteLine("  --move-minimum-word-count=<val>    Min words for move detection (default: 3)");
-        Console.WriteLine("  --no-detect-format-changes         Disable formatting change detection");
+        Console.WriteLine("  --no-detect-format-changes         Disable run formatting change detection");
+        Console.WriteLine("  --detect-paragraph-format-changes  Track paragraph formatting and list changes (wmlcomparer only)");
         Console.WriteLine("  --no-conflate-spaces               Distinguish breaking/non-breaking spaces");
         Console.WriteLine("  --date-time=<ISO8601>              Custom timestamp for revisions");
         Console.WriteLine("  -h, --help                         Show this help message");


### PR DESCRIPTION
`WmlComparerSettings.DetectParagraphFormatChanges` (default **false**) tracks alignment, indentation, spacing, paragraph style and list membership as native `w:pPrChange` markup, mirroring the existing run-level pass that emits `w:rPrChange`.

### Why

A paragraph-format-only change is currently *silently lossy*, not merely untracked.

A paragraph mark hashes as its element name plus its text value, and every `w:pPr` child is attribute-only. So a paragraph whose formatting alone changed hashes identically on both sides, correlates as `Equal`, and is rebuilt from the **right** document. The revised formatting is therefore already applied to the result and the original's discarded, with nothing reported — leaving `reject` unable to restore it.

### How

`ReduceToParagraphPropertiesChange` produces both the comparison key and the archived copy, so what is compared is exactly what is stored. It excludes what a `w:pPrChange` may not carry — its inner `w:pPr` is a `CT_PPrBase`, so the mark's own `w:rPr` and an inline `w:sectPr` are dropped — and strips revision-save ids and internal bookkeeping at every level, so they neither trip a false positive nor leak into the archive.

Accept and reject needed no new code: `RevisionProcessor` already handles `w:pPrChange`.

Lists ride the same path for free (`w:numPr` is an ordinary `w:pPr` child). Renumbering caused by editing `numbering.xml` is not a `w:pPr` change and is not tracked — Word does not track that either.

### A crash fixed in passing

Adding the emission branch also closed a crash reachable **without** this option, under default settings.

Run-level detection can stamp `FormatChanged` on a paragraph mark inside a text box: a paragraph there hangs off the run carrying the drawing, so unlike an ordinary paragraph mark it has a run ancestor, whose properties the run pass reads. The paragraph-properties transform had no branch for that status and threw `Internal error - unknown status: FormatChanged` on text-box documents.

### Two pre-existing defects on the default-on run path

Both affect `w:rPrChange` today and are fixed here because the paragraph path shares the code:

- Archived properties round-trip through an internal attribute. Without an explicit namespace declaration XLinq wrote them as a default-namespace `<rPr xmlns="…">` that re-declared the namespace on every child — and that survived into the produced document. Only visible when the old `w:rPr` was non-empty.
- A property with no `w:val` is compared by its serialized form when reporting changed property names, so an untouched `w:rFonts` counted as changed whenever the two copies carried different internal ids.

### Scope and limits

- **Default off**, because enabling it changes the output of comparisons that produce no revision today.
- `GetRevisions()` reports these as `FormatChanged` alongside run changes, carrying the paragraph's text. The revision type enum is unchanged. Reporting is deliberately *not* gated by the setting — a document that already contains a `w:pPrChange` is reported either way, exactly as `w:rPrChange` already was; that is what keeps a document produced with the option from going silent when read back with defaults.
- Body scope only: no formatting change inside a footnote or endnote is detected. This is pre-existing and shared exactly with the run-level pass — a *text* change in the same note is detected, so notes are compared and it is the format passes that miss them. Pinned by `PF022`, which fails if that ever changes.
- The paragraph mark's own run properties (`w:pPr/w:rPr`) and section changes remain out of scope.
- CLI: `redline --detect-paragraph-format-changes`.

### Tests

`WmlComparerParagraphFormatTests` — 25 tests covering detection (alignment, indent/spacing, style, list add/remove/level/format), accept and reject round-tripping the properties, `GetRevisions` reporting, independence from `DetectFormatChanges`, and the schema validity of every output.

The false-positive guards carry more weight than the positive cases and are the reason several of them exist: identical documents, revision-save-id-only differences, the same properties in a different source order (at both levels), and a section-only difference must each produce **zero** revisions.

One run-level test was added to `WmlComparerFormatChangeTests` for the changed-property-name fix, since that path is on by default.
