### PR TITLE
Place paginated running content at the distances w:pgMar declares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,32 @@ All notable changes to this project will be documented in this file.
   pause→type→resume loop, and the save round-trip.
 
 ### Fixed
+- **Paginated headers, footers, and body text sit at the distances `w:pgMar`
+  declares.** `w:header` and `w:footer` are distances from the PAPER EDGE to the
+  top of the header story and the bottom of the footer story — four independent
+  numbers with `w:top`/`w:bottom`, not two nested boxes. The paginator ignored
+  both, anchoring the header bottom-aligned above the top margin and the footer
+  top-aligned below the bottom margin, which pulled the two stories toward the
+  body by exactly `margin − distance` (25 px on a Word-default page) and left the
+  top and bottom of the sheet blank. `resolvePageBands()`
+  (`npm/src/page-geometry.ts`) is now the single owner of the model — the header
+  grows down from `w:header`, the footer grows up from `w:footer`, and the body
+  band starts at `w:top` unless the header has already run past it and ends at
+  `w:bottom` unless the footer has already climbed above it — and
+  `PaginationEngine.getPageBands()` is the one place band placement, the flow
+  loop's page budget, and the footnote area's anchor all read, so they cannot
+  disagree about where the body ends. A story taller than its margin now pushes
+  the body instead of drawing over it, and the note block follows the body's real
+  bottom edge rather than the raw bottom margin. The generated
+  `pagination-running-content-geometry` regression pins first/even/odd header and
+  footer coordinates, the inheriting second section's own distances, band
+  disjointness, the overflowing-story case, and a header-less section. Against
+  LibreOffice, `DB001-Sections.docx` improves from severe (SSIM 0.99586, worst ink
+  F1 0.00000) to close (0.99934 / 0.99797) and `DB005-Headers-With-Images.docx`
+  from severe (0.99773 / 0.00000) to close (0.99921 / 0.96486);
+  `DB002-Landscape-Section.docx` also improves (0.91746 / 0.50174 →
+  0.92607 / 0.60042). `PageDimensions` gains correctly named `headerDistance` /
+  `footerDistance`; `headerHeight` / `footerHeight` remain as deprecated aliases.
 - **Right, center, and decimal tab stops retain their OOXML targets across native and WASM
   rendering.** Tab measurement no longer includes an invented trailing blank; unavailable-font
   estimates are normalized to CSS layout units; empty tabs advance with an explicit box instead of

--- a/Docxodus.Tests/PaginatedHeaderFooterContentTests.cs
+++ b/Docxodus.Tests/PaginatedHeaderFooterContentTests.cs
@@ -101,4 +101,47 @@ public class PaginatedHeaderFooterContentTests
         Assert.Contains("2025", html);
         Assert.Contains("7", html);
     }
+
+    /// <summary>The declaration block of one CSS rule, e.g. <c>.page-header</c>.</summary>
+    private static string RuleBody(string css, string selector)
+    {
+        var start = css.IndexOf(selector + " {", System.StringComparison.Ordinal);
+        Assert.True(start >= 0, $"stylesheet has no `{selector}` rule");
+        var open = css.IndexOf('{', start);
+        var close = css.IndexOf('}', open);
+        return css.Substring(open + 1, close - open - 1);
+    }
+
+    /// <summary>
+    /// Issue #377 — the paginated stylesheet is the second owner of Word's band model, next to the
+    /// paginator's per-page inline geometry, and the two must agree.
+    /// </summary>
+    /// <remarks>
+    /// <c>w:header</c> is the distance from the paper's top edge to the TOP of the header story,
+    /// which then grows downward, and <c>w:footer</c> the distance to the BOTTOM of the footer
+    /// story, which grows upward. Bottom-aligning the header and top-aligning the footer — the
+    /// stylesheet's former shape, paired with <c>top: 0</c>/<c>bottom: 0</c> anchors — instead
+    /// pinned both stories to the MARGINS and pulled them toward the body by
+    /// <c>margin − distance</c>.
+    /// </remarks>
+    [Fact]
+    public void PHF011_RunningContentBandsAreAnchoredToTheirDeclaredDistances()
+    {
+        var html = PaginatedHtml(BuildDocWithTabbedFooter());
+
+        // The distances themselves reach the client: 720 twips = 36 pt.
+        Assert.Contains("data-header-height=\"36.0\"", html);
+        Assert.Contains("data-footer-height=\"36.0\"", html);
+
+        var header = RuleBody(html, ".page-header");
+        var footer = RuleBody(html, ".page-footer");
+
+        Assert.Contains("justify-content: flex-start;", header);
+        Assert.Contains("justify-content: flex-end;", footer);
+
+        // The paginator sets `top`/`bottom` per page from the section's own distances; a
+        // stylesheet edge would silently win for any band it happened to leave unset.
+        Assert.DoesNotContain("top:", header);
+        Assert.DoesNotContain("bottom:", footer);
+    }
 }

--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -2135,26 +2135,28 @@ namespace Docxodus
             sb.AppendLine("    transform-origin: top left;");
             sb.AppendLine("}");
 
-            // Header area within page (positioned at top, constrained to top margin height)
+            // Header band. Word measures w:header from the paper's top edge to the TOP of the
+            // header story, which then grows downward — so the band is top-anchored and
+            // top-aligned. The paginator supplies the page-specific top/height; anchoring it to
+            // the top margin instead would pull the header down onto the body text.
             sb.AppendLine($".{prefix}header {{");
             sb.AppendLine("    position: absolute;");
-            sb.AppendLine("    top: 0;");
             sb.AppendLine("    overflow: hidden;");
             sb.AppendLine("    box-sizing: border-box;");
             sb.AppendLine("    display: flex;");
             sb.AppendLine("    flex-direction: column;");
-            sb.AppendLine("    justify-content: flex-end;"); // Align content to bottom of header area
+            sb.AppendLine("    justify-content: flex-start;");
             sb.AppendLine("}");
 
-            // Footer area within page (positioned at bottom, constrained to bottom margin height)
+            // Footer band — the mirror: w:footer is the distance to the BOTTOM of the footer
+            // story, which grows upward, so the band is bottom-anchored and bottom-aligned.
             sb.AppendLine($".{prefix}footer {{");
             sb.AppendLine("    position: absolute;");
-            sb.AppendLine("    bottom: 0;");
             sb.AppendLine("    overflow: hidden;");
             sb.AppendLine("    box-sizing: border-box;");
             sb.AppendLine("    display: flex;");
             sb.AppendLine("    flex-direction: column;");
-            sb.AppendLine("    justify-content: flex-start;"); // Align content to top of footer area
+            sb.AppendLine("    justify-content: flex-end;");
             sb.AppendLine("}");
 
             // Page number indicator

--- a/docs/architecture/paginated_headers_footers.md
+++ b/docs/architecture/paginated_headers_footers.md
@@ -183,6 +183,26 @@ Word's page margins include header/footer space:
 - `w:top`: Distance from page top to body content top
 - `w:bottom`: Distance from page bottom to body content bottom
 
+These are **four independent distances from the paper edge**, not two nested boxes. The header is
+laid out from `w:header` *downward*; the footer from `w:footer` *upward*. The body then starts at
+`w:top` unless the header has already run past it, and ends at `w:bottom` unless the footer has
+already climbed above it:
+
+```
+bodyTop    = max(w:top,    w:header + headerContentHeight)
+bodyBottom = min(pageHeight - w:bottom, pageHeight - w:footer - footerContentHeight)
+```
+
+A section with no story of that kind contributes nothing: the distance alone reserves no space,
+so a header-less document keeps its body on `w:top`. `resolvePageBands()` in
+`npm/src/page-geometry.ts` is the single owner of these four lines, and
+`PaginationEngine.getPageBands()` feeds it the registry's measured story heights.
+
+Anchoring the bands to the MARGINS instead — header bottom-aligned above `w:top`, footer
+top-aligned below `w:bottom` — collapses both toward the body by exactly `margin − distance`
+(25 px on a Word-default page) and leaves the top and bottom of the sheet blank. That was the
+shipped behavior until issue #377.
+
 ## Implementation Details
 
 ### C# Changes
