### PR TITLE
Fix edited moves leaving replaced text after Reject All

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ All notable changes to this project will be documented in this file.
   the CRUD rules are documented in `docs/architecture/docx_mutation_api.md`.
 
 ### Fixed
+- **`DocxDiff` edited moves no longer leave replaced text behind after Reject All in Word-compatible
+  consumers (issue #359).** `MoveModifyBlock` destinations were fragmented into `w:moveTo` spans around
+  nested `w:ins`/`w:del` edits. Docxodus's own revision processor accepted and rejected that shape, but
+  Word-class consumers treat the nested revisions independently: rejecting the move restored its nested
+  deletion at the destination, stranding the old word after the source paragraph was restored. Produced
+  OOXML now represents an edited move as one complete left `w:moveFrom` and one complete right `w:moveTo`,
+  so the destination is accepted or rejected atomically. The edit script and revisions APIs still expose
+  the `MoveModifyBlock` token-level change; `RenderMoves=false` and `SimplifyMoveMarkup` retain their
+  deliberate whole-block delete/insert projections.
 - **Table row/column CRUD is now grid-aware instead of cell-index-aware.** `InsertTableRow`,
   `InsertTableColumn`, `DeleteTableColumn` and `SetColumnWidths` addressed cells by their position
   in `w:tr`, which silently corrupted any table containing a merge. They now resolve cells through

--- a/Docxodus.Tests/Ir/Diff/IrMarkupRendererTests.cs
+++ b/Docxodus.Tests/Ir/Diff/IrMarkupRendererTests.cs
@@ -1294,11 +1294,11 @@ public class IrMarkupRendererTests
     }
 
     [Fact]
-    public void Render_move_and_edit_nests_ins_del_inside_moveTo_and_round_trips()
+    public void Render_move_and_edit_uses_complete_atomic_move_pair_and_round_trips()
     {
-        // Paragraph A is relocated AND edited (one word changed): a MoveModify. The destination moveTo range
-        // must carry nested ins/del for the in-move edit, and RevisionProcessor (the oracle) must accept it to
-        // the right and reject it to the left.
+        // Paragraph A is relocated AND edited (one word changed): a MoveModify. Keep its rich token diff in the
+        // data surface, but encode the document as complete old/new move halves. Word and LibreOffice process
+        // ordinary ins/del nested in a moveTo range independently; on Reject All that strands the nested del.
         var left = MoveDoc(
             "This is paragraph A with enough words for move detection here.",
             "This is paragraph B with sufficient content to anchor it firmly.");
@@ -1311,22 +1311,27 @@ public class IrMarkupRendererTests
         using var ms = new MemoryStream(rendered.DocumentByteArray);
         using var wd = WordprocessingDocument.Open(ms, false);
         var body = wd.MainDocumentPart!.GetXDocument().Root!.Element(W.body)!;
-        // The destination's move range contains the relocated unchanged spans plus the separate in-move edit
-        // revisions.  A plain right-side moveTo clone would accept/reject correctly but hide this edit.
+        var source = Assert.Single(body.Elements(W.p),
+            p => p.Descendants(W.moveFromRangeStart).Any());
         var destination = Assert.Single(body.Elements(W.p),
             p => p.Descendants(W.moveToRangeStart).Any());
         Assert.NotEmpty(destination.Descendants(W.moveTo));
-        Assert.NotEmpty(destination.Descendants(W.ins));
-        Assert.NotEmpty(destination.Descendants(W.del));
+        Assert.DoesNotContain(destination.Descendants(W.ins), e => !e.Ancestors(W.pPr).Any());
+        Assert.DoesNotContain(destination.Descendants(W.del), e => !e.Ancestors(W.pPr).Any());
+        Assert.Equal("This is paragraph A with enough words for move detection here.",
+            string.Concat(source.Descendants(W.moveFrom).Descendants()
+                .Where(e => e.Name == W.t || e.Name == W.delText).Select(e => (string?)e)));
+        Assert.Equal("This is paragraph A with PLENTY words for move detection here.",
+            string.Concat(destination.Descendants(W.moveTo).Descendants(W.t).Select(t => (string?)t)));
         AssertRoundTrip(left, right, settings, label: "move-modify");
     }
 
     [Fact]
