### PR TITLE
docs(changelog): cut v9.5.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [9.5.0] - 2026-08-08
+
 ### Fixed
 - **Dragging a block in the editor now shows what is moving and where it will land.** The drag
   handle floats in the page margin, so the natural gesture — press it and pull straight down —


### PR DESCRIPTION
## Summary
- Cut `[9.5.0] - 2026-08-08` from the accumulated `[Unreleased]` entries (editor drop-target fix, page-width layout/zoom fix, `DocumentViewport` addition, continuous-view sheet-width change) — minor bump per the `### Added`/`### Changed` entries.
- Leaves `[Unreleased]` empty above the new section, per the documented release process.

## Test plan
- [ ] Changelog-only change; no code affected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgwjcDyH7LtUGBd13GrtBf)_