@@ -408,36 +428,34 @@ private createPage(
 ): PageInfo {
   // ... existing page box and content area creation ...
 
-  const sectionHf = hfRegistry.get(sectionIndex);
+  const bands = this.getPageBands(dims, sectionIndex, pageInSection, pageNumber);
 
-  // Add header
-  const headerSource = this.selectHeader(sectionHf, pageInSection, pageNumber);
+  // Add header — anchored to w:header, growing downward
+  const headerSource = this.selectHeader(sectionIndex, pageInSection, pageNumber);
   if (headerSource) {
     const headerDiv = document.createElement('div');
     headerDiv.className = `${this.cssPrefix}header`;
-    headerDiv.style.cssText = `
-      position: absolute;
-      top: ${dims.headerHeight}pt;
-      left: ${dims.marginLeft}pt;
-      width: ${dims.contentWidth}pt;
-      overflow: hidden;
-    `;
+    headerDiv.style.top = `${bands.headerTop}pt`;
+    headerDiv.style.height = `${bands.headerHeight}pt`;
+    headerDiv.style.left = `${dims.marginLeft}pt`;
+    headerDiv.style.width = `${dims.contentWidth}pt`;
     headerDiv.appendChild(headerSource.cloneNode(true) as HTMLElement);
     pageBox.appendChild(headerDiv);
   }
 
-  // Add footer
-  const footerSource = this.selectFooter(sectionHf, pageInSection, pageNumber);
+  // Body — between whatever the two stories left
+  contentArea.style.top = `${bands.bodyTop}pt`;
+  contentArea.style.height = `${bands.bodyHeight}pt`;
+
+  // Add footer — anchored to w:footer, growing upward
+  const footerSource = this.selectFooter(sectionIndex, pageInSection, pageNumber);
   if (footerSource) {
     const footerDiv = document.createElement('div');
     footerDiv.className = `${this.cssPrefix}footer`;
-    footerDiv.style.cssText = `
-      position: absolute;
-      bottom: ${dims.footerHeight}pt;
-      left: ${dims.marginLeft}pt;
-      width: ${dims.contentWidth}pt;
-      overflow: hidden;
-    `;
+    footerDiv.style.bottom = `${dims.footerDistance}pt`;
+    footerDiv.style.height = `${bands.footerHeight}pt`;
+    footerDiv.style.left = `${dims.marginLeft}pt`;
+    footerDiv.style.width = `${dims.contentWidth}pt`;
     footerDiv.appendChild(footerSource.cloneNode(true) as HTMLElement);
     pageBox.appendChild(footerDiv);
   }
@@ -448,18 +466,30 @@ private createPage(
 
 ### CSS Additions
 
+The stylesheet owns only the band's INVARIANTS; the paginator sets `top`/`bottom`/`left`/`width`/
+`height` per page from the section's own distances. A stylesheet edge (`top: 0`, `bottom: 0`)
+would silently win for any band the paginator left unset, so there is none.
+
 ```css
 /* Paginated Header/Footer CSS */
+/* w:header is the distance to the TOP of the story, which grows downward. */
 .page-header {
   position: absolute;
   overflow: hidden;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
 }
 
+/* w:footer is the distance to the BOTTOM of the story, which grows upward. */
 .page-footer {
   position: absolute;
   overflow: hidden;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
 }
 
 /* Hide system page number when document has its own footer */
@@ -525,23 +555,36 @@ interface SectionHeaderFooter {
 }
 ```
 
-### Height Calculation
+### Band Resolution
 
-For any page position, the effective heights are computed deterministically:
+For any page position, the three bands are resolved deterministically:
 
 ```typescript
-private getEffectiveHeights(
+private getPageBands(
   dims: PageDimensions,
   sectionIndex: number,
   pageInSection: number,
   globalPageNumber: number
-): { headerHeight: number; footerHeight: number; contentHeight: number }
+): PageBands   // headerTop/headerHeight, bodyTop/bodyHeight, footerTop/footerHeight
 ```
 
-The effective header height is `max(marginTop, measuredHeaderHeight)`. This ensures:
-1. Headers always fit within their allocated space
-2. Content area adjusts to accommodate larger headers
-3. Page breaks are calculated with correct available space
+It selects the story heights the page's position calls for (mirroring `selectHeader`/
+`selectFooter`) and hands them to `resolvePageBands()`, which applies the margin model in
+[Margin Model](#margin-model) above. This is the **single owner** of "where does anything sit
+vertically on this page": band placement in `createPage`, the body budget the flow loop spends,
+and the footnote area's anchor all read the same object, so they cannot disagree about where the
+body ends. Consequences:
+
+1. A story taller than its margin pushes the body instead of drawing over it
+2. The note area follows the body's real bottom edge, not the raw bottom margin
+3. Page breaks are calculated with the space the page actually has
+
+A pathological story that would leave no body at all is capped, so the body band always keeps at
+least `MIN_BODY_BAND_PT`; the surplus is returned to whichever band over-claimed it.
+
+`measureHeaderFooterHeight()` therefore measures the story ALONE — no padding of its own. Padding
+added there and not to the rendered band (or vice versa) is exactly how a header silently starts
+overlapping body text.
 
 ### Flow Algorithm Integration
 
@@ -549,15 +592,15 @@ The `flowToPages()` algorithm uses dynamic content heights per page position:
 
 ```typescript
 for (const block of blocks) {
-  // Get effective height for CURRENT page position
-  const { contentHeight } = getEffectiveHeights(dims, sectionIndex, pageInSection, pageNumber);
+  // Get the body band for the CURRENT page position
+  const { bodyHeight } = getPageBands(dims, sectionIndex, pageInSection, pageNumber);
 
   if (blockFitsInRemainingSpace) {
     // Add to current page
   } else {
     // Start new page - recalculate for new position
-    const newHeights = getEffectiveHeights(dims, sectionIndex, pageInSection + 1, pageNumber + 1);
-    remainingHeight = newHeights.contentHeight;
+    const next = getPageBands(dims, sectionIndex, pageInSection + 1, pageNumber + 1);
+    remainingHeight = next.bodyHeight;
   }
 }
 ```

--- a/npm/src/page-geometry.ts
+++ b/npm/src/page-geometry.ts
@@ -33,9 +33,13 @@ export interface PageDimensions {
   marginBottom: number;
   /** Left margin in points */
   marginLeft: number;
-  /** Header distance from top of page in points */
+  /** `w:pgMar/@w:header` — page top edge to the TOP of the header story, in points. */
+  headerDistance: number;
+  /** `w:pgMar/@w:footer` — page bottom edge to the BOTTOM of the footer story, in points. */
+  footerDistance: number;
+  /** @deprecated Misnamed alias of {@link headerDistance} — it never held a height. */
   headerHeight: number;
-  /** Footer distance from bottom of page in points */
+  /** @deprecated Misnamed alias of {@link footerDistance} — it never held a height. */
   footerHeight: number;
 }
 
@@ -43,8 +47,10 @@ export interface PageDimensions {
 export const DEFAULT_PAGE_WIDTH = 612;
 export const DEFAULT_PAGE_HEIGHT = 792;
 export const DEFAULT_MARGIN = 72; // 1 inch
-/** Default header/footer distance (0.5 inch). */
-export const DEFAULT_HEADER_FOOTER_HEIGHT = 36;
+/** Default header/footer distance from the paper edge (0.5 inch). */
+export const DEFAULT_HEADER_FOOTER_DISTANCE = 36;
+/** @deprecated Misnamed alias of {@link DEFAULT_HEADER_FOOTER_DISTANCE}. */
+export const DEFAULT_HEADER_FOOTER_HEIGHT = DEFAULT_HEADER_FOOTER_DISTANCE;
 
 /** Converts pixels to points (assuming 96 DPI screen). */
 export function pxToPt(px: number): number {
@@ -66,8 +72,12 @@ export function parseSectionDimensions(section: HTMLElement): PageDimensions {
   const marginRight = parseFloat(section.dataset.marginRight || "") || DEFAULT_MARGIN;
   const marginBottom = parseFloat(section.dataset.marginBottom || "") || DEFAULT_MARGIN;
   const marginLeft = parseFloat(section.dataset.marginLeft || "") || DEFAULT_MARGIN;
-  const headerHeight = parseFloat(section.dataset.headerHeight || "") || DEFAULT_HEADER_FOOTER_HEIGHT;
-  const footerHeight = parseFloat(section.dataset.footerHeight || "") || DEFAULT_HEADER_FOOTER_HEIGHT;
+  // `data-header-height`/`data-footer-height` carry `w:pgMar/@w:header` and `@w:footer`, which
+  // are distances from the paper edge — the attribute names predate that being understood.
+  const headerDistance =
+    parseFloat(section.dataset.headerHeight || "") || DEFAULT_HEADER_FOOTER_DISTANCE;
+  const footerDistance =
+    parseFloat(section.dataset.footerHeight || "") || DEFAULT_HEADER_FOOTER_DISTANCE;
 
   return {
     pageWidth,
@@ -78,8 +88,92 @@ export function parseSectionDimensions(section: HTMLElement): PageDimensions {
     marginRight,
     marginBottom,
     marginLeft,
-    headerHeight,
-    footerHeight,
+    headerDistance,
+    footerDistance,
+    headerHeight: headerDistance,
+    footerHeight: footerDistance,
+  };
+}
+
+/**
+ * Where a page's three bands sit, in points measured from the page's TOP edge.
+ *
+ * Resolved by {@link resolvePageBands} from the section's page setup plus the measured
+ * height of the running content actually selected for that page.
+ */
+export interface PageBands {
+  /** Top of the header band; it grows downward from here. */
+  headerTop: number;
+  /** Height of the header band (the measured header story, clipped to the body's top). */
+  headerHeight: number;
+  /** Top of the body text band. */
+  bodyTop: number;
+  /** Height of the body text band. */
+  bodyHeight: number;
+  /** Top of the footer band; it grows upward, so its BOTTOM is the fixed edge. */
+  footerTop: number;
+  /** Height of the footer band (the measured footer story, clipped to the body's bottom). */
+  footerHeight: number;
+}
+
+/**
+ * A body band this short cannot hold a single line, and a page that can hold nothing sends
+ * every block down the oversized-block path. Running content may push the body — Word does
+ * that — but it may not delete it, so a pathological header/footer gives this much back.
+ */
+export const MIN_BODY_BAND_PT = 12;
+
+/**
+ * Word's page band model.
+ *
+ * `w:header`/`w:footer` are DISTANCES from the paper edge to the running content, and
+ * `w:top`/`w:bottom` are distances from the paper edge to the body text — four independent
+ * numbers, not two nested boxes. The header is laid out from `headerDistance` downward and
+ * the footer from `footerDistance` upward; the body then starts at the top margin unless the
+ * header has already run past it, and ends at the bottom margin unless the footer has
+ * already climbed above it.
+ *
+ * Anchoring the bands to the margins instead — header bottom-aligned to `marginTop`, footer
+ * top-aligned to `pageHeight - marginBottom` — collapses both toward the body by exactly
+ * `margin - distance`, which is what this function replaced.
+ */
+export function resolvePageBands(
+  dims: PageDimensions,
+  headerContentHeight: number,
+  footerContentHeight: number,
+): PageBands {
+  const headerTop = dims.headerDistance;
+  const footerBottom = dims.pageHeight - dims.footerDistance;
+
+  // A page with NO running story has nothing below the paper edge to push the body: the
+  // distance alone reserves no space. (Word's own empty header is still a story — one empty
+  // paragraph with a real line height — so zero here means absent, not blank.)
+  const headerReach = headerContentHeight > 0 ? headerTop + headerContentHeight : 0;
+  const footerReach = footerContentHeight > 0 ? footerBottom - footerContentHeight : dims.pageHeight;
+
+  let bodyTop = Math.max(dims.marginTop, headerReach);
+  let bodyBottom = Math.min(dims.pageHeight - dims.marginBottom, footerReach);
+
+  // Hand back whatever the bands over-claimed, in proportion to how far each grew past its
+  // own margin, so a tall header does not silently consume the whole page.
+  const shortfall = MIN_BODY_BAND_PT - (bodyBottom - bodyTop);
+  if (shortfall > 0) {
+    const headerGrowth = bodyTop - dims.marginTop;
+    const footerGrowth = dims.pageHeight - dims.marginBottom - bodyBottom;
+    const growth = headerGrowth + footerGrowth;
+    if (growth > 0) {
+      bodyTop -= (shortfall * headerGrowth) / growth;
+      bodyBottom += (shortfall * footerGrowth) / growth;
+    }
+  }
+
+  return {
+    headerTop,
+    headerHeight: Math.max(0, Math.min(headerContentHeight, bodyTop - headerTop)),
+    bodyTop,
+    bodyHeight: Math.max(0, bodyBottom - bodyTop),
+    footerTop: footerBottom - Math.max(0, Math.min(footerContentHeight, footerBottom - bodyBottom)),
+    footerHeight: Math.max(0, Math.min(footerContentHeight, footerBottom - bodyBottom)),
   };
 }
 

--- a/npm/src/pagination.ts
+++ b/npm/src/pagination.ts
@@ -13,10 +13,11 @@ import {
   parseSectionDimensions,
   ptToPx,
   pxToPt,
+  resolvePageBands,
 } from "./page-geometry.js";
-import type { PageDimensions } from "./page-geometry.js";
+import type { PageBands, PageDimensions } from "./page-geometry.js";
 
-export type { PageDimensions } from "./page-geometry.js";
+export type { PageBands, PageDimensions } from "./page-geometry.js";
 
 /**
  * Headers and footers for a specific section.
@@ -503,9 +504,9 @@ export class PaginationEngine {
    */
   private smallestEffectiveContentHeight(dims: PageDimensions, sectionIndex: number): number {
     return Math.min(
-      this.getEffectiveHeights(dims, sectionIndex, 1, 1).contentHeight,
-      this.getEffectiveHeights(dims, sectionIndex, 2, 1).contentHeight,
-      this.getEffectiveHeights(dims, sectionIndex, 2, 2).contentHeight
+      this.getPageBands(dims, sectionIndex, 1, 1).bodyHeight,
+      this.getPageBands(dims, sectionIndex, 2, 1).bodyHeight,
+      this.getPageBands(dims, sectionIndex, 2, 2).bodyHeight
     );
   }
 
@@ -1256,6 +1257,7 @@ export class PaginationEngine {
     pageBox: HTMLElement,
     footnoteIds: string[],
     dims: PageDimensions,
+    bands: PageBands,
     footnoteHeight: number,
     continuation?: FootnoteContinuation | null,
     partialFootnotes?: PartialFootnote[]
@@ -1274,13 +1276,15 @@ export class PaginationEngine {
     // Calculate max height for footnotes area (content height minus margin for body content)
     const maxFootnoteHeight = Math.min(
       footnoteHeight,
-      dims.contentHeight * MAX_FOOTNOTE_AREA_RATIO
+      bands.bodyHeight * MAX_FOOTNOTE_AREA_RATIO
     );
 
     const footnotesDiv = document.createElement("div");
     footnotesDiv.className = `${this.cssPrefix}footnotes`;
     footnotesDiv.style.position = "absolute";
-    footnotesDiv.style.bottom = `${dims.marginBottom}pt`; // Above footer area
+    // Notes sit at the FOOT OF THE BODY BAND, not at the bottom margin: a footer taller than
+    // its margin raises that edge, and anchoring to the raw margin would draw notes over it.
+    footnotesDiv.style.bottom = `${dims.pageHeight - (bands.bodyTop + bands.bodyHeight)}pt`;
     footnotesDiv.style.left = `${dims.marginLeft}pt`;
     footnotesDiv.style.width = `${dims.contentWidth}pt`;
     footnotesDiv.style.boxSizing = "border-box";
@@ -1393,73 +1397,64 @@ export class PaginationEngine {
   }
 
   /**
-   * Computes effective header, footer, and content heights for a specific page position.
-   * Uses pre-measured header/footer heights from the registry.
-   * This method is deterministic - same inputs always produce same outputs.
-   * This enables lazy loading compatibility since available height can be computed
-   * for any page position without knowing the page's content.
+   * The header, body, and footer bands for one page position.
+   *
+   * The single owner of "where does anything sit vertically on this page" — placement in
+   * {@link createPage}, the body budget the flow loop spends, and the note area's anchor all
+   * read it, so those three cannot disagree about where the body ends.
+   *
+   * Deterministic: it depends only on the section's page setup and the registry's pre-measured
+   * story heights, never on the page's content, which is what keeps it lazy-loading compatible.
    */
-  private getEffectiveHeights(
+  private getPageBands(
     dims: PageDimensions,
     sectionIndex: number,
     pageInSection: number,
     globalPageNumber: number
-  ): { headerHeight: number; footerHeight: number; contentHeight: number } {
+  ): PageBands {
     const sectionHf = this.hfRegistry.get(sectionIndex);
+    return resolvePageBands(
+      dims,
+      this.selectStoryHeight(
+        sectionHf?.headerFirstHeight,
+        sectionHf?.headerEvenHeight,
+        sectionHf?.headerDefaultHeight,
+        pageInSection,
+        globalPageNumber
+      ),
+      this.selectStoryHeight(
+        sectionHf?.footerFirstHeight,
+        sectionHf?.footerEvenHeight,
+        sectionHf?.footerDefaultHeight,
+        pageInSection,
+        globalPageNumber
+      )
+    );
+  }
 
-    // Determine effective header height
-    let headerHeight = dims.marginTop;
-    if (sectionHf) {
-      let measuredHeaderHeight: number | undefined;
-
-      // Select the appropriate header height based on page position
-      if (pageInSection === 1 && sectionHf.headerFirstHeight != null) {
-        measuredHeaderHeight = sectionHf.headerFirstHeight;
-      } else if (globalPageNumber % 2 === 0 && sectionHf.headerEvenHeight != null) {
-        measuredHeaderHeight = sectionHf.headerEvenHeight;
-      } else if (sectionHf.headerDefaultHeight != null) {
-        measuredHeaderHeight = sectionHf.headerDefaultHeight;
-      }
-
-      if (measuredHeaderHeight != null) {
-        // Use the larger of margin height or measured content height
-        headerHeight = Math.max(dims.marginTop, measuredHeaderHeight);
-      }
-    }
-
-    // Determine effective footer height
-    let footerHeight = dims.marginBottom;
-    if (sectionHf) {
-      let measuredFooterHeight: number | undefined;
-
-      // Select the appropriate footer height based on page position
-      if (pageInSection === 1 && sectionHf.footerFirstHeight != null) {
-        measuredFooterHeight = sectionHf.footerFirstHeight;
-      } else if (globalPageNumber % 2 === 0 && sectionHf.footerEvenHeight != null) {
-        measuredFooterHeight = sectionHf.footerEvenHeight;
-      } else if (sectionHf.footerDefaultHeight != null) {
-        measuredFooterHeight = sectionHf.footerDefaultHeight;
-      }
-
-      if (measuredFooterHeight != null) {
-        // Use the larger of margin height or measured content height
-        footerHeight = Math.max(dims.marginBottom, measuredFooterHeight);
-      }
-    }
-
-    // Calculate effective content height
-    // contentHeight from dims is: pageHeight - marginTop - marginBottom
-    // We need to adjust for any header/footer expansion beyond margins
-    const headerExpansion = headerHeight - dims.marginTop;
-    const footerExpansion = footerHeight - dims.marginBottom;
-    const contentHeight = dims.contentHeight - headerExpansion - footerExpansion;
-
-    return { headerHeight, footerHeight, contentHeight };
+  /**
+   * The measured height of the running story this page position selects, mirroring
+   * {@link selectHeader}/{@link selectFooter}. Zero when the page has no such story.
+   */
+  private selectStoryHeight(
+    first: number | undefined,
+    even: number | undefined,
+    fallback: number | undefined,
+    pageInSection: number,
+    globalPageNumber: number
+  ): number {
+    if (pageInSection === 1 && first != null) return first;
+    if (globalPageNumber % 2 === 0 && even != null) return even;
+    return fallback ?? 0;
   }
 
   /**
    * Measures the content height of a header or footer element.
-   * This is needed because headers/footers can contain more content than fits in the margin area.
+   *
+   * This is what tells {@link resolvePageBands} whether the story stays inside its margin or
+   * pushes the body, so it must measure the story ALONE — any padding added here would have to
+   * be added to the rendered band too, and the two drifting apart is exactly how a header
+   * silently starts overlapping body text.
    */
   private measureHeaderFooterHeight(
     source: HTMLElement,
@@ -1471,8 +1466,6 @@ export class PaginationEngine {
     measureContainer.style.visibility = "hidden";
     measureContainer.style.width = `${contentWidth}pt`;
     measureContainer.style.left = "-9999px";
-    // Add padding to match the actual rendering
-    measureContainer.style.paddingBottom = "4pt";
 
     // Clone and add the header/footer content
     for (const child of Array.from(source.childNodes)) {
@@ -1510,7 +1503,7 @@ export class PaginationEngine {
     let pageInSection = 1;
 
     // Get effective content height for first page (accounts for header/footer sizes)
-    let { contentHeight: effectiveContentHeight } = this.getEffectiveHeights(
+    let { bodyHeight: effectiveContentHeight } = this.getPageBands(
       dims, sectionIndex, pageInSection, pageNumber
     );
     let remainingHeight = effectiveContentHeight;
@@ -1568,8 +1561,8 @@ export class PaginationEngine {
       currentContent = [];
 
       // Get effective content height for new page position
-      const newHeights = this.getEffectiveHeights(dims, sectionIndex, pageInSection, pageNumber);
-      effectiveContentHeight = newHeights.contentHeight;
+      const newBands = this.getPageBands(dims, sectionIndex, pageInSection, pageNumber);
+      effectiveContentHeight = newBands.bodyHeight;
       remainingHeight = effectiveContentHeight;
 
       prevMarginBottomPt = 0; // Reset margin tracking for new page
@@ -1659,7 +1652,7 @@ export class PaginationEngine {
           const currentAvailableHeight = remainingHeight - currentFootnoteHeight;
 
           if (currentChainHeight > currentAvailableHeight) {
-            const nextPageHeights = this.getEffectiveHeights(
+            const nextPageBands = this.getPageBands(
               dims,
               sectionIndex,
               pageInSection + 1,
@@ -1681,7 +1674,7 @@ export class PaginationEngine {
 
             if (
               freshChainBodyHeight + freshChainFootnoteHeight <=
-              nextPageHeights.contentHeight
+              nextPageBands.bodyHeight
             ) {
               finishPage();
             }
@@ -1991,8 +1984,8 @@ export class PaginationEngine {
     // first page, not from the document's.
     pageBox.dataset.pageInSection = String(pageInSection);
 
-    // Get pre-computed effective heights for this page position (no re-measurement needed)
-    const effectiveHeights = this.getEffectiveHeights(dims, sectionIndex, pageInSection, pageNumber);
+    // Where the three bands sit on this page (no re-measurement needed)
+    const bands = this.getPageBands(dims, sectionIndex, pageInSection, pageNumber);
 
     // Add header if available for this section/page
     const headerSource = this.selectHeader(sectionIndex, pageInSection, pageNumber);
@@ -2001,16 +1994,19 @@ export class PaginationEngine {
       const headerDiv = document.createElement("div");
       headerDiv.className = `${this.cssPrefix}header`;
       headerDiv.style.position = "absolute";
-      headerDiv.style.top = "0"; // Start at page top
+      // `w:header` is the distance to the TOP of the story, and the story grows downward from
+      // there; `flex-start` therefore pins the edge the OOXML actually declares, and content
+      // taller than the measurement clips at the bottom rather than sliding up the page.
+      headerDiv.style.top = `${bands.headerTop}pt`;
+      headerDiv.style.bottom = "auto";
       headerDiv.style.left = `${dims.marginLeft}pt`;
       headerDiv.style.width = `${dims.contentWidth}pt`;
-      headerDiv.style.height = `${effectiveHeights.headerHeight}pt`; // Use pre-computed effective height
+      headerDiv.style.height = `${bands.headerHeight}pt`;
       headerDiv.style.overflow = "hidden";
       headerDiv.style.boxSizing = "border-box";
       headerDiv.style.display = "flex";
       headerDiv.style.flexDirection = "column";
-      headerDiv.style.justifyContent = "flex-end"; // Align content to bottom of header area
-      headerDiv.style.paddingBottom = "4pt"; // Small gap before content area
+      headerDiv.style.justifyContent = "flex-start";
       // Clone the header content (skip the wrapper div's data attributes)
       for (const child of Array.from(headerSource.childNodes)) {
         const clonedheaderDiv = child.cloneNode(true) as HTMLElement;
@@ -2021,8 +2017,8 @@ export class PaginationEngine {
     }
 
     // Create content area using pre-computed effective heights
-    const contentAreaTop = effectiveHeights.headerHeight;
-    const contentAreaHeight = effectiveHeights.contentHeight;
+    const contentAreaTop = bands.bodyTop;
+    const contentAreaHeight = bands.bodyHeight;
 
     const contentArea = document.createElement("div");
     contentArea.className = `${this.cssPrefix}content`;
@@ -2043,7 +2039,7 @@ export class PaginationEngine {
     // Add footnotes if any references appear on this page (or continuation from previous)
     const hasContinuation = continuation && continuation.remainingElements.length > 0;
     if (footnoteIds.length > 0 || hasContinuation) {
-      this.addPageFootnotes(pageBox, footnoteIds, dims, footnoteHeight, continuation, partialFootnotes);
+      this.addPageFootnotes(pageBox, footnoteIds, dims, bands, footnoteHeight, continuation, partialFootnotes);
 
     }
 
@@ -2053,16 +2049,18 @@ export class PaginationEngine {
       const footerDiv = document.createElement("div");
       footerDiv.className = `${this.cssPrefix}footer`;
       footerDiv.style.position = "absolute";
-      footerDiv.style.bottom = "0"; // Start at page bottom
+      // `w:footer` is the distance to the BOTTOM of the story, and the story grows upward from
+      // there — the mirror of the header, so `flex-end` and a bottom anchor.
+      footerDiv.style.top = "auto";
+      footerDiv.style.bottom = `${dims.footerDistance}pt`;
       footerDiv.style.left = `${dims.marginLeft}pt`;
       footerDiv.style.width = `${dims.contentWidth}pt`;
-      footerDiv.style.height = `${effectiveHeights.footerHeight}pt`; // Use pre-computed effective height
+      footerDiv.style.height = `${bands.footerHeight}pt`;
       footerDiv.style.overflow = "hidden";
       footerDiv.style.boxSizing = "border-box";
       footerDiv.style.display = "flex";
       footerDiv.style.flexDirection = "column";
-      footerDiv.style.justifyContent = "flex-start"; // Align content to top of footer area
-      footerDiv.style.paddingTop = "4pt"; // Small gap after content area
+      footerDiv.style.justifyContent = "flex-end";
       // Clone the footer content (skip the wrapper div's data attributes)
       for (const child of Array.from(footerSource.childNodes)) {
         const clonedfooterDiv = child.cloneNode(true) as HTMLElement;

--- a/npm/tests/docx-running-content-fixture.ts
+++ b/npm/tests/docx-running-content-fixture.ts
@@ -1,0 +1,179 @@
+import { storedZip, xml, R_NS, W_NS } from './docx-zip.js';
+
+/**
+ * A generated two-section document with first/even/default running stories, for pinning where
+ * headers, footers, and body text sit on the page.
+ *
+ * Word's page setup is FOUR independent distances from the paper edge, not two nested boxes:
+ * `w:header` to the top of the header story, `w:footer` to the bottom of the footer story, and
+ * `w:top`/`w:bottom` to the body text. Section 2 declares its own distances and margins while
+ * declaring NO header/footer references, so it also covers the transition where a later section
+ * inherits stories from an earlier one but must not inherit its geometry.
+ */
+
+/** Page setup for one section, in twips (1/20 pt) — the units `w:pgMar` itself uses. */
+export interface SectionGeometryTwips {
+  marginTop: number;
+  marginBottom: number;
+  headerDistance: number;
+  footerDistance: number;
+}
+
+export interface RunningContentGeometry {
+  first: SectionGeometryTwips;
+  second: SectionGeometryTwips;
+}
+
+/** Twips → points, the unit the rendered page boxes are sized in. */
+export const twipsToPt = (twips: number): number => twips / 20;
+
+/** Section 1 uses Word's own defaults; section 2 deliberately differs in all four distances. */
+export const DEFAULT_RUNNING_CONTENT_GEOMETRY: RunningContentGeometry = {
+  first: { marginTop: 1440, marginBottom: 1440, headerDistance: 720, footerDistance: 720 },
+  second: { marginTop: 1800, marginBottom: 1080, headerDistance: 1080, footerDistance: 360 },
+};
+
+/** Distinct, single-line story text so a spec can tell which variant a page selected. */
+export const STORY_TEXT = {
+  headerFirst: 'HEADER FIRST',
+  headerDefault: 'HEADER DEFAULT',
+  headerEven: 'HEADER EVEN',
+  footerFirst: 'FOOTER FIRST',
+  footerDefault: 'FOOTER DEFAULT',
+  footerEven: 'FOOTER EVEN',
+} as const;
+
+const PAGE_WIDTH_TWIPS = 12240; // 8.5 in
+const PAGE_HEIGHT_TWIPS = 15840; // 11 in
+const SIDE_MARGIN_TWIPS = 1440;
+
+/** Page width and height in points, for a spec that asserts against the paper edge. */
+export const PAGE_WIDTH_PT = twipsToPt(PAGE_WIDTH_TWIPS);
+export const PAGE_HEIGHT_PT = twipsToPt(PAGE_HEIGHT_TWIPS);
+
+function story(text: string): string {
+  return `<w:p><w:pPr><w:spacing w:before="0" w:after="0" w:line="240" w:lineRule="auto"/></w:pPr><w:r><w:t>${text}</w:t></w:r></w:p>`;
+}
+
+/** `lines` paragraphs, the first carrying `text` so a spec can still identify the variant. */
+function multiLineStory(text: string, lines: number): string {
+  return Array.from({ length: Math.max(1, lines) }, (_, i) =>
+    story(i === 0 ? text : `${text} cont ${i}`)).join('');
+}
+
+function headerPart(text: string, lines: number): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:hdr xmlns:w="${W_NS}">${multiLineStory(text, lines)}</w:hdr>`;
+}
+
+function footerPart(text: string, lines: number): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:ftr xmlns:w="${W_NS}">${multiLineStory(text, lines)}</w:ftr>`;
+}
+
+function bodyParagraphs(label: string, count: number): string {
+  return Array.from({ length: count }, (_, i) => story(`${label} body line ${i + 1}`)).join('');
+}
+
+function sectPr(geometry: SectionGeometryTwips, references: string): string {
+  return `${references}<w:pgSz w:w="${PAGE_WIDTH_TWIPS}" w:h="${PAGE_HEIGHT_TWIPS}"/>` +
+    `<w:pgMar w:top="${geometry.marginTop}" w:right="${SIDE_MARGIN_TWIPS}"` +
+    ` w:bottom="${geometry.marginBottom}" w:left="${SIDE_MARGIN_TWIPS}"` +
+    ` w:header="${geometry.headerDistance}" w:footer="${geometry.footerDistance}" w:gutter="0"/>` +
+    `<w:cols w:space="720"/><w:titlePg/>`;
+}
+
+/**
+ * @param geometry per-section page setup; the default gives the two sections different
+ *   header/footer distances AND margins, so a renderer that reuses section 1's numbers fails.
+ * @param linesPerSection body lines per section — enough for at least THREE pages each, so the
+ *   first, even, and odd/default story variants all get a page to be checked on.
+ * @param storyLines paragraphs per running story. More than one, against a small margin, is how
+ *   a story is made to reach past its margin and push the body — Word's overflow case.
+ */
+export function generateRunningContentDocx(
+  geometry: RunningContentGeometry = DEFAULT_RUNNING_CONTENT_GEOMETRY,
+  linesPerSection = 180,
+  storyLines = 1,
+): Uint8Array {
+  const references =
+    '<w:headerReference w:type="first" r:id="rId10"/>' +
+    '<w:headerReference w:type="default" r:id="rId11"/>' +
+    '<w:headerReference w:type="even" r:id="rId12"/>' +
+    '<w:footerReference w:type="first" r:id="rId13"/>' +
+    '<w:footerReference w:type="default" r:id="rId14"/>' +
+    '<w:footerReference w:type="even" r:id="rId15"/>';
+
+  return storedZip([
+    {
+      name: '[Content_Types].xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
+  <Override PartName="/word/settings.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml"/>
+  <Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>
+  <Override PartName="/word/header2.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>
+  <Override PartName="/word/header3.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>
+  <Override PartName="/word/footer1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml"/>
+  <Override PartName="/word/footer2.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml"/>
+  <Override PartName="/word/footer3.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml"/>
+</Types>`),
+    },
+    {
+      name: '_rels/.rels',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${R_NS}/officeDocument" Target="word/document.xml"/>
+</Relationships>`),
+    },
+    {
+      name: 'word/_rels/document.xml.rels',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${R_NS}/styles" Target="styles.xml"/>
+  <Relationship Id="rId2" Type="${R_NS}/settings" Target="settings.xml"/>
+  <Relationship Id="rId10" Type="${R_NS}/header" Target="header1.xml"/>
+  <Relationship Id="rId11" Type="${R_NS}/header" Target="header2.xml"/>
+  <Relationship Id="rId12" Type="${R_NS}/header" Target="header3.xml"/>
+  <Relationship Id="rId13" Type="${R_NS}/footer" Target="footer1.xml"/>
+  <Relationship Id="rId14" Type="${R_NS}/footer" Target="footer2.xml"/>
+  <Relationship Id="rId15" Type="${R_NS}/footer" Target="footer3.xml"/>
+</Relationships>`),
+    },
+    {
+      name: 'word/styles.xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles xmlns:w="${W_NS}">
+  <w:docDefaults><w:rPrDefault><w:rPr>
+    <w:rFonts w:ascii="Liberation Serif" w:hAnsi="Liberation Serif"/>
+    <w:sz w:val="24"/><w:szCs w:val="24"/>
+  </w:rPr></w:rPrDefault></w:docDefaults>
+  <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+</w:styles>`),
+    },
+    {
+      name: 'word/settings.xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:settings xmlns:w="${W_NS}"><w:evenAndOddHeaders/></w:settings>`),
+    },
+    { name: 'word/header1.xml', data: xml(headerPart(STORY_TEXT.headerFirst, storyLines)) },
+    { name: 'word/header2.xml', data: xml(headerPart(STORY_TEXT.headerDefault, storyLines)) },
+    { name: 'word/header3.xml', data: xml(headerPart(STORY_TEXT.headerEven, storyLines)) },
+    { name: 'word/footer1.xml', data: xml(footerPart(STORY_TEXT.footerFirst, storyLines)) },
+    { name: 'word/footer2.xml', data: xml(footerPart(STORY_TEXT.footerDefault, storyLines)) },
+    { name: 'word/footer3.xml', data: xml(footerPart(STORY_TEXT.footerEven, storyLines)) },
+    {
+      name: 'word/document.xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="${W_NS}" xmlns:r="${R_NS}"><w:body>
+  ${bodyParagraphs('S1', linesPerSection)}
+  <w:p><w:pPr><w:sectPr>${sectPr(geometry.first, references)}</w:sectPr></w:pPr></w:p>
+  ${bodyParagraphs('S2', linesPerSection)}
+  <w:sectPr>${sectPr(geometry.second, '')}</w:sectPr>
+</w:body></w:document>`),
+    },
+  ]);
+}

--- a/npm/tests/docx-tab-fixture.ts
+++ b/npm/tests/docx-tab-fixture.ts
@@ -1,60 +1,4 @@
-type ZipEntry = { name: string; data: Buffer };
-
-const encoder = new TextEncoder();
-
-function crc32(bytes: Uint8Array): number {
-  let crc = 0xffffffff;
-  for (const byte of bytes) {
-    crc ^= byte;
-    for (let bit = 0; bit < 8; bit += 1)
-      crc = (crc >>> 1) ^ ((crc & 1) ? 0xedb88320 : 0);
-  }
-  return (crc ^ 0xffffffff) >>> 0;
-}
-
-function storedZip(entries: ZipEntry[]): Uint8Array {
-  const localParts: Buffer[] = [];
-  const centralParts: Buffer[] = [];
-  let offset = 0;
-
-  for (const entry of entries) {
-    const name = Buffer.from(entry.name, 'utf8');
-    const checksum = crc32(entry.data);
-    const local = Buffer.alloc(30);
-    local.writeUInt32LE(0x04034b50, 0);
-    local.writeUInt16LE(20, 4);
-    local.writeUInt32LE(checksum, 14);
-    local.writeUInt32LE(entry.data.length, 18);
-    local.writeUInt32LE(entry.data.length, 22);
-    local.writeUInt16LE(name.length, 26);
-    localParts.push(local, name, entry.data);
-
-    const central = Buffer.alloc(46);
-    central.writeUInt32LE(0x02014b50, 0);
-    central.writeUInt16LE(20, 4);
-    central.writeUInt16LE(20, 6);
-    central.writeUInt32LE(checksum, 16);
-    central.writeUInt32LE(entry.data.length, 20);
-    central.writeUInt32LE(entry.data.length, 24);
-    central.writeUInt16LE(name.length, 28);
-    central.writeUInt32LE(offset, 42);
-    centralParts.push(central, name);
-    offset += local.length + name.length + entry.data.length;
-  }
-
-  const centralDirectory = Buffer.concat(centralParts);
-  const end = Buffer.alloc(22);
-  end.writeUInt32LE(0x06054b50, 0);
-  end.writeUInt16LE(entries.length, 8);
-  end.writeUInt16LE(entries.length, 10);
-  end.writeUInt32LE(centralDirectory.length, 12);
-  end.writeUInt32LE(offset, 16);
-  return new Uint8Array(Buffer.concat([...localParts, centralDirectory, end]));
-}
-
-function xml(value: string): Buffer {
-  return Buffer.from(encoder.encode(value));
-}
+import { storedZip, xml, W_NS } from './docx-zip.js';
 
 export type TabAlignment = 'right' | 'center' | 'decimal';
 
@@ -65,7 +9,6 @@ export function generateTabDocx(
   leader?: 'dot',
 ): Uint8Array {
   const leaderAttribute = leader ? ` w:leader="${leader}"` : '';
-  const wordNamespace = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
   return storedZip([
     {
       name: '[Content_Types].xml',
@@ -96,7 +39,7 @@ export function generateTabDocx(
     {
       name: 'word/styles.xml',
       data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<w:styles xmlns:w="${wordNamespace}">
+<w:styles xmlns:w="${W_NS}">
   <w:docDefaults><w:rPrDefault><w:rPr>
     <w:rFonts w:ascii="Liberation Mono" w:hAnsi="Liberation Mono"/>
     <w:sz w:val="24"/><w:szCs w:val="24"/>
@@ -107,12 +50,12 @@ export function generateTabDocx(
     {
       name: 'word/settings.xml',
       data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<w:settings xmlns:w="${wordNamespace}"><w:defaultTabStop w:val="720"/></w:settings>`),
+<w:settings xmlns:w="${W_NS}"><w:defaultTabStop w:val="720"/></w:settings>`),
     },
     {
       name: 'word/document.xml',
       data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<w:document xmlns:w="${wordNamespace}"><w:body>
+<w:document xmlns:w="${W_NS}"><w:body>
   <w:p><w:pPr><w:tabs><w:tab w:val="${alignment}" w:pos="5760"${leaderAttribute}/></w:tabs></w:pPr>
     <w:r><w:t>${before}</w:t></w:r><w:r><w:tab/></w:r><w:r><w:t>${after}</w:t></w:r>
   </w:p>

--- a/npm/tests/docx-zip.ts
+++ b/npm/tests/docx-zip.ts
@@ -1,0 +1,71 @@
+/**
+ * Minimal stored-entry ZIP writer, so a spec can GENERATE the DOCX it needs at runtime.
+ *
+ * Regressions that need an exotic `w:sectPr`, tab stop, or story layout would otherwise have to
+ * commit a binary fixture; the visual-parity corpus guard rejects those, and a committed binary
+ * hides the very XML the test is about. Building the package from readable strings keeps the
+ * document under review in the diff.
+ */
+
+type ZipEntry = { name: string; data: Buffer };
+
+const encoder = new TextEncoder();
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1)
+      crc = (crc >>> 1) ^ ((crc & 1) ? 0xedb88320 : 0);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+/** Packs `entries` with no compression (method 0) — smallest correct writer for a test. */
+export function storedZip(entries: ZipEntry[]): Uint8Array {
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const name = Buffer.from(entry.name, 'utf8');
+    const checksum = crc32(entry.data);
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt32LE(checksum, 14);
+    local.writeUInt32LE(entry.data.length, 18);
+    local.writeUInt32LE(entry.data.length, 22);
+    local.writeUInt16LE(name.length, 26);
+    localParts.push(local, name, entry.data);
+
+    const central = Buffer.alloc(46);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(20, 4);
+    central.writeUInt16LE(20, 6);
+    central.writeUInt32LE(checksum, 16);
+    central.writeUInt32LE(entry.data.length, 20);
+    central.writeUInt32LE(entry.data.length, 24);
+    central.writeUInt16LE(name.length, 28);
+    central.writeUInt32LE(offset, 42);
+    centralParts.push(central, name);
+    offset += local.length + name.length + entry.data.length;
+  }
+
+  const centralDirectory = Buffer.concat(centralParts);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(entries.length, 8);
+  end.writeUInt16LE(entries.length, 10);
+  end.writeUInt32LE(centralDirectory.length, 12);
+  end.writeUInt32LE(offset, 16);
+  return new Uint8Array(Buffer.concat([...localParts, centralDirectory, end]));
+}
+
+/** UTF-8 bytes of an XML part. */
+export function xml(value: string): Buffer {
+  return Buffer.from(encoder.encode(value));
+}
+
+export const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+export const R_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';

--- a/npm/tests/pagination-running-content-geometry.spec.ts
+++ b/npm/tests/pagination-running-content-geometry.spec.ts
@@ -1,0 +1,292 @@
+import { test, expect, Page } from '@playwright/test';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  DEFAULT_RUNNING_CONTENT_GEOMETRY,
+  PAGE_HEIGHT_PT,
+  STORY_TEXT,
+  generateRunningContentDocx,
+  twipsToPt,
+} from './docx-running-content-fixture.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * Issue #377 — where headers, footers, and body text sit vertically on a paginated page.
+ *
+ * `w:pgMar` declares FOUR independent distances from the paper edge: `w:header` to the TOP of
+ * the header story, `w:footer` to the BOTTOM of the footer story, and `w:top`/`w:bottom` to the
+ * body text. The engine used to ignore the first two and anchor the running content to the
+ * MARGINS instead — header bottom-aligned above `w:top`, footer top-aligned below `w:bottom` —
+ * which pulled both bands toward the body by exactly `margin − distance` (25 px on a Word
+ * default page) and left the top and bottom of the sheet blank.
+ *
+ * These assertions restate the OOXML contract, not the implementation: each band edge is
+ * checked against the paper edge the spec says owns it, and the bands are required to stay
+ * disjoint so a tall story can never draw over body text.
+ */
+
+const PT_TO_PX = 4 / 3;
+/** Sub-pixel tolerance: band offsets are set in `pt` and read back from layout in `px`. */
+const TOL = 0.75;
+
+interface BandBox {
+  top: number;
+  bottom: number;
+  height: number;
+  text: string;
+}
+
+interface PageGeometry {
+  page: number;
+  sectionIndex: number;
+  boxTop: number;
+  boxBottom: number;
+  header: BandBox | null;
+  body: BandBox | null;
+  footer: BandBox | null;
+}
+
+const MEASURE = () => {
+  const box = (el: Element | null): unknown => {
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    return {
+      top: r.top,
+      bottom: r.bottom,
+      height: r.height,
+      text: (el.textContent || '').replace(/\s+/g, ' ').trim(),
+    };
+  };
+  const container = document.getElementById('pagination-container') as HTMLElement;
+  return Array.from(container.querySelectorAll('.page-box')).map((b, i) => {
+    const r = b.getBoundingClientRect();
+    return {
+      page: i + 1,
+      sectionIndex: Number((b as HTMLElement).dataset.sectionIndex ?? -1),
+      boxTop: r.top,
+      boxBottom: r.bottom,
+      header: box(b.querySelector('.page-header')),
+      body: box(b.querySelector('.page-content')),
+      footer: box(b.querySelector('.page-footer')),
+    };
+  });
+};
+
+async function paginateGeneratedDocument(page: Page, docx: Uint8Array): Promise<PageGeometry[]> {
+  await page.goto('/test-harness.html');
+  await page.waitForFunction(() => (window as any).DocxodusReady === true, { timeout: 30000 });
+
+  const html = await page.evaluate((bytes) => {
+    const converter = (window as any).Docxodus.DocumentConverter;
+    return converter.ConvertDocxToHtmlComplete(
+      new Uint8Array(bytes), 'Document', 'docx-', true, '', -1, 'comment-',
+      /* paginationMode */ 1, /* paginationScale */ 1, 'page-',
+      /* renderAnnotations */ false, 0, 'annot-',
+      /* footnotes */ false, /* headersAndFooters */ true,
+      /* trackedChanges */ false, false, false,
+    ) as string;
+  }, Array.from(docx));
+
+  expect(html.startsWith('{'), `conversion failed: ${html.slice(0, 300)}`).toBe(false);
+
+  await page.setContent(html);
+  await page.addScriptTag({ path: path.join(__dirname, '../dist/pagination.bundle.js') });
+  return page.evaluate(({ measure }: { measure: string }) => {
+    const staging = document.getElementById('pagination-staging') as HTMLElement;
+    const container = document.getElementById('pagination-container') as HTMLElement;
+    const { PaginationEngine } = (window as any).DocxodusPagination;
+    new PaginationEngine(staging, container, { scale: 1, showPageNumbers: false }).paginate();
+    // eslint-disable-next-line no-eval
+    return (0, eval)(`(${measure})`)();
+  }, { measure: MEASURE.toString() }) as Promise<PageGeometry[]>;
+}
+
+/** The section geometry, in CSS pixels, that a page belonging to `sectionIndex` must obey. */
+function expectedPx(sectionIndex: number, geometry = DEFAULT_RUNNING_CONTENT_GEOMETRY) {
+  const g = sectionIndex === 0 ? geometry.first : geometry.second;
+  return {
+    marginTop: twipsToPt(g.marginTop) * PT_TO_PX,
+    marginBottom: twipsToPt(g.marginBottom) * PT_TO_PX,
+    headerDistance: twipsToPt(g.headerDistance) * PT_TO_PX,
+    footerDistance: twipsToPt(g.footerDistance) * PT_TO_PX,
+  };
+}
+
+test.describe('Paginated running-content geometry', () => {
+  let pages: PageGeometry[];
+
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    try {
+      pages = await paginateGeneratedDocument(page, generateRunningContentDocx());
+    } finally {
+      await page.close();
+    }
+  });
+
+  test('every page carries both running stories, across the inheriting section', async () => {
+    expect(pages.length).toBeGreaterThanOrEqual(4);
+    // Both sections must be represented, or the inheritance half of this fixture is untested.
+    expect(new Set(pages.map((p) => p.sectionIndex))).toEqual(new Set([0, 1]));
+
+    const missing = pages.filter((p) => !p.header?.text || !p.footer?.text);
+    expect(missing.map((p) => p.page), 'pages missing a header or footer story').toEqual([]);
+
+    const headers = pages.map((p) => p.header!.text);
+    expect(headers[0]).toBe(STORY_TEXT.headerFirst);
+    expect(pages[0].footer!.text).toBe(STORY_TEXT.footerFirst);
+    expect(headers).toContain(STORY_TEXT.headerEven);
+    expect(headers).toContain(STORY_TEXT.headerDefault);
+
+    // Section 2 declares no references of its own; it must still show the inherited stories.
+    const inherited = pages.filter((p) => p.sectionIndex === 1);
+    expect(inherited.length).toBeGreaterThan(0);
+    expect(inherited.every((p) => !!p.header!.text && !!p.footer!.text)).toBe(true);
+  });
+
+  test('the header story starts at w:header from the top of the paper', async () => {
+    for (const p of pages) {
+      const expected = expectedPx(p.sectionIndex);
+      expect(
+        p.header!.top - p.boxTop,
+        `page ${p.page} (section ${p.sectionIndex}) header top`,
+      ).toBeCloseTo(expected.headerDistance, 0);
+    }
+  });
+
+  test('the footer story ends at w:footer from the bottom of the paper', async () => {
+    for (const p of pages) {
+      const expected = expectedPx(p.sectionIndex);
+      expect(
+        p.boxBottom - p.footer!.bottom,
+        `page ${p.page} (section ${p.sectionIndex}) footer bottom`,
+      ).toBeCloseTo(expected.footerDistance, 0);
+    }
+  });
+
+  test('body text starts at the top margin unless the header has already passed it', async () => {
+    for (const p of pages) {
+      const expected = expectedPx(p.sectionIndex);
+      const wanted = Math.max(expected.marginTop, expected.headerDistance + p.header!.height);
+      expect(
+        p.body!.top - p.boxTop,
+        `page ${p.page} (section ${p.sectionIndex}) body top`,
+      ).toBeCloseTo(wanted, 0);
+    }
+  });
+
+  test('body text ends at the bottom margin unless the footer has already passed it', async () => {
+    for (const p of pages) {
+      const expected = expectedPx(p.sectionIndex);
+      const wanted = Math.max(expected.marginBottom, expected.footerDistance + p.footer!.height);
+      expect(
+        p.boxBottom - p.body!.bottom,
+        `page ${p.page} (section ${p.sectionIndex}) body bottom`,
+      ).toBeCloseTo(wanted, 0);
+    }
+  });
+
+  test('the three bands never overlap', async () => {
+    const overlaps = pages.filter(
+      (p) => p.header!.bottom > p.body!.top + TOL || p.body!.bottom > p.footer!.top + TOL,
+    );
+    expect(
+      overlaps.map((p) => p.page),
+      'pages where a running story overlaps the body band',
+    ).toEqual([]);
+  });
+
+  test('the second section uses its OWN distances, not the first section\'s', async () => {
+    const s1 = pages.find((p) => p.sectionIndex === 0)!;
+    const s2 = pages.find((p) => p.sectionIndex === 1)!;
+    // The fixture deliberately differs in every distance, so equal offsets mean the renderer
+    // carried section 1's page setup across the transition.
+    expect(s2.header!.top - s2.boxTop).not.toBeCloseTo(s1.header!.top - s1.boxTop, 0);
+    expect(s2.boxBottom - s2.footer!.bottom).not.toBeCloseTo(s1.boxBottom - s1.footer!.bottom, 0);
+    expect(s2.boxBottom - s2.boxTop).toBeCloseTo(PAGE_HEIGHT_PT * PT_TO_PX, 0);
+  });
+});
+
+/** Margins too small to contain the stories, so both must push the body inward. */
+const TIGHT_GEOMETRY = {
+  first: { marginTop: 720, marginBottom: 720, headerDistance: 360, footerDistance: 360 },
+  second: { marginTop: 720, marginBottom: 720, headerDistance: 360, footerDistance: 360 },
+};
+
+test.describe('Running content that outgrows its margin', () => {
+  test('a tall story pushes the body instead of drawing over it', async ({ page }) => {
+    const pages = await paginateGeneratedDocument(
+      page,
+      generateRunningContentDocx(TIGHT_GEOMETRY, 120, 4),
+    );
+
+    expect(pages.length).toBeGreaterThan(0);
+    for (const p of pages) {
+      const expected = expectedPx(p.sectionIndex, TIGHT_GEOMETRY);
+      // The fixture is built so the stories really do overflow; if they stopped doing so the
+      // rest of this test would pass vacuously.
+      expect(
+        expected.headerDistance + p.header!.height,
+        `page ${p.page} header should reach past the top margin`,
+      ).toBeGreaterThan(expected.marginTop);
+
+      expect(p.body!.top - p.boxTop, `page ${p.page} body top`)
+        .toBeCloseTo(expected.headerDistance + p.header!.height, 0);
+      expect(p.boxBottom - p.body!.bottom, `page ${p.page} body bottom`)
+        .toBeCloseTo(expected.footerDistance + p.footer!.height, 0);
+      expect(p.header!.bottom, `page ${p.page} header/body overlap`)
+        .toBeLessThanOrEqual(p.body!.top + TOL);
+      expect(p.body!.bottom, `page ${p.page} body/footer overlap`)
+        .toBeLessThanOrEqual(p.footer!.top + TOL);
+    }
+  });
+});
+
+/**
+ * A page with no running story at all. `w:header`/`w:footer` are still declared — every real
+ * `w:pgMar` carries them — but they reserve nothing when there is no story to place, so the body
+ * must sit on its margins. Anchoring the body at `headerDistance` unconditionally moved every
+ * header-less document's text down by the distance instead.
+ */
+const NO_STORY_STAGING = `
+  <style>#staging { font: 12px/12px Arial; } #staging p { margin: 0; height: 12pt; }</style>
+  <div id="pagination-staging">
+    <div data-section-index="0"
+         data-page-width="300" data-page-height="300"
+         data-content-width="276" data-content-height="276"
+         data-margin-top="12" data-margin-right="12"
+         data-margin-bottom="12" data-margin-left="12"
+         data-header-height="36" data-footer-height="36">
+      ${Array.from({ length: 40 }, (_, i) => `<p>line ${i}</p>`).join('')}
+    </div>
+  </div>
+  <div id="pagination-container"></div>`;
+
+test.describe('Pages with no running content', () => {
+  test('a declared header distance reserves nothing when the section has no story', async ({
+    page,
+  }) => {
+    await page.setContent(NO_STORY_STAGING);
+    await page.addScriptTag({ path: path.join(__dirname, '../dist/pagination.bundle.js') });
+    const measured = await page.evaluate(({ measure }: { measure: string }) => {
+      const staging = document.getElementById('pagination-staging') as HTMLElement;
+      const container = document.getElementById('pagination-container') as HTMLElement;
+      const { PaginationEngine } = (window as any).DocxodusPagination;
+      new PaginationEngine(staging, container, { scale: 1, showPageNumbers: false }).paginate();
+      // eslint-disable-next-line no-eval
+      return (0, eval)(`(${measure})`)();
+    }, { measure: MEASURE.toString() }) as PageGeometry[];
+
+    expect(measured.length).toBeGreaterThan(1);
+    for (const p of measured) {
+      expect(p.header, `page ${p.page} should have no header band`).toBeNull();
+      expect(p.footer, `page ${p.page} should have no footer band`).toBeNull();
+      // 12 pt margins on a 300 pt page, with a 36 pt header distance that must not bind.
+      expect(p.body!.top - p.boxTop, `page ${p.page} body top`).toBeCloseTo(12 * PT_TO_PX, 0);
+      expect(p.boxBottom - p.body!.bottom, `page ${p.page} body bottom`)
+        .toBeCloseTo(12 * PT_TO_PX, 0);
+    }
+  });
+});

--- a/npm/tests/visual-parity/BASELINE.md
+++ b/npm/tests/visual-parity/BASELINE.md
@@ -68,16 +68,16 @@ The complete 12-case corpus was rerun after rebuilding the production WASM bundl
 report remained outside the checkout under `/tmp`; no benchmark artifacts or additional corpus files
 were added to the repository.
 
-| Signal | Initial | Current |
-|---|---:|---:|
-| Cases | 12 | 12 |
-| Paired pages | 20 | 21 |
-| Conversion errors | 0 | 0 |
-| Page-count mismatches | 1 | 0 |
-| Case severity | 1 close, 1 minor, 0 major, 10 severe | 2 close, 1 minor, 0 major, 9 severe |
-| Page severity | 1 close, 1 minor, 2 major, 16 severe | 2 close, 1 minor, 1 major, 17 severe |
-| Mean SSIM | 0.974586 | 0.978298 |
-| Mean tolerant ink F1 | 0.394106 | 0.412753 |
+| Signal | Initial | After PRs #372–#374 | Current |
+|---|---:|---:|---:|
+| Cases | 12 | 12 | 12 |
+| Paired pages | 20 | 21 | 21 |
+| Conversion errors | 0 | 0 | 0 |
+| Page-count mismatches | 1 | 0 | 0 |
+| Case severity | 1 close, 1 minor, 0 major, 10 severe | 2 close, 1 minor, 0 major, 9 severe | 4 close, 1 minor, 0 major, 7 severe |
+| Page severity | 1 close, 1 minor, 2 major, 16 severe | 2 close, 1 minor, 1 major, 17 severe | 13 close, 1 minor, 0 major, 7 severe |
+| Mean SSIM | 0.974586 | 0.978298 | 0.979855 |
+| Mean tolerant ink F1 | 0.394106 | 0.412753 | 0.835366 |
 
 Resolved items:
 
@@ -92,6 +92,17 @@ Resolved items:
    0.96817, perceptual diff 0.01436). Page count, page size, and bounded alignment all match exactly.
    The renderer consumes the portable chart caches and stored drawing extent, so it does not need
    the optional embedded workbook, a JavaScript chart library, or an Office process.
+4. **Running-content vertical placement (issue #377).** `w:header`/`w:footer` are distances from
+   the paper edge to the top of the header story and the bottom of the footer story; the paginator
+   ignored both and anchored the stories to the MARGINS, pulling each toward the body by exactly
+   `margin − distance`. Measured against LibreOffice on `running-content` page 2, the header ink sat
+   at y 77–86 against LibreOffice's 52–61 and the footer at 969–978 against 994–1003 — 25 px in
+   each direction on a page whose `w:header`/`w:footer` are both 720 twips and whose margins are
+   1440. Both tracked cases become **close**: `multi-section` SSIM 0.99586 → 0.99934 with worst ink
+   F1 0.00000 → 0.99797, `running-content` 0.99773 → 0.99921 and 0.00000 → 0.96486.
+   `landscape-section` improves as a side effect (0.91746 → 0.92607, 0.50174 → 0.60042). Story
+   inheritance and page counts are unchanged, which the generated regression asserts alongside the
+   coordinates.
 
 ## Current case results and triage
 
@@ -103,9 +114,9 @@ single blank or disjoint page rather than averaging it away.
 | text-formatting | 1/1 | close | 0.99725 | 0.96770 | Control case; fonts and small caps are close. |
 | merged-table | 1/1 | minor | 0.96348 | 1.00000 | Ink geometry aligns; fill/border color dominates the perceptual delta. |
 | numbered-lists | 1/1 | severe | 0.99426 | 0.55580 | Whole content is about 28 px lower in Docxodus. The OOXML top margin is 1701 twips (113.4 px at 96 DPI), which matches Docxodus; LibreOffice appears to import it differently. Treat as a reference-specific deviation unless Word evidence says otherwise. |
-| multi-section | 6/6 | severe | 0.99586 | 0.00000 | Page count and inherited stories now match after PR #372. Header, body, and footer bands are vertically collapsed toward one another on content pages; nearly empty pages therefore retain disjoint ink. |
-| landscape-section | 1/1 | severe | 0.91746 | 0.50174 | Page dimensions match; paragraph spacing/font wrapping differs. |
-| running-content | 5/5 | severe | 0.99773 | 0.00000 | PR #372 resolves the missing page and inherited story semantics. The remaining difference is running-content vertical placement, including odd-page text near the sheet edge. |
+| multi-section | 6/6 | close | 0.99934 | 0.99797 | Header/body/footer bands now sit at the distances `w:pgMar` declares (issue #377), across the landscape/portrait section transition. |
+| landscape-section | 1/1 | severe | 0.92607 | 0.60042 | Page dimensions match; paragraph spacing/font wrapping differs. Improved as a side effect of issue #377. |
+| running-content | 5/5 | close | 0.99921 | 0.96486 | PR #372 resolved the missing page and inherited story semantics; issue #377 resolved the vertical placement of the inherited stories themselves. |
 | inline-image | 1/1 | severe | 0.93660 | 0.64760 | Image and text are separate source paragraphs; the discrepancy is indentation/font/wrapping, not an inline-flow failure. |
 | chart | 1/1 | close | 0.98687 | 0.96817 | Cached clustered column data now renders as accessible inline SVG at the stored extent; bars, grid, colors, labels, title, and bottom legend align closely. Other chart families and stacked groupings remain unsupported. |
 | shape | 1/1 | severe | 0.96967 | 0.50719 | Textbox content exists but is roughly 5 px right and 13 px down with a small size difference: drawing-anchor geometry. |
@@ -147,15 +158,14 @@ renderer heuristic.
 
 ## Prioritized next work
 
-The former first priority (blank charts), the PR #372 rerun, and aligned tab geometry are resolved
-above. The remaining order is:
+The former first priority (blank charts), the PR #372 rerun, aligned tab geometry, and
+header/body/footer vertical placement (issue #377) are resolved above. The remaining order is:
 
 1. Correct drawing-anchor offsets with a generated textbox geometry regression.
-2. Correct inherited header/body/footer vertical placement independently of the now-fixed story
-   selection and page-count semantics.
-3. Correct footnote block vertical placement independently of the now-fixed separator width.
-4. Define and provision one font-substitution contract shared by Chromium and LibreOffice CI before
-   treating paragraph-wrap differences as renderer regressions.
+2. Correct footnote block vertical placement independently of the now-fixed separator width
+   (issue #378).
+3. Define and provision one font-substitution contract shared by Chromium and LibreOffice CI before
+   treating paragraph-wrap differences as renderer regressions (issue #379).
 
 The list-margin discrepancy should not be changed merely to imitate LibreOffice: current evidence
 supports Docxodus's use of the declared OOXML margin. LibreOffice is a comparison implementation, not

--- a/npm/tests/visual-parity/BASELINE.md
+++ b/npm/tests/visual-parity/BASELINE.md
@@ -68,6 +68,12 @@ The complete 12-case corpus was rerun after rebuilding the production WASM bundl
 report remained outside the checkout under `/tmp`; no benchmark artifacts or additional corpus files
 were added to the repository.
 
+`Current` is one clean-worktree rerun of the whole corpus on this branch after it merged `main`, so
+it measures the running-content fix (issue #377) and the DrawingML anchor fix (PR #381) TOGETHER
+rather than splicing two separately measured runs. The two fixes touch disjoint cases, and every
+per-case figure below reproduced its own branch's measurement exactly; only the corpus-wide means
+move.
+
 | Signal | Initial | After PRs #372–#374 | Current |
 |---|---:|---:|---:|
 | Cases | 12 | 12 | 12 |
@@ -76,8 +82,8 @@ were added to the repository.
 | Page-count mismatches | 1 | 0 | 0 |
 | Case severity | 1 close, 1 minor, 0 major, 10 severe | 2 close, 1 minor, 0 major, 9 severe | 4 close, 1 minor, 0 major, 7 severe |
 | Page severity | 1 close, 1 minor, 2 major, 16 severe | 2 close, 1 minor, 1 major, 17 severe | 13 close, 1 minor, 0 major, 7 severe |
-| Mean SSIM | 0.974586 | 0.978298 | 0.979855 |
-| Mean tolerant ink F1 | 0.394106 | 0.412753 | 0.835366 |
+| Mean SSIM | 0.974586 | 0.978298 | 0.980074 |
+| Mean tolerant ink F1 | 0.394106 | 0.412753 | 0.841237 |
 
 Resolved items:
 


### PR DESCRIPTION
Closes #377.

## Problem

`w:pgMar/@w:header` and `@w:footer` are distances **from the paper edge** — to the TOP of the header story and the BOTTOM of the footer story. Together with `w:top`/`w:bottom` they are four independent numbers, not two nested boxes. The repo's own `docs/architecture/paginated_headers_footers.md` already drew this model; the paginator did not implement it.

Instead it anchored the header at `top: 0` with `height: max(marginTop, measured)` and bottom-aligned content, and the footer at `bottom: 0` with `height: max(marginBottom, measured)` and top-aligned content. That pins both stories to the **margins**, pulling each toward the body by exactly `margin − distance`.

Measured against LibreOffice on `DB005-Headers-With-Images.docx` page 2 (`w:header`/`w:footer` = 720 twips, margins 1440):

| Band | Docxodus ink rows | LibreOffice ink rows | Delta |
|---|---|---|---|
| header | y 77–86 | y 52–61 | 25 px too low |
| footer | y 969–978 | y 994–1003 | 25 px too high |

Same 25 px on the landscape pages of `DB001-Sections.docx`, confirming it is page-size independent.

## Fix

`resolvePageBands()` (`npm/src/page-geometry.ts`) becomes the single owner of Word's band model:

```
bodyTop    = max(w:top,    w:header + headerContentHeight)
bodyBottom = min(pageHeight - w:bottom, pageHeight - w:footer - footerContentHeight)
```

The header is laid out from `w:header` downward (`flex-start`), the footer from `w:footer` upward (`flex-end`). A section with **no** story of a kind reserves nothing for it, so a header-less document keeps its body on `w:top`. A pathological story that would leave no body at all is capped at `MIN_BODY_BAND_PT`, with the surplus returned to whichever band over-claimed it.

`PaginationEngine.getPageBands()` (replacing `getEffectiveHeights`) is the one place that band placement in `createPage`, the flow loop's per-page body budget, and the footnote area's anchor all read — so they cannot disagree about where the body ends. Consequences that fall out of that, rather than being patched separately:

- a story taller than its margin **pushes** the body instead of drawing over it (the old `expansion = measured − margin` predicate was only correct under margin-anchoring);
- the note block anchors to the body's real bottom edge, not the raw bottom margin, so a tall footer can no longer be drawn over;
- `measureHeaderFooterHeight` measures the story **alone** — its 4 pt padding and the rendered band's 4 pt padding were two copies of the same fudge, and padding on one and not the other is exactly how a header silently starts overlapping text.

The paginated stylesheet is the second owner of the model, so it changes with the code: it now declares only the band invariants (`flex-start`/`flex-end`), and no `top`/`bottom` edge that could silently win over the paginator's per-page geometry.

`PageDimensions` gains correctly named `headerDistance`/`footerDistance`; `headerHeight`/`footerHeight` stay as `@deprecated` aliases, so the public export surface is unbroken.

## Tests

New `npm/tests/pagination-running-content-geometry.spec.ts` (9 tests) drives a **generated** two-section DOCX — no new tracked fixture, which the visual-parity corpus guard would reject — through the real WASM converter and the paginator, and pins:

- the header's top against `w:header` and the footer's bottom against `w:footer`, on first / even / odd pages;
- body top and bottom against the margin-or-story rule;
- band disjointness;
- the **inheriting** second section using its own four distances while still showing section 1's stories (PR #372's semantics unperturbed);
- a tall multi-paragraph story pushing the body, with a guard so the case cannot pass vacuously;
- a section with a declared header distance but **no** story keeping its body on the margin.

It fails 5/7 on the pre-fix engine. `PHF011` in `Docxodus.Tests/PaginatedHeaderFooterContentTests.cs` pins the stylesheet half. The zip writer behind the generated fixtures is factored out of `docx-tab-fixture.ts` into `tests/docx-zip.ts`.

## Results

Full 12-case LibreOffice benchmark, before → after:

| Case | Severity | SSIM | Worst ink F1 |
|---|---|---|---|
| multi-section | severe → **close** | 0.99586 → 0.99934 | 0.00000 → 0.99797 |
| running-content | severe → **close** | 0.99773 → 0.99921 | 0.00000 → 0.96486 |
| landscape-section | severe (unchanged) | 0.91746 → 0.92607 | 0.50174 → 0.60042 |

Aggregate: mean SSIM 0.978298 → 0.979855, mean tolerant ink F1 0.412753 → **0.835366**, case severity 2 close/1 minor/9 severe → 4 close/1 minor/7 severe. No case regressed; page counts still match LibreOffice on every case.

`dotnet test` 3419/3419 pass. Full Playwright suite passes except the four `tabs-visual` snapshot comparisons, which **fail identically on `main`** in this environment (2 px height drift from font substitution — the subject of #379) and one `editor-block-drag` flake that passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)