-    public void Render_moved_format_change_is_tracked_at_destination()
+    public void Render_moved_format_change_is_preserved_by_complete_move_halves()
     {
-        // Exact text relocation with a bold change is a MoveModify: its destination must carry both the native
-        // move wrapper and the old run formatting. Without that projection, reviewers see only a move and reject
-        // cannot reconstruct the left formatting.
+        // Exact text relocation with a bold change is a MoveModify. The source and destination move halves
+        // already carry the complete old and new formatting, so no independently-rejectable nested format
+        // revision is needed to reconstruct either side.
         const string anchor = "Anchor paragraph holds the document spine steady.";
         const string moved = "Moved paragraph contains enough distinct words for move detection today.";
         const string trailing = "Trailing paragraph also has enough words to stabilize matching.";
@@ -1353,11 +1358,14 @@ public class IrMarkupRendererTests
         using var ms = new MemoryStream(rendered.DocumentByteArray);
         using var wd = WordprocessingDocument.Open(ms, false);
         var body = wd.MainDocumentPart!.GetXDocument().Root!.Element(W.body)!;
+        var source = Assert.Single(body.Elements(W.p),
+            p => p.Descendants(W.moveFromRangeStart).Any());
         var destination = Assert.Single(body.Elements(W.p),
             p => p.Descendants(W.moveToRangeStart).Any());
         Assert.NotEmpty(destination.Descendants(W.moveTo));
-        var oldRunFormat = Assert.Single(destination.Descendants(W.rPrChange));
-        Assert.Null(oldRunFormat.Element(W.rPr)!.Element(W.b));
+        Assert.Empty(destination.Descendants(W.rPrChange));
+        Assert.Empty(source.Descendants(W.b));
+        Assert.NotEmpty(destination.Descendants(W.b));
         AssertRoundTrip(left, right, settings, label: "move-format");
     }
 
@@ -1402,6 +1410,55 @@ public class IrMarkupRendererTests
         Assert.Empty(body.Descendants(W.moveTo));
         Assert.True(body.Descendants(W.ins).Any() || body.Descendants(W.del).Any(), "demoted move must use ins/del");
         AssertRoundTrip(left, right, settings, label: "move-demoted");
+    }
+
+    [Fact]
+    public void Render_issue_359_move_and_edit_keeps_the_destination_atomic()
+    {
+        const string movedLeft =
+            "The governing law of this Agreement is the law of Delaware without regard to conflicts principles.";
+        const string movedRight =
+            "The governing law of this Agreement is the law of California without regard to conflicts principles.";
+        var left = MoveDoc(
+            "Introduction paragraph with some length to it.",
+            movedLeft,
+            "Payment terms are net thirty days from invoice.",
+            "Closing paragraph with final remarks.");
+        var right = MoveDoc(
+            "Introduction paragraph with some length to it.",
+            "Payment terms are net thirty days from invoice.",
+            "Closing paragraph with final remarks.",
+            movedRight);
+        var settings = new IrDiffSettings();
+
+        var script = IrEditScriptBuilder.Build(IrReader.Read(left), IrReader.Read(right), settings);
+        Assert.Equal(2, script.Operations.Count(op => op.Kind == IrEditOpKind.MoveModifyBlock));
+
+        // Exercise the public facade as reported, including its package-normalization/backfill passes.
+        var rendered = DocxDiff.Compare(left, right);
+        var revisions = DocxDiff.GetRevisions(left, right);
+        Assert.Equal(2, revisions.Count(revision => revision.Type == DocxDiffRevisionType.Moved));
+        Assert.Contains(revisions,
+            revision => revision.Type == DocxDiffRevisionType.Inserted && revision.Text.Contains("California"));
+        Assert.Contains(revisions,
+            revision => revision.Type == DocxDiffRevisionType.Deleted && revision.Text.Contains("Delaware"));
+        Assert.Equal(0, SchemaErrorCount(rendered));
+
+        using var ms = new MemoryStream(rendered.DocumentByteArray);
+        using var wd = WordprocessingDocument.Open(ms, false);
+        var body = wd.MainDocumentPart!.GetXDocument().Root!.Element(W.body)!;
+        var source = Assert.Single(body.Elements(W.p),
+            p => p.Descendants(W.moveFromRangeStart).Any());
+        var destination = Assert.Single(body.Elements(W.p),
+            p => p.Descendants(W.moveToRangeStart).Any());
+        Assert.DoesNotContain(destination.Descendants(W.ins), e => !e.Ancestors(W.pPr).Any());
+        Assert.DoesNotContain(destination.Descendants(W.del), e => !e.Ancestors(W.pPr).Any());
+        Assert.Equal(movedLeft,
+            string.Concat(source.Descendants(W.moveFrom).Descendants()
+                .Where(e => e.Name == W.t || e.Name == W.delText).Select(e => (string?)e)));
+        Assert.Equal(movedRight,
+            string.Concat(destination.Descendants(W.moveTo).Descendants(W.t).Select(t => (string?)t)));
+        AssertRoundTrip(left, right, settings, label: "issue-359");
     }
 
     [Fact]

