### PR TITLE
Render cached clustered charts as accessible SVG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ All notable changes to this project will be documented in this file.
   pause→type→resume loop, and the save round-trip.
 
 ### Fixed
+- **Cached clustered column and horizontal bar charts render instead of disappearing.** A
+  `c:barChart` drawing with portable cached categories/values is now projected to accessible inline
+  SVG at its stored Word extent, including title, legend, value grid, axis labels, gap/overlap,
+  theme/default series colors, and DrawingML font sizes. Rendering does not require the optional
+  embedded workbook, a JavaScript chart library, or an Office process; unsupported chart families
+  continue through the existing fallback path. An independently generated workbook-free DOCX pins
+  the semantic output. In the tracked LibreOffice benchmark, `HC043-Chart.docx` improves from a
+  blank severe result (SSIM 0.92933, ink F1 0) to close (SSIM 0.98687, ink F1 0.96817).
 - **Empty paragraphs measure automatic line spacing from the font's native line
   box.** OOXML `w:lineRule="auto"` is a multiple of the font's single-line
   height, but the converter expressed it as a percentage of CSS font size,

--- a/Docxodus.Tests/HtmlConversionOpsTests.cs
+++ b/Docxodus.Tests/HtmlConversionOpsTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text;
+using System.Xml.Linq;
 using DocumentFormat.OpenXml.Packaging;
 using Docxodus;
 using Docxodus.Internal;
@@ -175,7 +176,7 @@ public class HtmlConversionOpsTests
     }
 
     [Fact]
-    public void HCO085_PaginatedFootnoteSeparator_UsesWordDefaultTwoInchWidth()
+    public void HCO086_PaginatedFootnoteSeparator_UsesWordDefaultTwoInchWidth()
     {
         // The CSS is emitted only when note rendering is enabled. Use an independently generated
         // package so the regression has no fixture or snapshot licensing dependency.
@@ -190,6 +191,117 @@ public class HtmlConversionOpsTests
         Assert.Contains("width: 2in;", html);
         Assert.Contains("max-width: 100%;", html);
         Assert.DoesNotContain("width: 33%;", html);
+    }
+
+    [Theory]
+    [InlineData("col", "column")]
+    [InlineData("bar", "bar")]
+    public void HCO087_CachedClusteredChart_RendersAccessibleSvgAtStoredExtent(
+        string barDirection, string expectedChartType)
+    {
+        // Build the package independently: chart caches are the portable OOXML display source,
+        // while the embedded workbook is optional and must not be needed by the browser renderer.
+        XNamespace w = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+        XNamespace wp = "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing";
+        XNamespace a = "http://schemas.openxmlformats.org/drawingml/2006/main";
+        XNamespace c = "http://schemas.openxmlformats.org/drawingml/2006/chart";
+        XNamespace r = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
+        static XElement Series(XNamespace c, int index, string name, double[] values)
+        {
+            var categories = new[] { "Alpha", "Beta", "Gamma" };
+            return new XElement(c + "ser",
+                new XElement(c + "idx", new XAttribute("val", index)),
+                new XElement(c + "order", new XAttribute("val", index)),
+                new XElement(c + "tx",
+                    new XElement(c + "strRef",
+                        new XElement(c + "strCache",
+                            new XElement(c + "ptCount", new XAttribute("val", 1)),
+                            new XElement(c + "pt", new XAttribute("idx", 0),
+                                new XElement(c + "v", name))))),
+                new XElement(c + "cat",
+                    new XElement(c + "strRef",
+                        new XElement(c + "strCache",
+                            new XElement(c + "ptCount", new XAttribute("val", categories.Length)),
+                            categories.Select((value, point) =>
+                                new XElement(c + "pt", new XAttribute("idx", point),
+                                    new XElement(c + "v", value)))))),
+                new XElement(c + "val",
+                    new XElement(c + "numRef",
+                        new XElement(c + "numCache",
+                            new XElement(c + "formatCode", "General"),
+                            new XElement(c + "ptCount", new XAttribute("val", values.Length)),
+                            values.Select((value, point) =>
+                                new XElement(c + "pt", new XAttribute("idx", point),
+                                    new XElement(c + "v",
+                                        value.ToString("R", System.Globalization.CultureInfo.InvariantCulture))))))));
+        }
+
+        using var stream = new MemoryStream();
+        using (var doc = WordprocessingDocument.Create(stream,
+                   DocumentFormat.OpenXml.WordprocessingDocumentType.Document))
+        {
+            var main = doc.AddMainDocumentPart();
+            var chartPart = main.AddNewPart<ChartPart>();
+            var chartRelationshipId = main.GetIdOfPart(chartPart);
+            chartPart.PutXDocument(new XDocument(
+                new XElement(c + "chartSpace",
+                    new XElement(c + "chart",
+                        new XElement(c + "title"),
+                        new XElement(c + "plotArea",
+                            new XElement(c + "barChart",
+                                new XElement(c + "barDir", new XAttribute("val", barDirection)),
+                                new XElement(c + "grouping", new XAttribute("val", "clustered")),
+                                Series(c, 0, "North", new[] { 2.0, 4.0, 3.0 }),
+                                Series(c, 1, "South", new[] { 3.0, 1.0, 5.0 }),
+                                new XElement(c + "gapWidth", new XAttribute("val", 150))),
+                            new XElement(c + "valAx",
+                                new XElement(c + "scaling"))),
+                        new XElement(c + "legend")))));
+            main.PutXDocument(new XDocument(
+                new XElement(w + "document",
+                    new XAttribute(XNamespace.Xmlns + "w", w),
+                    new XAttribute(XNamespace.Xmlns + "wp", wp),
+                    new XAttribute(XNamespace.Xmlns + "a", a),
+                    new XAttribute(XNamespace.Xmlns + "c", c),
+                    new XAttribute(XNamespace.Xmlns + "r", r),
+                    new XElement(w + "body",
+                        new XElement(w + "p",
+                            new XElement(w + "r",
+                                new XElement(w + "drawing",
+                                    new XElement(wp + "inline",
+                                        new XElement(wp + "extent",
+                                            new XAttribute("cx", 5486400),
+                                            new XAttribute("cy", 3200400)),
+                                        new XElement(wp + "docPr",
+                                            new XAttribute("id", 1),
+                                            new XAttribute("name", "Generated chart")),
+                                        new XElement(a + "graphic",
+                                            new XElement(a + "graphicData",
+                                                new XAttribute("uri", c.NamespaceName),
+                                                new XElement(c + "chart",
+                                                    new XAttribute(r + "id", chartRelationshipId)))))))),
+                        new XElement(w + "sectPr")))));
+        }
+
+        var html = HtmlConversionOps.ConvertToHtml(stream.ToArray(),
+            new HtmlConversionOptions { FabricateCssClasses = false });
+        var root = XElement.Parse(html);
+        var svg = root.Descendants().Single(element => element.Name.LocalName == "svg");
+        var bars = svg.Descendants()
+            .Where(element => (string?)element.Attribute("class") == "docx-chart-bar")
+            .ToList();
+
+        Assert.Equal(expectedChartType, (string?)svg.Attribute("data-chart-type"));
+        Assert.Equal("Generated chart", (string?)svg.Attribute("aria-label"));
+        Assert.Contains("width: 432pt", (string?)svg.Attribute("style"));
+        Assert.Contains("height: 252pt", (string?)svg.Attribute("style"));
+        Assert.Equal(6, bars.Count);
+        Assert.Contains("Chart Title", svg.Value);
+        Assert.Contains("Alpha", svg.Value);
+        Assert.Contains("North", svg.Value);
+        Assert.Contains(bars, bar => (string?)bar.Attribute("fill") == "#5B9BD5");
+        Assert.Contains(bars, bar => (string?)bar.Attribute("fill") == "#ED7D31");
     }
 
     [Fact]

