### PR TITLE
Align the web editor surface with the OS-Legal house style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Editor surface restyled to the OS-Legal house design system**
+  (github.com/Open-Source-Legal/OS-Legal-Style): the ribbon chrome
+  (`npm/src/ribbon-chrome.ts`, style version 6) moves from the ad-hoc blue/gray
+  palette to the house tokens — deep-teal accent `#0F766E`, slate foreground
+  scale, white surfaces over a warm `#FAFAFA`/`#F1F5F9` canvas, 6/12px radii,
+  and 0.03–0.06-opacity "light touch" shadows; Inter leads the UI font stack
+  (hosts load it, system-ui fallback), Save becomes the surface's one primary
+  accent button, and the loading overlay trades the neon cyan/violet look for
+  the house dark-slate `#0F172A` + teal family with a Georgia serif headline.
+  The GitHub Pages demo pages follow: `docs/demo/index.html` is re-skinned to
+  the light "warm precision" look (Georgia headlines, teal CTAs, white cards),
+  `player.html` to the dark-sidebar variant, and `app.html`'s frame syncs with
+  the new desk color. No DOM, `data-dxr` addressing, or behavior changes.
+
 ## [9.6.0] - 2026-08-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ All notable changes to this project will be documented in this file.
   `player.html` to the dark-sidebar variant, and `app.html`'s frame syncs with
   the new desk color. No DOM, `data-dxr` addressing, or behavior changes.
 
+### Added
+- **`frame` option on the ribbon surface** (`RibbonOptions.frame`,
+  `"card" | "flush"`): `"card"` makes the surface carry its own embed boundary —
+  14px rounded corners, hairline border, house shadow, `overflow: clip` so the
+  sticky chrome, scrollbars, and loading overlay respect the curve. Default
+  `"flush"` for `mountRibbon` (full-bleed hosts unchanged); `createRibbonEditor`
+  defaults to `"card"` since it is the drop-into-a-page path (the three
+  `docs/demo/` hosts pin `"flush"` — they frame the surface themselves). The
+  document scroll area also gains soft top/bottom edge fades (sticky gradient
+  veils) in both frames, so content dissolves at the chrome instead of
+  hard-clipping.
+
 ## [9.6.0] - 2026-08-08
 
 ### Added

--- a/docs/demo/app.html
+++ b/docs/demo/app.html
@@ -32,11 +32,17 @@
   <meta name="twitter:description" content="Open, edit and save a real .docx with no server." />
   <meta name="twitter:image" content="https://raw.githubusercontent.com/JSv4/Docxodus/main/docs/images/editor/editor-overview.png" />
 
+  <!-- Inter — the surface's UI typeface (falls back to system-ui offline). -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+
   <style>
     html, body { height: 100%; }
     /* 100dvh, not 100vh: on mobile browsers the URL bar collapses and 100vh leaves a
        dead strip the surface can never scroll into. */