--- a/Docxodus/Ir/Diff/IrMarkupRenderer.cs
+++ b/Docxodus/Ir/Diff/IrMarkupRenderer.cs
@@ -771,21 +771,7 @@ internal static class IrMarkupRenderer
     internal static void RenderBlockOpsWordShaped(
         IEnumerable<IrEditOp> ops, RenderState state, List<XElement> sink)
     {
-        // A MoveModify destination deliberately owns only its RIGHT anchor: its paired LEFT anchor lives on
-        // the separately emitted source op.  Resolve that pairing for THIS operation list before rendering.
-        // Scoping matters because note/header/cell projections allocate move-group ids locally; a nested cell
-        // render must not replace the body scope's source lookup once it returns.
         var opList = ops as IReadOnlyList<IrEditOp> ?? ops.ToList();
-        var previousMoveSources = state.ActiveMoveSourceAnchors;
-        var moveSources = new Dictionary<int, string>();
-        foreach (var candidate in opList)
-            if (candidate.IsMoveSource == true && candidate.MoveGroupId is { } groupId &&
-                candidate.LeftAnchor is { } leftAnchor)
-                moveSources[groupId] = leftAnchor;
-        state.ActiveMoveSourceAnchors = moveSources;
-
-        try
-        {
         var pendingInserts = new List<IrEditOp>();
         var pendingDeletes = new List<IrEditOp>();
 
@@ -825,11 +811,6 @@ internal static class IrMarkupRenderer
             RenderBlockOp(op, state, sink);
         }
         FlushGap(storyEnd: true);
-        }
-        finally
-        {
-            state.ActiveMoveSourceAnchors = previousMoveSources;
-        }
     }
 
     /// <summary>One gap op's rendered elements plus the facts the arrangement grammar keys on.</summary>
@@ -1255,9 +1236,12 @@ internal static class IrMarkupRenderer
                 // When move rendering is OFF (the DetectMoves=false analogue), a move is projected as a plain
                 // delete-here + insert-there pair: the SOURCE op (left anchor) emits a whole-block del, the
                 // DESTINATION op (right anchor) a whole-block ins. With move rendering ON, emit NATIVE move
-                // markup: source → moveFromRange + w:moveFrom; destination → moveToRange + w:moveTo (a
-                // MoveModify destination nests ins/del inside the moveTo for the in-move edits). Both halves
-                // share a deterministic w:name keyed by MoveGroupId.
+                // markup: source → moveFromRange + w:moveFrom; destination → moveToRange + w:moveTo.
+                // A MoveModify uses the COMPLETE left and right paragraphs for those halves. Its token diff
+                // remains available through the edit-script and revisions surfaces, but fragmenting the moveTo
+                // around nested ins/del is not interoperable: office consumers reject those nested revisions
+                // independently and can leave deleted destination text behind (issue #359). Both halves share
+                // a deterministic w:name keyed by MoveGroupId.
                 if (!state.Settings.RenderMoves)
                 {
                     if (op.IsMoveSource == true)
@@ -3930,12 +3914,12 @@ internal static class IrMarkupRenderer
     }
 
     /// <summary>
