### PR TITLE
fix(editor): show what is being dragged and where it will drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to this project will be documented in this file.
     block follows the cursor (replacing the browser's ghost of the 26 px grip), and a 2 px accent
     line with a leading dot marks the insertion point, positioned by `transform` so tracking the
     pointer costs no layout.
+  - The line is drawn in the MIDDLE of the gap between two blocks, not on the target's border-box
+    edge. A paragraph's `w:spacing` becomes a CSS margin, which sits outside the box, so an
+    edge-drawn line underlined the block's last line instead of reading as a gap between blocks.
 - **The editor's continuous view lays the document out at its own page width, and zooms to fit a
   narrow window instead of letting content run off the page.** Enlarging a block's font size on a
   phone pushed text and tables past the sheet, where the window clipped them. Three layers were

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **Dragging a block in the editor now shows what is moving and where it will land.** The drag
+  handle floats in the page margin, so the natural gesture — press it and pull straight down —
+  keeps the pointer in the gutter, where it never crosses a paragraph box. Because the drop
+  target was resolved by asking which element the pointer was over, that gesture found no target
+  for its whole duration: no drop line, and a release that silently did nothing. Only a drag
+  steered into the text column worked, which is why drops appeared to succeed with no preceding
+  feedback at all.
+  - Drop position is now resolved from the pointer's **vertical position** against the blocks
+    (`resolveDropAt`), not from element hit testing, so the gutter counts as being over the
+    document. Blocks are measured once per drag; scrolling is corrected by one subtraction.
+    Cost is 0.0 ms per `dragover` on a 234-block charter, and the flow no longer carries one
+    registered drop listener per block.
+  - A block the source cannot legally reach (across a section break, say) still offers no drop
+    and draws nothing — the line never snaps to a distant legal boundary the user did not point at.
+  - Three signals now run for the whole gesture: the source block dims, a preview chip naming the
+    block follows the cursor (replacing the browser's ghost of the 26 px grip), and a 2 px accent
+    line with a leading dot marks the insertion point, positioned by `transform` so tracking the
+    pointer costs no layout.
 - **The editor's continuous view lays the document out at its own page width, and zooms to fit a
   narrow window instead of letting content run off the page.** Enlarging a block's font size on a
   phone pushed text and tables past the sheet, where the window clipped them. Three layers were

--- a/docs/architecture/editor_ui_surface.md
+++ b/docs/architecture/editor_ui_surface.md
@@ -348,6 +348,13 @@ Three signals, each answering a different question:
 | Preview chip naming the block | *what* is under the cursor | `setCustomNativeDragPreview`; the browser would otherwise ghost the 26 px grip |
 | 2 px accent line with a leading dot | *where* it will land | `.docx-block-drop-indicator`, positioned by `transform` (no layout) with a one-shot 110 ms fade on each appearance |
 
+The line is drawn at the MIDDLE of the gap between the two blocks (`dropEdgeY`), not on the
+target's border-box edge: a paragraph's `w:spacing` becomes a CSS margin, which sits OUTSIDE the
+box, so an edge-drawn line underlines the block's last line rather than reading as a boundary
+between two blocks. At the ends of the flow there is no neighbour to bisect against, so half the
+block's own margin stands in — the only place a computed style is read, and only for those two
+blocks.
+
 `editor-block-drag.spec.ts` drags down the gutter without ever entering the text column and
 asserts all three, sampled per pointer step rather than only at the end.
 

--- a/docs/architecture/editor_ui_surface.md
+++ b/docs/architecture/editor_ui_surface.md
@@ -356,7 +356,11 @@ block's own margin stands in — the only place a computed style is read, and on
 blocks.
 
 `editor-block-drag.spec.ts` drags down the gutter without ever entering the text column and
-asserts all three, sampled per pointer step rather than only at the end.
+asserts all three, sampled per pointer step rather than only at the end. A second test pins the
+line's POSITION on a document with real `w:spacing` — strictly inside the gap, on neither block's
+edge, and clear of the last block past the end of the flow. That is a separate test on purpose:
+every DOM-level assertion in the first one passes while the line is drawn in the wrong place,
+because it is shown, is the right width, and tracks the pointer either way.
 
 A review-mode move used to force a full remount, on the reasoning that the move-from/move-to
 pair had to stay canonical. It does not: the render plan signs every unit with a content hash,

--- a/docs/architecture/editor_ui_surface.md
+++ b/docs/architecture/editor_ui_surface.md
@@ -315,8 +315,41 @@ and answers each candidate with index arithmetic. `DocxSessionMoveBlockTests` pi
 against the original set-membership definition for every (source, target, side) triple, because
 "faster" is only interesting if it decides identically. On the UI side, hovering consumes a
 memoized answer and schedules the ask for idle time (so the handle withdraws from an immovable
-block a beat later rather than the pointer paying for the query), and drop targets are
-registered when a drag begins rather than on every hover.
+block a beat later rather than the pointer paying for the query).
+
+#### Drag feedback, and why drop position is geometry
+
+The handle floats in the page MARGIN, 32 px left of the block's text column. So the natural
+gesture — press it and pull straight down — keeps the pointer in the gutter, where it never
+crosses a paragraph box. Resolving the drop target by asking which element the pointer is over
+therefore found nothing for the entire gesture: no drop line, and a release that silently did
+nothing. Drops only worked if the user happened to steer into the text.
+
+There is now **one** drop target, on the document flow, and `DocxEditor.resolveDropAt` decides
+where a release lands from the pointer's vertical position:
+
+- every movable block is measured once at drag start (`captureDropZones`, ~1.4 ms on the
+  charter; nothing reflows mid-drag, and scrolling — including drag autoscroll — moves the flow
+  rigidly, which `dropZoneShift` corrects with one subtraction);
+- the nearest block by vertical distance is the target, the half the pointer is in picks the
+  side, snapped to the other side when only that one is legal;
+- when neither side is legal — the pointer is in a region this block cannot reach, e.g. across a
+  section break — there is no drop and nothing is drawn. Snapping to a distant legal boundary
+  would move the block somewhere the user never pointed at.
+
+Resolution costs **0.0 ms** per `dragover` on the charter, and the flow no longer carries one
+registered drop listener per block (234 of them, re-registered at every drag start).
+
+Three signals, each answering a different question:
+
+| Signal | Answers | Mechanism |
+|--------|---------|-----------|
+| Source block dimmed to 38 % | *what* is moving | `.docx-block-drag-source`, added after the preview snapshot so the chip is not dimmed too |
+| Preview chip naming the block | *what* is under the cursor | `setCustomNativeDragPreview`; the browser would otherwise ghost the 26 px grip |
+| 2 px accent line with a leading dot | *where* it will land | `.docx-block-drop-indicator`, positioned by `transform` (no layout) with a one-shot 110 ms fade on each appearance |
+
+`editor-block-drag.spec.ts` drags down the gutter without ever entering the text column and
+asserts all three, sampled per pointer step rather than only at the end.
 
 A review-mode move used to force a full remount, on the reasoning that the move-from/move-to
 pair had to stay canonical. It does not: the render plan signs every unit with a content hash,

--- a/npm/src/editor.ts
+++ b/npm/src/editor.ts
@@ -27,6 +27,8 @@ import {
   dropTargetForElements,
   monitorForElements,
 } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
+import { pointerOutsideOfPreview } from "@atlaskit/pragmatic-drag-and-drop/element/pointer-outside-of-preview";
 import {
   autoScrollForElements,
   autoScrollWindowForElements,
@@ -216,6 +218,29 @@ const EDITABLE_TAGS = new Set(["P", "H1", "H2", "H3", "H4", "H5", "H6"]);
 const BLOCK_DRAG_TYPE = "docxodus-block";
 const blockDragStyledDocuments = new WeakSet<Document>();
 
+/** One-line description of a block, for the handle's label and the drag preview chip. */
+function blockPreviewText(unit: HTMLElement): string {
+  if (unit.tagName === "TABLE") return "Table";
+  const text = (unit.textContent ?? "").trim().replace(/\s+/g, " ");
+  return text.length > 48 ? `${text.slice(0, 48)}…` : text;
+}
+
+/**
+ * A capture-time snapshot of one movable block's box, in viewport coordinates.
+ *
+ * Taken once per drag: nothing reflows while a drag is in flight, so re-measuring every block on
+ * every `dragover` would buy nothing. Scrolling (including drag autoscroll) moves the whole flow
+ * rigidly, which `dropZoneShift` corrects for with one subtraction.
+ */
+interface BlockDropZone {
+  unit: HTMLElement;
+  anchorId: string;
+  top: number;
+  bottom: number;
+  left: number;
+  width: number;
+}
+
 function ensureBlockDragStyles(doc: Document): void {
   if (blockDragStyledDocuments.has(doc)) return;
   blockDragStyledDocuments.add(doc);
@@ -230,10 +255,28 @@ function ensureBlockDragStyles(doc: Document): void {
 }
 .docx-block-handle:hover, .docx-block-handle:focus-visible { color: #344054; border-color: #98a2b3; outline: none; }
 .docx-block-handle[aria-pressed="true"] { color: #175cd3; border-color: #84adff; background: #eff8ff; }
-.docx-block-handle.docx-block-dragging { cursor: grabbing; opacity: .78; }
+.docx-block-handle.docx-block-dragging { cursor: grabbing; opacity: .35; }
+/* The block being carried. Dimming it is the "a drag is happening" signal that survives the
+   pointer being anywhere on screen — the drop line only says where, not what. */
+.docx-block-drag-source { opacity: .38; transition: opacity 120ms ease-out; }
+/* Positioned by transform so tracking the pointer costs no layout. Flipping display none→block
+   restarts the fade — one cheap entry animation per appearance, none while it tracks. */
 .docx-block-drop-indicator {
-  position: fixed; z-index: 2147482999; display: none; height: 3px; pointer-events: none;
-  border-radius: 999px; background: #2e90fa; box-shadow: 0 0 0 1px rgba(255,255,255,.85);
+  position: fixed; top: 0; left: 0; z-index: 2147482999; display: none; height: 0;
+  pointer-events: none; border-top: 2px solid #2e90fa;
+  filter: drop-shadow(0 1px 2px rgba(46,144,250,.5));
+  animation: docx-block-drop-in 110ms ease-out;
+}
+.docx-block-drop-indicator::before {
+  content: ""; position: absolute; top: -5px; left: -2px; width: 8px; height: 8px;
+  border-radius: 50%; background: #2e90fa;
+}
+@keyframes docx-block-drop-in { from { opacity: 0; } to { opacity: 1; } }
+.docx-block-drag-preview {
+  max-width: 320px; padding: 6px 10px; border: 1px solid #b2ddff; border-radius: 6px;
+  background: #eff8ff; color: #175cd3; box-shadow: 0 6px 16px rgba(16,24,40,.18);
+  font: 500 13px/1.35 system-ui, sans-serif; white-space: nowrap; overflow: hidden;
+  text-overflow: ellipsis;
 }
 .docx-block-move-menu {
   position: fixed; z-index: 2147483001; display: none; min-width: 150px; padding: 5px;
@@ -811,7 +854,11 @@ export class DocxEditor {
   private blockMoveLive: HTMLElement | null = null;
   private blockDragSource: HTMLElement | null = null;
   private blockDragCleanup: Array<() => void> = [];
-  private blockDragTargetCleanup: Array<() => void> = [];
+  /** Block boxes measured at drag start — see `BlockDropZone`. Empty when no drag is in flight. */
+  private dropZones: BlockDropZone[] = [];
+  /** Combined scroll offset when `dropZones` was measured, and the scroller measured against. */
+  private dropZoneOrigin = 0;
+  private dropZoneScroller: HTMLElement | null = null;
   private blockDragging = false;
   private blockDragPointerDown = false;
   /** Anchors the current drag source may legally move next to, per the engine's own rules.
@@ -1291,11 +1338,8 @@ export class DocxEditor {
     handle.style.display = "flex";
     handle.style.left = `${Math.max(4, rect.left - 32)}px`;
     handle.style.top = `${Math.max(4, rect.top + (unit.tagName === "TABLE" ? 6 : Math.max(0, (rect.height - 28) / 2)))}px`;
-    const preview = (unit.textContent ?? "").trim().replace(/\s+/g, " ").slice(0, 48);
+    const preview = blockPreviewText(unit);
     handle.setAttribute("aria-label", preview ? `Move block: ${preview}` : "Move block");
-    // Drop targets are registered when a drag actually begins (and once at mount), not on
-    // hover: re-registering one listener per body block every time the pointer crosses a
-    // paragraph boundary is work no drop can use.
   }
 
   private hideBlockHandle(): void {
@@ -1308,14 +1352,21 @@ export class DocxEditor {
     if (source && this.blockDragHandle?.style.display !== "none") this.showBlockHandle(source);
   }
 
-  private showDropIndicator(target: HTMLElement, position: "before" | "after"): void {
+  /** Draw the drop line on `zone`'s requested edge, or take it away when there is no target. */
+  private paintDropIndicator(data: Record<string | symbol, unknown>): void {
     const indicator = this.blockDropIndicator;
+    const zone = data.zone as BlockDropZone | undefined;
     if (!indicator) return;
-    const rect = this.unitWrapperOf(target).getBoundingClientRect();
+    if (!zone) {
+      this.hideDropIndicator();
+      return;
+    }
+    const edge = data.position === "after" ? zone.bottom : zone.top;
+    const y = Math.round(edge + this.dropZoneShift()) - 1;
+    // Position before revealing, so the entry fade never plays at a stale spot.
+    indicator.style.transform = `translate3d(${Math.round(zone.left)}px, ${y}px, 0)`;
+    indicator.style.width = `${Math.max(24, Math.round(zone.width))}px`;
     indicator.style.display = "block";
-    indicator.style.left = `${rect.left}px`;
-    indicator.style.top = `${position === "before" ? rect.top - 1 : rect.bottom - 1}px`;
-    indicator.style.width = `${Math.max(24, rect.width)}px`;
   }
 
   private hideDropIndicator(): void {
@@ -1410,48 +1461,60 @@ export class DocxEditor {
     return position ? sides[position] : sides.before || sides.after;
   }
 
-  /**
-   * The side of `unit` a drop at `clientY` should land on: the half the pointer is in, snapped to
-   * the other side when only that one is legal. Snapping rather than refusing keeps a reachable
-   * target usable — the illegal side is usually illegal only because a section break or a
-   * cross-block range sits between the two blocks on that side.
-   */
-  private dropPositionFor(unit: HTMLElement, clientY: number): "before" | "after" {
-    const rect = unit.getBoundingClientRect();
-    const preferred = clientY < rect.top + rect.height / 2 ? "before" : "after";
-    if (this.isValidMoveTarget(unit, preferred)) return preferred;
-    const other = preferred === "before" ? "after" : "before";
-    return this.isValidMoveTarget(unit, other) ? other : preferred;
+  /** Measure every movable block once, at drag start. See `BlockDropZone`. */
+  private captureDropZones(): void {
+    this.dropZoneScroller = this.scrollContainer();
+    this.dropZoneOrigin = this.scrollOffsetSum();
+    this.dropZones = [];
+    for (const unit of this.bodyUnitNodes()) {
+      const anchorId = this.isMovableBlockUnit(unit) ? this.anchorIdOf(unit) : null;
+      if (!anchorId) continue;
+      const rect = this.unitWrapperOf(unit).getBoundingClientRect();
+      this.dropZones.push({
+        unit, anchorId, top: rect.top, bottom: rect.bottom, left: rect.left, width: rect.width,
+      });
+    }
   }
 
-  private refreshBlockDropTargets(): void {
-    for (const cleanup of this.blockDragTargetCleanup.splice(0)) cleanup();
-    if (!this.blockDragHandle || this.options.paginated) return;
-    for (const unit of this.bodyUnitNodes().filter((el) => this.isMovableBlockUnit(el))) {
-      this.blockDragTargetCleanup.push(dropTargetForElements({
-        element: unit,
-        // A target the engine would refuse is not a drop target at all, so Pragmatic never
-        // fires onDragEnter for it and no indicator is drawn over it.
-        canDrop: ({ source }) =>
-          source.data.type === BLOCK_DRAG_TYPE && source.data.sourceAnchorId !== this.anchorIdOf(unit) &&
-          this.isValidMoveTarget(unit),
-        getData: ({ input }) => ({
-          type: BLOCK_DRAG_TYPE,
-          targetAnchorId: this.anchorIdOf(unit),
-          position: this.dropPositionFor(unit, input.clientY),
-          targetElement: unit,
-        }),
-        onDragEnter: ({ self }) => {
-          const pos = self.data.position === "after" ? "after" : "before";
-          this.showDropIndicator(unit, pos);
-        },
-        onDrag: ({ self }) => {
-          const pos = self.data.position === "after" ? "after" : "before";
-          this.showDropIndicator(unit, pos);
-        },
-        onDragLeave: () => this.hideDropIndicator(),
-      }));
+  private scrollOffsetSum(): number {
+    const view = this.container.ownerDocument.defaultView;
+    return (view?.scrollY ?? 0) + (this.dropZoneScroller?.scrollTop ?? 0);
+  }
+
+  /** How far the measured boxes have travelled since capture, from scrolling (drag autoscroll). */
+  private dropZoneShift(): number {
+    return this.dropZoneOrigin - this.scrollOffsetSum();
+  }
+
+  /**
+   * Where a drop at `clientY` lands, or null when nothing there is legal.
+   *
+   * Resolution is by VERTICAL GEOMETRY over the measured blocks, not by which element the pointer
+   * is over: the drag handle floats in the page margin, so a drag straight down the gutter — the
+   * natural gesture — never crosses a paragraph box, and element hit testing gave those drags no
+   * indicator and no drop at all. The nearest block by vertical distance is the target; the half
+   * the pointer is in picks the side, snapped to the other side when only that one is legal
+   * (a section break or a cross-block range usually makes exactly one side illegal). When neither
+   * side is legal — the pointer is in a region this block cannot reach — there is no drop, and
+   * nothing is drawn.
+   */
+  private resolveDropAt(clientY: number): { zone: BlockDropZone; position: "before" | "after" } | null {
+    const y = clientY - this.dropZoneShift();
+    let best: BlockDropZone | null = null;
+    let bestGap = Infinity;
+    for (const zone of this.dropZones) {
+      const gap = y < zone.top ? zone.top - y : y > zone.bottom ? y - zone.bottom : 0;
+      if (gap < bestGap) {
+        best = zone;
+        bestGap = gap;
+      }
+      if (gap === 0) break; // inside this block; zones are in document order and never overlap
     }
+    if (!best || best.unit === this.blockDragSource) return null;
+    const preferred = y < (best.top + best.bottom) / 2 ? "before" : "after";
+    if (this.isValidMoveTarget(best.unit, preferred)) return { zone: best, position: preferred };
+    const other = preferred === "before" ? "after" : "before";
+    return this.isValidMoveTarget(best.unit, other) ? { zone: best, position: other } : null;
   }
 
   private closeBlockMoveMenu(restoreFocus = false): void {
@@ -1640,19 +1703,58 @@ export class DocxEditor {
         const source = this.currentBlockDragSource();
         return { type: BLOCK_DRAG_TYPE, sourceAnchorId: source ? this.anchorIdOf(source) : undefined };
       },
+      // The browser would otherwise ghost the 26px grip, which says nothing about what is moving.
+      onGenerateDragPreview: ({ nativeSetDragImage }) => {
+        const source = this.currentBlockDragSource();
+        setCustomNativeDragPreview({
+          nativeSetDragImage,
+          getOffset: pointerOutsideOfPreview({ x: "14px", y: "10px" }),
+          render: ({ container }) => {
+            const chip = doc.createElement("div");
+            chip.className = "docx-block-drag-preview";
+            chip.textContent = (source && blockPreviewText(source)) || "Move block";
+            container.appendChild(chip);
+            return () => chip.remove();
+          },
+        });
+      },
       onDragStart: () => {
+        const source = this.currentBlockDragSource();
         this.blockDragging = true;
         handle.classList.add("docx-block-dragging");
+        // After the preview snapshot, so the chip is not dimmed too.
+        source?.classList.add("docx-block-drag-source");
         this.closeBlockMoveMenu();
-        this.refreshBlockMoveTargets(this.currentBlockDragSource());
-        this.refreshBlockDropTargets();
+        this.refreshBlockMoveTargets(source);
+        this.captureDropZones();
       },
       onDrop: () => {
         this.blockDragging = false;
         this.blockDragPointerDown = false;
+        this.dropZones = [];
         handle.classList.remove("docx-block-dragging");
+        // Cleared by selector rather than from a captured reference: a completed move may have
+        // re-rendered the block, and the node that carries the class outlives either handle on it.
+        doc.querySelectorAll(".docx-block-drag-source")
+          .forEach((el) => el.classList.remove("docx-block-drag-source"));
         this.hideDropIndicator();
       },
+    }));
+    // ONE drop target for the whole flow. Which block a drop belongs to is decided by
+    // `resolveDropAt` from the pointer's vertical position, so the gutter the handle is dragged
+    // down counts as being over the document — see that method.
+    this.blockDragCleanup.push(dropTargetForElements({
+      element: this.editRoot,
+      canDrop: ({ source }) => source.data.type === BLOCK_DRAG_TYPE,
+      getData: ({ input }) => {
+        const hit = this.resolveDropAt(input.clientY);
+        return hit
+          ? { type: BLOCK_DRAG_TYPE, targetAnchorId: hit.zone.anchorId, position: hit.position, zone: hit.zone }
+          : { type: BLOCK_DRAG_TYPE };
+      },
+      onDragEnter: ({ self }) => this.paintDropIndicator(self.data),
+      onDrag: ({ self }) => this.paintDropIndicator(self.data),
+      onDragLeave: () => this.hideDropIndicator(),
     }));
     this.blockDragCleanup.push(monitorForElements({
       canMonitor: ({ source }) => source.data.type === BLOCK_DRAG_TYPE,
@@ -1685,14 +1787,14 @@ export class DocxEditor {
       canScroll: ({ source }) => source.data.type === BLOCK_DRAG_TYPE,
       getAllowedAxis: () => "vertical",
     }));
-    this.refreshBlockDropTargets();
   }
 
   private teardownBlockDrag(): void {
     this.blockMoveTargetPrefetch?.();
     this.blockMoveTargetPrefetch = null;
     this.blockMoveTargetCache.clear();
-    for (const cleanup of this.blockDragTargetCleanup.splice(0)) cleanup();
+    this.dropZones = [];
+    this.dropZoneScroller = null;
     for (const cleanup of this.blockDragCleanup.splice(0)) cleanup();
     this.blockDragHandle?.remove();
     this.blockDropIndicator?.remove();

--- a/npm/src/editor.ts
+++ b/npm/src/editor.ts
@@ -235,10 +235,15 @@ function blockPreviewText(unit: HTMLElement): string {
 interface BlockDropZone {
   unit: HTMLElement;
   anchorId: string;
+  /** Position in `dropZones`, so a neighbour is one index away — see `dropEdgeY`. */
+  index: number;
   top: number;
   bottom: number;
   left: number;
   width: number;
+  /** Own outer margin, read only for the first/last zone — see `dropEdgeY`. */
+  marginBefore: number;
+  marginAfter: number;
 }
 
 function ensureBlockDragStyles(doc: Document): void {
@@ -1361,12 +1366,33 @@ export class DocxEditor {
       this.hideDropIndicator();
       return;
     }
-    const edge = data.position === "after" ? zone.bottom : zone.top;
-    const y = Math.round(edge + this.dropZoneShift()) - 1;
+    const y = Math.round(this.dropEdgeY(zone, data.position === "after" ? "after" : "before")
+      + this.dropZoneShift()) - 1;
     // Position before revealing, so the entry fade never plays at a stale spot.
     indicator.style.transform = `translate3d(${Math.round(zone.left)}px, ${y}px, 0)`;
     indicator.style.width = `${Math.max(24, Math.round(zone.width))}px`;
     indicator.style.display = "block";
+  }
+
+  /**
+   * Where to draw the line for an insertion on `position` of `zone` — the MIDDLE of the gap to
+   * the neighbour on that side, not the zone's own border-box edge. A paragraph's `w:spacing`
+   * becomes a CSS margin, which sits outside the box, so drawing on the edge underlines the
+   * block's last line instead of reading as a gap between two blocks. Falls back to the raw edge
+   * at the ends of the flow, and degrades to the same value when blocks are contiguous.
+   */
+  private dropEdgeY(zone: BlockDropZone, position: "before" | "after"): number {
+    const neighbour = this.dropZones[zone.index + (position === "after" ? 1 : -1)];
+    // At the ends of the flow there is nothing to bisect against, so half the block's own
+    // margin stands in for half the gap — the same position, one contributor instead of two.
+    if (!neighbour) {
+      return position === "after"
+        ? zone.bottom + zone.marginAfter / 2
+        : zone.top - zone.marginBefore / 2;
+    }
+    return position === "after"
+      ? (zone.bottom + neighbour.top) / 2
+      : (neighbour.bottom + zone.top) / 2;
   }
 
   private hideDropIndicator(): void {
@@ -1463,16 +1489,29 @@ export class DocxEditor {
 
   /** Measure every movable block once, at drag start. See `BlockDropZone`. */
   private captureDropZones(): void {
+    const view = this.container.ownerDocument.defaultView;
     this.dropZoneScroller = this.scrollContainer();
     this.dropZoneOrigin = this.scrollOffsetSum();
     this.dropZones = [];
+    const boxes: HTMLElement[] = [];
     for (const unit of this.bodyUnitNodes()) {
       const anchorId = this.isMovableBlockUnit(unit) ? this.anchorIdOf(unit) : null;
       if (!anchorId) continue;
-      const rect = this.unitWrapperOf(unit).getBoundingClientRect();
+      const box = this.unitWrapperOf(unit);
+      const rect = box.getBoundingClientRect();
+      boxes.push(box);
       this.dropZones.push({
-        unit, anchorId, top: rect.top, bottom: rect.bottom, left: rect.left, width: rect.width,
+        unit, anchorId, index: this.dropZones.length,
+        top: rect.top, bottom: rect.bottom, left: rect.left, width: rect.width,
+        marginBefore: 0, marginAfter: 0,
       });
+    }
+    // Only the flow's two ends ever consult a margin, so only they are worth a style read.
+    const ends = new Set([0, this.dropZones.length - 1].filter((i) => i >= 0 && i < boxes.length));
+    for (const i of ends) {
+      const style = view?.getComputedStyle(boxes[i]);
+      this.dropZones[i].marginBefore = parseFloat(style?.marginTop ?? "0") || 0;
+      this.dropZones[i].marginAfter = parseFloat(style?.marginBottom ?? "0") || 0;
     }
   }
 

--- a/npm/tests/editor-block-drag.spec.ts
+++ b/npm/tests/editor-block-drag.spec.ts
@@ -172,6 +172,69 @@ test.describe('DocxEditor — block drag handle', () => {
     await expect(page.locator('.docx-block-drop-indicator')).toBeHidden();
   });
 
+  // A paragraph's w:spacing becomes a CSS margin, which sits OUTSIDE the border box, so the
+  // visual gap between two blocks is not where either box edge is. Drawing the drop line on the
+  // target's edge underlines that block's last line instead of reading as a boundary — which
+  // every DOM-level assertion above is blind to, since the line is shown, is the right width,
+  // and tracks the pointer either way. This pins the position itself.
+  test('the drop line is drawn in the gap between blocks, not on a block edge', async ({ page }) => {
+    await openParagraphDocument(page, ['Alpha', 'Beta', 'Gamma', 'Delta']);
+    // Real spacing, written through the session rather than injected as CSS, so the geometry
+    // under test is the geometry a document with `w:spacing` actually produces.
+    await page.evaluate(() => {
+      const D = (window as any).Docxodus;
+      const { editor } = (window as any).__drag;
+      for (const unit of editor['bodyUnitNodes']() as HTMLElement[]) {
+        const id = editor['anchorIdOf'](unit);
+        if (id) D.DocxSessionBridge.SetParagraphFormat(editor.sessionHandle, id,
+          JSON.stringify({ spacingBefore: 240, spacingAfter: 240 }));
+      }
+      editor['remount']();
+    });
+
+    // Driven through the drag internals rather than a native drag: this is a geometry assertion,
+    // and Chromium's asynchronous drag-event dispatch would only add settle timing to it.
+    const geo = await page.evaluate(() => {
+      const { editor } = (window as any).__drag;
+      const units = editor['bodyUnitNodes']() as HTMLElement[];
+      const source = units[0];
+      editor['blockDragSource'] = source;
+      editor['refreshBlockMoveTargets'](source);
+      editor['captureDropZones']();
+
+      const lineTopFor = (y: number): number | null => {
+        const hit = editor['resolveDropAt'](y);
+        if (!hit) return null;
+        editor['paintDropIndicator']({ zone: hit.zone, position: hit.position });
+        const line = document.querySelector<HTMLElement>('.docx-block-drop-indicator')!;
+        return getComputedStyle(line).display === 'none'
+          ? null
+          : line.getBoundingClientRect().top;
+      };
+
+      const box = (el: HTMLElement) => el.getBoundingClientRect();
+      const gamma = box(units[2]);
+      const delta = box(units[3]);
+      return {
+        // Lower half of Gamma ⇒ insert after Gamma, i.e. in the Gamma/Delta gap.
+        betweenBlocks: lineTopFor(gamma.bottom - 2),
+        gammaBottom: gamma.bottom,
+        deltaTop: delta.top,
+        // Below the last block ⇒ insert after Delta, where there is no neighbour to bisect.
+        endOfFlow: lineTopFor(delta.bottom + 40),
+        deltaBottom: delta.bottom,
+      };
+    });
+
+    // There is a real gap to land in — otherwise the assertions below prove nothing.
+    expect(geo.deltaTop - geo.gammaBottom).toBeGreaterThan(6);
+    // Strictly inside the gap, on neither block's edge.
+    expect(geo.betweenBlocks).toBeGreaterThan(geo.gammaBottom + 1);
+    expect(geo.betweenBlocks).toBeLessThan(geo.deltaTop - 1);
+    // Past the end of the flow the line still clears the last block's text.
+    expect(geo.endOfFlow).toBeGreaterThan(geo.deltaBottom + 1);
+  });
+
   test('a cell hover selects and moves its whole table', async ({ page }) => {
     await openParagraphDocument(page, ['Before', 'After']);
     await page.evaluate(() => {

--- a/npm/tests/editor-block-drag.spec.ts
+++ b/npm/tests/editor-block-drag.spec.ts
@@ -89,6 +89,89 @@ test.describe('DocxEditor — block drag handle', () => {
     expect((await unitState(page)).map((x) => x.text)).toEqual(['Two', 'Three', 'One']);
   });
 
+  // The handle floats in the page margin, so the natural gesture — press it and pull straight
+  // down — never crosses a paragraph box. Element hit testing therefore found no drop target for
+  // the whole gesture: no drop line, and a release that silently did nothing. Drop position is
+  // resolved from the pointer's vertical position against the blocks instead.
+  test('a drag down the left gutter shows the drop line and lands', async ({ page }) => {
+    const names = ['One', 'Two', 'Three', 'Four', 'Five', 'Six'];
+    await openParagraphDocument(page, names);
+    await page.locator('#block-drag-host p[data-anchor]').filter({ hasText: 'One' }).hover();
+    const handle = page.locator('.docx-block-handle');
+    await expect(handle).toBeVisible();
+
+    // The custom drag preview is mounted only for the browser's snapshot and torn down again,
+    // so it has to be observed rather than queried.
+    await page.evaluate(() => {
+      (window as any).__previews = [];
+      new MutationObserver((records) => {
+        for (const r of records)
+          for (const node of Array.from(r.addedNodes))
+            if (node instanceof HTMLElement)
+              (window as any).__previews.push(
+                ...Array.from(node.querySelectorAll('.docx-block-drag-preview')).map(
+                  (el) => el.textContent,
+                ),
+              );
+      }).observe(document.body, { childList: true, subtree: true });
+    });
+    const sample = () => page.evaluate(() => {
+      const line = document.querySelector<HTMLElement>('.docx-block-drop-indicator')!;
+      const rect = line.getBoundingClientRect();
+      return {
+        shown: getComputedStyle(line).display !== 'none',
+        top: Math.round(rect.top),
+        width: Math.round(rect.width),
+        dimmed: document.querySelector('.docx-block-drag-source')?.textContent?.trim() ?? null,
+      };
+    });
+
+    const hb = (await handle.boundingBox())!;
+    const last = page.locator('#block-drag-host p[data-anchor]').filter({ hasText: 'Six' });
+    const lb = (await last.boundingBox())!;
+    const gutterX = hb.x + hb.width / 2;
+    expect(gutterX).toBeLessThan(lb.x); // the pointer never enters the text column
+
+    await page.mouse.move(gutterX, hb.y + hb.height / 2);
+    await page.mouse.down();
+    const endY = lb.y + lb.height - 2;
+    const steps = [];
+    for (let i = 1; i <= 6; i++) {
+      await page.mouse.move(gutterX, hb.y + ((endY - hb.y) * i) / 6, { steps: 4 });
+      steps.push(await sample());
+    }
+    // Chromium dispatches drag events asynchronously from the synthetic mouse move, so the line
+    // can trail a step. Nudge until it settles on the edge the release will actually use.
+    await expect.poll(async () => {
+      await page.mouse.move(gutterX, endY - 2);
+      await page.mouse.move(gutterX, endY);
+      return (await sample()).top;
+    }).toBeGreaterThan(lb.y + lb.height / 2);
+    const previews = await page.evaluate(() => (window as any).__previews as string[]);
+    await page.mouse.up();
+
+    // The line appears as soon as the pointer clears the block being dragged (over that block
+    // there is no drop position to show), and then tracks continuously to the end of the gesture.
+    const firstShown = steps.findIndex((s) => s.shown);
+    expect(firstShown).toBeGreaterThanOrEqual(0);
+    expect(firstShown).toBeLessThanOrEqual(2);
+    const shown = steps.slice(firstShown);
+    expect(shown.every((s) => s.shown)).toBe(true);
+    expect(new Set(shown.map((s) => s.top)).size).toBeGreaterThan(1);
+    expect(shown.map((s) => s.width)).toEqual(shown.map(() => Math.round(lb.width)));
+    // The block being carried is dimmed for the whole gesture, and the preview names it.
+    // (Sampled from `firstShown`: the browser needs a few pixels of travel before it starts a
+    // native drag at all, so the opening sample can precede dragstart.)
+    expect(shown.map((s) => s.dimmed)).toEqual(shown.map(() => 'One'));
+    expect(previews).toContain('One');
+
+    // What the line predicted is where the block lands.
+    expect((await unitState(page)).map((x) => x.text)).toEqual([...names.slice(1), 'One']);
+    // Nothing is left dimmed once the move lands.
+    expect(await page.locator('.docx-block-drag-source').count()).toBe(0);
+    await expect(page.locator('.docx-block-drop-indicator')).toBeHidden();
+  });
+
   test('a cell hover selects and moves its whole table', async ({ page }) => {
     await openParagraphDocument(page, ['Before', 'After']);
     await page.evaluate(() => {

--- a/npm/tests/editor-move-latency-bench.spec.ts
+++ b/npm/tests/editor-move-latency-bench.spec.ts
@@ -35,7 +35,8 @@ const BUDGETS: Record<string, number> = {
   // must not touch the engine at document scale.
   'hover (block boundary crossed)': 100,
   'blockUnitOf (DOM resolve)': 20,
-  'refreshBlockDropTargets': 100,
+  'resolveDropAt (per dragover)': 5,
+  'captureDropZones': 100,
   // One-per-gesture engine queries.
   'ValidMoveTargets (bridge)': 250,
   'ValidMoveTargets review (bridge)': 250,
@@ -121,8 +122,16 @@ test.describe('DocxEditor — block-move latency benchmark', () => {
         editor['closeBlockMoveMenu']();
       });
 
-      // ── 5. Drop-target registration (one per body unit). ───────────────
-      measure('refreshBlockDropTargets', 3, () => { editor['refreshBlockDropTargets'](); });
+      // ── 5. Drag-start block measurement, and the per-dragover resolve it
+      //       buys: the latter runs on every pointer move during a drag, so it
+      //       is the one that decides whether the drop line tracks smoothly.
+      measure('captureDropZones', 3, () => { editor['captureDropZones'](); });
+      editor['blockDragSource'] = src;
+      editor['refreshBlockMoveTargets'](src);
+      measure('resolveDropAt (per dragover)', 60, (() => {
+        let i = 0;
+        return () => { editor['resolveDropAt'](100 + ((i++ * 37) % 600)); };
+      })());
 
       // ── 6. The move itself, direct mode (reconcile repaint). ───────────
       const a = movable[10];


### PR DESCRIPTION
## The bug

The block drag handle floats in the page **margin**, 32 px left of the block's text column. So the natural gesture — press it and pull straight down — keeps the pointer in the gutter, where it never crosses a paragraph box.

Drop position was resolved by asking which element the pointer was over. For that gesture the answer was "nothing", for the whole duration: no drop line, and a release that silently did nothing. Only a drag steered into the text column worked — which is why drops appeared to succeed with no preceding feedback at all.

Measured on the pre-change build, dragging straight down the gutter:

```
GUTTER indicator shown:  []                      (never)
GUTTER result order:     ["One","Two","Three"]   (drop was a no-op)
```

Same gesture after:

```
GUTTER indicator shown:  [block, block, …]
GUTTER result order:     ["Two","Three","One"]
```

## The fix

**Drop position is geometry, not hit testing.** One drop target on the document flow; `resolveDropAt` picks the nearest block by vertical distance, and the half the pointer is in picks the side — snapped to the other side when only that one is legal. A block the source cannot legally reach still offers no drop and draws nothing: the line never snaps to a distant legal boundary the user did not point at, so the existing section-break partitioning holds unchanged.

Blocks are measured once at drag start. Nothing reflows mid-drag, and scrolling — including drag autoscroll — moves the flow rigidly, which one subtraction corrects.

**Three signals, each answering a different question:**

| Signal | Answers |
|---|---|
| Source block dims to 38 % | *what* is moving |
| Preview chip naming the block follows the cursor | *what* is under the cursor (the browser otherwise ghosts the 26 px grip) |
| 2 px accent line with a leading dot | *where* it will land |

The line is positioned by `transform`, so tracking the pointer costs no layout, and gets a one-shot 110 ms fade per appearance rather than a transition that would smear while tracking.

## Performance

Measured by `editor-move-latency-bench.spec.ts` on `NVCA-Model-COI.docx` (234 body blocks, 392 bookmarks, 3 section breaks):

| | Before | After |
|---|---|---|
| Per-drag-start block work | 1.5 ms (`refreshBlockDropTargets`) | 1.3 ms (`captureDropZones`) |
| Per `dragover` | — | 0.0 ms (`resolveDropAt`, new budget 5 ms) |
| Registered drop listeners on the flow | 234, re-registered at every drag start | 1, registered once |

A wash on the per-gesture cost; the win is correctness plus 233 fewer listeners. The bench's `refreshBlockDropTargets` row is replaced by the two rows above.

## Tests

`editor-block-drag.spec.ts` gains a regression test that drags down the gutter **without ever entering the text column** (asserted), sampling per pointer step rather than only at the end: the line appears as soon as the pointer clears the source block and then tracks continuously, at the block's width, to more than one position; the source stays dimmed; the preview names the block; and what the line predicted is where the block lands. Cleanup is asserted too — nothing left dimmed, line hidden.

- `editor-block-drag.spec.ts` — 6/6, run 5× for flake
- Full chromium suite — 327 passed. The 17 `worker.spec.ts` / `worker-prepare.spec.ts` failures in this environment reproduce on a clean tree with these changes stashed, so they are pre-existing and unrelated.

## Docs

- `CHANGELOG.md` under `[Unreleased] / Fixed`
- `docs/architecture/editor_ui_surface.md` — new "Drag feedback, and why drop position is geometry" subsection; corrects the now-stale claim that drop targets are registered per block at drag start

No public API change: no new setting, no WASM/npm surface change, `blockDrag` is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_014dVpwDeHP8cygerAkvBA27)_