-    body { margin: 0; height: 100dvh; background: #dfe3ea; overscroll-behavior: none; }
+    /* Matches the surface's --dxr-desk so the page never flashes a different gray. */
+    body { margin: 0; height: 100dvh; background: #f1f5f9; overscroll-behavior: none; }
     #app { height: 100%; }
 
     /* A single "back to the landing page" affordance, docked over the ribbon's own
@@ -47,14 +53,15 @@
       right: max(8px, env(safe-area-inset-right));
       top: 7px;
       padding: 4px 10px;
-      border: 1px solid #d3dae4;
+      border: 1px solid #e2e8f0;
       border-radius: 999px;
-      background: #f7f9fc;
-      color: #5d6975;
-      font: 600 11.5px/1.6 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      background: #fff;
+      color: #475569;
+      font: 600 11.5px/1.6 "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
       text-decoration: none;
+      box-shadow: 0 1px 2px rgba(15, 23, 42, .04);
     }
-    #home:hover { color: #101418; background: #fff; border-color: #b9c4d4; }
+    #home:hover { color: #1e293b; border-color: #cbd5e1; background: #f8fafc; }
     /* Reserve the pill's corner. The compact title bar scrolls horizontally and ends
        with Undo/Redo, which a floating pill would otherwise sit on top of. */
     #app .dxr-titlebar { padding-right: 84px; }
@@ -93,9 +100,9 @@
     } catch (error) {
       document.getElementById("app").innerHTML =
         '<div style="display:grid;place-items:center;height:100%;padding:24px;text-align:center;'
-        + 'font:14px/1.6 system-ui,sans-serif;color:#33465b"><div><strong>The editor could not start.</strong>'
-        + '<p id="bootError" style="margin:8px 0 16px;color:#5d6975"></p>'
-        + '<button onclick="location.reload()" style="font:inherit;padding:8px 14px;border:1px solid #d3dae4;'
+        + 'font:14px/1.6 system-ui,sans-serif;color:#334155"><div><strong>The editor could not start.</strong>'
+        + '<p id="bootError" style="margin:8px 0 16px;color:#475569"></p>'
+        + '<button onclick="location.reload()" style="font:inherit;padding:8px 14px;border:1px solid #e2e8f0;'
         + 'border-radius:8px;background:#fff;cursor:pointer">Retry</button></div></div>';
       document.getElementById("bootError").textContent = String(error).slice(0, 220);
     }

--- a/docs/demo/app.html
+++ b/docs/demo/app.html
@@ -89,6 +89,8 @@
       // here on. Only the module import above can fail with nothing on screen.
       window.__ribbon = await createRibbonEditor("#app", BLANK ? null : DOC, {
         documentName: BLANK ? "untitled.docx" : "docxodus-demo-guide.docx",
+        // Full-bleed: the page IS the surface, so no card boundary.
+        frame: "flush",
         // Bands are a Word-authoring feature rather than a first-30-seconds one; the
         // Layout tab turns them on without reloading.
         headerFooter: false,

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -400,6 +400,9 @@
       // dark frame around it and the status chip above it.
       window.__ribbon = await createRibbonEditor("#workspace", DOC, {
         documentName: "docxodus-demo.docx",
+        // The landing page frames the surface itself (status head + card), so the
+        // surface stays flush inside it.
+        frame: "flush",
         // Relay the surface's own status into the chip, without demoting the dot
         // back to "loading" for routine post-boot messages ("Saved …").
         onStatus: (text) => setStatus(text, statusbar.dataset.state === "ready" ? "ready" : "loading"),

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -39,46 +39,48 @@
   <meta name="twitter:description" content="Open a live .docx editor powered by WebAssembly—no server, lossless output." />
   <meta name="twitter:image" content="https://raw.githubusercontent.com/JSv4/Docxodus/main/docs/images/editor/editor-overview.png" />
 
+  <!-- Inter — the house UI typeface (headlines fall to Georgia, a system serif). -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+
   <style>
+    /* OS-Legal design system (github.com/Open-Source-Legal/OS-Legal-Style):
+       warm light canvas, deep-teal accent, slate foregrounds, Georgia headlines,
+       and light-touch shadows. Structure over decoration. */
     :root {
-      color-scheme: dark;
-      --ink: #07111f;
-      --line: rgba(160, 186, 218, .17);
-      --muted: #9cb0c8;
-      --text: #f7fbff;
-      --cyan: #52e5ff;
-      --violet: #b26cff;
-      --green: #52e0a2;
-      --danger: #ff7f91;
+      color-scheme: light;
+      --accent: #0F766E;
+      --accent-hover: #0D9488;
+      --accent-active: #115E59;
+      --ink: #1E293B;
+      --muted: #475569;
+      --faint: #94A3B8;
+      --canvas: #FAFAFA;
+      --surface: #FFFFFF;
+      --line: #E2E8F0;
+      --line-strong: #CBD5E1;
+      --sidebar: #0F172A;
+      --success: #059669;
+      --danger: #DC2626;
+      --serif: Georgia, "Times New Roman", serif;
+      --shadow-md: 0 1px 3px rgba(15, 23, 42, .06), 0 4px 6px rgba(15, 23, 42, .03);
+      --shadow-lg: 0 4px 6px rgba(15, 23, 42, .05), 0 10px 15px rgba(15, 23, 42, .04);
+      --shadow-xl: 0 8px 16px rgba(15, 23, 42, .06), 0 20px 25px rgba(15, 23, 42, .05);
     }
     * { box-sizing: border-box; }
     html { scroll-behavior: smooth; }
     body {
       margin: 0;
       min-width: 320px;
-      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      background:
-        radial-gradient(circle at 12% 8%, rgba(42, 116, 255, .18), transparent 34rem),
-        radial-gradient(circle at 90% 4%, rgba(178, 108, 255, .16), transparent 32rem),
-        var(--ink);
-      color: var(--text);
-    }
-    body::before {
-      position: fixed;
-      inset: 0;
-      z-index: -1;
-      content: "";
-      pointer-events: none;
-      background-image:
-        linear-gradient(rgba(255,255,255,.025) 1px, transparent 1px),
-        linear-gradient(90deg, rgba(255,255,255,.025) 1px, transparent 1px);
-      background-size: 42px 42px;
-      mask-image: linear-gradient(to bottom, #000 0, transparent 72%);
+      font-family: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: var(--canvas);
+      color: var(--ink);
     }
     a { color: inherit; }
     button { font: inherit; }
 
-    .hero { position: relative; overflow: hidden; border-bottom: 1px solid var(--line); }
+    .hero { position: relative; overflow: hidden; background: var(--surface); border-bottom: 1px solid var(--line); }
     .hero::after {
       position: absolute;
       width: 34rem;
@@ -87,124 +89,126 @@
       top: -20rem;
       border-radius: 50%;
       content: "";
-      background: rgba(82, 229, 255, .12);
+      background: rgba(15, 118, 110, .07);
       filter: blur(80px);
       pointer-events: none;
     }
     .hero-inner { width: min(1180px, calc(100% - 40px)); margin: 0 auto; }
     .topbar { min-height: 76px; display: flex; align-items: center; justify-content: space-between; gap: 12px; }
-    .brand { display: inline-flex; align-items: center; gap: 12px; font-weight: 760;
+    .brand { display: inline-flex; align-items: center; gap: 12px; font-weight: 700;
       letter-spacing: -.02em; text-decoration: none; }
-    .brand-mark { position: relative; width: 31px; height: 36px; border: 1px solid rgba(255,255,255,.5);
-      border-radius: 7px; background: linear-gradient(145deg, rgba(82,229,255,.3), rgba(92,124,255,.25));
-      box-shadow: 0 0 30px rgba(82,229,255,.24); transform: rotate(-4deg); }
+    .brand-mark { position: relative; width: 31px; height: 36px; border: 1px solid var(--line-strong);
+      border-radius: 7px; background: var(--surface);
+      box-shadow: var(--shadow-md); transform: rotate(-4deg); }
     .brand-mark::before, .brand-mark::after { position: absolute; left: 7px; content: "";
-      height: 2px; border-radius: 2px; background: #fff; opacity: .85; }
-    .brand-mark::before { top: 11px; width: 15px; box-shadow: 0 7px 0 rgba(255,255,255,.65); }
-    .brand-mark::after { top: 25px; width: 10px; background: var(--cyan); }
+      height: 2px; border-radius: 2px; background: var(--line-strong); }
+    .brand-mark::before { top: 11px; width: 15px; box-shadow: 0 7px 0 var(--line); }
+    .brand-mark::after { top: 25px; width: 10px; background: var(--accent); }
     nav { display: flex; align-items: center; gap: 8px; }
     nav a { color: var(--muted); padding: 8px 11px; border-radius: 9px; font-size: 13px;
       text-decoration: none; transition: color .2s, background .2s; }
-    nav a:hover { color: #fff; background: rgba(255,255,255,.07); }
-    nav .nav-cta { color: #07111f; background: var(--cyan); font-weight: 750; }
-    nav .nav-cta:hover { color: #07111f; background: #8eedff; }
+    nav a:hover { color: var(--ink); background: #F1F5F9; }
+    nav .nav-cta { color: #fff; background: var(--accent); font-weight: 600; }
+    nav .nav-cta:hover { color: #fff; background: var(--accent-hover); }
 
     .hero-grid { display: grid; grid-template-columns: minmax(0, 1.2fr) minmax(300px, .8fr);
       align-items: center; gap: clamp(36px, 7vw, 92px); padding: 68px 0 82px; }
-    .eyebrow { display: inline-flex; align-items: center; gap: 9px; margin-bottom: 20px; color: var(--cyan);
-      font-size: 12px; font-weight: 800; letter-spacing: .14em; text-transform: uppercase; }
-    .eyebrow::before { width: 28px; height: 1px; content: ""; background: currentColor; box-shadow: 0 0 12px currentColor; }
-    h1 { max-width: 760px; margin: 0; font-size: clamp(40px, 7vw, 78px); line-height: .98;
-      letter-spacing: -.064em; font-weight: 820; }
-    h1 span { color: transparent; background: linear-gradient(95deg, var(--cyan), #9ab2ff 48%, #d99aff);
-      background-clip: text; -webkit-background-clip: text; }
-    .hero-copy { max-width: 650px; margin: 25px 0 0; color: #afc0d4; font-size: clamp(16px, 2vw, 19px);
+    .eyebrow { display: inline-flex; align-items: center; gap: 9px; margin-bottom: 20px; color: var(--accent);
+      font-size: 12px; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; }
+    .eyebrow::before { width: 28px; height: 1px; content: ""; background: currentColor; }
+    h1 { max-width: 760px; margin: 0; font-family: var(--serif); font-size: clamp(40px, 7vw, 74px);
+      line-height: 1.02; letter-spacing: -.02em; font-weight: 500; }
+    h1 span { color: var(--accent); font-style: italic; }
+    .hero-copy { max-width: 650px; margin: 25px 0 0; color: var(--muted); font-size: clamp(16px, 2vw, 19px);
       line-height: 1.65; }
     .hero-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 12px; margin-top: 32px; }
     .hero-button { display: inline-flex; align-items: center; gap: 10px; min-height: 44px; padding: 12px 17px;
-      border: 1px solid rgba(255,255,255,.16); border-radius: 12px; background: rgba(255,255,255,.055);
-      color: inherit; font-size: 13px; font-weight: 730; text-decoration: none; cursor: pointer;
-      transition: transform .2s, border-color .2s; }
-    .hero-button:hover { transform: translateY(-2px); border-color: rgba(82,229,255,.55); }
-    .hero-button.primary { color: #07111f; border-color: transparent; background: linear-gradient(135deg, var(--cyan), #88f7df);
-      box-shadow: 0 12px 34px rgba(82,229,255,.18); }
-    .proof-row { display: flex; flex-wrap: wrap; gap: 18px; margin-top: 28px; color: #8299b4; font-size: 12px; }
+      border: 1px solid var(--line); border-radius: 10px; background: var(--surface);
+      color: inherit; font-size: 13px; font-weight: 600; text-decoration: none; cursor: pointer;
+      box-shadow: var(--shadow-md); transition: transform .2s, border-color .2s, box-shadow .2s; }
+    .hero-button:hover { transform: translateY(-2px); border-color: var(--line-strong); box-shadow: var(--shadow-lg); }
+    .hero-button.primary { color: #fff; border-color: transparent; background: var(--accent);
+      box-shadow: 0 4px 14px rgba(15, 118, 110, .2); }
+    .hero-button.primary:hover { background: var(--accent-hover); box-shadow: 0 8px 24px rgba(15, 118, 110, .25); }
+    .proof-row { display: flex; flex-wrap: wrap; gap: 18px; margin-top: 28px; color: var(--muted); font-size: 12px; }
     .proof-row span { display: inline-flex; align-items: center; gap: 7px; }
-    .proof-row span::before { width: 6px; height: 6px; border-radius: 50%; content: ""; background: var(--green);
-      box-shadow: 0 0 12px rgba(82,224,162,.7); }
+    .proof-row span::before { width: 6px; height: 6px; border-radius: 50%; content: ""; background: var(--success); }
 
     .capability-stack { position: relative; min-height: 350px; perspective: 900px; }
     .capability-card { position: absolute; width: min(100%, 360px); padding: 22px; border: 1px solid var(--line);
-      border-radius: 19px; background: linear-gradient(145deg, rgba(18,40,66,.94), rgba(8,19,34,.88));
-      box-shadow: 0 24px 60px rgba(0,0,0,.3); backdrop-filter: blur(18px); }
+      border-radius: 16px; background: var(--surface); box-shadow: var(--shadow-xl); }
     .capability-card:nth-child(1) { right: 0; top: 0; transform: rotate(2deg); }
     .capability-card:nth-child(2) { left: 0; top: 116px; transform: rotate(-3deg); }
     .capability-card:nth-child(3) { right: 8px; top: 235px; transform: rotate(1deg); }
     .capability-top { display: flex; align-items: center; justify-content: space-between; margin-bottom: 15px; }
     .capability-icon { display: grid; width: 34px; height: 34px; place-items: center; border-radius: 10px;
-      color: var(--cyan); background: rgba(82,229,255,.1); border: 1px solid rgba(82,229,255,.2); }
-    .capability-tag { color: #7f96b1; font-size: 10px; font-weight: 750; letter-spacing: .11em; text-transform: uppercase; }
+      color: var(--accent); background: #F0FDFA; border: 1px solid #99F6E4; }
+    .capability-tag { color: var(--faint); font-size: 10px; font-weight: 600; letter-spacing: .11em; text-transform: uppercase; }
     .capability-card strong { display: block; font-size: 15px; }
-    .capability-card p { margin: 7px 0 0; color: #8fa5bd; font-size: 12.5px; line-height: 1.5; }
+    .capability-card p { margin: 7px 0 0; color: var(--muted); font-size: 12.5px; line-height: 1.5; }
 
     #stage { width: min(1220px, calc(100% - 32px)); margin: 54px auto 70px; }
-    .section-kicker { margin: 0 0 10px; color: var(--cyan); font-size: 11px; font-weight: 800;
+    .section-kicker { margin: 0 0 10px; color: var(--accent); font-size: 11px; font-weight: 700;
       letter-spacing: .14em; text-transform: uppercase; }
-    .section-title { margin: 0 0 8px; font-size: clamp(26px, 4vw, 42px); letter-spacing: -.045em; }
-    .section-sub { margin: 0 0 23px; max-width: 62ch; color: #93a8c1; font-size: 14px; line-height: 1.6; }
-    .section-sub a { color: var(--cyan); }
-    #frame { overflow: hidden; border: 1px solid rgba(159,185,216,.2); border-radius: 22px;
-      background: #f4f7fb; box-shadow: 0 32px 90px rgba(0,0,0,.42), 0 0 0 1px rgba(255,255,255,.025) inset; }
+    .section-title { margin: 0 0 8px; font-family: var(--serif); font-weight: 500;
+      font-size: clamp(26px, 4vw, 42px); letter-spacing: -.02em; }
+    .section-sub { margin: 0 0 23px; max-width: 62ch; color: var(--muted); font-size: 14px; line-height: 1.6; }
+    .section-sub a { color: var(--accent); }
+    #frame { overflow: hidden; border: 1px solid var(--line); border-radius: 16px;
+      background: var(--surface); box-shadow: var(--shadow-xl); }
     .workspace-head { min-height: 52px; display: flex; align-items: center; justify-content: space-between; gap: 18px;
-      padding: 10px 16px; color: #a9bad0; background: #0e1a2a; border-bottom: 1px solid rgba(255,255,255,.08); }
+      padding: 10px 16px; color: #CBD5E1; background: var(--sidebar); border-bottom: 1px solid rgba(255,255,255,.08); }
     #statusbar { min-width: 0; display: flex; align-items: center; gap: 10px; font-size: 12.5px; }
-    #statusbar .dot { flex: 0 0 auto; width: 8px; height: 8px; border-radius: 50%; background: #ffc65d;
-      box-shadow: 0 0 0 5px rgba(255,198,93,.1), 0 0 14px rgba(255,198,93,.4); }
-    #statusbar[data-state="ready"] .dot { background: var(--green);
-      box-shadow: 0 0 0 5px rgba(82,224,162,.1), 0 0 14px rgba(82,224,162,.45); }
-    #statusbar[data-state="error"] .dot { background: var(--danger);
-      box-shadow: 0 0 0 5px rgba(255,127,145,.1), 0 0 14px rgba(255,127,145,.45); }
+    #statusbar .dot { flex: 0 0 auto; width: 8px; height: 8px; border-radius: 50%; background: #FBBF24;
+      box-shadow: 0 0 0 5px rgba(251,191,36,.12); }
+    #statusbar[data-state="ready"] .dot { background: #34D399;
+      box-shadow: 0 0 0 5px rgba(52,211,153,.12); }
+    #statusbar[data-state="error"] .dot { background: #F87171;
+      box-shadow: 0 0 0 5px rgba(248,113,113,.12); }
     #pageStatus { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .privacy-chip { flex: 0 0 auto; padding: 6px 9px; border: 1px solid rgba(82,224,162,.18); border-radius: 999px;
-      color: #9be9c7; background: rgba(82,224,162,.07); font-size: 10.5px; font-weight: 720; }
+    .privacy-chip { flex: 0 0 auto; padding: 6px 9px; border: 1px solid rgba(52,211,153,.25); border-radius: 999px;
+      color: #6EE7B7; background: rgba(52,211,153,.08); font-size: 10.5px; font-weight: 600; }
 
     /* The editor mount. Height is fixed so the surface scrolls the DOCUMENT rather than
        the page — the ribbon has to stay reachable while you scroll a long contract. */
     #workspace { height: clamp(560px, 78vh, 820px); }
 
     .feature-strip { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; margin-top: 18px; overflow: hidden;
-      border: 1px solid var(--line); border-radius: 16px; background: var(--line); }
-    .feature-strip article { padding: 20px; background: #0a1728; }
-    .feature-strip small { color: var(--cyan); font: 750 9px/1 ui-monospace, monospace; letter-spacing: .12em; }
+      border: 1px solid var(--line); border-radius: 16px; background: var(--line); box-shadow: var(--shadow-md); }
+    .feature-strip article { padding: 20px; background: var(--surface); }
+    .feature-strip small { color: var(--accent); font: 600 9px/1 ui-monospace, monospace; letter-spacing: .12em; }
     .feature-strip strong { display: block; margin-top: 10px; font-size: 14px; }
-    .feature-strip p { margin: 7px 0 0; color: #8299b4; font-size: 12px; line-height: 1.55; }
-    footer { padding: 0 20px 44px; text-align: center; color: #667f9b; font-size: 11px; }
-    footer a { color: #91a9c5; }
+    .feature-strip p { margin: 7px 0 0; color: var(--muted); font-size: 12px; line-height: 1.55; }
+    footer { padding: 0 20px 44px; text-align: center; color: var(--faint); font-size: 11px; }
+    footer a { color: var(--muted); }
 
     #embedDialog { width: min(720px, calc(100% - 28px)); max-height: min(720px, calc(100vh - 28px));
-      padding: 0; overflow: auto; border: 1px solid rgba(159,185,216,.24); border-radius: 20px;
-      color: var(--text); background: linear-gradient(145deg, #101f33, #081422); box-shadow: 0 30px 100px rgba(0,0,0,.65); }
-    #embedDialog::backdrop { background: rgba(2,8,16,.76); backdrop-filter: blur(8px); }
+      padding: 0; overflow: auto; border: 1px solid var(--line); border-radius: 16px;
+      color: var(--ink); background: var(--surface); box-shadow: var(--shadow-xl); }
+    #embedDialog::backdrop { background: rgba(15, 23, 42, .45); backdrop-filter: blur(6px); }
     .embed-inner { padding: clamp(22px, 5vw, 34px); }
     .embed-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 20px; }
-    .embed-kicker { color: var(--cyan); font-size: 10px; font-weight: 850; letter-spacing: .15em; text-transform: uppercase; }
-    .embed-head h2 { margin: 8px 0 0; font-size: clamp(24px, 5vw, 35px); letter-spacing: -.045em; }
+    .embed-kicker { color: var(--accent); font-size: 10px; font-weight: 700; letter-spacing: .15em; text-transform: uppercase; }
+    .embed-head h2 { margin: 8px 0 0; font-family: var(--serif); font-weight: 500;
+      font-size: clamp(24px, 5vw, 35px); letter-spacing: -.02em; }
     .dialog-close { width: 34px; height: 34px; flex: 0 0 auto; border: 1px solid var(--line); border-radius: 9px;
-      color: #a9bad0; background: rgba(255,255,255,.05); font-size: 19px; cursor: pointer; }
-    .embed-intro { margin: 14px 0 21px; color: #9db0c7; font-size: 13px; line-height: 1.6; }
-    .embed-option { margin-top: 16px; padding: 16px; border: 1px solid var(--line); border-radius: 14px;
-      background: rgba(255,255,255,.035); }
+      color: var(--muted); background: var(--surface); font-size: 19px; cursor: pointer; }
+    .dialog-close:hover { background: #F1F5F9; color: var(--ink); }
+    .embed-intro { margin: 14px 0 21px; color: var(--muted); font-size: 13px; line-height: 1.6; }
+    .embed-option { margin-top: 16px; padding: 16px; border: 1px solid var(--line); border-radius: 12px;
+      background: var(--canvas); }
     .embed-option-head { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 10px;
       flex-wrap: wrap; }
     .embed-option strong { font-size: 13px; }
-    .embed-option p { margin: 0 0 10px; color: #8ba0b9; font-size: 11.5px; line-height: 1.5; }
-    .copy-button { padding: 7px 10px; border: 1px solid rgba(82,229,255,.25); border-radius: 8px;
-      color: var(--cyan); background: rgba(82,229,255,.07); font-size: 10px; font-weight: 800; cursor: pointer; }
-    .embed-code { margin: 0; padding: 13px; overflow-x: auto; border-radius: 9px; color: #cde7ff;
-      background: #050d17; font: 10.5px/1.65 ui-monospace, SFMono-Regular, Consolas, monospace; white-space: pre; }
-    .social-note { display: flex; gap: 11px; margin-top: 18px; padding: 14px; border: 1px solid rgba(178,108,255,.18);
-      border-radius: 12px; color: #9db0c7; background: rgba(178,108,255,.055); font-size: 11.5px; line-height: 1.55; }
-    .social-note strong { color: #d9c4ff; }
+    .embed-option p { margin: 0 0 10px; color: var(--muted); font-size: 11.5px; line-height: 1.5; }
+    .copy-button { padding: 7px 10px; border: 1px solid #99F6E4; border-radius: 8px;
+      color: var(--accent); background: #F0FDFA; font-size: 10px; font-weight: 700; cursor: pointer; }
+    .copy-button:hover { background: #CCFBF1; }
+    .embed-code { margin: 0; padding: 13px; overflow-x: auto; border-radius: 9px; color: #E2E8F0;
+      background: var(--sidebar); font: 10.5px/1.65 ui-monospace, SFMono-Regular, Consolas, monospace; white-space: pre; }
+    .social-note { display: flex; gap: 11px; margin-top: 18px; padding: 14px; border: 1px solid #99F6E4;
+      border-radius: 12px; color: var(--muted); background: #F0FDFA; font-size: 11.5px; line-height: 1.55; }
+    .social-note strong { color: var(--accent-active); }
 
     @media (max-width: 820px) {
       .hero-grid { grid-template-columns: 1fr; padding-top: 48px; }

--- a/docs/demo/player.html
+++ b/docs/demo/player.html
@@ -165,6 +165,8 @@
           // Pinned, not measured: this page exists to BE the compact layout, and a
           // host site may size the iframe wide enough to trip the roomy one.
           chrome: "compact",
+          // The iframe's own border-radius is the boundary here.
+          frame: "flush",
           documentName: "docxodus-demo.docx",
           hint: false,
           loader: { eyebrow: "Private · local · WebAssembly", meta: "DOCX → WASM → DOCX" },

--- a/docs/demo/player.html
+++ b/docs/demo/player.html
@@ -23,18 +23,21 @@
       ?engine=<module URL of embed bundle>   default: jsDelivr docxodus@9.6.0
       ?doc=<docx URL>                        default: local branded product guide
   -->
+  <!-- Inter — the surface's UI typeface (falls back to system-ui offline). -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
-    :root { color-scheme: dark; --cyan: #52e5ff; --violet: #b26cff; }
+    /* OS-Legal house style, dark-sidebar variant: slate #0F172A ground with the
+       deep-teal accent family. See github.com/Open-Source-Legal/OS-Legal-Style. */
+    :root { color-scheme: dark; --teal: #2DD4BF; --teal-soft: #5EEAD4; }
     * { box-sizing: border-box; }
     html, body { height: 100%; }
     body { position: relative; margin: 0; overflow: hidden; font-family: Inter, ui-sans-serif, system-ui,
-      -apple-system, "Segoe UI", sans-serif; background: #07111f; color: #f5f9ff; display: flex; flex-direction: column; }
+      -apple-system, "Segoe UI", sans-serif; background: #0F172A; color: #F8FAFC; display: flex; flex-direction: column; }
     body::before { position: absolute; inset: 0; content: ""; pointer-events: none; background:
-      radial-gradient(circle at 15% 14%, rgba(54,126,255,.28), transparent 52%),
-      radial-gradient(circle at 86% 82%, rgba(178,108,255,.22), transparent 48%),
-      linear-gradient(rgba(255,255,255,.025) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(255,255,255,.025) 1px, transparent 1px);
-      background-size: auto, auto, 30px 30px, 30px 30px; }
+      radial-gradient(circle at 15% 14%, rgba(13,148,136,.24), transparent 52%),
+      radial-gradient(circle at 86% 82%, rgba(45,212,191,.12), transparent 48%); }
 
     /* ── Animated poster ─────────────────────────────────────────────────────
        Shown until the visitor asks for the editor. Once they do, the surface's
@@ -43,39 +46,39 @@
       align-items: center; justify-content: center; text-align: center; padding: 22px; }
     #boot[hidden] { display: none; }
     .boot-art { position: relative; width: 126px; height: 126px; margin-bottom: 14px; }
-    .ring { position: absolute; inset: 2px; border: 1px solid rgba(82,229,255,.25); border-radius: 50%;
+    .ring { position: absolute; inset: 2px; border: 1px solid rgba(45,212,191,.25); border-radius: 50%;
       animation: spin 7s linear infinite; }
-    .ring.two { inset: 17px; border-style: dashed; border-color: rgba(178,108,255,.4);
+    .ring.two { inset: 17px; border-style: dashed; border-color: rgba(94,234,212,.35);
       animation-duration: 4.5s; animation-direction: reverse; }
     .ring::before { position: absolute; top: -4px; left: 50%; width: 8px; height: 8px; border-radius: 50%;
-      content: ""; background: var(--cyan); box-shadow: 0 0 14px var(--cyan); }
-    .mark { position: absolute; inset: 30px 37px; padding: 17px 11px; border: 1px solid rgba(255,255,255,.35);
-      border-radius: 10px; background: linear-gradient(150deg, rgba(255,255,255,.2), rgba(255,255,255,.06));
+      content: ""; background: var(--teal); box-shadow: 0 0 14px rgba(45,212,191,.8); }
+    .mark { position: absolute; inset: 30px 37px; padding: 17px 11px; border: 1px solid rgba(255,255,255,.32);
+      border-radius: 10px; background: linear-gradient(150deg, rgba(255,255,255,.18), rgba(255,255,255,.05));
       box-shadow: 0 17px 35px rgba(0,0,0,.35); animation: float 3s ease-in-out infinite; }
     .mark::before { position: absolute; top: -7px; right: -8px; padding: 3px 5px; border-radius: 5px;
-      color: #07111f; background: var(--cyan); content: "DOCX"; font-size: 6px; font-weight: 900; letter-spacing: .1em; }
+      color: #042F2E; background: var(--teal); content: "DOCX"; font-size: 6px; font-weight: 900; letter-spacing: .1em; }
     .mark span { display: block; height: 3px; margin-bottom: 7px; border-radius: 2px; background: rgba(255,255,255,.7);
       transform-origin: left; animation: pulse-line 1.9s ease-in-out infinite; }
     .mark span:nth-child(2) { width: 74%; animation-delay: -.5s; }
-    .mark span:nth-child(3) { width: 88%; background: #ff8298; animation-delay: -1s; }
-    .boot-kicker { color: var(--cyan); font-size: 9px; font-weight: 850; letter-spacing: .16em; text-transform: uppercase; }
-    #boot h1 { margin: 7px 0 9px; font-size: clamp(25px, 7vw, 34px); line-height: 1; letter-spacing: -.045em; }
-    #boot h1 span { color: transparent; background: linear-gradient(90deg, var(--cyan), #c48cff);
-      background-clip: text; -webkit-background-clip: text; }
-    #boot > p { max-width: 340px; margin: 0; color: #9ab0c9; font-size: 12.5px; line-height: 1.5; }
+    .mark span:nth-child(3) { width: 88%; background: #F87171; animation-delay: -1s; }
+    .boot-kicker { color: var(--teal-soft); font-size: 9px; font-weight: 700; letter-spacing: .16em; text-transform: uppercase; }
+    #boot h1 { margin: 7px 0 9px; font-family: Georgia, "Times New Roman", serif; font-weight: 500;
+      font-size: clamp(25px, 7vw, 34px); line-height: 1.05; letter-spacing: -.02em; }
+    #boot h1 span { color: var(--teal-soft); font-style: italic; }
+    #boot > p { max-width: 340px; margin: 0; color: #94A3B8; font-size: 12.5px; line-height: 1.5; }
     .feature-ticker { width: min(340px, 100%); min-height: 51px; display: flex; align-items: center; gap: 10px;
-      margin: 15px 0; padding: 10px 12px; border: 1px solid rgba(136,166,201,.15); border-radius: 11px;
-      background: rgba(255,255,255,.045); text-align: left; }
-    .feature-ticker .number { color: var(--violet); font: 800 9px ui-monospace, monospace; }
+      margin: 15px 0; padding: 10px 12px; border: 1px solid rgba(148,163,184,.16); border-radius: 11px;
+      background: rgba(255,255,255,.04); text-align: left; }
+    .feature-ticker .number { color: var(--teal); font: 800 9px ui-monospace, monospace; }
     .feature-ticker strong { display: block; font-size: 10.5px; }
-    .feature-ticker span:last-child { display: block; margin-top: 2px; color: #7890ab; font-size: 9.5px; line-height: 1.35; }
+    .feature-ticker span:last-child { display: block; margin-top: 2px; color: #8BA0B9; font-size: 9.5px; line-height: 1.35; }
     .feature-ticker.swap { animation: swap .35s ease; }
-    #start { min-width: 196px; min-height: 44px; padding: 10px 20px; border: 0; border-radius: 999px; color: #07111f;
-      background: linear-gradient(135deg, var(--cyan), #89f7dd); box-shadow: 0 11px 28px rgba(82,229,255,.18);
-      font: inherit; font-size: 12px; font-weight: 820; cursor: pointer; transition: transform .2s, box-shadow .2s; }
-    #start:hover { transform: translateY(-2px); box-shadow: 0 15px 34px rgba(82,229,255,.25); }
-    #start:disabled { color: #c1d1e2; background: rgba(255,255,255,.08); box-shadow: none; cursor: wait; transform: none; }
-    #bootStatus { min-height: 16px; margin-top: 12px; color: #7991ac; font-size: 9.5px; }
+    #start { min-width: 196px; min-height: 44px; padding: 10px 20px; border: 0; border-radius: 999px; color: #042F2E;
+      background: linear-gradient(135deg, var(--teal), var(--teal-soft)); box-shadow: 0 11px 28px rgba(45,212,191,.2);
+      font: inherit; font-size: 12px; font-weight: 700; cursor: pointer; transition: transform .2s, box-shadow .2s; }
+    #start:hover { transform: translateY(-2px); box-shadow: 0 15px 34px rgba(45,212,191,.28); }
+    #start:disabled { color: #94A3B8; background: rgba(255,255,255,.08); box-shadow: none; cursor: wait; transform: none; }
+    #bootStatus { min-height: 16px; margin-top: 12px; color: #64748B; font-size: 9.5px; }
 
     /* ── Editor ──────────────────────────────────────────────────────────── */
     #app { position: relative; z-index: 1; flex: 1; min-height: 0; }
@@ -84,9 +87,9 @@
        costs no height in an already small frame. It sits OUTSIDE #app because the
        embed factory takes ownership of that element's children. */
     #brandLink { position: fixed; z-index: 50; right: 8px; top: 8px; padding: 3px 8px;
-      border: 1px solid #d3dae4; border-radius: 999px; background: #f7f9fc; color: #5d6975;
-      font: 600 10px/1.5 system-ui, sans-serif; text-decoration: none; }
-    #brandLink:hover { color: #101418; background: #fff; }
+      border: 1px solid #E2E8F0; border-radius: 999px; background: #fff; color: #475569;
+      font: 600 10px/1.5 system-ui, sans-serif; text-decoration: none; box-shadow: 0 1px 2px rgba(15,23,42,.04); }
+    #brandLink:hover { color: #1E293B; border-color: #CBD5E1; }
     /* Reserve the pill's corner so it never covers the title bar's Undo/Redo. */
     #app .dxr-titlebar { padding-right: 78px; }
     body:has(.dxr[data-state="loading"]) #brandLink { display: none; }

--- a/npm/src/embed.ts
+++ b/npm/src/embed.ts
@@ -470,6 +470,9 @@ export async function createRibbonEditor(
   mount.root.style.minHeight = "0";
   const ribbon = mountRibbon(mount.root, {
     documentName: ribbonOptions.documentName ?? nameFromSource(source),
+    // A drop-in embed sits in the middle of someone's page, so it carries its own
+    // boundary (rounded card + shadow). Full-bleed hosts pass frame: "flush".
+    frame: "card",
     ...ribbonOptions,
     // Exports arrive after the runtime boots; the loader covers that gap.
     exports: undefined,

--- a/npm/src/ribbon-chrome.ts
+++ b/npm/src/ribbon-chrome.ts
@@ -23,7 +23,7 @@
  */
 
 /** Bumped whenever RIBBON_CSS changes, so a stale injected stylesheet is replaced. */
-export const RIBBON_STYLE_VERSION = "5";
+export const RIBBON_STYLE_VERSION = "6";
 export const RIBBON_STYLE_ATTR = "data-docxodus-ribbon-styles";
 
 /**
@@ -34,19 +34,34 @@ export const RIBBON_STYLE_ATTR = "data-docxodus-ribbon-styles";
  */
 export const RIBBON_CSS = `
 .dxr {
-  --dxr-ink: #101418;
+  /* OS-Legal design tokens (github.com/Open-Source-Legal/OS-Legal-Style):
+     deep-teal accent, slate foreground scale, warm neutral surfaces, and
+     "light touch" shadows at 0.03-0.06 opacity — structure over decoration. */
+  --dxr-ink: #1e293b;
   --dxr-sheet: #ffffff;
-  --dxr-chrome: #eef1f6;
-  --dxr-chrome-sunk: #e3e8f0;
-  --dxr-rule: #d3dae4;
-  --dxr-accent: #1f5fd0;
-  --dxr-wash: #dde8fb;
-  --dxr-muted: #5d6975;
-  --dxr-data: #0b6f6a;
-  --dxr-danger: #a3341f;
-  --dxr-desk: #dfe3ea;
-  --dxr-ui: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --dxr-chrome: #ffffff;
+  --dxr-chrome-sunk: #f8fafc;
+  --dxr-rule: #e2e8f0;
+  --dxr-rule-strong: #cbd5e1;
+  --dxr-accent: #0f766e;
+  --dxr-accent-hover: #0d9488;
+  --dxr-accent-active: #115e59;
+  --dxr-wash: #f0fdfa;
+  --dxr-wash-edge: #99f6e4;
+  --dxr-muted: #475569;
+  --dxr-faint: #94a3b8;
+  --dxr-data: #0f766e;
+  --dxr-danger: #dc2626;
+  --dxr-danger-wash: #fef2f2;
+  --dxr-desk: #f1f5f9;
+  --dxr-ui: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --dxr-serif: Georgia, "Times New Roman", serif;
   --dxr-mono: ui-monospace, SFMono-Regular, "Cascadia Mono", Consolas, monospace;
+  --dxr-shadow-sm: 0 1px 2px rgba(15, 23, 42, .04);
+  --dxr-shadow-md: 0 1px 3px rgba(15, 23, 42, .06), 0 4px 6px rgba(15, 23, 42, .03);
+  --dxr-shadow-lg: 0 4px 6px rgba(15, 23, 42, .05), 0 10px 15px rgba(15, 23, 42, .04);
+  --dxr-shadow-xl: 0 8px 16px rgba(15, 23, 42, .06), 0 20px 25px rgba(15, 23, 42, .05);
+  --dxr-ease: cubic-bezier(.4, 0, .2, 1);
   --dxr-tap: 30px;
 
   position: relative;
@@ -90,12 +105,13 @@ export const RIBBON_CSS = `
   font-weight: 600;
   letter-spacing: -.01em;
 }
+/* A filled circle, echoing the OS-Legal "Node" motif rather than a diamond. */
 .dxr-brand .dxr-mark {
   flex: 0 0 auto;
   width: 9px;
   height: 9px;
+  border-radius: 50%;
   background: var(--dxr-accent);
-  clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);
 }
 .dxr-brand .dxr-docname {
   overflow: hidden;
@@ -132,14 +148,15 @@ export const RIBBON_CSS = `
   padding: 6px 15px 7px;
   border: 1px solid transparent;
   border-bottom: none;
-  border-radius: 5px 5px 0 0;
+  border-radius: 6px 6px 0 0;
   background: none;
   color: var(--dxr-muted);
   font: inherit;
   font-size: 12.5px;
   cursor: pointer;
+  transition: background-color .15s var(--dxr-ease), color .15s var(--dxr-ease);
 }
-.dxr-tab:hover { color: var(--dxr-ink); background: #e6ebf3; }
+.dxr-tab:hover { color: var(--dxr-ink); background: #f1f5f9; }
 .dxr-tab[aria-selected="true"] {
   color: var(--dxr-ink);
   font-weight: 600;
@@ -175,7 +192,7 @@ export const RIBBON_CSS = `
 .dxr-group:last-child { border-right: none; }
 .dxr-group:first-child { padding-left: 0; }
 .dxr-glabel {
-  color: var(--dxr-muted);
+  color: var(--dxr-faint);
   font-size: 9.5px;
   font-weight: 600;
   letter-spacing: .11em;
@@ -188,44 +205,59 @@ export const RIBBON_CSS = `
   min-height: var(--dxr-tap);
   padding: 5px 9px;
   border: 1px solid transparent;
-  border-radius: 4px;
+  border-radius: 6px;
   background: none;
   color: var(--dxr-ink);
   font: inherit;
   font-size: 13px;
   line-height: 1.15;
   cursor: pointer;
+  transition: background-color .15s var(--dxr-ease), border-color .15s var(--dxr-ease),
+    color .15s var(--dxr-ease);
 }
 .dxr label.dxr-btn { display: inline-flex; align-items: center; }
-.dxr button:hover, .dxr label.dxr-btn:hover { background: #d6deea; }
-.dxr button:active { background: #c8d3e3; }
+.dxr button:hover, .dxr label.dxr-btn:hover { background: #f1f5f9; }
+.dxr button:active { background: #e2e8f0; }
 .dxr button:disabled { opacity: .38; cursor: default; background: none; }
-.dxr button.dxr-on { color: var(--dxr-accent); background: var(--dxr-wash); border-color: #b3ccf2; }
+.dxr button.dxr-on { color: var(--dxr-accent); background: var(--dxr-wash); border-color: var(--dxr-wash-edge); }
 .dxr-quick button, .dxr-quick label.dxr-btn {
   padding: 4px 10px;
   border-color: var(--dxr-rule);
-  background: #f7f9fc;
+  background: var(--dxr-sheet);
+  box-shadow: var(--dxr-shadow-sm);
   font-size: 12.5px;
 }
-.dxr-quick button:hover, .dxr-quick label.dxr-btn:hover { background: #fff; border-color: #b9c4d4; }
-.dxr-quick button:disabled:hover { background: #f7f9fc; border-color: var(--dxr-rule); }
+.dxr-quick button:hover, .dxr-quick label.dxr-btn:hover { background: var(--dxr-chrome-sunk); border-color: var(--dxr-rule-strong); }
+.dxr-quick button:disabled { box-shadow: none; }
+.dxr-quick button:disabled:hover { background: var(--dxr-sheet); border-color: var(--dxr-rule); }
+/* Save is the surface's one primary action — the house accent button. */
+.dxr-quick button[data-dxr="save"]:not(:disabled) {
+  border-color: transparent;
+  background: var(--dxr-accent);
+  color: #fff;
+  font-weight: 600;
+  box-shadow: 0 4px 14px rgba(15, 118, 110, .2);
+}
+.dxr-quick button[data-dxr="save"]:not(:disabled):hover { background: var(--dxr-accent-hover); }
+.dxr-quick button[data-dxr="save"]:not(:disabled):active { background: var(--dxr-accent-active); }
 .dxr button.dxr-icon { min-width: var(--dxr-tap); text-align: center; }
 /* Icons are inline SVG drawn from the same shapes the control acts on (text lines,
    rules), so alignment and indent read at a glance instead of relying on arrow
    glyphs that collide with undo/redo. currentColor keeps them in step with state. */
 .dxr button svg { display: block; margin: 0 auto; fill: currentColor; }
 .dxr button.dxr-wide { display: inline-flex; align-items: center; justify-content: center; gap: 6px; }
-.dxr button.dxr-danger:hover { color: var(--dxr-danger); background: #f6dcd6; }
+.dxr button.dxr-danger:hover { color: var(--dxr-danger); background: var(--dxr-danger-wash); }
 .dxr select, .dxr input[type="number"], .dxr input[type="text"] {
   min-height: var(--dxr-tap);
   padding: 4px 6px;
   border: 1px solid var(--dxr-rule);
-  border-radius: 4px;
-  background: #f7f9fc;
+  border-radius: 6px;
+  background: var(--dxr-sheet);
   color: var(--dxr-ink);
   font: inherit;
   font-size: 12.5px;
 }
+.dxr select:hover, .dxr input:hover { border-color: var(--dxr-rule-strong); }
 .dxr select:focus-visible, .dxr input:focus-visible, .dxr button:focus-visible,
 .dxr .dxr-tab:focus-visible, .dxr label.dxr-btn:focus-within {
   outline: 2px solid var(--dxr-accent);
@@ -256,7 +288,7 @@ export const RIBBON_CSS = `
   height: 25px;
   padding: 0 10px;
   overflow-x: auto;
-  background: #f7f9fc;
+  background: #fafafa;
   border-top: 1px solid var(--dxr-rule);
   color: var(--dxr-muted);
   font-family: var(--dxr-mono);
@@ -275,7 +307,7 @@ export const RIBBON_CSS = `
 .dxr-rail .dxr-cell:first-child { padding-left: 0; }
 .dxr-rail .dxr-cell:last-child { border-right: none; }
 .dxr-rail .dxr-k {
-  color: #8b96a3;
+  color: var(--dxr-faint);
   font-family: var(--dxr-ui);
   font-size: 9.5px;
   letter-spacing: .1em;
@@ -283,7 +315,7 @@ export const RIBBON_CSS = `
 }
 .dxr-rail .dxr-v { color: var(--dxr-data); }
 .dxr-rail .dxr-v.dxr-flash { animation: dxr-railflash .45s ease-out; }
-@keyframes dxr-railflash { from { background: #b9ecdf; } to { background: transparent; } }
+@keyframes dxr-railflash { from { background: #ccfbf1; } to { background: transparent; } }
 
 /* ── Hint ─────────────────────────────────────────────────────────────────── */
 .dxr-hint {
@@ -298,8 +330,8 @@ export const RIBBON_CSS = `
 .dxr-hint kbd {
   padding: 0 4px;
   border: 1px solid var(--dxr-rule);
-  border-radius: 3px;
-  background: #e8ecf3;
+  border-radius: 4px;
+  background: #f1f5f9;
   font-family: var(--dxr-mono);
   font-size: 11px;
 }
@@ -320,7 +352,7 @@ export const RIBBON_CSS = `
   outline-offset: 2px;
   border-radius: 2px;
 }
-@media (hover: hover) { .dxr-surface [contenteditable="true"]:hover { background: #f2f7ff; } }
+@media (hover: hover) { .dxr-surface [contenteditable="true"]:hover { background: var(--dxr-wash); } }
 
 /* Header/footer bands: stories live in their own OOXML parts outside the body,
    so they dock as their own regions. Styled from the same tokens as the ribbon
@@ -332,9 +364,10 @@ export const RIBBON_CSS = `
   margin: 0 auto 14px;
   padding: 9px 72px 13px;
   border: 1px solid var(--dxr-rule);
-  border-left: 2px solid #c2ccd9;
-  border-radius: 3px;
+  border-left: 2px solid #5eead4;
+  border-radius: 6px;
   background: var(--dxr-sheet);
+  box-shadow: var(--dxr-shadow-sm);
 }
 .dxr-surface .docx-hf-band + .docx-body-flow { margin-top: 0; }
 .dxr-surface .docx-hf-band[data-hf-band="footer"] { margin: 14px auto 0; }
@@ -353,8 +386,8 @@ export const RIBBON_CSS = `
 .dxr-surface .docx-hf-chrome select, .dxr-surface .docx-hf-chrome input {
   padding: 3px 5px;
   border: 1px solid var(--dxr-rule);
-  border-radius: 4px;
-  background: #f7f9fc;
+  border-radius: 6px;
+  background: var(--dxr-chrome-sunk);
   color: var(--dxr-ink);
   font: inherit;
   font-family: var(--dxr-ui);
@@ -368,22 +401,22 @@ export const RIBBON_CSS = `
 .dxr-surface .docx-hf-warning {
   margin: 0 0 8px -60px;
   padding: 7px 9px;
-  border: 1px solid #e8d9a8;
-  border-left: 2px solid #c9a227;
-  border-radius: 3px;
-  background: #fdf6e3;
-  color: #6b5310;
+  border: 1px solid #fde68a;
+  border-left: 2px solid #d97706;
+  border-radius: 6px;
+  background: #fffbeb;
+  color: #92400e;
   font-size: 12px;
   line-height: 1.45;
 }
 .dxr-surface .docx-hf-warning button {
   margin-left: 6px;
   padding: 2px 8px;
-  border-color: #e8d9a8;
+  border-color: #fde68a;
   background: #fff;
   font-size: 12px;
 }
-.dxr-surface .docx-hf-placeholder { color: #9aa4b1; font-style: italic; }
+.dxr-surface .docx-hf-placeholder { color: var(--dxr-faint); font-style: italic; }
 .dxr-surface .docx-hf-inherited {
   color: var(--dxr-muted);
   font-style: italic;
@@ -403,7 +436,7 @@ export const RIBBON_CSS = `
   padding: 56px 0;
   border-radius: 3px;
   background: var(--dxr-sheet);
-  box-shadow: 0 1px 3px rgba(16, 20, 24, .14), 0 8px 24px rgba(16, 20, 24, .05);
+  box-shadow: 0 1px 3px rgba(15, 23, 42, .08), 0 12px 24px rgba(15, 23, 42, .06);
 }
 
 /* ── Table size picker ────────────────────────────────────────────────────── */
@@ -413,9 +446,9 @@ export const RIBBON_CSS = `
   z-index: 30;
   padding: 9px;
   border: 1px solid var(--dxr-rule);
-  border-radius: 6px;
+  border-radius: 12px;
   background: #fff;
-  box-shadow: 0 4px 16px rgba(16, 20, 24, .18);
+  box-shadow: var(--dxr-shadow-xl);
 }
 .dxr-pop[data-open] { display: block; }
 .dxr-gridcells { display: grid; grid-template-columns: repeat(10, 16px); gap: 2px; }
@@ -423,11 +456,11 @@ export const RIBBON_CSS = `
   width: 16px;
   height: 16px;
   border: 1px solid var(--dxr-rule);
-  border-radius: 2px;
-  background: #f2f5f9;
+  border-radius: 3px;
+  background: var(--dxr-chrome-sunk);
   cursor: pointer;
 }
-.dxr-gridcells div[data-on] { background: var(--dxr-wash); border-color: var(--dxr-accent); }
+.dxr-gridcells div[data-on] { background: #ccfbf1; border-color: var(--dxr-accent); }
 .dxr-popfoot {
   display: flex;
   justify-content: space-between;
@@ -510,11 +543,11 @@ export const RIBBON_CSS = `
   display: grid;
   place-items: center;
   padding: 24px;
-  color: #f4f9ff;
+  color: #f8fafc;
   background:
-    radial-gradient(circle at 20% 20%, rgba(63, 128, 255, .24), transparent 22rem),
-    radial-gradient(circle at 82% 80%, rgba(176, 91, 255, .22), transparent 24rem),
-    linear-gradient(145deg, #071221 0%, #0b1930 52%, #101426 100%);
+    radial-gradient(circle at 20% 20%, rgba(13, 148, 136, .2), transparent 22rem),
+    radial-gradient(circle at 82% 80%, rgba(45, 212, 191, .1), transparent 24rem),
+    linear-gradient(150deg, #0b1220 0%, #0f172a 55%, #0f2723 100%);
   transition: opacity .55s ease, visibility .55s ease;
 }
 .dxr-loader[hidden] { display: none; }
@@ -533,14 +566,14 @@ export const RIBBON_CSS = `
 .dxr-orbit {
   position: absolute;
   inset: 7%;
-  border: 1px solid rgba(115, 204, 255, .22);
+  border: 1px solid rgba(45, 212, 191, .24);
   border-radius: 50%;
   animation: dxr-spin 9s linear infinite;
 }
 .dxr-orbit.dxr-two {
   inset: 20%;
   border-style: dashed;
-  border-color: rgba(196, 128, 255, .32);
+  border-color: rgba(94, 234, 212, .3);
   animation-duration: 6s;
   animation-direction: reverse;
 }
@@ -550,19 +583,19 @@ export const RIBBON_CSS = `
   height: 10px;
   border-radius: 50%;
   content: "";
-  background: #52e5ff;
-  box-shadow: 0 0 18px #52e5ff;
+  background: #2dd4bf;
+  box-shadow: 0 0 18px rgba(45, 212, 191, .8);
 }
 .dxr-orbit::before { top: -5px; left: 50%; }
-.dxr-orbit::after { right: 7%; bottom: 12%; background: #b26cff; box-shadow: 0 0 18px #b26cff; }
+.dxr-orbit::after { right: 7%; bottom: 12%; background: #5eead4; box-shadow: 0 0 18px rgba(94, 234, 212, .7); }
 .dxr-card {
   position: absolute;
   inset: 24% 28%;
   padding: 20px 15px;
-  border: 1px solid rgba(255, 255, 255, .33);
+  border: 1px solid rgba(255, 255, 255, .3);
   border-radius: 14px;
-  background: linear-gradient(150deg, rgba(255, 255, 255, .18), rgba(255, 255, 255, .06));
-  box-shadow: 0 22px 50px rgba(0, 0, 0, .35), 0 0 45px rgba(71, 150, 255, .13);
+  background: linear-gradient(150deg, rgba(255, 255, 255, .16), rgba(255, 255, 255, .05));
+  box-shadow: 0 22px 50px rgba(0, 0, 0, .35), 0 0 45px rgba(13, 148, 136, .15);
   backdrop-filter: blur(10px);
   animation: dxr-float 3.6s ease-in-out infinite;
 }
@@ -572,8 +605,8 @@ export const RIBBON_CSS = `
   right: -9px;
   padding: 4px 7px;
   border-radius: 6px;
-  background: #52e5ff;
-  color: #06111d;
+  background: #2dd4bf;
+  color: #042f2e;
   content: "DOCX";
   font-size: 8px;
   font-weight: 900;
@@ -590,46 +623,49 @@ export const RIBBON_CSS = `
 }
 .dxr-card i:nth-child(2) { width: 76%; animation-delay: -.45s; }
 .dxr-card i:nth-child(3) { width: 88%; animation-delay: -.85s; }
-.dxr-card i:nth-child(4) { width: 58%; background: rgba(255, 111, 139, .75); animation-delay: -1.2s; }
+.dxr-card i:nth-child(4) { width: 58%; background: rgba(248, 113, 113, .75); animation-delay: -1.2s; }
 .dxr-chip {
   position: absolute;
   display: grid;
   width: 34px;
   height: 34px;
   place-items: center;
-  border: 1px solid rgba(255, 255, 255, .17);
+  border: 1px solid rgba(255, 255, 255, .16);
   border-radius: 11px;
-  background: rgba(12, 28, 49, .88);
+  background: rgba(15, 30, 46, .88);
   box-shadow: 0 12px 30px rgba(0, 0, 0, .28);
   font-size: 11px;
   font-weight: 850;
 }
-.dxr-chip.dxr-b { left: 2%; top: 30%; color: #52e5ff; animation: dxr-chip 3s ease-in-out infinite; }
-.dxr-chip.dxr-r { right: -2%; bottom: 24%; color: #ff8da0; animation: dxr-chip 3s -1.4s ease-in-out infinite; }
-.dxr-chip.dxr-s { left: 20%; bottom: 0; color: #52e0a2; animation: dxr-chip 3s -.7s ease-in-out infinite; }
-.dxr-eyebrow { color: #52e5ff; font-size: 10px; font-weight: 850; letter-spacing: .16em; text-transform: uppercase; }
+.dxr-chip.dxr-b { left: 2%; top: 30%; color: #5eead4; animation: dxr-chip 3s ease-in-out infinite; }
+.dxr-chip.dxr-r { right: -2%; bottom: 24%; color: #fca5a5; animation: dxr-chip 3s -1.4s ease-in-out infinite; }
+.dxr-chip.dxr-s { left: 20%; bottom: 0; color: #6ee7b7; animation: dxr-chip 3s -.7s ease-in-out infinite; }
+.dxr-eyebrow { color: #5eead4; font-size: 10px; font-weight: 850; letter-spacing: .16em; text-transform: uppercase; }
+/* Georgia headline — the house pairing of a serif headline over Inter UI copy. */
 .dxr-loader h2 {
   margin: 10px auto 10px;
   max-width: 520px;
-  font-size: clamp(23px, 5vw, 40px);
-  line-height: 1.05;
-  letter-spacing: -.045em;
+  font-family: var(--dxr-serif);
+  font-size: clamp(23px, 5vw, 38px);
+  font-weight: 500;
+  line-height: 1.08;
+  letter-spacing: -.02em;
 }
-.dxr-loader-copy > p { margin: 0 auto; max-width: 46ch; color: #9eb2c9; font-size: 13.5px; line-height: 1.6; }
+.dxr-loader-copy > p { margin: 0 auto; max-width: 46ch; color: #94a3b8; font-size: 13.5px; line-height: 1.6; }
 .dxr-ad {
   display: flex;
   gap: 12px;
   margin: 20px auto 0;
   max-width: 420px;
   padding: 13px;
-  border: 1px solid rgba(126, 160, 200, .16);
-  border-radius: 13px;
+  border: 1px solid rgba(148, 163, 184, .16);
+  border-radius: 12px;
   background: rgba(255, 255, 255, .04);
   text-align: left;
 }
-.dxr-ad .dxr-num { color: #b26cff; font: 800 10px/1.4 var(--dxr-mono); }
+.dxr-ad .dxr-num { color: #2dd4bf; font: 800 10px/1.4 var(--dxr-mono); }
 .dxr-ad strong { display: block; font-size: 12.5px; }
-.dxr-ad .dxr-adcopy { display: block; margin-top: 4px; color: #849bb5; font-size: 11.5px; line-height: 1.45; }
+.dxr-ad .dxr-adcopy { display: block; margin-top: 4px; color: #8ba0b9; font-size: 11.5px; line-height: 1.45; }
 .dxr-ad[data-swap] { animation: dxr-swap .4s ease; }
 .dxr-track {
   height: 3px;
@@ -643,8 +679,8 @@ export const RIBBON_CSS = `
   width: 12%;
   height: 100%;
   border-radius: inherit;
-  background: linear-gradient(90deg, #52e5ff, #5c7cff, #b26cff);
-  box-shadow: 0 0 16px rgba(82, 229, 255, .55);
+  background: linear-gradient(90deg, #14b8a6, #2dd4bf, #5eead4);
+  box-shadow: 0 0 16px rgba(45, 212, 191, .5);
   transition: width .65s cubic-bezier(.22, .8, .28, 1);
 }
 .dxr-meta {
@@ -653,7 +689,7 @@ export const RIBBON_CSS = `
   gap: 14px;
   margin: 9px auto 0;
   max-width: 420px;
-  color: #647e9c;
+  color: #64748b;
   font: 700 9px/1 var(--dxr-mono);
   letter-spacing: .09em;
   text-transform: uppercase;
@@ -662,9 +698,9 @@ export const RIBBON_CSS = `
   display: none;
   margin-top: 18px;
   padding: 9px 14px;
-  border: 1px solid rgba(255, 127, 145, .4);
+  border: 1px solid rgba(248, 113, 113, .4);
   border-radius: 9px;
-  background: rgba(255, 127, 145, .12);
+  background: rgba(248, 113, 113, .12);
   color: #fff;
   cursor: pointer;
 }

--- a/npm/src/ribbon-chrome.ts
+++ b/npm/src/ribbon-chrome.ts
@@ -23,7 +23,7 @@
  */
 
 /** Bumped whenever RIBBON_CSS changes, so a stale injected stylesheet is replaced. */
-export const RIBBON_STYLE_VERSION = "6";
+export const RIBBON_STYLE_VERSION = "7";
 export const RIBBON_STYLE_ATTR = "data-docxodus-ribbon-styles";
 
 /**
@@ -47,7 +47,7 @@ export const RIBBON_CSS = `
   --dxr-accent-hover: #0d9488;
   --dxr-accent-active: #115e59;
   --dxr-wash: #f0fdfa;
-  --dxr-wash-edge: #99f6e4;
+  --dxr-wash-on: #ccfbf1;
   --dxr-muted: #475569;
   --dxr-faint: #94a3b8;
   --dxr-data: #0f766e;
@@ -143,26 +143,25 @@ export const RIBBON_CSS = `
   scrollbar-width: none;
 }
 .dxr-tabs::-webkit-scrollbar { display: none; }
+/* Line-variant tabs (the house Tabs default): no boxes, no fills — the selected
+   tab is a 2px accent underline sitting on the panel's own hairline. */
 .dxr-tab {
   flex: 0 0 auto;
-  padding: 6px 15px 7px;
-  border: 1px solid transparent;
-  border-bottom: none;
-  border-radius: 6px 6px 0 0;
+  padding: 7px 14px 8px;
+  border: none;
   background: none;
   color: var(--dxr-muted);
   font: inherit;
   font-size: 12.5px;
+  font-weight: 500;
   cursor: pointer;
-  transition: background-color .15s var(--dxr-ease), color .15s var(--dxr-ease);
+  transition: color .15s var(--dxr-ease), box-shadow .15s var(--dxr-ease);
 }
-.dxr-tab:hover { color: var(--dxr-ink); background: #f1f5f9; }
+.dxr-tab:hover { color: var(--dxr-ink); }
 .dxr-tab[aria-selected="true"] {
   color: var(--dxr-ink);
   font-weight: 600;
-  background: var(--dxr-chrome-sunk);
-  border-color: var(--dxr-rule);
-  box-shadow: inset 0 2px 0 var(--dxr-accent);
+  box-shadow: inset 0 -2px 0 var(--dxr-accent);
 }
 /* Contextual tab — present only while the caret is inside a table. */
 .dxr-tab[data-contextual] { color: var(--dxr-accent); }
@@ -201,46 +200,52 @@ export const RIBBON_CSS = `
 .dxr-row { display: flex; gap: 3px; align-items: center; }
 
 /* ── Controls ─────────────────────────────────────────────────────────────── */
+/* One button family, house-style: every control is a ghost — no borders, no
+   fills, no per-button boxes. Hover paints a quiet slate wash; the active
+   (toggled) state paints a teal one. Save alone is the flat primary, so the
+   surface has exactly one accent-colored action. */
 .dxr button, .dxr label.dxr-btn {
   min-height: var(--dxr-tap);
   padding: 5px 9px;
-  border: 1px solid transparent;
+  border: none;
   border-radius: 6px;
   background: none;
   color: var(--dxr-ink);
   font: inherit;
   font-size: 13px;
+  font-weight: 500;
   line-height: 1.15;
   cursor: pointer;
-  transition: background-color .15s var(--dxr-ease), border-color .15s var(--dxr-ease),
-    color .15s var(--dxr-ease);
+  transition: background-color .15s var(--dxr-ease), color .15s var(--dxr-ease),
+    box-shadow .15s var(--dxr-ease), transform .15s var(--dxr-ease);
 }
 .dxr label.dxr-btn { display: inline-flex; align-items: center; }
 .dxr button:hover, .dxr label.dxr-btn:hover { background: #f1f5f9; }
 .dxr button:active { background: #e2e8f0; }
 .dxr button:disabled { opacity: .38; cursor: default; background: none; }
-.dxr button.dxr-on { color: var(--dxr-accent); background: var(--dxr-wash); border-color: var(--dxr-wash-edge); }
-.dxr-quick button, .dxr-quick label.dxr-btn {
-  padding: 4px 10px;
-  border-color: var(--dxr-rule);
-  background: var(--dxr-sheet);
-  box-shadow: var(--dxr-shadow-sm);
-  font-size: 12.5px;
-}
-.dxr-quick button:hover, .dxr-quick label.dxr-btn:hover { background: var(--dxr-chrome-sunk); border-color: var(--dxr-rule-strong); }
-.dxr-quick button:disabled { box-shadow: none; }
-.dxr-quick button:disabled:hover { background: var(--dxr-sheet); border-color: var(--dxr-rule); }
-/* Save is the surface's one primary action — the house accent button. */
+.dxr button.dxr-on { color: var(--dxr-accent); background: var(--dxr-wash-on); }
+.dxr-quick button, .dxr-quick label.dxr-btn { padding: 4px 10px; font-size: 12.5px; }
+/* Save — the house primary: flat accent, sm shadow, the 1px lift on hover. */
 .dxr-quick button[data-dxr="save"]:not(:disabled) {
-  border-color: transparent;
   background: var(--dxr-accent);
   color: #fff;
   font-weight: 600;
-  box-shadow: 0 4px 14px rgba(15, 118, 110, .2);
+  box-shadow: var(--dxr-shadow-sm);
 }
-.dxr-quick button[data-dxr="save"]:not(:disabled):hover { background: var(--dxr-accent-hover); }
-.dxr-quick button[data-dxr="save"]:not(:disabled):active { background: var(--dxr-accent-active); }
-.dxr button.dxr-icon { min-width: var(--dxr-tap); text-align: center; }
+.dxr-quick button[data-dxr="save"]:not(:disabled):hover {
+  background: var(--dxr-accent-hover);
+  box-shadow: var(--dxr-shadow-md);
+  transform: translateY(-1px);
+}
+.dxr-quick button[data-dxr="save"]:not(:disabled):active {
+  background: var(--dxr-accent-active);
+  box-shadow: var(--dxr-shadow-sm);
+  transform: translateY(0);
+}
+/* Icon controls sit quieter than text ones until touched (house IconButton). */
+.dxr button.dxr-icon { min-width: var(--dxr-tap); text-align: center; color: var(--dxr-muted); }
+.dxr button.dxr-icon:hover:not(:disabled) { color: var(--dxr-ink); }
+.dxr button.dxr-icon.dxr-on { color: var(--dxr-accent); }
 /* Icons are inline SVG drawn from the same shapes the control acts on (text lines,
    rules), so alignment and indent read at a glance instead of relying on arrow
    glyphs that collide with undo/redo. currentColor keeps them in step with state. */
@@ -387,7 +392,7 @@ export const RIBBON_CSS = `
   padding: 3px 5px;
   border: 1px solid var(--dxr-rule);
   border-radius: 6px;
-  background: var(--dxr-chrome-sunk);
+  background: var(--dxr-sheet);
   color: var(--dxr-ink);
   font: inherit;
   font-family: var(--dxr-ui);
@@ -826,8 +831,8 @@ export const RIBBON_HTML = `
           )}</button>
         </div>
         <div class="dxr-row">
-          <button type="button" data-list="bullet" title="Bullet list">&#8226; List</button>
-          <button type="button" data-list="decimal" title="Numbered list">1. List</button>
+          <button type="button" data-list="bullet" title="Bullet list">Bullets</button>
+          <button type="button" data-list="decimal" title="Numbered list">Numbered</button>
           <button type="button" data-pagebreak title="Start this block on a new page">Page break</button>
         </div>
       </div>

--- a/npm/src/ribbon-chrome.ts
+++ b/npm/src/ribbon-chrome.ts
@@ -23,7 +23,7 @@
  */
 
 /** Bumped whenever RIBBON_CSS changes, so a stale injected stylesheet is replaced. */
-export const RIBBON_STYLE_VERSION = "7";
+export const RIBBON_STYLE_VERSION = "8";
 export const RIBBON_STYLE_ATTR = "data-docxodus-ribbon-styles";
 
 /**
@@ -76,6 +76,18 @@ export const RIBBON_CSS = `
   -webkit-text-size-adjust: 100%;
 }
 .dxr *, .dxr *::before, .dxr *::after { box-sizing: border-box; }
+
+/* ── Card frame ────────────────────────────────────────────────────────────────
+   A drop-in embed carries its OWN boundary instead of hoping the host clips it:
+   rounded corners, a hairline, and the house elevation. overflow: clip keeps
+   the sticky chrome, scrollbars, and the loading overlay inside the curve.
+   Full-bleed hosts mount with data-frame="flush" and stay edge-to-edge. */
+.dxr[data-frame="card"] {
+  border: 1px solid var(--dxr-rule);
+  border-radius: 14px;
+  box-shadow: var(--dxr-shadow-xl);
+  overflow: clip;
+}
 
 /* Touch devices get bigger hit targets everywhere the token is used. */
 @media (pointer: coarse) { .dxr { --dxr-tap: 40px; } }
@@ -351,6 +363,27 @@ export const RIBBON_CSS = `
    SHOULD win.
    (No backticks in this file's comments: the stylesheet is a template literal.) */
 .dxr-scroll { flex: 1 1 auto; min-height: 0; overflow: auto; -webkit-overflow-scrolling: touch; }
+/* Soft scroll boundaries: content dissolves at the chrome and at the bottom edge
+   instead of hard-clipping. Sticky gradient veils cost one paint layer each and
+   never intercept input. */
+.dxr-scroll::before, .dxr-scroll::after {
+  content: "";
+  position: sticky;
+  z-index: 3;
+  display: block;
+  height: 26px;
+  pointer-events: none;
+}
+.dxr-scroll::before {
+  top: 0;
+  margin-bottom: -26px;
+  background: linear-gradient(to bottom, var(--dxr-desk), transparent);
+}
+.dxr-scroll::after {
+  bottom: 0;
+  margin-top: -26px;
+  background: linear-gradient(to top, var(--dxr-desk), transparent);
+}
 .dxr[data-chrome] .dxr-surface { margin: 26px auto; padding: 0 16px 96px; }
 .dxr-surface [contenteditable="true"]:focus {
   outline: 2px solid var(--dxr-accent);

--- a/npm/src/ribbon.ts
+++ b/npm/src/ribbon.ts
@@ -88,6 +88,14 @@ export interface RibbonOptions extends DocxEditorOptions {
   exports?: DocxEditorExports;
   /** Layout density. Default "auto". */
   chrome?: RibbonChromeMode;
+  /**
+   * Boundary treatment. "flush" (default) is edge-to-edge for full-bleed hosts
+   * and hosts that frame the surface themselves; "card" makes the surface carry
+   * its own boundary — rounded corners, hairline border, house shadow — for a
+   * drop-in embed in the middle of a page. `createRibbonEditor` defaults to
+   * "card", since that is the drop-in path.
+   */
+  frame?: "card" | "flush";
   /** Root width, in px, below which "auto" picks compact. Default 720. */
   compactBreakpoint?: number;
   /** Show the anchor rail (full chrome only). Default true. */
@@ -316,6 +324,7 @@ class RibbonSurface implements RibbonEditor {
     const root = doc.createElement("div");
     root.className = "dxr";
     root.dataset.state = "idle";
+    root.dataset.frame = this.options.frame ?? "flush";
     root.innerHTML = RIBBON_HTML;
     for (const el of Array.from(root.querySelectorAll<HTMLElement>("[data-dxr]"))) {
       el.id = this.idPrefix + el.dataset.dxr;


### PR DESCRIPTION
## What

Rethemes the shipped editor surface and its demo hosts to the [OS-Legal design system](https://github.com/Open-Source-Legal/OS-Legal-Style) — deep-teal accent, slate foreground scale, warm neutral surfaces, Inter UI type with Georgia headlines, and "light touch" 0.03–0.06-opacity shadows.

### Ribbon surface (`npm/src/ribbon-chrome.ts`, style version 5 → 6)

- **Tokens**: `--dxr-accent` moves from ad-hoc blue `#1f5fd0` to the house deep teal `#0F766E` (with `-hover`/`-active` companions), foregrounds move to the slate scale (`#1E293B`/`#475569`/`#94A3B8`), chrome goes white over a `#F8FAFC` sunk panel and `#F1F5F9` desk, rules become slate-200/300. New shadow tokens carry the house elevation scale.
- **Type**: Inter leads the UI stack (hosts load it; falls back to `system-ui` offline). The loading overlay's headline switches to Georgia — the house serif-headline-over-Inter-copy pairing.
- **Controls**: 6px radii, slate hover/active washes, teal on-state with a teal-50 wash, danger states on the house red. **Save becomes the surface's one primary accent button** when enabled.
- **Loading overlay**: the neon cyan/violet look becomes the house dark-sidebar variant — `#0F172A` slate ground with the teal family for orbits, chips, progress, and eyebrow.
- **Brand mark**: the diamond becomes a filled teal circle, echoing the OS-Legal "Node" motif.
- No DOM, `data-dxr` addressing, or behavior changes — CSS values only, so all historical selectors and specs keep working.

### Demo hosts (`docs/demo/`)

- `index.html` — full re-skin from the dark neon theme to the light "warm precision" look: Georgia headlines with teal italic accents, teal CTAs, white capability/feature cards, dark-slate workspace head and code blocks, and a properly loaded Inter.
- `player.html` — dark-sidebar variant: slate `#0F172A` ground, teal accent family, Georgia headline.
- `app.html` — desk color and About-pill synced with the new surface tokens; loads Inter.

## Verification

- `npm run build` (WASM + TS + all bundles) green.
- 22 Playwright specs pass: `editor.spec.ts`, `editor-demo-grid.spec.ts`, `ribbon-surface.spec.ts`, `social-demo.spec.ts` — covering the full editing flow, the table grid picker, compact/full chrome density, and all three demo pages booting the shared surface.
- Screenshots (desktop + mobile, light + dark variants) captured of the editor, landing page, player poster, and loading overlay.

---
_Generated by [Claude Code](https://claude.ai/code/session_016gKxbd12XNkFtp82dxGUDe)_