-    /// Emit the DESTINATION half of a move: the RIGHT paragraph bracketed by <c>w:moveToRangeStart</c>/
-    /// <c>w:moveToRangeEnd</c> with content wrapped in <c>w:moveTo</c> and the paragraph mark marked inserted.
-    /// A plain <see cref="IrEditOpKind.MoveBlock"/> wraps every run in <c>w:moveTo</c>; a
-    /// <see cref="IrEditOpKind.MoveModifyBlock"/> (the destination carries a token diff) renders the in-move
-    /// edits as NESTED <c>w:ins</c>/<c>w:del</c> inside the moveTo range — moved-and-unchanged text in
-    /// <c>w:moveTo</c>, newly-inserted text in <c>w:ins</c>, removed text in <c>w:del</c>.
+    /// Emit the DESTINATION half of a move: the complete RIGHT paragraph bracketed by
+    /// <c>w:moveToRangeStart</c>/<c>w:moveToRangeEnd</c>, with every run wrapped in <c>w:moveTo</c> and the
+    /// paragraph mark marked moved-to. This atomic shape is required for both <see cref="IrEditOpKind.MoveBlock"/>
+    /// and <see cref="IrEditOpKind.MoveModifyBlock"/>. The latter's token diff remains part of the edit-script and
+    /// revisions surfaces; nesting ordinary <c>w:ins</c>/<c>w:del</c> inside the destination move range makes
+    /// office consumers reject the nested changes separately and can strand old text at the destination.
     /// </summary>
     private static void EmitMoveDestination(IrEditOp op, RenderState state, List<XElement> sink)
     {
@@ -3946,66 +3930,12 @@ internal static class IrMarkupRenderer
             return;
         }
         string moveName = state.MoveName(gid);
-        string? leftAnchor = state.MoveSourceAnchor(gid);
-        var leftMovedPara = SourceElement(leftAnchor, state.Left);
-
-        if (!op.RequiresWholeParagraphReplace &&
-            op.Kind == IrEditOpKind.MoveModifyBlock && op.TokenDiff is { } tokenDiff &&
-            op.TextboxDiffs is null && leftMovedPara?.Name == W.p && leftAnchor is not null)
-        {
-            // Build the destination paragraph from the token diff, like RenderModifiedParagraph, but with the
-            // moved-and-equal spans wrapped in w:moveTo (instead of left unwrapped) so the whole relocated
-            // content vanishes on reject and appears on accept. Insert spans → w:ins, Delete spans → w:del.
-            var para = BuildMoveModifyDestination(op, tokenDiff, leftAnchor, state);
-            if (para != null)
-            {
-                MarkParagraphMark(para, RevKind.MoveTo, state);
-                BracketParagraphWithMoveRange(para, isFrom: false, moveName, state);
-                sink.Add(para);
-                return;
-            }
-        }
 
         var dest = StripUnids(new XElement(src));
         state.RegisterMediaReferences(dest);
-        // A moved paragraph whose pPr also changed tracks the property change at the DESTINATION
-        // (Word's own shape: moveTo content + pPrChange). Source/reject keeps the left paragraph verbatim.
-        if (leftMovedPara?.Name == W.p)
-            ApplyBlockFormatChanges(dest, leftMovedPara, src, state);
         MarkWholeParagraphAs(dest, RevKind.MoveTo, state);
         BracketParagraphWithMoveRange(dest, isFrom: false, moveName, state);
         sink.Add(dest);