--- a/Docxodus/WmlToHtmlConverter.Charts.cs
+++ b/Docxodus/WmlToHtmlConverter.Charts.cs
@@ -1,0 +1,514 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace Docxodus
+{
+    public static partial class WmlToHtmlConverter
+    {
+        private static readonly XNamespace Svg = "http://www.w3.org/2000/svg";
+
+        private sealed class CachedChartSeries
+        {
+            public string Name { get; init; }
+
+            public string Color { get; init; }
+
+            public Dictionary<int, double> Values { get; init; }
+        }
+
+        /// <summary>
+        /// Projects the cached data of a standard clustered Word bar/column chart into inline SVG.
+        /// Word stores those values in the chart part specifically so consumers can display the
+        /// chart without recalculating its embedded workbook. Keeping this projection in the DOCX
+        /// converter makes charts visible in both standalone and WASM output without a JS runtime
+        /// dependency or a server-side Office process.
+        /// </summary>
+        private static XElement ProcessChart(WordprocessingDocument wordDoc, XElement drawing)
+        {
+            var chartReference = drawing.Descendants(C.chart).FirstOrDefault();
+            var relationshipId = (string)chartReference?.Attribute(R.id);
+            if (string.IsNullOrWhiteSpace(relationshipId))
+                return null;
+
+            ChartPart chartPart;
+            try
+            {
+                chartPart = wordDoc.MainDocumentPart?.GetPartById(relationshipId) as ChartPart;
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                return null;
+            }
+            catch (InvalidOperationException)
+            {
+                return null;
+            }
+
+            var chartSpace = chartPart?.GetXDocument().Root;
+            var chart = chartSpace?.Element(C.chart);
+            var plotArea = chart?.Element(C.plotArea);
+            var barChart = plotArea?.Element(C.barChart);
+            if (barChart == null)
+                return null;
+
+            var grouping = (string)barChart.Element(C.grouping)?.Attribute("val");
+            if (!string.IsNullOrEmpty(grouping) && grouping != "clustered")
+                return null;
+
+            var container = drawing.Elements().FirstOrDefault(e => e.Name == WP.inline || e.Name == WP.anchor);
+            var extent = container?.Element(WP.extent);
+            var widthEmu = (long?)extent?.Attribute("cx");
+            var heightEmu = (long?)extent?.Attribute("cy");
+            if (widthEmu is null or <= 0 || heightEmu is null or <= 0)
+                return null;
+
+            var width = widthEmu.Value / 9525.0;   // EMUs -> CSS px at the converter's 96-DPI contract
+            var height = heightEmu.Value / 9525.0;
+            if (width < 80 || height < 60)
+                return null;
+
+            var theme = LoadThemeColorScheme(wordDoc);
+            var series = barChart.Elements(C.ser)
+                .Select((element, index) => ReadCachedChartSeries(element, index, theme))
+                .Where(item => item != null && item.Values.Count > 0)
+                .ToList();
+            if (series.Count == 0)
+                return null;
+
+            var categoryCount = series.SelectMany(item => item.Values.Keys).DefaultIfEmpty(-1).Max() + 1;
+            if (categoryCount <= 0)
+                return null;
+
+            var categories = ReadCachedCategories(barChart.Elements(C.ser).First(), categoryCount);
+            var title = ReadChartTitle(chart);
+            var titleFontSize = ReadChartFontSize(chart.Element(C.title), 14 * 96 / 72.0);
+            var legend = chart.Element(C.legend);
+            var showLegend = legend != null && !IsDeleted(legend);
+            var legendFontSize = ReadChartFontSize(legend, 9 * 96 / 72.0);
+            var horizontal = (string)barChart.Element(C.barDir)?.Attribute("val") == "bar";
+            var gapWidth = ReadIntAttribute(barChart.Element(C.gapWidth), "val", 150, 0, 500);
+            var overlap = ReadIntAttribute(barChart.Element(C.overlap), "val", 0, -100, 100);
+
+            var categoryAxis = plotArea.Element(C.catAx);
+            var valueAxis = plotArea.Element(C.valAx);
+            var categoryFontSize = ReadChartFontSize(categoryAxis, 9 * 96 / 72.0);
+            var valueFontSize = ReadChartFontSize(valueAxis, 9 * 96 / 72.0);
+            var scaling = valueAxis?.Element(C.c + "scaling");
+            var explicitMinimum = ReadDoubleAttribute(scaling?.Element(C.min), "val");
+            var explicitMaximum = ReadDoubleAttribute(scaling?.Element(C.max), "val");
+            var explicitMajorUnit = ReadDoubleAttribute(valueAxis?.Element(C.majorUnit), "val");
+
+            var altText = (string)container?.Element(WP.docPr)?.Attribute("descr")
+                ?? (string)container?.Element(WP.docPr)?.Attribute("name")
+                ?? title
+                ?? "Chart";
+            var svg = new XElement(Svg + "svg",
+                new XAttribute("viewBox", $"0 0 {Format(width)} {Format(height)}"),
+                new XAttribute("role", "img"),
+                new XAttribute("aria-label", altText),
+                new XAttribute("data-chart-type", horizontal ? "bar" : "column"),
+                new XAttribute("style", string.Format(CultureInfo.InvariantCulture,
+                    "display: inline-block; width: {0:0.##}pt; height: {1:0.##}pt; vertical-align: top;",
+                    widthEmu.Value / 12700.0, heightEmu.Value / 12700.0)),
+                new XElement(Svg + "title", altText),
+                new XElement(Svg + "rect",
+                    new XAttribute("x", "0.5"),
+                    new XAttribute("y", "0.5"),
+                    new XAttribute("width", Format(width - 1)),
+                    new XAttribute("height", Format(height - 1)),
+                    new XAttribute("fill", "#FFFFFF"),
+                    new XAttribute("stroke", "#D0D0D0"),
+                    new XAttribute("stroke-width", "1")));
+
+            if (!string.IsNullOrWhiteSpace(title))
+                AddSvgText(svg, width / 2, Math.Max(titleFontSize, height * 0.105), title,
+                    "middle", titleFontSize);
+
+            var values = series.SelectMany(item => item.Values.Values).ToList();
+            var scale = BuildChartScale(values, explicitMinimum, explicitMaximum, explicitMajorUnit);
+            if (horizontal)
+                RenderHorizontalBarChart(svg, width, height, title, showLegend, series, categories,
+                    categoryCount, gapWidth, overlap, scale, categoryFontSize, valueFontSize);
+            else
+                RenderColumnChart(svg, width, height, title, showLegend, series, categories,
+                    categoryCount, gapWidth, overlap, scale, categoryFontSize, valueFontSize);
+
+            if (showLegend)
+                RenderChartLegend(svg, width, height, series, legendFontSize);
+
+            return svg;
+        }
+
+        private sealed class ChartScale
+        {
+            public double Minimum { get; init; }
+
+            public double Maximum { get; init; }
+
+            public double MajorUnit { get; init; }
+        }
+
+        private static ChartScale BuildChartScale(IReadOnlyCollection<double> values,
+            double? explicitMinimum, double? explicitMaximum, double? explicitMajorUnit)
+        {
+            var dataMinimum = Math.Min(0, values.Min());
+            var dataMaximum = Math.Max(0, values.Max());
+            var rawRange = Math.Max(1e-9, dataMaximum - dataMinimum);
+            var majorUnit = explicitMajorUnit is > 0
+                ? explicitMajorUnit.Value
+                : NiceNumber(rawRange / 5, true);
+            if (majorUnit <= 0 || double.IsNaN(majorUnit) || double.IsInfinity(majorUnit))
+                majorUnit = 1;
+
+            var minimum = explicitMinimum ?? Math.Floor(dataMinimum / majorUnit) * majorUnit;
+            // Office adds one tick of headroom when the largest value lands exactly on a major
+            // gridline. Besides matching the stock chart, this keeps the tallest bar off the frame.
+            var maximum = explicitMaximum ??
+                Math.Ceiling((dataMaximum + majorUnit * 0.001) / majorUnit) * majorUnit;
+            if (maximum <= minimum)
+                maximum = minimum + majorUnit;
+
+            // Protect output size against a malformed axis with a microscopic explicit unit.
+            if ((maximum - minimum) / majorUnit > 20)
+                majorUnit = NiceNumber((maximum - minimum) / 10, true);
+
+            return new ChartScale { Minimum = minimum, Maximum = maximum, MajorUnit = majorUnit };
+        }
+
+        private static double NiceNumber(double value, bool round)
+        {
+            var exponent = Math.Floor(Math.Log10(Math.Max(value, 1e-9)));
+            var fraction = value / Math.Pow(10, exponent);
+            double niceFraction;
+            if (round)
+                niceFraction = fraction < 1.5 ? 1 : fraction < 3 ? 2 : fraction < 7 ? 5 : 10;
+            else
+                niceFraction = fraction <= 1 ? 1 : fraction <= 2 ? 2 : fraction <= 5 ? 5 : 10;
+            return niceFraction * Math.Pow(10, exponent);
+        }
+
+        private static void RenderColumnChart(XElement svg, double width, double height, string title,
+            bool showLegend, IReadOnlyList<CachedChartSeries> series, IReadOnlyList<string> categories,
+            int categoryCount, int gapWidth, int overlap, ChartScale scale,
+            double categoryFontSize, double valueFontSize)
+        {
+            var plotLeft = Math.Max(22, 10 + FormatAxisValue(scale.Maximum, scale.MajorUnit).Length * 6);
+            var plotRight = width - 12;
+            var plotTop = string.IsNullOrWhiteSpace(title) ? 14 : 60;
+            var plotBottom = height - (showLegend ? 54 : 28);
+            var plotWidth = Math.Max(1, plotRight - plotLeft);
+            var plotHeight = Math.Max(1, plotBottom - plotTop);
+            var range = scale.Maximum - scale.Minimum;
+            double Y(double value) => plotBottom - (value - scale.Minimum) / range * plotHeight;
+
+            for (var value = scale.Minimum; value <= scale.Maximum + scale.MajorUnit * 0.0001;
+                 value += scale.MajorUnit)
+            {
+                var y = Y(value);
+                svg.Add(new XElement(Svg + "line",
+                    new XAttribute("x1", Format(plotLeft)),
+                    new XAttribute("x2", Format(plotRight)),
+                    new XAttribute("y1", Format(y)),
+                    new XAttribute("y2", Format(y)),
+                    new XAttribute("stroke", "#D9D9D9"),
+                    new XAttribute("stroke-width", "1")));
+                AddSvgText(svg, plotLeft - 5, y, FormatAxisValue(value, scale.MajorUnit), "end",
+                    valueFontSize, true);
+            }
+
+            var slot = plotWidth / categoryCount;
+            var negativeOverlapGap = Math.Max(0, -overlap / 100.0);
+            var positiveOverlap = Math.Max(0, overlap / 100.0);
+            var denominator = series.Count + gapWidth / 100.0 +
+                              (series.Count - 1) * (negativeOverlapGap - positiveOverlap);
+            var barWidth = Math.Max(1, slot / Math.Max(1, denominator));
+            var barStep = barWidth * (1 + negativeOverlapGap - positiveOverlap);
+            var groupWidth = barWidth + Math.Max(0, series.Count - 1) * barStep;
+            var zeroY = Y(0);
+
+            for (var categoryIndex = 0; categoryIndex < categoryCount; categoryIndex++)
+            {
+                var groupLeft = plotLeft + categoryIndex * slot + (slot - groupWidth) / 2;
+                for (var seriesIndex = 0; seriesIndex < series.Count; seriesIndex++)
+                {
+                    if (!series[seriesIndex].Values.TryGetValue(categoryIndex, out var value))
+                        continue;
+                    var valueY = Y(value);
+                    var top = Math.Min(zeroY, valueY);
+                    var barHeight = Math.Max(0.5, Math.Abs(zeroY - valueY));
+                    svg.Add(ChartBar(groupLeft + seriesIndex * barStep, top, barWidth, barHeight,
+                        series[seriesIndex], seriesIndex, categoryIndex, value));
+                }
+
+                AddSvgText(svg, plotLeft + (categoryIndex + 0.5) * slot, plotBottom + 15,
+                    categories[categoryIndex], "middle", categoryFontSize);
+            }
+        }
+
+        private static void RenderHorizontalBarChart(XElement svg, double width, double height, string title,
+            bool showLegend, IReadOnlyList<CachedChartSeries> series, IReadOnlyList<string> categories,
+            int categoryCount, int gapWidth, int overlap, ChartScale scale,
+            double categoryFontSize, double valueFontSize)
+        {
+            var longestCategory = categories.DefaultIfEmpty(string.Empty).Max(item => item?.Length ?? 0);
+            var plotLeft = Math.Min(width * 0.38, Math.Max(40, 12 + longestCategory * 6));
+            var plotRight = width - 12;
+            var plotTop = string.IsNullOrWhiteSpace(title) ? 14 : 60;
+            var plotBottom = height - (showLegend ? 54 : 32);
+            var plotWidth = Math.Max(1, plotRight - plotLeft);
+            var plotHeight = Math.Max(1, plotBottom - plotTop);
+            var range = scale.Maximum - scale.Minimum;
+            double X(double value) => plotLeft + (value - scale.Minimum) / range * plotWidth;
+
+            for (var value = scale.Minimum; value <= scale.Maximum + scale.MajorUnit * 0.0001;
+                 value += scale.MajorUnit)
+            {
+                var x = X(value);
+                svg.Add(new XElement(Svg + "line",
+                    new XAttribute("x1", Format(x)),
+                    new XAttribute("x2", Format(x)),
+                    new XAttribute("y1", Format(plotTop)),
+                    new XAttribute("y2", Format(plotBottom)),
+                    new XAttribute("stroke", "#D9D9D9"),
+                    new XAttribute("stroke-width", "1")));
+                AddSvgText(svg, x, plotBottom + 15, FormatAxisValue(value, scale.MajorUnit), "middle",
+                    valueFontSize);
+            }
+
+            var slot = plotHeight / categoryCount;
+            var negativeOverlapGap = Math.Max(0, -overlap / 100.0);
+            var positiveOverlap = Math.Max(0, overlap / 100.0);
+            var denominator = series.Count + gapWidth / 100.0 +
+                              (series.Count - 1) * (negativeOverlapGap - positiveOverlap);
+            var barHeight = Math.Max(1, slot / Math.Max(1, denominator));
+            var barStep = barHeight * (1 + negativeOverlapGap - positiveOverlap);
+            var groupHeight = barHeight + Math.Max(0, series.Count - 1) * barStep;
+            var zeroX = X(0);
+
+            for (var categoryIndex = 0; categoryIndex < categoryCount; categoryIndex++)
+            {
+                var groupTop = plotTop + categoryIndex * slot + (slot - groupHeight) / 2;
+                AddSvgText(svg, plotLeft - 6, plotTop + (categoryIndex + 0.5) * slot,
+                    categories[categoryIndex], "end", categoryFontSize, true);
+                for (var seriesIndex = 0; seriesIndex < series.Count; seriesIndex++)
+                {
+                    if (!series[seriesIndex].Values.TryGetValue(categoryIndex, out var value))
+                        continue;
+                    var valueX = X(value);
+                    var left = Math.Min(zeroX, valueX);
+                    var barWidth = Math.Max(0.5, Math.Abs(zeroX - valueX));
+                    svg.Add(ChartBar(left, groupTop + seriesIndex * barStep, barWidth, barHeight,
+                        series[seriesIndex], seriesIndex, categoryIndex, value));
+                }
+            }
+        }
+
+        private static XElement ChartBar(double x, double y, double width, double height,
+            CachedChartSeries series, int seriesIndex, int categoryIndex, double value) =>
+            new XElement(Svg + "rect",
+                new XAttribute("class", "docx-chart-bar"),
+                new XAttribute("data-chart-series", seriesIndex),
+                new XAttribute("data-chart-category", categoryIndex),
+                new XAttribute("data-chart-value", value.ToString("R", CultureInfo.InvariantCulture)),
+                new XAttribute("x", Format(x)),
+                new XAttribute("y", Format(y)),
+                new XAttribute("width", Format(width)),
+                new XAttribute("height", Format(height)),
+                new XAttribute("fill", series.Color));
+
+        private static void RenderChartLegend(XElement svg, double width, double height,
+            IReadOnlyList<CachedChartSeries> series, double fontSize)
+        {
+            const double interItemGap = 7.5;
+            var widths = series.Select(item => 20.5 + Math.Max(1, item.Name.Length) * fontSize * 0.375)
+                .ToList();
+            var total = widths.Sum() - interItemGap;
+            var x = Math.Max(4, (width - total) / 2);
+            var y = height - 11;
+            for (var index = 0; index < series.Count; index++)
+            {
+                svg.Add(new XElement(Svg + "rect",
+                    new XAttribute("x", Format(x)),
+                    new XAttribute("y", Format(y - 4)),
+                    new XAttribute("width", "8"),
+                    new XAttribute("height", "8"),
+                    new XAttribute("fill", series[index].Color)));
+                AddSvgText(svg, x + 12, y, series[index].Name, "start", fontSize, true);
+                x += widths[index];
+            }
+        }
+
+        private static void AddSvgText(XElement svg, double x, double y, string value,
+            string anchor, double fontSize, bool middleBaseline = false)
+        {
+            if (string.IsNullOrEmpty(value))
+                return;
+            svg.Add(new XElement(Svg + "text",
+                new XAttribute("x", Format(x)),
+                new XAttribute("y", Format(y)),
+                new XAttribute("text-anchor", anchor),
+                middleBaseline ? new XAttribute("dominant-baseline", "middle") : null,
+                new XAttribute("fill", "#595959"),
+                new XAttribute("font-family", "Calibri, Carlito, sans-serif"),
+                new XAttribute("font-size", Format(fontSize)),
+                new XText(value)));
+        }
+
+        private static CachedChartSeries ReadCachedChartSeries(XElement series, int index,
+            ThemeColorScheme theme)
+        {
+            var values = ReadCachedPoints(series.Element(C.val));
+            if (values.Count == 0)
+                return null;
+            var name = ReadCachedText(series.Element(C.tx));
+            if (string.IsNullOrWhiteSpace(name))
+                name = $"Series {index + 1}";
+            return new CachedChartSeries
+            {
+                Name = name,
+                Color = ReadChartColor(series.Element(C.spPr), index, theme),
+                Values = values,
+            };
+        }
+
+        private static IReadOnlyList<string> ReadCachedCategories(XElement firstSeries, int count)
+        {
+            var points = firstSeries.Element(C.cat)?.Descendants(C.pt)
+                .Select(point => new
+                {
+                    Index = ReadIntAttribute(point, "idx", -1, -1, int.MaxValue),
+                    Value = point.Element(C.v)?.Value,
+                })
+                .Where(point => point.Index >= 0)
+                .GroupBy(point => point.Index)
+                .ToDictionary(group => group.Key, group => group.First().Value ?? string.Empty)
+                ?? new Dictionary<int, string>();
+            return Enumerable.Range(0, count)
+                .Select(index => points.TryGetValue(index, out var value) && !string.IsNullOrWhiteSpace(value)
+                    ? value
+                    : (index + 1).ToString(CultureInfo.InvariantCulture))
+                .ToList();
+        }
+
+        private static Dictionary<int, double> ReadCachedPoints(XElement valueContainer)
+        {
+            if (valueContainer == null)
+                return new Dictionary<int, double>();
+            return valueContainer.Descendants(C.pt)
+                .Select(point => new
+                {
+                    Index = ReadIntAttribute(point, "idx", -1, -1, int.MaxValue),
+                    Text = point.Element(C.v)?.Value,
+                })
+                .Where(point => point.Index >= 0 &&
+                                double.TryParse(point.Text, NumberStyles.Float,
+                                    CultureInfo.InvariantCulture, out _))
+                .GroupBy(point => point.Index)
+                .ToDictionary(group => group.Key, group =>
+                    double.Parse(group.First().Text, NumberStyles.Float, CultureInfo.InvariantCulture));
+        }
+
+        private static string ReadChartTitle(XElement chart)
+        {
+            var title = chart?.Element(C.title);
+            if (title == null || IsDeleted(title))
+                return null;
+            var explicitText = string.Concat(title.Descendants(A.t).Select(element => element.Value));
+            if (string.IsNullOrWhiteSpace(explicitText))
+                explicitText = ReadCachedText(title.Element(C.tx));
+            return string.IsNullOrWhiteSpace(explicitText) ? "Chart Title" : explicitText;
+        }
+
+        private static string ReadCachedText(XElement container) =>
+            container?.Descendants(C.v).Select(element => element.Value)
+                .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
+
+        private static string ReadChartColor(XElement shapeProperties, int seriesIndex,
+            ThemeColorScheme theme)
+        {
+            var fill = shapeProperties?.Element(A.solidFill);
+            var rgb = (string)fill?.Element(A.srgbClr)?.Attribute("val");
+            var schemeColor = fill?.Element(A.schemeClr);
+            if (!IsHexColor(rgb) && schemeColor != null)
+            {
+                var name = (string)schemeColor.Attribute("val");
+                if (!string.IsNullOrEmpty(name))
+                    theme?.Colors.TryGetValue(name, out rgb);
+                if (IsHexColor(rgb))
+                    rgb = ApplyChartLuminosity(rgb, schemeColor);
+            }
+
+            if (!IsHexColor(rgb))
+            {
+                var defaults = new[]
+                {
+                    "5B9BD5", "ED7D31", "A5A5A5", "FFC000", "4472C4", "70AD47",
+                };
+                rgb = defaults[seriesIndex % defaults.Length];
+            }
+            return "#" + rgb.ToUpperInvariant();
+        }
+
+        private static string ApplyChartLuminosity(string color, XElement schemeColor)
+        {
+            var red = int.Parse(color.Substring(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+            var green = int.Parse(color.Substring(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+            var blue = int.Parse(color.Substring(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+            var lumMod = ReadDoubleAttribute(schemeColor.Element(A.lumMod), "val") ?? 100000;
+            var lumOff = ReadDoubleAttribute(schemeColor.Element(A.lumOff), "val") ?? 0;
+            int Apply(int channel) => (int)Math.Round(Math.Clamp(
+                channel * lumMod / 100000 + 255 * lumOff / 100000, 0, 255));
+            return $"{Apply(red):X2}{Apply(green):X2}{Apply(blue):X2}";
+        }
+
+        private static bool IsDeleted(XElement element) =>
+            string.Equals((string)element.Element(C.delete)?.Attribute("val"), "1",
+                StringComparison.OrdinalIgnoreCase) ||
+            string.Equals((string)element.Element(C.delete)?.Attribute("val"), "true",
+                StringComparison.OrdinalIgnoreCase);
+
+        private static int ReadIntAttribute(XElement element, string name, int fallback, int minimum, int maximum)
+        {
+            return int.TryParse((string)element?.Attribute(name), NumberStyles.Integer,
+                       CultureInfo.InvariantCulture, out var value)
+                ? Math.Clamp(value, minimum, maximum)
+                : fallback;
+        }
+
+        private static double? ReadDoubleAttribute(XElement element, string name)
+        {
+            return double.TryParse((string)element?.Attribute(name), NumberStyles.Float,
+                CultureInfo.InvariantCulture, out var value) && double.IsFinite(value)
+                ? value
+                : null;
+        }
+
+        private static double ReadChartFontSize(XElement textContainer, double fallback)
+        {
+            var size = textContainer?.Descendants(A.defRPr)
+                .Select(element => ReadDoubleAttribute(element, "sz"))
+                .FirstOrDefault(value => value is > 0);
+            // DrawingML stores font size in hundredths of a point. CSS uses 96 px per inch.
+            return size is > 0 ? size.Value / 75.0 : fallback;
+        }
+
+        private static string FormatAxisValue(double value, double majorUnit)
+        {
+            if (Math.Abs(value) < majorUnit * 0.0001)
+                value = 0;
+            var decimals = majorUnit >= 1 ? 0 : Math.Min(4,
+                Math.Max(0, (int)Math.Ceiling(-Math.Log10(majorUnit))));
+            return value.ToString("F" + decimals, CultureInfo.InvariantCulture);
+        }
+
+        private static string Format(double value) =>
+            value.ToString("0.###", CultureInfo.InvariantCulture);
+    }
+}

--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -808,7 +808,7 @@ namespace Docxodus
         public int EstimatedPageCount { get; set; }
     }
 
-    public static class WmlToHtmlConverter
+    public static partial class WmlToHtmlConverter
     {
         /// <summary>
         /// Converts the HTML XElement to a string, removing whitespace between inline elements
@@ -8412,6 +8412,10 @@ namespace Docxodus
         {
             if (element.Name == W.drawing)
             {
+                var chart = ProcessChart(wordDoc, element);
+                if (chart != null)
+                    return chart;
+
                 // Preserve established image output for the uncommon shape that carries both an
                 // image and textbox body. A textbox-only drawing falls through when no image can
                 // be resolved (including a malformed/missing relationship).

--- a/docs/architecture/docx_converter.md
+++ b/docs/architecture/docx_converter.md
@@ -296,6 +296,20 @@ settings.ImageHandler = imageInfo =>
 };
 ```
 
+### Charts
+
+Standard DrawingML `c:barChart` parts with `clustered` grouping render as accessible inline SVG.
+Both column (`c:barDir="col"`) and horizontal bar (`c:barDir="bar"`) directions are supported. The
+converter reads the chart's portable cached categories, series names, and numeric values rather than
+recalculating the optional embedded workbook, and preserves the drawing's stored `wp:extent`.
+
+The SVG projection includes the title, value grid and labels, category labels, bottom legend,
+gap/overlap, explicit or inferred value scale, theme/default series colors, and DrawingML text sizes.
+It carries `role="img"`, an `aria-label`, a `<title>`, and stable `data-chart-*` attributes for
+inspection. Unsupported chart families and stacked/percent-stacked groupings continue through the
+existing drawing fallback; 3-D effects, trend lines, data labels, secondary axes, and exact Office
+chart styling are not projected.
+
 ### Bidirectional Text (RTL)
 
 The converter handles right-to-left text:
@@ -429,7 +443,7 @@ The following are **discarded** and will not appear in output:
 
 **Document features:**
 - Math equations (OMML)
-- Charts
+- Chart families other than clustered column/horizontal bar charts
 - Diagrams (SmartArt)
 - Complex text boxes
 - Headers and footers
@@ -454,7 +468,6 @@ Only **HYPERLINK** fields are converted to `<a>` elements. All other field types
 - **WMF files excluded** - Known to cause memory issues
 - **EMF not supported** - Not in allowed content types
 - **SVG not supported** - Not in allowed content types
-- **Charts not rendered** - Appear as empty space
 - **Requires ImageHandler** - Returns `null` without callback
 
 ### Font Metrics

--- a/npm/tests/visual-parity/BASELINE.md
+++ b/npm/tests/visual-parity/BASELINE.md
@@ -1,4 +1,4 @@
-# Visual parity baseline — 2026-08-09
+# Visual parity baseline and remediation log — 2026-08-09
 
 This is the first stratified Docxodus-versus-LibreOffice full-page baseline. It is diagnostic, not a
 claim that LibreOffice is always correct and not yet a release gate.
@@ -40,7 +40,7 @@ Two clean full render passes produced identical normalized metrics and all 60 Do
 LibreOffice, and overlay PNG SHA-256 hashes. The final ink-F1 edge-case correction changed no image
 hashes. Generated reports and images remained under `/tmp` and were not copied into the repository.
 
-## Aggregate result
+## Initial aggregate result
 
 | Signal | Result |
 |---|---:|
@@ -57,7 +57,43 @@ The low mean ink F1 is intentional: absent or displaced ink scores zero even whe
 page is identical and SSIM remains high. A benchmark bug originally returned F1=1 when precision and
 recall were both zero; the generated one-sided-content regression now pins the correct zero score.
 
-## Case results and triage
+## Remediation rerun
+
+The baseline's two pending pull requests are now on `main`: pagination remediation PR #372 at
+`7199e54` and this benchmark itself in PR #373 at `404d9da`. The branch from that exact fresh main
+also repairs the integration-only duplicate `HCO085` test identifier by assigning the footnote and
+chart regressions unique `HCO086`/`HCO087` identifiers.
+
+The complete 12-case corpus was rerun after rebuilding the production WASM bundle. The generated
+report remained outside the checkout under `/tmp`; no benchmark artifacts or additional corpus files
+were added to the repository.
+
+| Signal | Initial | Current |
+|---|---:|---:|
+| Cases | 12 | 12 |
+| Paired pages | 20 | 21 |
+| Conversion errors | 0 | 0 |
+| Page-count mismatches | 1 | 0 |
+| Case severity | 1 close, 1 minor, 0 major, 10 severe | 2 close, 1 minor, 0 major, 9 severe |
+| Page severity | 1 close, 1 minor, 2 major, 16 severe | 2 close, 1 minor, 1 major, 17 severe |
+| Mean SSIM | 0.974586 | 0.978298 |
+| Mean tolerant ink F1 | 0.394106 | 0.412753 |
+
+Resolved items:
+
+1. **Pagination count and story inheritance (PR #372).** `running-content` now produces the same
+   five pages as LibreOffice instead of four, and both `running-content` and `multi-section` retain
+   inherited odd/even/default header and footer stories. Residual header/body/footer vertical
+   placement still scores severe and remains a distinct geometry problem.
+2. **Executable benchmark baseline (PR #373).** The corpus guard, all-page LibreOffice comparison,
+   perceptual/ink metrics, artifacts, and scheduled/manual workflow are now part of `main`.
+3. **Cached clustered bar/column rendering (this branch).** `HC043-Chart.docx` moves from a blank,
+   severe result (SSIM 0.92933, ink F1 0) to a populated, **close** result (SSIM 0.98687, ink F1
+   0.96817, perceptual diff 0.01436). Page count, page size, and bounded alignment all match exactly.
+   The renderer consumes the portable chart caches and stored drawing extent, so it does not need
+   the optional embedded workbook, a JavaScript chart library, or an Office process.
+
+## Current case results and triage
 
 `SSIM` is the mean over paired pages. `Ink F1` is the worst paired-page value, so it exposes a
 single blank or disjoint page rather than averaging it away.
@@ -65,15 +101,15 @@ single blank or disjoint page rather than averaging it away.
 | Case | Pages D/L | Severity | SSIM | Ink F1 | Triage |
 |---|---:|---|---:|---:|---|
 | text-formatting | 1/1 | close | 0.99725 | 0.96770 | Control case; fonts and small caps are close. |
-| merged-table | 1/1 | minor | 0.95958 | 0.99968 | Ink geometry aligns; fill/border color dominates the perceptual delta. |
-| numbered-lists | 1/1 | severe | 0.99405 | 0.55098 | Whole content is about 28 px lower in Docxodus. The OOXML top margin is 1701 twips (113.4 px at 96 DPI), which matches Docxodus; LibreOffice appears to import it differently. Treat as a reference-specific deviation unless Word evidence says otherwise. |
-| multi-section | 6/6 | severe | 0.99677 | 0.00000 | Four pages are nearly blank but have disjoint running content; page 4 lacks an inherited story. First-page header/body/footer offsets also differ. This overlaps the isolated pagination work in PR #372 and should be remeasured after that lands. |
+| merged-table | 1/1 | minor | 0.96348 | 1.00000 | Ink geometry aligns; fill/border color dominates the perceptual delta. |
+| numbered-lists | 1/1 | severe | 0.99426 | 0.55580 | Whole content is about 28 px lower in Docxodus. The OOXML top margin is 1701 twips (113.4 px at 96 DPI), which matches Docxodus; LibreOffice appears to import it differently. Treat as a reference-specific deviation unless Word evidence says otherwise. |
+| multi-section | 6/6 | severe | 0.99586 | 0.00000 | Page count and inherited stories now match after PR #372. Header, body, and footer bands are vertically collapsed toward one another on content pages; nearly empty pages therefore retain disjoint ink. |
 | landscape-section | 1/1 | severe | 0.91746 | 0.50174 | Page dimensions match; paragraph spacing/font wrapping differs. |
-| running-content | 4/5 | severe | 0.99779 | 0.00000 | One page is missing and inherited header/footer stories diverge. This is also in PR #372's pagination cluster. |
+| running-content | 5/5 | severe | 0.99773 | 0.00000 | PR #372 resolves the missing page and inherited story semantics. The remaining difference is running-content vertical placement, including odd-page text near the sheet edge. |
 | inline-image | 1/1 | severe | 0.93660 | 0.64760 | Image and text are separate source paragraphs; the discrepancy is indentation/font/wrapping, not an inline-flow failure. |
-| chart | 1/1 | severe | 0.92933 | 0.00000 | Docxodus emits a blank page where LibreOffice renders the chart: a clear unsupported-content gap. |
+| chart | 1/1 | close | 0.98687 | 0.96817 | Cached clustered column data now renders as accessible inline SVG at the stored extent; bars, grid, colors, labels, title, and bottom legend align closely. Other chart families and stacked groupings remain unsupported. |
 | shape | 1/1 | severe | 0.96967 | 0.50719 | Textbox content exists but is roughly 5 px right and 13 px down with a small size difference: drawing-anchor geometry. |
-| fields-and-tabs | 1/1 | severe | 0.89207 | 0.34460 | Cached TOC leaders/page numbers are now present in print layout, but the right tab/leader span is too short and displaced; hyperlink styling and font metrics also differ. |
+| fields-and-tabs | 1/1 | severe | 0.89089 | 0.30293 | Cached TOC leaders/page numbers are present in print layout, but the right tab/leader span is too short and displaced; hyperlink styling and font metrics also differ. |
 | footnote | 1/1 | severe | 0.99218 | 0.56597 | Separator width now matches Word/LibreOffice's two-inch default; the note block remains about 13 px too high. |
 | tracked-deletion | 1/1 | severe | 0.93177 | 0.46817 | Identical accepted-revision bytes are now compared. Remaining differences cluster around Calibri Light substitution, heading metrics, and wrapping rather than revision semantics. |
 
@@ -90,6 +126,11 @@ single blank or disjoint page rather than averaging it away.
 3. **One-sided ink metric.** A zero-precision/zero-recall case incorrectly returned F1=1. It now
    returns zero, has a synthetic regression, and correctly upgrades the blank chart result from major
    to severe.
+4. **Cached chart projection.** Standard clustered column and horizontal bar charts now project
+   cached series, categories, title, legend, axis scale, theme/default series colors, overlap/gap,
+   DrawingML font sizes, and stored extent into accessible inline SVG. An independently generated
+   DOCX regression deliberately omits an embedded workbook and checks semantic SVG output; the
+   tracked `HC043` fixture supplies the separate pixel-level LibreOffice validation.
 
 An attempted explicit `Calibri Light -> Carlito` browser fallback was rejected: it worsened the
 accepted-revision case (SSIM 0.93177 to 0.92905; ink F1 0.46817 to 0.42477) despite a small SSIM gain
@@ -98,16 +139,17 @@ renderer heuristic.
 
 ## Prioritized next work
 
-1. Implement a chart fallback/rendering path; blank content is the most unambiguous user-visible
-   failure.
-2. Reduce right/center/decimal tab-stop layout to generated documents and fix leader width plus
+The former first priority (blank charts) and the PR #372 rerun are resolved above. The remaining
+order is:
+
+1. Reduce right/center/decimal tab-stop layout to generated documents and fix leader width plus
    post-tab alignment. The existing tab reference analysis already identifies `ProcessTab` and
    `CalcWidthOfRunInTwips` as the likely path; browser geometry assertions should accompany the fix.
-3. Land or rebase PR #372, then rerun `multi-section` and `running-content` before doing overlapping
-   pagination work here.
-4. Correct drawing-anchor offsets with a generated textbox geometry regression.
-5. Correct footnote block vertical placement independently of the now-fixed separator width.
-6. Define and provision one font-substitution contract shared by Chromium and LibreOffice CI before
+2. Correct drawing-anchor offsets with a generated textbox geometry regression.
+3. Correct inherited header/body/footer vertical placement independently of the now-fixed story
+   selection and page-count semantics.
+4. Correct footnote block vertical placement independently of the now-fixed separator width.
+5. Define and provision one font-substitution contract shared by Chromium and LibreOffice CI before
    treating paragraph-wrap differences as renderer regressions.
 
 The list-margin discrepancy should not be changed merely to imitate LibreOffice: current evidence


### PR DESCRIPTION
## What changed

- render standard cached DrawingML `c:barChart` parts as accessible inline SVG
- support clustered column and horizontal-bar directions using cached series/categories, stored extent, axis scale, gap/overlap, theme/default colors, title, legend, and DrawingML font sizes
- keep unsupported chart families and stacked groupings on the existing drawing fallback
- add independently generated, workbook-free column and horizontal-bar regressions
- update the converter architecture docs, changelog, and visual-parity remediation log
- resolve the post-merge duplicate `HCO085` integration collision with unique `HCO086`/`HCO087` identifiers

## Why

The tracked `HC043-Chart.docx` fixture contains a chart part and portable cached values, but no preview image. `ProcessImage` handled pictures and text boxes only, so the drawing returned no HTML and the page was blank even though all display data was available in the DOCX.

## Impact

The chart case improves from blank/severe (SSIM 0.92933, ink F1 0) to populated/close:

- SSIM: **0.98687**
- tolerant ink F1: **0.96817**
- perceptual diff: **0.01436**
- page count, dimensions, and bounded alignment: exact

Rendering is self-contained: it does not require the optional embedded workbook, a JavaScript chart dependency, or an Office process.

The remediation log also records the merged PR #372 pagination rerun: the full corpus now compares 21/21 pages with zero page-count mismatches.

## Validation

- `.NET build`: 0 errors
- `HtmlConversionOpsTests`: 46 passed
- visual-parity metric regressions: 5 passed
- TypeScript/pretest: passed
- production WASM publish + trim/AOT: passed; 3296 KB Brotli wire size against 4096 KB budget
- focused chart-vs-LibreOffice benchmark: 1/1 page, **close**
- full 12-case browser-vs-LibreOffice corpus: passed; 21 paired pages, 0 conversion errors, 0 page-count mismatches

No untracked harness, corpus, image, investigation note, or lockfile was staged.