-    }
-
-    /// <summary>Build a MoveModify destination paragraph from its token diff: Equal/FormatChanged spans →
-    /// <c>w:moveTo</c> (moved-and-unchanged), Insert spans → <c>w:ins</c>, Delete spans → <c>w:del</c>. Returns
-    /// null if the source elements are unexpectedly missing (caller falls back to a plain whole-paragraph
-    /// moveTo).</summary>
-    private static XElement? BuildMoveModifyDestination(
-        IrEditOp op, IrTokenDiff tokenDiff, string leftAnchor, RenderState state)
-    {
-        var leftPara = SourceElement(leftAnchor, state.Left);
-        var rightPara = SourceElement(op.RightAnchor, state.RightSource);
-        if (leftPara == null || rightPara == null)
-            return null;
-
-        var leftRuns = new SourceRunModel(leftPara);
-        var rightRuns = new SourceRunModel(rightPara);
-        var leftTokens = ParagraphTokens(leftAnchor, state.Left, state.Settings);
-        var rightTokens = ParagraphTokens(op.RightAnchor, state.RightSource, state.Settings);
-
-        var newPara = new XElement(W.p);
-        var rightPPr = rightPara.Element(W.pPr);
-        if (rightPPr != null)
-            newPara.Add(StripUnids(new XElement(rightPPr)));
-        ApplyBlockFormatChanges(newPara, leftPara, rightPara, state);
-
-        // The regular fine renderer already knows how to produce both FormatChanged rPrChange markers and
-        // the field-safe insert/delete projection. Its optional stable-span wrapper gives this move destination
-        // the one additional shape it needs: unchanged and format-changed right spans live in w:moveTo.
-        newPara.Add(BuildTokenOpContent(tokenDiff, leftTokens, rightTokens, leftRuns, rightRuns, state,
-            stableSpanKind: RevKind.MoveTo));
-        return newPara;
     }
 
     /// <summary>Wrap every run-level child of a paragraph in the given move/revision kind (like
@@ -5105,21 +5035,14 @@ internal static class IrMarkupRenderer
     private static List<XElement> BuildTokenOpContent(
         IrTokenDiff tokenDiff,
         IReadOnlyList<IrDiffToken> leftTokens, IReadOnlyList<IrDiffToken> rightTokens,
-        SourceRunModel leftRuns, SourceRunModel rightRuns, RenderState state,
-        RevKind? stableSpanKind = null)
+        SourceRunModel leftRuns, SourceRunModel rightRuns, RenderState state)
     {
         var content = new List<XElement>();
 
-        // Fine paragraph changes normally leave equal/format-changed spans bare. A MoveModify destination
-        // supplies MoveTo here instead: the spans still receive their ordinary rPrChange history first, then
-        // the resulting run-level element is wrapped as relocated content.
         void AddStableSpan(XElement runLevel)
         {
             state.RegisterMediaReferences(runLevel);
-            if (stableSpanKind is { } kind)
-                content.AddRange(WrapFieldAware(runLevel, kind, state));
-            else
-                content.Add(runLevel);
+            content.Add(runLevel);
         }
 
         foreach (var tokenOp in CoalesceTokenOpsWordShaped(
@@ -8087,16 +8010,6 @@ internal static class IrMarkupRenderer
         public IrDocument Left { get; }
         public IrDocument Right { get; }
         public IrDiffSettings Settings { get; }
-
-        /// <summary>LEFT source anchor by move-group id for the operation list currently being rendered.
-        /// Move destinations intentionally carry only their RIGHT anchor; nested render scopes replace this
-        /// map temporarily because cell, note, and header projections each use local move-group ids.</summary>
-        public IReadOnlyDictionary<int, string> ActiveMoveSourceAnchors { get; set; } =
-            new Dictionary<int, string>();
-
-        /// <summary>Resolve the LEFT source anchor for the active move-group scope, if present.</summary>
-        public string? MoveSourceAnchor(int moveGroupId) =>
-            ActiveMoveSourceAnchors.TryGetValue(moveGroupId, out var anchor) ? anchor : null;
 
         /// <summary>The document the CURRENTLY-emitting op draws inserted/modified ("right-side") block elements
         /// and token text from. In a two-way render this is always <see cref="Right"/> (set once in the ctor and

--- a/docs/architecture/ir_diff_engine.md
+++ b/docs/architecture/ir_diff_engine.md
@@ -93,6 +93,15 @@ The `IrEditScript` is an ordered list of block operations (`IrEditOpKind`), plus
 | `SplitBlock` | One left paragraph split across N≥2 right paragraphs (M2.6) | left + `splitMergeAnchors` (the N rights) |
 | `MergeBlock` | N≥2 left paragraphs fused into one right paragraph (M2.6) | right + `splitMergeAnchors` (the N lefts) |
 
+**Edited-move markup boundary.** A `MoveModifyBlock` remains rich in the edit-script and revisions
+surfaces: its destination carries the token diff describing the edit within the relocation. Produced
+OOXML deliberately does not nest that token diff inside the move range. It emits the complete left
+paragraph as `w:moveFrom` and the complete right paragraph as `w:moveTo`, paired by `w:name`. Word-class
+consumers process ordinary `w:ins`/`w:del` nested among destination `w:moveTo` fragments as independent
+revisions; Reject All can therefore restore a nested deletion after rejecting the destination move and
+leave an orphaned old word. Complete move halves make accept/reject atomic while preserving the detailed
+change in the non-markup APIs (issue #359).
+
 **Footnote/endnote structural fidelity.** The `noteOps` carry per-note block diffs that the markup renderer applies *inside* the produced footnotes/endnotes part, after which `IrMarkupRenderer.RenumberNoteIds` re-sequences every reference + definition into body-reference document order (mirroring `WmlComparer`'s `ChangeFootnoteEndnoteReferencesToUniqueRange`). The invariants this path guarantees — verified by `DocxDiffScenarioTests.Scenario_PreservesFootnoteStructure` (every edit×feature scenario) and `DocxDiffFootnoteRobustnessTests`, with a headless-LibreOffice load backstop:
 - **Definition ids are unique** and every body reference resolves to exactly one definition. A `continuationNotice` (or any typed) reserved note at a *positive* id keeps its id and leads the part; real notes renumber to a range disjoint from the kept reserved ids (the counter seeds above the highest positive reserved id), so a reserved note never collides with a renumbered real note.
 - **A reference is never dropped.** A footnote/endnote reference is a zero-width inline; the token-diff run rebuilder (`SourceRunModel.Slice`) attributes a boundary zero-width to exactly the op whose token range owns it (`ZeroWidthBoundaries`), so a reference at the tail of an edited paragraph survives and is never double-counted.


### PR DESCRIPTION
## Summary

- serialize edited moves as one complete `w:moveFrom` source and one complete `w:moveTo` destination
- keep the `MoveModifyBlock` token diff in the edit-script and revisions APIs
- remove the segmented move-destination renderer and its source-anchor state
- add exact issue-359 regression coverage, architecture guidance, and changelog notes

Closes #359.

## Root cause

Commit `9378da0` activated a move-destination renderer that split edited destination paragraphs into `w:moveTo` spans around ordinary `w:ins`/`w:del` revisions. Docxodus's own revision processor treated that shape as reversible, but Word-compatible consumers process the nested revisions independently. Reject All therefore restored the deleted destination token after rejecting the move, leaving the old word behind.

The produced OOXML now makes the destination atomic. Detailed edit information remains available from the non-markup APIs.

## Validation

- reproduced the reported orphaned `Delaware` using the exact issue attachments in headless LibreOffice
- before fix: LibreOffice recognized 6 revisions and Reject All left the orphan
- after fix: LibreOffice recognizes 3 revisions, matching the pre-regression parent
- LibreOffice Reject All restores the original Delaware document with zero revisions
- LibreOffice Accept All produces the revised California document with zero revisions
- public `DocxDiff.Compare` regression is schema-valid and preserves public move/insert/delete revision data
- `IrMarkupRendererTests`: 61/61 passed
- related parity, revision, composite, and fuzz suites: 62/62 passed
- Release solution build: 0 errors
- full test run: 3402 passed, 3 skipped; one unrelated byte-equality concurrency test failed in-suite and passed immediately in isolation
