### PR TITLE
Put the paginated footnote block where Word puts it

### DIFF
--- a/.github/workflows/visual-parity.yml
+++ b/.github/workflows/visual-parity.yml
@@ -40,11 +40,26 @@ jobs:
         with:
           node-version: '22'
 
+      # The font set is half the contract: Carlito, Caladea, and the Liberation family are the
+      # freely redistributable metric clones of the Office families every fixture names. No font
+      # is vendored into this repository.
       - name: Install deterministic rendering tools and fonts
         run: >-
           sudo apt-get update && sudo apt-get install -y
           libreoffice-writer poppler-utils fonts-liberation2
           fonts-crosextra-carlito fonts-crosextra-caladea
+
+      # The other half: WHICH clone each family resolves to. Chromium and LibreOffice both read
+      # fontconfig, so installing the fragment system-wide makes them substitute identically —
+      # the run then measures the renderer instead of the host. The benchmark also layers this
+      # file in itself; installing it here makes the CI machine reproduce a local run exactly.
+      - name: Apply the shared font-substitution contract
+        run: |
+          sudo cp npm/tests/visual-parity/fontconfig/60-docxodus-office-substitutes.conf /etc/fonts/conf.d/
+          fc-cache -f
+          for family in Calibri "Calibri Light" Cambria "Times New Roman" Arial "Courier New"; do
+            printf '%-16s -> ' "$family"; fc-match "$family" --format='%{family} (%{file})\n'
+          done
 
       - name: Install npm dependencies
         run: cd npm && npm ci
@@ -60,6 +75,14 @@ jobs:
           DOCXODUS_VISUAL_PARITY_OUTPUT: ${{ runner.temp }}/docxodus-visual-parity
           DOCXODUS_VISUAL_PARITY_FILTER: ${{ inputs.filter }}
           DOCXODUS_VISUAL_PARITY_STRICT: ${{ inputs.strict && '1' || '0' }}
+          # Measure the SYSTEM install from the previous step rather than layering the fragment
+          # again. Otherwise the run would satisfy the contract by itself and a broken system
+          # install — the path the README tells humans to use — would never be exercised.
+          DOCXODUS_VISUAL_PARITY_HOST_FONTS: '1'
+          # And having made the run depend on that install, require it: a machine that is supposed
+          # to have the fonts must fail loudly rather than skip, or the weekly run quietly becomes
+          # a green no-op that produces no report.
+          DOCXODUS_VISUAL_PARITY_REQUIRE_FONTS: '1'
         run: cd npm && npm run test:visual-parity
 
       - name: Upload visual comparison report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,31 @@ All notable changes to this project will be documented in this file.
   pause→type→resume loop, and the save round-trip.
 
 ### Fixed
+- **The LibreOffice visual-parity benchmark could not tell a renderer regression
+  from a change in the font environment.** (Benchmark infrastructure; no public
+  surface changes.) Neither engine ships Microsoft's Office fonts, so every
+  Office family a fixture names is substituted — and when the two
+  substitute differently, their line breaking differs for reasons that have
+  nothing to do with this repository. The policy is now a fontconfig fragment
+  (`npm/tests/visual-parity/fontconfig/`) that Chromium and LibreOffice both read,
+  binding Calibri and Calibri Light to Carlito, Cambria to Caladea, and Times New
+  Roman / Arial / Courier New to the matching Liberation faces — all freely
+  redistributable metric clones the distributions package; no font is vendored.
+  The benchmark layers the fragment over the host's configuration outside the
+  checkout (nothing is written to `$HOME` or `/etc`), resolves every declared
+  family before either engine starts, records the exact font file each one used in
+  `summary.json`, and skips — or fails under `DOCXODUS_VISUAL_PARITY_STRICT=1` —
+  with the package to install rather than reporting numbers from an unknown font
+  environment. A generated probe compares the two engines' glyph advances and
+  wrapped line counts and reports a mismatch as *font environment drift, not a
+  renderer regression*; `npm/tests/font-contract.spec.ts` pins the fragment
+  against its TypeScript declaration and the detector's sensitivity, and needs no
+  LibreOffice. The earlier Chromium-only `Calibri Light → Carlito` fallback stays
+  rejected: it changed one engine's mind and made the two disagree more.
+  `tracked-deletion` improves (SSIM 0.93177 → 0.95011, ink F1 0.46817 → 0.62634)
+  now that both engines resolve Calibri Light identically; `fields-and-tabs` ink F1
+  drops (0.30164 → 0.15913, SSIM 0.88672 → 0.89415) because the substitution had
+  been masking a real TOC line-height difference.
 - **The paginated footnote block sits where Word puts it.** The note area is
   bottom-aligned to the body text band, so its height IS its position — every
   point of slack inside it lifts everything above it, which is why the note text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,27 @@ All notable changes to this project will be documented in this file.
   pause→type→resume loop, and the save round-trip.
 
 ### Fixed
+- **The paginated footnote block sits where Word puts it.** The note area is
+  bottom-aligned to the body text band, so its height IS its position — every
+  point of slack inside it lifts everything above it, which is why the note text
+  and the already-correct two-inch separator were both about 13 px too high.
+  Four pieces of slack are gone: `margin-bottom` on the last note (spacing now
+  falls BETWEEN notes, so the last one ends on the edge the block is anchored to);
+  the separator as a bare rule with a hard-coded 6 pt gap under it (`w:separator`
+  is a RUN, so it is now a line of the note font with the rule on its baseline —
+  the space around it comes from the document's own metrics); `vertical-align:
+  super` on the reference mark, which grew the line box it sits in; and a fixed
+  `line-height: 1.4` that overrode the note style's single spacing. Word's
+  `w:continuationSeparator` — full text-column width — is now drawn on a page that
+  opens with carried-over note text, instead of the two-inch separator. The back
+  reference is an HTML navigation affordance and no longer prints on a paginated
+  page, and the note's reference mark is printed alone, without the added period
+  Word never writes. `PaginationEngine.buildNoteArea()` is the single builder the
+  renderer and all four measurement paths share, so the height the flow loop
+  reserves and the block the page draws can no longer drift apart. Against
+  LibreOffice, `CA008-Footnote-Reference.docx` moves from severe (SSIM 0.99218,
+  ink F1 0.56597) to **close** (0.99481 / 0.95875), with the separator within 2 px
+  and the note text's bottom edge exact.
 - **Paginated headers, footers, and body text sit at the distances `w:pgMar`
   declares.** `w:header` and `w:footer` are distances from the PAPER EDGE to the
   top of the header story and the bottom of the footer story — four independent

--- a/Docxodus.Tests/HtmlConversionOpsTests.cs
+++ b/Docxodus.Tests/HtmlConversionOpsTests.cs
@@ -326,6 +326,53 @@ public class HtmlConversionOpsTests
         Assert.DoesNotContain("width: 33%;", html);
     }
 
+    /// <summary>
+    /// Issue #378 — the note area's composition, which is what puts the separator where it goes.
+    /// </summary>
+    /// <remarks>
+    /// The block is bottom-aligned to the body band, so its height is its position: every point
+    /// of slack inside it lifts the separator by the same amount. Three pieces of slack moved the
+    /// separator 14 px up the page — a trailing margin below the LAST note, a bare rule with a
+    /// hard-coded gap under it instead of the separator paragraph's own line, and a
+    /// line-box-inflating `vertical-align: super` on the reference mark. This pins the shape that
+    /// replaced them; `pagination-footnote-geometry.spec.ts` pins the resulting coordinates.
+    /// </remarks>
+    [Fact]
+    public void HCO091_PaginatedNoteArea_HasNoSlackOfItsOwn()
+    {
+        string html = HtmlConversionOps.ConvertToHtml(DocumentOnlyDocxBytes("Body with note CSS"),
+            new HtmlConversionOptions
+            {
+                PaginationMode = (int)PaginationMode.Paginated,
+                RenderFootnotesAndEndnotes = true,
+                FabricateCssClasses = false,
+            });
+
+        // Spacing goes BETWEEN notes, so the last note ends on the edge the block is anchored to.
+        Assert.Contains(".footnote-item + .footnote-item {", html);
+        Assert.DoesNotContain("margin-bottom: 4pt;", html);
+
+        // The separator is a line of the note font with the rule on its baseline, not a rule
+        // with tuned margins. The word joiner is what makes that line real in Blink.
+        Assert.Contains(".footnote-separator::after {", html);
+        Assert.Contains("content: \"\\2060\";", html);
+        Assert.Contains("vertical-align: baseline;", html);
+        Assert.DoesNotContain("margin: 0 0 6pt 0;", html);
+
+        // `w:continuationSeparator` spans the whole text column.
+        Assert.Contains(".footnote-separator-continuation hr {", html);
+
+        // The reference mark must not grow the note's line box.
+        Assert.DoesNotContain("vertical-align: super;", html);
+
+        // Note paragraphs are single-spaced unless their own style says otherwise; a fixed 1.4
+        // overrode that for every note and, on a bottom-anchored block, moved the separator too.
+        Assert.DoesNotContain("line-height: 1.4;", html);
+
+        // A paginated page is a facsimile of paper: no HTML navigation affordance on it.
+        Assert.Contains(".footnote-backref {", html);
+    }
+
     [Theory]
     [InlineData("col", "column")]
     [InlineData("bar", "bar")]

--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -1811,36 +1811,78 @@ namespace Docxodus
             // Page footnotes container
             sb.AppendLine($".{prefix}footnotes {{");
             sb.AppendLine("    font-size: 0.85em;");
-            sb.AppendLine("    line-height: 1.4;");
+            // Word's note paragraphs are single-spaced unless their style says otherwise, and
+            // `w:lineRule="auto"` at 240 means exactly the font's own line box. A fixed 1.4 here
+            // won over that for every note whose style sets no spacing of its own — 17% of
+            // invented leading, which on a bottom-anchored block also lifts the separator.
+            sb.AppendLine("    line-height: normal;");
             sb.AppendLine("}");
 
-            // Separator line above footnotes - using background instead of border
-            // to avoid subpixel rendering issues that can cause the line to disappear during scrolling
-            sb.AppendLine($".{prefix}footnotes hr {{");
+            // The separator band. `w:separator` is a RUN inside the separator note's paragraph,
+            // so Word draws the rule on that paragraph's BASELINE: the space above and below it
+            // is the note font's own line box, not two tuned margins. Giving the band a line box
+            // and sitting the rule on its baseline reproduces that from the document's metrics —
+            // the previous `1px rule + 6pt bottom margin + nothing above` was 14 px off.
+            sb.AppendLine($".{prefix}footnotes .footnote-separator {{");
+            sb.AppendLine("    margin: 0;");
+            sb.AppendLine("}");
+
+            // The band's own line box is what gives the rule its space. Blink does not apply the
+            // strut to a line whose only content is an atomic inline, so a band holding just the
+            // rule collapses to the rule's own 1 px; a zero-width word joiner is the standard way
+            // to make the line real without adding anything visible or selectable.
+            sb.AppendLine($".{prefix}footnotes .footnote-separator::after {{");
+            sb.AppendLine("    content: \"\\2060\";");
+            sb.AppendLine("}");
+
+            // An empty inline-block takes its baseline from its bottom margin edge, so a
+            // zero-height box with a top border draws the rule exactly on the text baseline.
+            sb.AppendLine($".{prefix}footnotes .footnote-separator hr {{");
+            sb.AppendLine("    display: inline-block;");
+            sb.AppendLine("    vertical-align: baseline;");
             sb.AppendLine("    border: none;");
-            sb.AppendLine("    height: 1px;");
-            sb.AppendLine("    background-color: #999;");
+            // Word draws the separator in the automatic text colour, not a web grey.
+            sb.AppendLine("    border-top: 1px solid currentColor;");
+            sb.AppendLine("    height: 0;");
             // Word's built-in footnote separator is two inches long. A percentage makes the
             // rule drift with paper size/margins (6.5in Letter text yielded 2.145in) and does
             // not match either Word or LibreOffice's fixed default separator.
             sb.AppendLine("    width: 2in;");
             sb.AppendLine("    max-width: 100%;");
-            sb.AppendLine("    margin: 0 0 6pt 0;");
-            sb.AppendLine("    opacity: 0.6;");
+            sb.AppendLine("    margin: 0;");
             sb.AppendLine("}");
 
-            // Individual footnote item (in registry and on page)
-            sb.AppendLine(".footnote-item {");
-            sb.AppendLine("    margin-bottom: 4pt;");
+            // Word's `w:continuationSeparator` — drawn when a page opens with note text carried
+            // over — spans the whole text column instead of the two-inch default.
+            sb.AppendLine($".{prefix}footnotes .footnote-separator-continuation hr {{");
+            sb.AppendLine("    width: 100%;");
             sb.AppendLine("}");
 
-            // Footnote number - inline with superscript styling
+            // Individual footnote item (in registry and on page). Spacing goes BETWEEN notes:
+            // the note area is bottom-aligned to the body band, so a trailing margin below the
+            // last note is dead space that lifts the whole block off the edge it is anchored to.
+            sb.AppendLine(".footnote-item + .footnote-item {");
+            sb.AppendLine("    margin-top: 4pt;");
+            sb.AppendLine("}");
+
+            // Footnote number - the note's reference mark, a superscript INSIDE the note's first
+            // line. `vertical-align: super` grows the line box, so every note gained leading the
+            // document never asked for; a relative offset raises the glyph without doing that.
             sb.AppendLine(".footnote-number {");
             sb.AppendLine("    font-weight: normal;");
             sb.AppendLine("    display: inline;");
-            sb.AppendLine("    vertical-align: super;");
+            sb.AppendLine("    vertical-align: baseline;");
+            sb.AppendLine("    position: relative;");
+            sb.AppendLine("    top: -0.35em;");
             sb.AppendLine("    font-size: 0.85em;");
             sb.AppendLine("    margin-right: 2pt;");
+            sb.AppendLine("}");
+
+            // The back-reference is an HTML navigation affordance, not document content. It
+            // belongs in the scrolling view; on a paginated page — a facsimile of paper — Word
+            // and LibreOffice print nothing there, so neither does this.
+            sb.AppendLine($".{prefix}footnotes .footnote-backref {{");
+            sb.AppendLine("    display: none;");
             sb.AppendLine("}");
 
             // Footnote content (inline with number)
@@ -3604,9 +3646,12 @@ namespace Docxodus
                     new XAttribute("data-footnote-id", footnoteId),
                     new XAttribute("data-display-number", displayNumber),
                     new XAttribute("class", "footnote-item"),
+                    // Word prints the note's reference MARK and nothing else — the gap to the text
+                    // is the note paragraph's own leading space, and there is no trailing period.
+                    // A paginated page is a facsimile of paper, so it prints the mark alone.
                     new XElement(Xhtml.span,
                         new XAttribute("class", "footnote-number"),
-                        new XText($"{displayNumber}. ")),
+                        new XText(displayNumber)),
                     new XElement(Xhtml.span,
                         new XAttribute("class", "footnote-content"),
                         content),

--- a/docs/ooxml_corner_cases.md
+++ b/docs/ooxml_corner_cases.md
@@ -9,6 +9,7 @@ This document tracks edge cases and quirks in Open XML document processing where
    - [List Numbering under Tracked Changes](#list-numbering-under-tracked-changes-deleted-paragraphs-dont-consume-numbers)
 2. [Footnotes](#footnotes)
    - [Footnote Count Discrepancy in Legal Templates](#footnote-count-discrepancy-in-legal-templates)
+   - [The Footnote Separator Is a Run, Not a Rule](#the-footnote-separator-is-a-run-not-a-rule)
 3. [Package Output](#package-output)
    - [Misleading Deflate Hints Cause Compression Loss](#misleading-deflate-hints-cause-compression-loss)
 4. [Contributing](#contributing)
@@ -1086,6 +1087,66 @@ rather than only under `PaginationMode.Paginated`. `npm/src/page-geometry.ts` re
 geometry outside Paginated mode), `HC058`/`HC059` (fixed vs AutoFit table layout);
 `npm/tests/editor-page-geometry.spec.ts` — the end-to-end assertion that a 66pt heading on a
 390px viewport leaves nothing overflowing the sheet.
+
+---
+
+### The Footnote Separator Is a Run, Not a Rule
+
+**Status:** Fixed (August 2026, issue #378)
+**Test File:** generated — `npm/tests/docx-footnote-fixture.ts`
+
+#### The Problem
+
+The paginated note area sat 14 px too high on a Word-default page. The separator's *width* had
+already been corrected to Word's two-inch default, which made the residual look like a second,
+unrelated width problem; it was not. The note area is bottom-aligned to the body text band, so
+every point of slack anywhere inside the block lifts everything above it by the same amount —
+the separator's position is a function of the block's height, not of its own styling.
+
+#### What the spec says
+
+ECMA-376 §17.11.23 defines `w:separator` as a **run-level** mark: the separator note's paragraph
+contains a run that "shall contain the horizontal line". It is therefore laid out like any other
+line of text, and the space above and below the rule is that paragraph's own line box.
+§17.11.5 `w:continuationSeparator` is the same shape for a page that opens with carried-over note
+text; Word draws it across the full text column rather than at the two-inch default length.
+
+The spec does not state where in the line the rule sits. LibreOffice draws it slightly above the
+baseline; Docxodus draws it on the baseline, which lands within ~2 px at 96 DPI.
+
+| Renderer | Separator rule (px from page top, 1 in margins, 11 in page) | Note text ink |
+|---|---:|---:|
+| LibreOffice 25.8 | 936–937 | 946–955 |
+| Docxodus (before) | 922 | 935–948 |
+| Docxodus (after) | 939 | 944–955 |
+
+#### Analysis
+
+Three pieces of slack, all of them CSS habits rather than OOXML:
+
+1. `.footnote-item { margin-bottom: 4pt }` put dead space *below* the last note — beneath content
+   whose bottom edge is the anchor. Spacing between notes belongs on `+ .footnote-item`.
+2. The separator was a bare 1 px rule with `margin: 0 0 6pt 0` — nothing above it, a tuned gap
+   below it — instead of a line box with the rule on its baseline.
+3. `vertical-align: super` on the note's reference mark grows the line box it sits in, so every
+   note carried leading the document never asked for. A relative offset raises the glyph without
+   doing that.
+4. `.page-footnotes { line-height: 1.4 }` overrode the note style's own spacing. Word's note
+   paragraphs are single-spaced unless their style says otherwise, and `w:lineRule="auto"` at 240
+   means exactly the font's line box — `normal` in CSS.
+
+A separate trap: in Blink a block whose only inline-level content is an **atomic** inline (here
+the rule) gets no strut, so the separator band collapses to the rule's own 1 px. A zero-width
+word joiner in generated content makes the line real.
+
+#### Relevant Code
+
+`Docxodus/WmlToHtmlConverter.cs` — `GenerateFootnoteCss`;
+`npm/src/pagination.ts` — `buildNoteArea`/`buildNoteSeparator`, the single builder the renderer
+and every measurement share;
+`npm/tests/pagination-footnote-geometry.spec.ts` — separator and note-block coordinates pinned
+separately;
+`Docxodus.Tests/HtmlConversionOpsTests.cs` — `HCO086` (width), `HCO091` (composition).
 
 ---
 

--- a/npm/src/pagination.ts
+++ b/npm/src/pagination.ts
@@ -1078,6 +1078,11 @@ export class PaginationEngine {
 
     const area = document.createElement("div");
     area.className = `${this.cssPrefix}footnotes`;
+    // Establishes a block formatting context, exactly as the rendered block does. Without it a
+    // margin on the first or last child would collapse OUT of the measured box and not out of the
+    // rendered one — the measure-versus-render drift this builder exists to prevent, and the very
+    // thing a future `margin` on `.footnote-item` would reintroduce.
+    area.style.overflow = "hidden";
     area.appendChild(this.buildNoteSeparator(hasContinuation));
 
     if (hasContinuation) {

--- a/npm/src/pagination.ts
+++ b/npm/src/pagination.ts
@@ -1043,8 +1043,106 @@ export class PaginationEngine {
   }
 
   /**
+   * The separator band Word draws above a page's notes.
+   *
+   * `w:separator` and `w:continuationSeparator` are RUNS inside the reserved notes' paragraphs,
+   * so the rule sits on a text baseline and the space around it is the note font's own line box
+   * — which is why the band is a block with a line box rather than a bare rule with margins.
+   * A page that opens with note text carried over from the previous page shows the CONTINUATION
+   * separator, which spans the whole text column instead of the two-inch default.
+   */
+  private buildNoteSeparator(isContinuation: boolean): HTMLElement {
+    const band = document.createElement("div");
+    band.className = isContinuation
+      ? "footnote-separator footnote-separator-continuation"
+      : "footnote-separator";
+    band.appendChild(document.createElement("hr"));
+    return band;
+  }
+
+  /**
+   * Builds a page's note area: separator band, carried-over note text, then this page's notes.
+   *
+   * The SINGLE description of what that block contains. The height the flow loop reserves and
+   * the block the page actually draws used to be assembled by four separate copies of this
+   * markup, so "how tall are the notes" and "what do the notes look like" could — and did —
+   * drift apart. Everything that needs either now goes through here.
+   */
+  private buildNoteArea(
+    footnoteIds: string[],
+    continuation?: FootnoteContinuation | null,
+    partialFootnotes?: PartialFootnote[]
+  ): HTMLElement {
+    const hasContinuation = !!continuation && continuation.remainingElements.length > 0;
+    const partialById = new Map((partialFootnotes ?? []).map((p) => [p.footnoteId, p]));
+
+    const area = document.createElement("div");
+    area.className = `${this.cssPrefix}footnotes`;
+    area.appendChild(this.buildNoteSeparator(hasContinuation));
+
+    if (hasContinuation) {
+      const contWrapper = document.createElement("div");
+      contWrapper.className = "footnote-continuation";
+      for (const el of continuation!.remainingElements) {
+        contWrapper.appendChild(el.cloneNode(true));
+      }
+      area.appendChild(contWrapper);
+    }
+
+    for (const id of footnoteIds) {
+      const footnote = this.footnoteRegistry.get(id);
+      if (!footnote) continue;
+
+      const partial = partialById.get(id);
+      if (!partial) {
+        area.appendChild(footnote.cloneNode(true));
+        continue;
+      }
+
+      // A note split across pages: only the part that fits, in the same wrapper a whole note
+      // uses, so it measures and renders identically to one.
+      const partialDiv = document.createElement("div");
+      partialDiv.className = "footnote-item";
+      partialDiv.dataset.footnoteId = id;
+
+      const numberSpan = footnote.querySelector(".footnote-number");
+      if (numberSpan) partialDiv.appendChild(numberSpan.cloneNode(true));
+
+      const contentSpan = document.createElement("span");
+      contentSpan.className = "footnote-content";
+      for (const el of partial.fittingElements) contentSpan.appendChild(el.cloneNode(true));
+      partialDiv.appendChild(contentSpan);
+
+      area.appendChild(partialDiv);
+    }
+
+    return area;
+  }
+
+  /**
+   * Lays `element` out at `contentWidth` off-screen and returns its height in points.
+   *
+   * Measurement must happen in the SAME styling context the notes render in — `.page-footnotes`
+   * carries the note font size and line height — which {@link buildNoteArea} guarantees by
+   * building the real block.
+   */
+  private measureOffscreen(element: HTMLElement, contentWidth: number): number {
+    const host = document.createElement("div");
+    host.style.position = "absolute";
+    host.style.visibility = "hidden";
+    host.style.width = `${contentWidth}pt`;
+    host.style.left = "-9999px";
+    host.appendChild(element);
+
+    this.stagingElement.appendChild(host);
+    const heightPt = pxToPt(element.getBoundingClientRect().height);
+    this.stagingElement.removeChild(host);
+
+    return heightPt;
+  }
+
+  /**
    * Measures the height of footnotes for given IDs (in points).
-   * Creates a temporary container to measure the footnotes.
    * @param footnoteIds - IDs of footnotes to measure
    * @param contentWidth - Width for measurement
    * @param continuation - Optional continuation content to include first
@@ -1058,51 +1156,7 @@ export class PaginationEngine {
     if ((footnoteIds.length === 0 && !hasContinuation) || this.footnoteRegistry.size === 0) {
       return 0;
     }
-
-    // Measure in the SAME styling context the notes render in: `.page-footnotes` carries
-    // font-size 0.85em and line-height 1.4, so measuring without the class sizes the note
-    // block against body type and the reserve can never match what is drawn.
-    // Create a temporary measurement container
-    const measureContainer = document.createElement("div");
-    measureContainer.style.position = "absolute";
-    measureContainer.style.visibility = "hidden";
-    measureContainer.style.width = `${contentWidth}pt`;
-    measureContainer.style.left = "-9999px";
-    measureContainer.className = this.cssPrefix + "footnotes";
-
-    // Add separator line (same as will be rendered)
-    const hr = document.createElement("hr");
-    measureContainer.appendChild(hr);
-
-    // Add continuation content first (if any)
-    if (hasContinuation) {
-      const contWrapper = document.createElement("div");
-      contWrapper.className = "footnote-continuation";
-      for (const el of continuation!.remainingElements) {
-        contWrapper.appendChild(el.cloneNode(true));
-      }
-      measureContainer.appendChild(contWrapper);
-    }
-
-    // Add footnotes
-    for (const id of footnoteIds) {
-      const footnote = this.footnoteRegistry.get(id);
-      if (footnote) {
-        measureContainer.appendChild(footnote.cloneNode(true));
-      }
-    }
-
-    // Append to staging for measurement
-    this.stagingElement.appendChild(measureContainer);
-
-    // Measure
-    const rect = measureContainer.getBoundingClientRect();
-    const heightPt = pxToPt(rect.height);
-
-    // Clean up
-    this.stagingElement.removeChild(measureContainer);
-
-    return heightPt;
+    return this.measureOffscreen(this.buildNoteArea(footnoteIds, continuation), contentWidth);
   }
 
   /**
@@ -1115,29 +1169,7 @@ export class PaginationEngine {
     if (!continuation || continuation.remainingElements.length === 0) {
       return 0;
     }
-
-    const measureContainer = document.createElement("div");
-    measureContainer.style.position = "absolute";
-    measureContainer.style.visibility = "hidden";
-    measureContainer.style.width = `${contentWidth}pt`;
-    measureContainer.style.left = "-9999px";
-    measureContainer.className = this.cssPrefix + "footnotes";
-
-    // Add separator line
-    const hr = document.createElement("hr");
-    measureContainer.appendChild(hr);
-
-    // Add continuation content
-    for (const el of continuation.remainingElements) {
-      measureContainer.appendChild(el.cloneNode(true));
-    }
-
-    this.stagingElement.appendChild(measureContainer);
-    const rect = measureContainer.getBoundingClientRect();
-    const heightPt = pxToPt(rect.height);
-    this.stagingElement.removeChild(measureContainer);
-
-    return heightPt;
+    return this.measureOffscreen(this.buildNoteArea([], continuation), contentWidth);
   }
 
   /**
@@ -1177,40 +1209,18 @@ export class PaginationEngine {
 
     const fits: HTMLElement[] = [];
     const overflow: HTMLElement[] = [];
-    let currentHeight = 0;
 
-    // Measure separator line height
-    const hrMeasure = document.createElement("div");
-    hrMeasure.style.position = "absolute";
-    hrMeasure.style.visibility = "hidden";
-    hrMeasure.style.width = `${contentWidth}pt`;
-    hrMeasure.style.left = "-9999px";
-    hrMeasure.className = this.cssPrefix + "footnotes";
-    const hr = document.createElement("hr");
-    hrMeasure.appendChild(hr);
-    this.stagingElement.appendChild(hrMeasure);
-    const hrHeight = pxToPt(hrMeasure.getBoundingClientRect().height);
-    this.stagingElement.removeChild(hrMeasure);
-
-    currentHeight = hrHeight;
-
-    // Also account for footnote number
-    const footnoteNumber = footnoteElement.querySelector(".footnote-number");
+    // The separator band is part of every note area, so its height is already spent before the
+    // first paragraph of this note can be placed.
+    let currentHeight = this.measureOffscreen(this.buildNoteArea([]), contentWidth);
 
     for (let i = 0; i < children.length; i++) {
       const child = children[i];
 
-      // Measure this element
-      const measureContainer = document.createElement("div");
-      measureContainer.style.position = "absolute";
-      measureContainer.style.visibility = "hidden";
-      measureContainer.style.width = `${contentWidth}pt`;
-      measureContainer.style.left = "-9999px";
-      measureContainer.className = this.cssPrefix + "footnotes";
-      measureContainer.appendChild(child.cloneNode(true));
-      this.stagingElement.appendChild(measureContainer);
-      const childHeight = pxToPt(measureContainer.getBoundingClientRect().height);
-      this.stagingElement.removeChild(measureContainer);
+      const measureHost = document.createElement("div");
+      measureHost.className = `${this.cssPrefix}footnotes`;
+      measureHost.appendChild(child.cloneNode(true));
+      const childHeight = this.measureOffscreen(measureHost, contentWidth);
 
       if (currentHeight + childHeight <= availableHeightPt) {
         fits.push(child.cloneNode(true) as HTMLElement);
@@ -1234,20 +1244,10 @@ export class PaginationEngine {
     const footnote = this.footnoteRegistry.get(footnoteId);
     if (!footnote) return 0;
 
-    const measureContainer = document.createElement("div");
-    measureContainer.style.position = "absolute";
-    measureContainer.style.visibility = "hidden";
-    measureContainer.style.width = `${contentWidth}pt`;
-    measureContainer.style.left = "-9999px";
-    measureContainer.className = this.cssPrefix + "footnotes";
-    measureContainer.appendChild(footnote.cloneNode(true));
-
-    this.stagingElement.appendChild(measureContainer);
-    const rect = measureContainer.getBoundingClientRect();
-    const heightPt = pxToPt(rect.height);
-    this.stagingElement.removeChild(measureContainer);
-
-    return heightPt;
+    const host = document.createElement("div");
+    host.className = `${this.cssPrefix}footnotes`;
+    host.appendChild(footnote.cloneNode(true));
+    return this.measureOffscreen(host, contentWidth);
   }
 
   /**
@@ -1270,20 +1270,20 @@ export class PaginationEngine {
       return;
     }
 
-    // Create a set of partial footnote IDs for quick lookup
-    const partialFootnoteIds = new Set(partialFootnotes?.map(p => p.footnoteId) || []);
-
     // Calculate max height for footnotes area (content height minus margin for body content)
     const maxFootnoteHeight = Math.min(
       footnoteHeight,
       bands.bodyHeight * MAX_FOOTNOTE_AREA_RATIO
     );
 
-    const footnotesDiv = document.createElement("div");
-    footnotesDiv.className = `${this.cssPrefix}footnotes`;
+    const footnotesDiv = this.buildNoteArea(footnoteIds, continuation, partialFootnotes);
     footnotesDiv.style.position = "absolute";
-    // Notes sit at the FOOT OF THE BODY BAND, not at the bottom margin: a footer taller than
-    // its margin raises that edge, and anchoring to the raw margin would draw notes over it.
+    // Word bottom-aligns the note area to the FOOT OF THE BODY BAND — the last note's line box
+    // ends on that edge. Two things follow, and both were wrong before: the anchor is the body
+    // band's bottom rather than the raw bottom margin (a footer taller than its margin raises
+    // it, and anchoring to the margin would draw notes over the footer), and the block must
+    // carry no trailing space of its own, or the whole note area floats above the edge it is
+    // anchored to — 7 px of `margin-bottom` on the last note lifted the separator with it.
     footnotesDiv.style.bottom = `${dims.pageHeight - (bands.bodyTop + bands.bodyHeight)}pt`;
     footnotesDiv.style.left = `${dims.marginLeft}pt`;
     footnotesDiv.style.width = `${dims.contentWidth}pt`;
@@ -1291,57 +1291,6 @@ export class PaginationEngine {
     // Constrain height and clip overflow to prevent footnotes covering body content
     footnotesDiv.style.maxHeight = `${maxFootnoteHeight}pt`;
     footnotesDiv.style.overflow = "hidden";
-
-    // Add separator line
-    const hr = document.createElement("hr");
-    footnotesDiv.appendChild(hr);
-
-    // Add continuation content first (if any)
-    if (hasContinuation) {
-      const contWrapper = document.createElement("div");
-      contWrapper.className = "footnote-continuation";
-      for (const el of continuation!.remainingElements) {
-        contWrapper.appendChild(el.cloneNode(true));
-      }
-      footnotesDiv.appendChild(contWrapper);
-    }
-
-    // Clone footnotes in order of appearance
-    for (const id of footnoteIds) {
-      // Check if this is a partial footnote
-      const partial = partialFootnotes?.find(p => p.footnoteId === id);
-      if (partial) {
-        // Render partial footnote (only the fitting elements)
-        const footnote = this.footnoteRegistry.get(id);
-        if (footnote) {
-          const partialDiv = document.createElement("div");
-          partialDiv.className = "footnote-item";
-          partialDiv.dataset.footnoteId = id;
-
-          // Add footnote number
-          const numberSpan = footnote.querySelector(".footnote-number");
-          if (numberSpan) {
-            partialDiv.appendChild(numberSpan.cloneNode(true));
-          }
-
-          // Add only the fitting content
-          const contentSpan = document.createElement("span");
-          contentSpan.className = "footnote-content";
-          for (const el of partial.fittingElements) {
-            contentSpan.appendChild(el.cloneNode(true));
-          }
-          partialDiv.appendChild(contentSpan);
-
-          footnotesDiv.appendChild(partialDiv);
-        }
-      } else {
-        // Render full footnote from registry
-        const footnote = this.footnoteRegistry.get(id);
-        if (footnote) {
-          footnotesDiv.appendChild(footnote.cloneNode(true));
-        }
-      }
-    }
 
     pageBox.appendChild(footnotesDiv);
   }

--- a/npm/tests/docx-footnote-fixture.ts
+++ b/npm/tests/docx-footnote-fixture.ts
@@ -1,0 +1,139 @@
+import { storedZip, xml, W_NS, R_NS } from './docx-zip.js';
+
+/**
+ * A generated document with footnotes, for pinning where the note area sits on the page.
+ *
+ * The note area is bottom-aligned to the body text band, and above the notes Word draws the
+ * `w:separator` note's paragraph — so its geometry is a composition of the body bottom, the
+ * separator's line box, and the notes' own spacing. Every part of that has to be independently
+ * observable, which is why the fixture's body and note text are fixed and single-line.
+ */
+
+const PAGE_WIDTH_TWIPS = 12240; // 8.5 in
+const PAGE_HEIGHT_TWIPS = 15840; // 11 in
+const MARGIN_TWIPS = 1440; // 1 in
+
+export const PAGE_HEIGHT_PT = PAGE_HEIGHT_TWIPS / 20;
+export const MARGIN_PT = MARGIN_TWIPS / 20;
+/** Word's built-in footnote separator length. */
+export const SEPARATOR_WIDTH_IN = 2;
+
+export interface FootnoteFixtureOptions {
+  /** Body paragraphs, in order; each element is the number of notes that paragraph cites. */
+  paragraphs: number[];
+  /** Lines in each note. More than one is how a note is made long enough to split a page. */
+  linesPerNote?: number;
+  /** Bottom margin in twips, when a test needs the body band's bottom edge to move. */
+  marginBottomTwips?: number;
+}
+
+function noteBody(index: number, lines: number): string {
+  return Array.from({ length: lines }, (_, i) =>
+    `<w:p><w:pPr><w:pStyle w:val="FootnoteText"/></w:pPr>` +
+    (i === 0
+      ? `<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r>`
+      : '') +
+    `<w:r><w:t xml:space="preserve"> Note ${index} line ${i + 1}.</w:t></w:r></w:p>`).join('');
+}
+
+export function generateFootnoteDocx(options: FootnoteFixtureOptions): Uint8Array {
+  const { paragraphs, linesPerNote = 1, marginBottomTwips = MARGIN_TWIPS } = options;
+
+  let nextNoteId = 1;
+  const notes: string[] = [];
+  const body = paragraphs
+    .map((citations, p) => {
+      const refs = Array.from({ length: citations }, () => {
+        const id = nextNoteId++;
+        notes.push(
+          `<w:footnote w:id="${id}">${noteBody(id, linesPerNote)}</w:footnote>`);
+        return `<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr>` +
+          `<w:footnoteReference w:id="${id}"/></w:r>`;
+      }).join('');
+      return `<w:p>${refs}<w:r><w:t>Body paragraph ${p + 1}.</w:t></w:r></w:p>`;
+    })
+    .join('');
+
+  // Word's two reserved notes. Their paragraphs are what the separator bands are drawn from.
+  const reserved =
+    `<w:footnote w:type="separator" w:id="-1"><w:p><w:pPr>` +
+    `<w:spacing w:after="0" w:line="240" w:lineRule="auto"/></w:pPr>` +
+    `<w:r><w:separator/></w:r></w:p></w:footnote>` +
+    `<w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:pPr>` +
+    `<w:spacing w:after="0" w:line="240" w:lineRule="auto"/></w:pPr>` +
+    `<w:r><w:continuationSeparator/></w:r></w:p></w:footnote>`;
+
+  return storedZip([
+    {
+      name: '[Content_Types].xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
+  <Override PartName="/word/settings.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml"/>
+  <Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>
+</Types>`),
+    },
+    {
+      name: '_rels/.rels',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${R_NS}/officeDocument" Target="word/document.xml"/>
+</Relationships>`),
+    },
+    {
+      name: 'word/_rels/document.xml.rels',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${R_NS}/styles" Target="styles.xml"/>
+  <Relationship Id="rId2" Type="${R_NS}/settings" Target="settings.xml"/>
+  <Relationship Id="rId3" Type="${R_NS}/footnotes" Target="footnotes.xml"/>
+</Relationships>`),
+    },
+    {
+      name: 'word/styles.xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles xmlns:w="${W_NS}">
+  <w:docDefaults><w:rPrDefault><w:rPr>
+    <w:rFonts w:ascii="Liberation Serif" w:hAnsi="Liberation Serif"/>
+    <w:sz w:val="24"/><w:szCs w:val="24"/>
+  </w:rPr></w:rPrDefault></w:docDefaults>
+  <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+  <w:style w:type="paragraph" w:styleId="FootnoteText">
+    <w:name w:val="footnote text"/>
+    <w:pPr><w:spacing w:after="0" w:line="240" w:lineRule="auto"/></w:pPr>
+    <w:rPr><w:sz w:val="20"/><w:szCs w:val="20"/></w:rPr>
+  </w:style>
+  <w:style w:type="character" w:styleId="FootnoteReference">
+    <w:name w:val="footnote reference"/>
+    <w:rPr><w:vertAlign w:val="superscript"/></w:rPr>
+  </w:style>
+</w:styles>`),
+    },
+    {
+      name: 'word/settings.xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:settings xmlns:w="${W_NS}"><w:footnotePr><w:footnote w:id="-1"/><w:footnote w:id="0"/></w:footnotePr></w:settings>`),
+    },
+    {
+      name: 'word/footnotes.xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:footnotes xmlns:w="${W_NS}">${reserved}${notes.join('')}</w:footnotes>`),
+    },
+    {
+      name: 'word/document.xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="${W_NS}" xmlns:r="${R_NS}"><w:body>
+  ${body}
+  <w:sectPr>
+    <w:pgSz w:w="${PAGE_WIDTH_TWIPS}" w:h="${PAGE_HEIGHT_TWIPS}"/>
+    <w:pgMar w:top="${MARGIN_TWIPS}" w:right="${MARGIN_TWIPS}" w:bottom="${marginBottomTwips}"
+             w:left="${MARGIN_TWIPS}" w:header="720" w:footer="720" w:gutter="0"/>
+    <w:cols w:space="720"/>
+  </w:sectPr>
+</w:body></w:document>`),
+    },
+  ]);
+}

--- a/npm/tests/docx-footnote-fixture.ts
+++ b/npm/tests/docx-footnote-fixture.ts
@@ -25,7 +25,20 @@ export interface FootnoteFixtureOptions {
   linesPerNote?: number;
   /** Bottom margin in twips, when a test needs the body band's bottom edge to move. */
   marginBottomTwips?: number;
+  /**
+   * Paragraphs in a default footer story, or 0 for no footer at all.
+   *
+   * Enough of them, against the default 1 inch bottom margin and 0.5 inch footer distance, and the
+   * footer reaches ABOVE its margin and raises the body band's bottom edge — which is the only
+   * shape that can tell "the notes are anchored to the body band" apart from "the notes are
+   * anchored to the bottom margin".
+   */
+  footerLines?: number;
 }
+
+/** `w:pgMar/@w:footer` in twips: the distance from the paper's bottom edge to the footer story. */
+export const FOOTER_DISTANCE_TWIPS = 720;
+export const FOOTER_DISTANCE_PT = FOOTER_DISTANCE_TWIPS / 20;
 
 function noteBody(index: number, lines: number): string {
   return Array.from({ length: lines }, (_, i) =>
@@ -37,7 +50,9 @@ function noteBody(index: number, lines: number): string {
 }
 
 export function generateFootnoteDocx(options: FootnoteFixtureOptions): Uint8Array {
-  const { paragraphs, linesPerNote = 1, marginBottomTwips = MARGIN_TWIPS } = options;
+  const {
+    paragraphs, linesPerNote = 1, marginBottomTwips = MARGIN_TWIPS, footerLines = 0,
+  } = options;
 
   let nextNoteId = 1;
   const notes: string[] = [];
@@ -73,7 +88,8 @@ export function generateFootnoteDocx(options: FootnoteFixtureOptions): Uint8Arra
   <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
   <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
   <Override PartName="/word/settings.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml"/>
-  <Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>
+  <Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>${footerLines > 0 ? `
+  <Override PartName="/word/footer1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml"/>` : ''}
 </Types>`),
     },
     {
@@ -89,7 +105,8 @@ export function generateFootnoteDocx(options: FootnoteFixtureOptions): Uint8Arra
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
   <Relationship Id="rId1" Type="${R_NS}/styles" Target="styles.xml"/>
   <Relationship Id="rId2" Type="${R_NS}/settings" Target="settings.xml"/>
-  <Relationship Id="rId3" Type="${R_NS}/footnotes" Target="footnotes.xml"/>
+  <Relationship Id="rId3" Type="${R_NS}/footnotes" Target="footnotes.xml"/>${footerLines > 0 ? `
+  <Relationship Id="rId4" Type="${R_NS}/footer" Target="footer1.xml"/>` : ''}
 </Relationships>`),
     },
     {
@@ -122,15 +139,22 @@ export function generateFootnoteDocx(options: FootnoteFixtureOptions): Uint8Arra
       data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:footnotes xmlns:w="${W_NS}">${reserved}${notes.join('')}</w:footnotes>`),
     },
+    ...(footerLines > 0 ? [{
+      name: 'word/footer1.xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:ftr xmlns:w="${W_NS}">${Array.from({ length: footerLines }, (_unused, i) =>
+  `<w:p><w:pPr><w:spacing w:before="0" w:after="0" w:line="240" w:lineRule="auto"/></w:pPr>` +
+  `<w:r><w:t>Footer line ${i + 1}</w:t></w:r></w:p>`).join('')}</w:ftr>`),
+    }] : []),
     {
       name: 'word/document.xml',
       data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:document xmlns:w="${W_NS}" xmlns:r="${R_NS}"><w:body>
   ${body}
-  <w:sectPr>
+  <w:sectPr>${footerLines > 0 ? '<w:footerReference w:type="default" r:id="rId4"/>' : ''}
     <w:pgSz w:w="${PAGE_WIDTH_TWIPS}" w:h="${PAGE_HEIGHT_TWIPS}"/>
     <w:pgMar w:top="${MARGIN_TWIPS}" w:right="${MARGIN_TWIPS}" w:bottom="${marginBottomTwips}"
-             w:left="${MARGIN_TWIPS}" w:header="720" w:footer="720" w:gutter="0"/>
+             w:left="${MARGIN_TWIPS}" w:header="720" w:footer="${FOOTER_DISTANCE_TWIPS}" w:gutter="0"/>
     <w:cols w:space="720"/>
   </w:sectPr>
 </w:body></w:document>`),

--- a/npm/tests/font-contract.spec.ts
+++ b/npm/tests/font-contract.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect } from '@playwright/test';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import {
+  FONT_CONTRACT_PACKAGES,
+  FONT_SUBSTITUTION_CONTRACT,
+  FONTCONFIG_FRAGMENT,
+  resolveFontContract,
+} from './visual-parity/fonts.js';
+import {
+  compareProbeLines,
+  PROBE_ADVANCE_TOLERANCE_PX,
+  PROBE_FAMILIES,
+  type InkLine,
+} from './visual-parity/font-probe.js';
+
+/**
+ * Issue #379 — the font-substitution contract itself, checked without needing LibreOffice.
+ *
+ * The visual-parity benchmark is opt-in and host-dependent; this spec is not. It pins the two
+ * things that would silently rot between benchmark runs: the shipped fontconfig fragment agreeing
+ * with the TypeScript declaration of the same contract, and the drift detector actually
+ * detecting drift.
+ */
+
+/** One ink line per entry, `right - left` wide, at an arbitrary but consistent y. */
+function lines(widths: number[]): InkLine[] {
+  return widths.map((width, index) => ({
+    top: index * 30,
+    bottom: index * 30 + 12,
+    left: 96,
+    right: 96 + width,
+  }));
+}
+
+/** The advance lines the probe compares, followed by some wrapped ones it only counts. */
+function probePage(advances: number[], wrapped = [600, 600, 400]): InkLine[] {
+  return lines([...advances, ...wrapped]);
+}
+
+const BASELINE_ADVANCES = [210, 213, 208, 226, 304, 210];
+
+test.describe('Font substitution contract', () => {
+  /** Every family→substitute binding the fragment actually declares, in either fontconfig form. */
+  function fragmentBindings(fragment: string): Map<string, string> {
+    const bindings = new Map<string, string>();
+    const aliases = fragment.matchAll(
+      /<alias[^>]*>\s*<family>([^<]+)<\/family>\s*<accept>\s*<family>([^<]+)<\/family>/g);
+    for (const [, family, substitute] of aliases) bindings.set(family, substitute);
+    const matches = fragment.matchAll(
+      /<test[^>]*name="family"[^>]*>\s*<string>([^<]+)<\/string>[\s\S]*?<edit name="family"[^>]*>\s*<string>([^<]+)<\/string>/g);
+    for (const [, family, substitute] of matches) bindings.set(family, substitute);
+    return bindings;
+  }
+
+  test('the shipped fontconfig fragment binds exactly the declared families', () => {
+    // Both engines read the fragment; the TypeScript list is only how the run REPORTS the
+    // contract. If they drift apart, every report describes a policy the renderers do not follow.
+    const bindings = fragmentBindings(readFileSync(FONTCONFIG_FRAGMENT, 'utf8'));
+    const declared = new Map(FONT_SUBSTITUTION_CONTRACT.map(e => [e.family, e.substitute]));
+
+    expect(Object.fromEntries([...bindings].sort()))
+      .toEqual(Object.fromEntries([...declared].sort()));
+    expect(FONT_CONTRACT_PACKAGES.length).toBeGreaterThan(0);
+  });
+
+  test('the drift detector flags a substituted face', () => {
+    // Calibri Light resolved to Noto Sans in one engine and Carlito in the other: a 38 px
+    // difference on the probe's short line, which is what this tolerance exists to catch.
+    const drifted = [...BASELINE_ADVANCES];
+    drifted[5] += 38;
+
+    const result = compareProbeLines(probePage(BASELINE_ADVANCES), probePage(drifted));
+    expect(result.agreed).toBe(false);
+    expect(result.problem).toContain(PROBE_FAMILIES[5]);
+    expect(result.maxAdvanceDeltaPx).toBe(38);
+  });
+
+  test('the drift detector flags a different wrapped line count', () => {
+    const result = compareProbeLines(
+      probePage(BASELINE_ADVANCES, [600, 600, 400]),
+      probePage(BASELINE_ADVANCES, [600, 600, 600, 200]),
+    );
+    expect(result.agreed).toBe(false);
+    expect(result.problem).toContain('different line counts');
+  });
+
+  test('the drift detector tolerates rasterisation noise', () => {
+    // Hinting moves a short line's end by a pixel or two between engines; that is not drift.
+    const noisy = BASELINE_ADVANCES.map((width, index) =>
+      width + (index % 2 === 0 ? PROBE_ADVANCE_TOLERANCE_PX : -PROBE_ADVANCE_TOLERANCE_PX));
+
+    const result = compareProbeLines(probePage(BASELINE_ADVANCES), probePage(noisy));
+    expect(result.agreed, result.problem).toBe(true);
+    expect(result.maxAdvanceDeltaPx).toBe(PROBE_ADVANCE_TOLERANCE_PX);
+    expect(result.advances.map(a => a.family)).toEqual(PROBE_FAMILIES);
+  });
+
+  test('an unsatisfied contract reports what to install', () => {
+    test.skip(spawnSync('fc-match', ['--version']).error !== undefined,
+      'fontconfig is not installed on this host');
+
+    // Resolve against the HOST configuration, deliberately without the repository fragment. The
+    // result is whatever this machine happens to do — the assertion is about the report, not the
+    // machine: either the contract holds, or it says exactly which family and package are wrong.
+    const status = resolveFontContract({ ...process.env, FONTCONFIG_FILE: undefined });
+    expect(status.entries.map(entry => entry.family))
+      .toEqual(FONT_SUBSTITUTION_CONTRACT.map(entry => entry.family));
+
+    if (status.satisfied) {
+      expect(status.problem).toBe('');
+      for (const entry of status.entries) expect(entry.resolvedFile).not.toBe('');
+    } else {
+      const broken = status.entries.filter(entry => !entry.satisfied);
+      expect(broken.length).toBeGreaterThan(0);
+      for (const entry of broken) {
+        expect(status.problem).toContain(entry.family);
+        expect(status.problem).toContain(entry.package);
+      }
+      expect(status.problem).toContain('README.md');
+    }
+  });
+});

--- a/npm/tests/pagination-footnote-geometry.spec.ts
+++ b/npm/tests/pagination-footnote-geometry.spec.ts
@@ -2,10 +2,12 @@ import { test, expect, Page } from '@playwright/test';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import {
+  FOOTER_DISTANCE_PT,
   MARGIN_PT,
   PAGE_HEIGHT_PT,
   SEPARATOR_WIDTH_IN,
   generateFootnoteDocx,
+  type FootnoteFixtureOptions,
 } from './docx-footnote-fixture.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -46,6 +48,10 @@ interface NoteGeometry {
   ruleBottom: number;
   ruleWidth: number;
   noteLineHeight: number;
+  footerTop: number;
+  footerBottom: number;
+  bodyIds: string[];
+  noteIds: string[];
   items: Array<{ top: number; bottom: number; marginTop: number }>;
 }
 
@@ -57,6 +63,7 @@ const MEASURE = () => {
     const body = box.querySelector('.page-content') as HTMLElement;
     const sep = notes?.querySelector('.footnote-separator') as HTMLElement | null;
     const rule = sep?.querySelector('hr') as HTMLElement | null;
+    const footer = box.querySelector('.page-footer') as HTMLElement | null;
     const rect = (el: Element | null) => (el ? el.getBoundingClientRect() : null);
     // One line of the note area's own font, measured rather than parsed: the area's resolved
     // `line-height` is `normal`, which is not a number the document can state for it.
@@ -82,6 +89,12 @@ const MEASURE = () => {
       ruleBottom: rect(rule)?.bottom ?? NaN,
       ruleWidth: rect(rule)?.width ?? NaN,
       noteLineHeight,
+      footerTop: rect(footer)?.top ?? NaN,
+      footerBottom: rect(footer)?.bottom ?? NaN,
+      bodyIds: Array.from(body.querySelectorAll('[data-footnote-id]'))
+        .map((el) => el.getAttribute('data-footnote-id')!),
+      noteIds: Array.from(notes?.querySelectorAll('.footnote-item') ?? [])
+        .map((el) => (el as HTMLElement).dataset.footnoteId!),
       items: Array.from(notes?.querySelectorAll('.footnote-item') ?? []).map((el) => ({
         top: el.getBoundingClientRect().top,
         bottom: el.getBoundingClientRect().bottom,
@@ -91,20 +104,24 @@ const MEASURE = () => {
   });
 };
 
-async function paginate(page: Page, docx: Uint8Array): Promise<NoteGeometry[]> {
+async function paginate(
+  page: Page,
+  docx: Uint8Array,
+  renderHeadersAndFooters = false,
+): Promise<NoteGeometry[]> {
   await page.goto('/test-harness.html');
   await page.waitForFunction(() => (window as any).DocxodusReady === true, { timeout: 30000 });
 
-  const html = await page.evaluate((bytes) => {
+  const html = await page.evaluate(({ bytes, headersAndFooters }) => {
     const c = (window as any).Docxodus.DocumentConverter;
     return c.ConvertDocxToHtmlComplete(
       new Uint8Array(bytes), 'Document', 'docx-', true, '', -1, 'comment-',
       /* paginationMode */ 1, /* paginationScale */ 1, 'page-',
       false, 0, 'annot-',
-      /* footnotes */ true, /* headersAndFooters */ false,
+      /* footnotes */ true, headersAndFooters,
       false, false, false,
     ) as string;
-  }, Array.from(docx));
+  }, { bytes: Array.from(docx), headersAndFooters: renderHeadersAndFooters });
   expect(html.startsWith('{'), `conversion failed: ${html.slice(0, 300)}`).toBe(false);
 
   await page.setContent(html);
@@ -186,6 +203,77 @@ test.describe('Paginated footnote block geometry', () => {
       expect(p.bodyBottom, `page ${p.page} body vs notes`).toBeLessThanOrEqual(p.notesTop + TOL);
     }
   });
+
+  /**
+   * The reserve the flow loop computes and the block the page draws are built by one builder, so
+   * they cannot disagree — but only measurement proves it. Several multi-line notes spread across
+   * pages is the shape that produced ~134 pt of superimposed body and note glyphs on a real
+   * 94-footnote document, and it is also the shape most sensitive to the note area's leading,
+   * which this change took from a fixed 1.4 to the note style's own single spacing.
+   *
+   * Citations are spread out on purpose. Crowding every note onto one page instead runs into the
+   * flow loop's separate 60% note-area cap, which admits more notes than it leaves room for and
+   * clips the overflow — reproduced identically before this branch's changes, so it is a
+   * pre-existing question about the CAP, not about the block's composition, and not this test's.
+   */
+  test('many multi-line notes still reserve exactly the space they render in',
+    async ({ page }) => {
+      const options: FootnoteFixtureOptions = {
+        paragraphs: Array.from({ length: 40 }, (_unused, i) => (i % 4 === 0 ? 1 : 0)),
+        linesPerNote: 3,
+      };
+      const pages = await paginate(page, generateFootnoteDocx(options));
+
+      expect(pages.length).toBeGreaterThan(1);
+      for (const p of pages) {
+        if (Number.isNaN(p.notesTop)) continue;
+        expect(p.bodyBottom, `page ${p.page} body overlaps its notes`)
+          .toBeLessThanOrEqual(p.notesTop + TOL);
+        expect(p.notesBottom, `page ${p.page} note block bottom`)
+          .toBeCloseTo(p.boxTop + (PAGE_HEIGHT_PT - MARGIN_PT) * PT_TO_PX, 0);
+        expect(p.items[p.items.length - 1].bottom, `page ${p.page} last note bottom`)
+          .toBeCloseTo(p.notesBottom, 0);
+      }
+
+      // Reserving space must not lose a note: everything cited has to render somewhere.
+      const cited = new Set(pages.flatMap((p) => p.bodyIds));
+      const rendered = new Set(pages.flatMap((p) => p.noteIds));
+      expect(cited.size).toBe(10);
+      expect([...cited].filter((id) => !rendered.has(id)), 'cited but never rendered').toEqual([]);
+    });
+});
+
+/**
+ * The note area follows the BODY BAND's bottom edge, not the raw bottom margin. The two coincide
+ * on an ordinary page, which is why this needs a footer tall enough to reach above its own margin:
+ * that raises the body band's bottom, and an anchor left on `w:bottom` would draw the notes over
+ * the footer. It is the seam between issues #377 and #378, so it gets its own document.
+ */
+test.describe('Notes against a footer that outgrows its margin', () => {
+  test('the note block ends where the body band ends, above the bottom margin',
+    async ({ page }) => {
+      const pages = await paginate(
+        page,
+        generateFootnoteDocx({ paragraphs: [1], footerLines: 6 }),
+        /* renderHeadersAndFooters */ true,
+      );
+      const p = pages[0];
+
+      expect(Number.isNaN(p.footerTop), 'the fixture must render a footer').toBe(false);
+      const footerHeight = p.footerBottom - p.footerTop;
+      const footerReach = FOOTER_DISTANCE_PT * PT_TO_PX + footerHeight;
+      // If the story stopped overflowing its margin, the rest of this test would pass vacuously.
+      expect(footerReach, 'the footer must reach past the bottom margin')
+        .toBeGreaterThan(MARGIN_PT * PT_TO_PX);
+
+      expect(p.notesBottom, 'note block bottom vs the body band bottom the footer raised')
+        .toBeCloseTo(p.boxBottom - footerReach, 0);
+      // The discriminating assertion: anchored to `w:bottom` the block would end lower than this.
+      expect(p.boxBottom - p.notesBottom, 'notes must clear the raw bottom margin')
+        .toBeGreaterThan(MARGIN_PT * PT_TO_PX + 1);
+      expect(p.notesBottom, 'notes must not overlap the footer band')
+        .toBeLessThanOrEqual(p.footerTop + TOL);
+    });
 });
 
 /**

--- a/npm/tests/pagination-footnote-geometry.spec.ts
+++ b/npm/tests/pagination-footnote-geometry.spec.ts
@@ -1,0 +1,260 @@
+import { test, expect, Page } from '@playwright/test';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  MARGIN_PT,
+  PAGE_HEIGHT_PT,
+  SEPARATOR_WIDTH_IN,
+  generateFootnoteDocx,
+} from './docx-footnote-fixture.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * Issue #378 — where a page's footnote block sits, and what it is made of.
+ *
+ * The separator's WIDTH was already correct; its POSITION was not, and the two were being
+ * confused because one number (the block's height) moved both. The note area is bottom-aligned
+ * to the body text band, so everything above that edge is the sum of what the block contains:
+ *
+ *   [separator band: one line of the note font, with the rule on its baseline]
+ *   [note, note, … with spacing BETWEEN them]
+ *   ─────────────────────────────────── body band bottom
+ *
+ * Two defects moved the whole block up by 14 px on a Word-default page: a `margin-bottom` on
+ * the last note left dead space below content that is anchored to that edge, and the separator
+ * was a bare 1 px rule with a hard-coded 6 pt gap under it and nothing above, rather than a
+ * paragraph line. These assertions therefore pin the separator and the note block SEPARATELY,
+ * so a future change to one cannot be masked by a compensating change to the other.
+ */
+
+const PT_TO_PX = 4 / 3;
+const TOL = 1;
+
+interface NoteGeometry {
+  page: number;
+  boxTop: number;
+  boxBottom: number;
+  bodyBottom: number;
+  notesTop: number;
+  notesBottom: number;
+  separatorTop: number;
+  separatorBottom: number;
+  separatorIsContinuation: boolean;
+  ruleTop: number;
+  ruleBottom: number;
+  ruleWidth: number;
+  noteLineHeight: number;
+  items: Array<{ top: number; bottom: number; marginTop: number }>;
+}
+
+const MEASURE = () => {
+  const container = document.getElementById('pagination-container') as HTMLElement;
+  return Array.from(container.querySelectorAll('.page-box')).map((box, i) => {
+    const b = box.getBoundingClientRect();
+    const notes = box.querySelector('.page-footnotes') as HTMLElement | null;
+    const body = box.querySelector('.page-content') as HTMLElement;
+    const sep = notes?.querySelector('.footnote-separator') as HTMLElement | null;
+    const rule = sep?.querySelector('hr') as HTMLElement | null;
+    const rect = (el: Element | null) => (el ? el.getBoundingClientRect() : null);
+    // One line of the note area's own font, measured rather than parsed: the area's resolved
+    // `line-height` is `normal`, which is not a number the document can state for it.
+    let noteLineHeight = NaN;
+    if (notes) {
+      const probe = document.createElement('div');
+      probe.textContent = ' ';
+      notes.appendChild(probe);
+      noteLineHeight = probe.getBoundingClientRect().height;
+      notes.removeChild(probe);
+    }
+    return {
+      page: i + 1,
+      boxTop: b.top,
+      boxBottom: b.bottom,
+      bodyBottom: rect(body)!.bottom,
+      notesTop: rect(notes)?.top ?? NaN,
+      notesBottom: rect(notes)?.bottom ?? NaN,
+      separatorTop: rect(sep)?.top ?? NaN,
+      separatorBottom: rect(sep)?.bottom ?? NaN,
+      separatorIsContinuation: !!sep?.classList.contains('footnote-separator-continuation'),
+      ruleTop: rect(rule)?.top ?? NaN,
+      ruleBottom: rect(rule)?.bottom ?? NaN,
+      ruleWidth: rect(rule)?.width ?? NaN,
+      noteLineHeight,
+      items: Array.from(notes?.querySelectorAll('.footnote-item') ?? []).map((el) => ({
+        top: el.getBoundingClientRect().top,
+        bottom: el.getBoundingClientRect().bottom,
+        marginTop: parseFloat(getComputedStyle(el as HTMLElement).marginTop),
+      })),
+    };
+  });
+};
+
+async function paginate(page: Page, docx: Uint8Array): Promise<NoteGeometry[]> {
+  await page.goto('/test-harness.html');
+  await page.waitForFunction(() => (window as any).DocxodusReady === true, { timeout: 30000 });
+
+  const html = await page.evaluate((bytes) => {
+    const c = (window as any).Docxodus.DocumentConverter;
+    return c.ConvertDocxToHtmlComplete(
+      new Uint8Array(bytes), 'Document', 'docx-', true, '', -1, 'comment-',
+      /* paginationMode */ 1, /* paginationScale */ 1, 'page-',
+      false, 0, 'annot-',
+      /* footnotes */ true, /* headersAndFooters */ false,
+      false, false, false,
+    ) as string;
+  }, Array.from(docx));
+  expect(html.startsWith('{'), `conversion failed: ${html.slice(0, 300)}`).toBe(false);
+
+  await page.setContent(html);
+  await page.addScriptTag({ path: path.join(__dirname, '../dist/pagination.bundle.js') });
+  return page.evaluate(({ measure }: { measure: string }) => {
+    const staging = document.getElementById('pagination-staging') as HTMLElement;
+    const container = document.getElementById('pagination-container') as HTMLElement;
+    const { PaginationEngine } = (window as any).DocxodusPagination;
+    new PaginationEngine(staging, container, { scale: 1, showPageNumbers: false }).paginate();
+    // eslint-disable-next-line no-eval
+    return (0, eval)(`(${measure})`)();
+  }, { measure: MEASURE.toString() }) as Promise<NoteGeometry[]>;
+}
+
+test.describe('Paginated footnote block geometry', () => {
+  test('the note block is bottom-aligned to the body band, with nothing below the last note',
+    async ({ page }) => {
+      const pages = await paginate(page, generateFootnoteDocx({ paragraphs: [1] }));
+      expect(pages).toHaveLength(1);
+      const p = pages[0];
+
+      // The anchor: the block's bottom edge IS the bottom of the body text band.
+      const bodyBandBottom = p.boxTop + (PAGE_HEIGHT_PT - MARGIN_PT) * PT_TO_PX;
+      expect(p.notesBottom, 'note block bottom vs body band bottom')
+        .toBeCloseTo(bodyBandBottom, 0);
+
+      // And the last note ends ON that edge — a trailing margin there lifts the entire block,
+      // separator included, off the edge it is anchored to.
+      expect(p.items).toHaveLength(1);
+      expect(p.items[0].bottom, 'last note bottom vs note block bottom')
+        .toBeCloseTo(p.notesBottom, 0);
+    });
+
+  test('the separator is one line of the note font with the rule on its baseline',
+    async ({ page }) => {
+      const pages = await paginate(page, generateFootnoteDocx({ paragraphs: [1] }));
+      const p = pages[0];
+
+      // `w:separator` is a run in a paragraph, so the band is a LINE, not a bare rule.
+      expect(p.separatorBottom - p.separatorTop, 'separator band height vs one note line')
+        .toBeCloseTo(p.noteLineHeight, 0);
+
+      // The rule sits on that line's baseline: real space above it, real space below it, both
+      // coming from the font's own metrics rather than a tuned margin.
+      expect(p.ruleTop - p.separatorTop, 'space above the rule').toBeGreaterThan(2);
+      expect(p.separatorBottom - p.ruleBottom, 'space below the rule').toBeGreaterThan(2);
+      // Baseline, not centre: a text baseline sits well below the middle of its line box.
+      expect(p.ruleBottom - p.separatorTop)
+        .toBeGreaterThan((p.separatorBottom - p.separatorTop) / 2);
+
+      // The band is the top of the block, and the notes follow it.
+      expect(p.separatorTop).toBeCloseTo(p.notesTop, 0);
+      expect(p.items[0].top).toBeCloseTo(p.separatorBottom, 0);
+    });
+
+  test('the separator keeps Word\'s two-inch default width', async ({ page }) => {
+    const pages = await paginate(page, generateFootnoteDocx({ paragraphs: [1] }));
+    expect(pages[0].ruleWidth).toBeCloseTo(SEPARATOR_WIDTH_IN * 96, 0);
+    expect(pages[0].separatorIsContinuation).toBe(false);
+  });
+
+  test('note spacing falls between notes, never after the last one', async ({ page }) => {
+    const pages = await paginate(page, generateFootnoteDocx({ paragraphs: [3] }));
+    const p = pages[0];
+    expect(p.items.length).toBe(3);
+
+    expect(p.items[0].marginTop, 'first note has no leading gap').toBeCloseTo(0, 0);
+    for (let i = 1; i < p.items.length; i++) {
+      expect(p.items[i].marginTop, `gap before note ${i + 1}`).toBeGreaterThan(2);
+    }
+    expect(p.items[p.items.length - 1].bottom, 'last note bottom vs block bottom')
+      .toBeCloseTo(p.notesBottom, 0);
+  });
+
+  test('the body band never runs into the note block', async ({ page }) => {
+    const pages = await paginate(page, generateFootnoteDocx({ paragraphs: [1, 1, 1] }));
+    for (const p of pages) {
+      if (Number.isNaN(p.notesTop)) continue;
+      expect(p.bodyBottom, `page ${p.page} body vs notes`).toBeLessThanOrEqual(p.notesTop + TOL);
+    }
+  });
+});
+
+/**
+ * `w:continuationSeparator` — the separator a page shows when it opens with note text carried
+ * over from the previous page. Word draws it across the whole text column instead of the
+ * two-inch default, and the engine used to draw the ordinary separator on every page.
+ */
+const CONTINUATION_STAGING = `
+  <style>
+    #pagination-staging { font: 12px/12px Arial; }
+    .body { height: 20pt; margin: 0; }
+    .footnote-item { margin: 0; }
+    .footnote-content > p { height: 10pt; margin: 0; }
+  </style>
+  <div id="pagination-staging">
+    <div id="pagination-footnote-registry">
+      <div class="footnote-item" data-footnote-id="f1">
+        <span class="footnote-number">1</span>
+        <span class="footnote-content">${
+          Array.from({ length: 30 }, (_, i) => `<p>note line ${i}</p>`).join('')
+        }</span>
+      </div>
+    </div>
+    <div data-section-index="0"
+         data-page-width="312" data-page-height="312"
+         data-content-width="300" data-content-height="300"
+         data-margin-top="6" data-margin-right="6"
+         data-margin-bottom="6" data-margin-left="6">
+      <p class="body">body 0 <sup data-footnote-id="f1">1</sup></p>
+      ${Array.from({ length: 10 }, (_, i) => `<p class="body">body ${i + 1}</p>`).join('')}
+    </div>
+  </div>
+  <div id="pagination-container"></div>`;
+
+test.describe('Continuation separator', () => {
+  test('a page that opens with carried-over note text shows the full-width separator',
+    async ({ page }) => {
+      await page.setContent(CONTINUATION_STAGING);
+      await page.addScriptTag({ path: path.join(__dirname, '../dist/pagination.bundle.js') });
+      const seps = await page.evaluate(() => {
+        const staging = document.getElementById('pagination-staging') as HTMLElement;
+        const container = document.getElementById('pagination-container') as HTMLElement;
+        const { PaginationEngine } = (window as any).DocxodusPagination;
+        new PaginationEngine(staging, container, {
+          scale: 1, showPageNumbers: false, fragmentParagraphs: true,
+        }).paginate();
+        return Array.from(container.querySelectorAll('.page-box')).map((box) => {
+          const notes = box.querySelector('.page-footnotes') as HTMLElement | null;
+          const sep = notes?.querySelector('.footnote-separator') as HTMLElement | null;
+          return {
+            hasNotes: !!notes,
+            hasContinuation: !!notes?.querySelector('.footnote-continuation'),
+            isContinuationSeparator: !!sep?.classList.contains('footnote-separator-continuation'),
+            ruleWidth: sep ? (sep.querySelector('hr') as HTMLElement).getBoundingClientRect().width : NaN,
+            notesWidth: notes ? notes.getBoundingClientRect().width : NaN,
+          };
+        });
+      });
+
+      const carried = seps.filter((s) => s.hasContinuation);
+      expect(carried.length, 'the fixture must actually split a note across pages')
+        .toBeGreaterThan(0);
+      for (const s of carried) {
+        expect(s.isContinuationSeparator).toBe(true);
+        expect(s.ruleWidth).toBeCloseTo(s.notesWidth, 0);
+      }
+      // The page the note STARTS on keeps the ordinary two-inch separator.
+      const started = seps.filter((s) => s.hasNotes && !s.hasContinuation);
+      expect(started.length).toBeGreaterThan(0);
+      expect(started.every((s) => !s.isContinuationSeparator)).toBe(true);
+    });
+});

--- a/npm/tests/visual-parity.spec.ts
+++ b/npm/tests/visual-parity.spec.ts
@@ -17,6 +17,20 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { REQUIRED_VISUAL_CATEGORIES, VISUAL_PARITY_CORPUS, type VisualCorpusEntry } from './visual-parity/corpus.js';
 import { compareImages, VISUAL_THRESHOLDS, type PageMetrics, type VisualSeverity } from './visual-parity/metrics.js';
 import { decodePng, encodePng } from './visual-parity/png.js';
+import {
+  FONT_CONTRACT_PACKAGES,
+  FONTCONFIG_FRAGMENT,
+  resolveFontContract,
+  writeFontconfigRoot,
+  type FontContractStatus,
+} from './visual-parity/fonts.js';
+import {
+  compareProbeLines,
+  generateFontProbeDocx,
+  inkLines,
+  PROBE_FAMILIES,
+  type FontProbeResult,
+} from './visual-parity/font-probe.js';
 
 test.skip(process.env.DOCXODUS_VISUAL_PARITY !== '1',
   'set DOCXODUS_VISUAL_PARITY=1 on a host with libreoffice and pdftoppm');
@@ -24,6 +38,28 @@ test.skip(process.env.DOCXODUS_VISUAL_PARITY !== '1',
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '../..');
 const severityOrder: VisualSeverity[] = ['close', 'minor', 'major', 'severe'];
+
+/**
+ * The font-substitution contract has to be in force before EITHER engine starts, and Chromium's
+ * fontconfig is read when the browser process launches — which happens when the first test
+ * requests a page, after this module is evaluated. So the layered fontconfig root is written
+ * here, at import time, and handed to the browser through `test.use` below and to every
+ * LibreOffice subprocess through its env.
+ *
+ * `DOCXODUS_VISUAL_PARITY_HOST_FONTS=1` opts out and measures the host as it is, which is how you
+ * reproduce a report from a machine that installed the fragment permanently instead.
+ */
+const useHostFonts = process.env.DOCXODUS_VISUAL_PARITY_HOST_FONTS === '1';
+const fontconfigRoot = useHostFonts || process.env.DOCXODUS_VISUAL_PARITY !== '1'
+  ? undefined
+  : writeFontconfigRoot(mkdtempSync(join(tmpdir(), 'docxodus-visual-fontconfig-')));
+const fontEnv: NodeJS.ProcessEnv = fontconfigRoot
+  ? { ...process.env, FONTCONFIG_FILE: fontconfigRoot }
+  : process.env;
+
+if (fontconfigRoot) {
+  test.use({ launchOptions: { env: { ...process.env, FONTCONFIG_FILE: fontconfigRoot } } });
+}
 
 interface PageResult extends PageMetrics {
   page: number;
@@ -121,7 +157,7 @@ function renderLibreOffice(docxPath: string, work: string): string[] {
   for (const directory of [pdfDir, profileDir, runtimeDir, homeDir]) mkdirSync(directory, { mode: 0o700 });
 
   const deterministicEnv = {
-    ...process.env,
+    ...fontEnv,
     HOME: homeDir,
     XDG_RUNTIME_DIR: runtimeDir,
     LANG: 'C.UTF-8',
@@ -240,6 +276,46 @@ async function renderDocxodus(page: Page, docxPath: string, output: string): Pro
   return paths;
 }
 
+/**
+ * Renders the synthetic wrapping probe through both engines and reports whether they agree.
+ *
+ * This is the signal that separates a renderer regression from a font-environment change: the
+ * probe's only variable is which face each engine resolved, so when its lines stop matching, the
+ * corpus numbers that moved with them did not move because of this repository.
+ */
+async function runFontProbe(page: Page, outputRoot: string): Promise<FontProbeResult & {
+  families: string[];
+  artifacts: { docxodus: string; libreoffice: string };
+}> {
+  const probeOutput = join(outputRoot, 'font-probe');
+  mkdirSync(probeOutput, { recursive: true });
+  const work = mkdtempSync(join(tmpdir(), 'docxodus-font-probe-'));
+  try {
+    const probePath = join(work, 'font-probe.docx');
+    writeFileSync(probePath, generateFontProbeDocx());
+
+    const libreofficePages = renderLibreOffice(probePath, work);
+    const libreofficePng = join(probeOutput, 'libreoffice-1.png');
+    writeFileSync(libreofficePng, readFileSync(libreofficePages[0]));
+    const docxodusPages = await renderDocxodus(page, probePath, probeOutput);
+
+    const comparison = compareProbeLines(
+      inkLines(decodePng(readFileSync(docxodusPages[0]))),
+      inkLines(decodePng(readFileSync(libreofficePng))),
+    );
+    return {
+      ...comparison,
+      families: PROBE_FAMILIES,
+      artifacts: {
+        docxodus: relative(outputRoot, docxodusPages[0]),
+        libreoffice: relative(outputRoot, libreofficePng),
+      },
+    };
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
+}
+
 function worse(a: VisualSeverity, b: VisualSeverity): VisualSeverity {
   return severityOrder.indexOf(a) >= severityOrder.indexOf(b) ? a : b;
 }
@@ -276,11 +352,35 @@ test('stratified tracked corpus matches LibreOffice at pixel level', async ({ pa
   }
   mkdirSync(outputRoot, { recursive: true, mode: 0o700 });
 
+  // The font contract gates the whole run: without it the two engines can be set in different
+  // faces, and every number below would be measuring the host rather than the renderer.
+  //
+  // Skipping is right for a developer who has not installed the fonts, and wrong for a machine
+  // that is supposed to have them: there, a contract that silently stops holding turns the whole
+  // benchmark into a green no-op that produces no report. `REQUIRE_FONTS` is separate from
+  // `STRICT` on purpose — strictness is about the corpus verdict, several cases are legitimately
+  // severe today, and a host that cannot even set up its fonts must fail for that reason alone.
+  const fontContract: FontContractStatus = resolveFontContract(fontEnv);
+  if (!fontContract.satisfied) {
+    const message = `${fontContract.problem}\nRequired packages: ${FONT_CONTRACT_PACKAGES.join(' ')}`;
+    if (process.env.DOCXODUS_VISUAL_PARITY_REQUIRE_FONTS === '1' ||
+        process.env.DOCXODUS_VISUAL_PARITY_STRICT === '1') {
+      throw new Error(message);
+    }
+    test.skip(true, message);
+  }
+
   await page.setViewportSize({ width: 1400, height: 1000 });
   await page.emulateMedia({ reducedMotion: 'reduce' });
   await page.goto('/test-harness.html');
   await page.waitForFunction(() => (window as any).DocxodusReady === true, { timeout: 90000 });
   await page.addScriptTag({ url: '/pagination.bundle.js' });
+
+  const fontProbe = await runFontProbe(page, outputRoot);
+  console.log(fontProbe.agreed
+    ? `Font probe: engines agree on ${fontProbe.docxodusLines} lines ` +
+      `(worst advance delta ${fontProbe.maxAdvanceDeltaPx} px)`
+    : `Font probe: FONT ENVIRONMENT DRIFT — ${fontProbe.problem}`);
 
   const cases: CaseResult[] = [];
   for (const [caseIndex, entry] of corpus.entries()) {
@@ -374,12 +474,17 @@ test('stratified tracked corpus matches LibreOffice at pixel level', async ({ pa
       chromium: page.context().browser()?.version() ?? 'unknown',
       libreoffice: commandVersion('libreoffice', ['--version']),
       pdftoppm: commandVersion('pdftoppm', ['-v']).split('\n')[0],
-      calibriMatch: commandVersion('fc-match', ['Calibri', '--format=%{family} %{file}']),
-      calibriLightMatch: commandVersion('fc-match', ['Calibri Light', '--format=%{family} %{file}']),
-      timesNewRomanMatch: commandVersion('fc-match', ['Times New Roman', '--format=%{family} %{file}']),
       locale: 'C.UTF-8',
       timezone: 'UTC',
     },
+    // The exact faces both engines rendered with, so a rerun can tell a renderer change from a
+    // font-environment change instead of guessing.
+    fontContract: {
+      ...fontContract,
+      fragment: relative(repoRoot, FONTCONFIG_FRAGMENT),
+      source: useHostFonts ? 'host fontconfig (DOCXODUS_VISUAL_PARITY_HOST_FONTS=1)' : 'repository fragment',
+    },
+    fontProbe,
     coverage: Object.fromEntries(REQUIRED_VISUAL_CATEGORIES.map(category => [
       category,
       VISUAL_PARITY_CORPUS.filter(entry => entry.categories.includes(category)).map(entry => entry.id),
@@ -390,6 +495,11 @@ test('stratified tracked corpus matches LibreOffice at pixel level', async ({ pa
   const summaryPath = join(outputRoot, 'summary.json');
   writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
   console.log(`Visual parity report: ${summaryPath}`);
+
+  // Reported before the corpus verdict on purpose: when the probe fails, the corpus numbers are
+  // not evidence about the renderer, and saying so first keeps the two from being confused.
+  expect(fontProbe.agreed, `font environment drift, not a renderer regression: ${fontProbe.problem}`)
+    .toBe(true);
 
   if (process.env.DOCXODUS_VISUAL_PARITY_STRICT === '1') {
     expect(cases.filter(result => result.severity === 'severe'),

--- a/npm/tests/visual-parity/BASELINE.md
+++ b/npm/tests/visual-parity/BASELINE.md
@@ -72,11 +72,13 @@ The complete 12-case corpus was rerun after rebuilding the production WASM bundl
 report remained outside the checkout under `/tmp`; no benchmark artifacts or additional corpus files
 were added to the repository.
 
-`Current` is one clean-worktree rerun of the whole corpus on this branch after it merged `main`, so
-it measures the running-content fix (issue #377) and the DrawingML anchor fix (PR #381) TOGETHER
-rather than splicing two separately measured runs. The two fixes touch disjoint cases, and every
-per-case figure below reproduced its own branch's measurement exactly; only the corpus-wide means
-move.
+`Current` is one clean-worktree rerun of the whole corpus on this branch, so it measures the
+running-content fix (issue #377), the footnote block fix (issue #378), the font-substitution
+contract (issue #379), and the DrawingML anchor fix (PR #381) TOGETHER rather than splicing
+separately measured runs. That matters most for the font contract, which changes substitution for
+EVERY case rather than one: the rerun confirms it leaves the other fixes' cases where they were —
+every per-case figure below reproduced the measurement made on the branch that produced it, so only
+the corpus-wide means move.
 
 | Signal | Initial | After PRs #372–#374 | Current |
 |---|---:|---:|---:|
@@ -86,8 +88,8 @@ move.
 | Page-count mismatches | 1 | 0 | 0 |
 | Case severity | 1 close, 1 minor, 0 major, 10 severe | 2 close, 1 minor, 0 major, 9 severe | 5 close, 1 minor, 0 major, 6 severe |
 | Page severity | 1 close, 1 minor, 2 major, 16 severe | 2 close, 1 minor, 1 major, 17 severe | 14 close, 1 minor, 0 major, 6 severe |
-| Mean SSIM | 0.974586 | 0.978298 | 0.981207 |
-| Mean tolerant ink F1 | 0.394106 | 0.412753 | 0.854815 |
+| Mean SSIM | 0.974586 | 0.978298 | 0.981426 |
+| Mean tolerant ink F1 | 0.394106 | 0.412753 | 0.860687 |
 
 Resolved items:
 

--- a/npm/tests/visual-parity/BASELINE.md
+++ b/npm/tests/visual-parity/BASELINE.md
@@ -74,10 +74,10 @@ were added to the repository.
 | Paired pages | 20 | 21 | 21 |
 | Conversion errors | 0 | 0 | 0 |
 | Page-count mismatches | 1 | 0 | 0 |
-| Case severity | 1 close, 1 minor, 0 major, 10 severe | 2 close, 1 minor, 0 major, 9 severe | 4 close, 1 minor, 0 major, 7 severe |
-| Page severity | 1 close, 1 minor, 2 major, 16 severe | 2 close, 1 minor, 1 major, 17 severe | 13 close, 1 minor, 0 major, 7 severe |
-| Mean SSIM | 0.974586 | 0.978298 | 0.979855 |
-| Mean tolerant ink F1 | 0.394106 | 0.412753 | 0.835366 |
+| Case severity | 1 close, 1 minor, 0 major, 10 severe | 2 close, 1 minor, 0 major, 9 severe | 5 close, 1 minor, 0 major, 6 severe |
+| Page severity | 1 close, 1 minor, 2 major, 16 severe | 2 close, 1 minor, 1 major, 17 severe | 14 close, 1 minor, 0 major, 6 severe |
+| Mean SSIM | 0.974586 | 0.978298 | 0.979980 |
+| Mean tolerant ink F1 | 0.394106 | 0.412753 | 0.854069 |
 
 Resolved items:
 
@@ -103,6 +103,14 @@ Resolved items:
    `landscape-section` improves as a side effect (0.91746 → 0.92607, 0.50174 → 0.60042). Story
    inheritance and page counts are unchanged, which the generated regression asserts alongside the
    coordinates.
+5. **Footnote block placement (issue #378).** The note area is bottom-aligned to the body band, so
+   the block's HEIGHT is its position — which is why the note text and the already-correct
+   two-inch separator were both about 13 px too high, and why fixing the separator's width could
+   not move it. Removing the block's own slack (a trailing margin below the last note, a bare rule
+   with a tuned gap instead of the separator paragraph's line, a line-box-inflating superscript
+   mark, and a fixed 1.4 line-height overriding the note style's single spacing) lands the
+   separator within 2 px of LibreOffice's and the note text's bottom edge exactly on it. The case
+   moves from severe (SSIM 0.99218, ink F1 0.56597) to **close** (0.99481 / 0.95875).
 
 ## Current case results and triage
 
@@ -121,7 +129,7 @@ single blank or disjoint page rather than averaging it away.
 | chart | 1/1 | close | 0.98687 | 0.96817 | Cached clustered column data now renders as accessible inline SVG at the stored extent; bars, grid, colors, labels, title, and bottom legend align closely. Other chart families and stacked groupings remain unsupported. |
 | shape | 1/1 | severe | 0.96967 | 0.50719 | Textbox content exists but is roughly 5 px right and 13 px down with a small size difference: drawing-anchor geometry. |
 | fields-and-tabs | 1/1 | severe | 0.88672 | 0.30164 | Right-tab page numbers now reach the declared 9350-twip target and leaders fill the rendered remainder. The whole-page score falls slightly because the corrected leader adds ink at the still-mismatched TOC line height; hyperlink styling, font metrics, and paragraph spacing remain separate differences. |
-| footnote | 1/1 | severe | 0.99218 | 0.56597 | Separator width now matches Word/LibreOffice's two-inch default; the note block remains about 13 px too high. |
+| footnote | 1/1 | close | 0.99481 | 0.95875 | Note block composition corrected (issue #378): the separator is a line with the rule on its baseline, spacing falls between notes, and the last note ends on the body band's bottom edge. |
 | tracked-deletion | 1/1 | severe | 0.93177 | 0.46817 | Identical accepted-revision bytes are now compared. Remaining differences cluster around Calibri Light substitution, heading metrics, and wrapping rather than revision semantics. |
 
 ## Fixes justified by the baseline
@@ -158,13 +166,12 @@ renderer heuristic.
 
 ## Prioritized next work
 
-The former first priority (blank charts), the PR #372 rerun, aligned tab geometry, and
-header/body/footer vertical placement (issue #377) are resolved above. The remaining order is:
+The former first priority (blank charts), the PR #372 rerun, aligned tab geometry,
+header/body/footer vertical placement (issue #377), and footnote block placement (issue #378) are
+resolved above. The remaining order is:
 
 1. Correct drawing-anchor offsets with a generated textbox geometry regression.
-2. Correct footnote block vertical placement independently of the now-fixed separator width
-   (issue #378).
-3. Define and provision one font-substitution contract shared by Chromium and LibreOffice CI before
+2. Define and provision one font-substitution contract shared by Chromium and LibreOffice CI before
    treating paragraph-wrap differences as renderer regressions (issue #379).
 
 The list-margin discrepancy should not be changed merely to imitate LibreOffice: current evidence

--- a/npm/tests/visual-parity/BASELINE.md
+++ b/npm/tests/visual-parity/BASELINE.md
@@ -33,8 +33,12 @@ does not replace the fast committed snapshots or the arcade export test.
 - False-positive controls: wait for fonts/images/two animation frames; disable animation, carets,
   shadows, labels, and page gaps; search only a +/-2 px translation; report page geometry
   independently; use no masks.
-- Environment: Chromium 143.0.7499.4; LibreOffice 25.8.7.3; Poppler 25.03.0; Calibri mapped by
-  fontconfig to Carlito, Calibri Light to Noto Sans, and Times New Roman to Liberation Serif.
+- Environment: Chromium 143.0.7499.4; LibreOffice 25.8.7.3; Poppler 25.03.0. Fonts are governed by
+  the shared substitution contract (issue #379): one fontconfig fragment both engines read, mapping
+  Calibri and Calibri Light to Carlito, Cambria to Caladea, and Times New Roman / Arial / Courier
+  New to the matching Liberation faces. The run resolves every declared family before either engine
+  starts, records the exact font file each one used, and skips (or fails, under strict mode) rather
+  than reporting numbers from an unknown font environment.
 
 Two clean full render passes produced identical normalized metrics and all 60 Docxodus,
 LibreOffice, and overlay PNG SHA-256 hashes. The final ink-F1 edge-case correction changed no image
@@ -76,8 +80,8 @@ were added to the repository.
 | Page-count mismatches | 1 | 0 | 0 |
 | Case severity | 1 close, 1 minor, 0 major, 10 severe | 2 close, 1 minor, 0 major, 9 severe | 5 close, 1 minor, 0 major, 6 severe |
 | Page severity | 1 close, 1 minor, 2 major, 16 severe | 2 close, 1 minor, 1 major, 17 severe | 14 close, 1 minor, 0 major, 6 severe |
-| Mean SSIM | 0.974586 | 0.978298 | 0.979980 |
-| Mean tolerant ink F1 | 0.394106 | 0.412753 | 0.854069 |
+| Mean SSIM | 0.974586 | 0.978298 | 0.981207 |
+| Mean tolerant ink F1 | 0.394106 | 0.412753 | 0.854815 |
 
 Resolved items:
 
@@ -111,6 +115,16 @@ Resolved items:
    mark, and a fixed 1.4 line-height overriding the note style's single spacing) lands the
    separator within 2 px of LibreOffice's and the note text's bottom edge exactly on it. The case
    moves from severe (SSIM 0.99218, ink F1 0.56597) to **close** (0.99481 / 0.95875).
+6. **Shared font-substitution contract (issue #379).** One fontconfig fragment now governs both
+   engines, so a family cannot be set in different faces on the two sides of the comparison. The
+   run resolves every declared family before starting, records the font file each one used, and
+   skips or fails rather than reporting numbers from an unknown environment; a generated probe
+   compares the engines' advances and wrapped line counts and labels a mismatch as font-environment
+   drift rather than a renderer regression. `tracked-deletion` improves markedly (SSIM 0.93177 →
+   0.95011, ink F1 0.46817 → 0.62634) because Chromium and LibreOffice previously disagreed about
+   Calibri Light. `fields-and-tabs` moves the other way on ink F1 (0.30164 → 0.15913, SSIM
+   0.88672 → 0.89415): the substitution had been masking a real TOC line-height difference, which
+   is now visible as the renderer signal it always was.
 
 ## Current case results and triage
 
@@ -128,9 +142,9 @@ single blank or disjoint page rather than averaging it away.
 | inline-image | 1/1 | severe | 0.93660 | 0.64760 | Image and text are separate source paragraphs; the discrepancy is indentation/font/wrapping, not an inline-flow failure. |
 | chart | 1/1 | close | 0.98687 | 0.96817 | Cached clustered column data now renders as accessible inline SVG at the stored extent; bars, grid, colors, labels, title, and bottom legend align closely. Other chart families and stacked groupings remain unsupported. |
 | shape | 1/1 | severe | 0.96967 | 0.50719 | Textbox content exists but is roughly 5 px right and 13 px down with a small size difference: drawing-anchor geometry. |
-| fields-and-tabs | 1/1 | severe | 0.88672 | 0.30164 | Right-tab page numbers now reach the declared 9350-twip target and leaders fill the rendered remainder. The whole-page score falls slightly because the corrected leader adds ink at the still-mismatched TOC line height; hyperlink styling, font metrics, and paragraph spacing remain separate differences. |
+| fields-and-tabs | 1/1 | severe | 0.89415 | 0.15913 | Right-tab page numbers now reach the declared 9350-twip target and leaders fill the rendered remainder. The whole-page score falls slightly because the corrected leader adds ink at the still-mismatched TOC line height; hyperlink styling, font metrics, and paragraph spacing remain separate differences. |
 | footnote | 1/1 | close | 0.99481 | 0.95875 | Note block composition corrected (issue #378): the separator is a line with the rule on its baseline, spacing falls between notes, and the last note ends on the body band's bottom edge. |
-| tracked-deletion | 1/1 | severe | 0.93177 | 0.46817 | Identical accepted-revision bytes are now compared. Remaining differences cluster around Calibri Light substitution, heading metrics, and wrapping rather than revision semantics. |
+| tracked-deletion | 1/1 | severe | 0.95011 | 0.62634 | Identical accepted-revision bytes, and both engines now resolve Calibri Light the same way (issue #379). Remaining differences are heading metrics and wrapping, not revision semantics. |
 
 ## Fixes justified by the baseline
 
@@ -161,18 +175,27 @@ single blank or disjoint page rather than averaging it away.
 
 An attempted explicit `Calibri Light -> Carlito` browser fallback was rejected: it worsened the
 accepted-revision case (SSIM 0.93177 to 0.92905; ink F1 0.46817 to 0.42477) despite a small SSIM gain
-on the TOC. Font substitution therefore remains an observed environment variable, not a hidden
-renderer heuristic.
+on the TOC. That result was the diagnosis, not a dead end — changing ONE engine's mind made the two
+disagree more, because LibreOffice was already resolving Calibri Light through its own substitution
+table. Issue #379 resolves it where it belongs: a fontconfig fragment both engines read, which moves
+the same case to SSIM 0.95011 / ink F1 0.62634. Font substitution is now a declared, verified
+contract rather than either an observed variable or a hidden renderer heuristic.
 
 ## Prioritized next work
 
 The former first priority (blank charts), the PR #372 rerun, aligned tab geometry,
-header/body/footer vertical placement (issue #377), and footnote block placement (issue #378) are
-resolved above. The remaining order is:
+header/body/footer vertical placement (issue #377), footnote block placement (issue #378), and the
+shared font-substitution contract (issue #379) are resolved above. The remaining order is:
 
 1. Correct drawing-anchor offsets with a generated textbox geometry regression.
-2. Define and provision one font-substitution contract shared by Chromium and LibreOffice CI before
-   treating paragraph-wrap differences as renderer regressions (issue #379).
+2. Investigate the paragraph line-height differences the font contract now exposes on
+   `fields-and-tabs`, `landscape-section`, and `inline-image` — with the fonts pinned, these are
+   renderer signals rather than environment noise.
+3. Make the paginator's 60% note-area cap defer rather than clip. A page whose citations would
+   fill more than that share admits more notes than it leaves room for, and the surplus is cut off
+   by the note block's `overflow: hidden` — 187 px on a generated twelve-note page, reproduced
+   identically before issue #378's changes, so it is a question about the cap and not about the
+   note block's composition.
 
 The list-margin discrepancy should not be changed merely to imitate LibreOffice: current evidence
 supports Docxodus's use of the declared OOXML margin. LibreOffice is a comparison implementation, not

--- a/npm/tests/visual-parity/README.md
+++ b/npm/tests/visual-parity/README.md
@@ -28,11 +28,9 @@ output directory so stale pages cannot contaminate a rerun.
   raster pixel.
 - LibreOffice exports PDF from a fresh per-document user profile. Poppler rasterizes the PDF at
   exactly 96 DPI.
-- Both processes use `C.UTF-8`, UTC, and the host fontconfig installation. The summary records the
-  Chromium, LibreOffice, Poppler, Calibri/Calibri Light substitutes, and Times New Roman substitute.
-  A missing Office font remains a triage signal rather than something the benchmark masks: for
-  example, a host may map Calibri Light to Noto Sans while LibreOffice applies its own substitution,
-  changing line wraps even when the renderer's OOXML geometry is correct.
+- Both processes use `C.UTF-8`, UTC, and the **shared font-substitution contract** below. The
+  summary records the Chromium, LibreOffice, and Poppler versions, and the exact font file each
+  declared family resolved to in this run.
 - The comparison uses final-revision view: insertions are included and deletions/move markup are not
   rendered. LibreOffice's headless PDF filter follows the file's saved redline-display state and
   provides no final-view switch, so manifest cases marked `revisionMode: 'accepted'` are accepted
@@ -46,6 +44,103 @@ output directory so stale pages cannot contaminate a rerun.
   chosen offset is always reported.
 - No masks are applied. A future mask must be a bounded rectangle tied to one manifest case/page and
   carry a specific justification; a document-wide or text-wide mask is not acceptable.
+
+## Font-substitution contract
+
+Neither engine ships Microsoft's Office fonts, so every Office family a fixture names is
+substituted. When the two engines substitute *differently*, their line breaking and baselines
+differ for reasons that have nothing to do with Docxodus — and a benchmark that cannot tell that
+apart from a renderer regression is not measuring the renderer.
+
+The policy is therefore **shared by both engines**, not implemented in one of them. A
+Chromium-only `Calibri Light → Carlito` fallback was tried and rejected: it made one engine change
+its mind, so the two disagreed *more* than before (accepted-revision SSIM 0.93177 → 0.92905, ink F1
+0.46817 → 0.42477). Chromium and LibreOffice both resolve families through fontconfig on Linux, so
+one fontconfig fragment governs both by construction.
+
+| Family | Substitute | Package | Metric clone |
+|---|---|---|---|
+| Calibri | Carlito | `fonts-crosextra-carlito` | yes |
+| Cambria | Caladea | `fonts-crosextra-caladea` | yes |
+| Times New Roman | Liberation Serif | `fonts-liberation2` | yes |
+| Arial | Liberation Sans | `fonts-liberation2` | yes |
+| Courier New | Liberation Mono | `fonts-liberation2` | yes |
+| Calibri Light | Carlito | `fonts-crosextra-carlito` | **no** |
+
+Calibri Light has no metric-compatible free clone — Carlito ships no Light weight. Left unbound it
+falls through to whichever generic sans each engine happens to prefer, which is exactly the
+non-determinism the contract removes. Binding it is a choice about *agreement*, not fidelity: text
+set in Calibri Light will not wrap where Word wraps it, and that must not be "corrected" in one
+renderer.
+
+The contract lives in exactly two places, and `font-contract.spec.ts` fails if they drift apart:
+
+- `fontconfig/60-docxodus-office-substitutes.conf` — what the engines read.
+- `fonts.ts` — what the run reports and verifies (`FONT_SUBSTITUTION_CONTRACT`).
+
+No font is bundled with this repository, and nothing here affects the library at run time.
+
+### Applying it
+
+The benchmark applies the fragment itself: it writes a fontconfig root outside the checkout that
+layers the fragment over the host's own configuration, and points both Chromium (through the
+browser launch environment) and every LibreOffice subprocess at it. Nothing is written into your
+home directory or `/etc`. You only need the packages:
+
+```bash
+sudo apt-get install -y fonts-liberation2 fonts-crosextra-carlito fonts-crosextra-caladea
+```
+
+To install the contract permanently instead — which is what CI does, and what makes other tools on
+the machine agree too:
+
+```bash
+sudo cp npm/tests/visual-parity/fontconfig/60-docxodus-office-substitutes.conf /etc/fonts/conf.d/
+fc-cache -f
+fc-match "Calibri Light"   # => Carlito
+```
+
+Then run with `DOCXODUS_VISUAL_PARITY_HOST_FONTS=1` to measure the host configuration as it is,
+rather than layering the fragment again.
+
+### When the contract is unavailable
+
+The run resolves every declared family through `fc-match` before either engine starts. If any
+family resolves to the wrong substitute the run **skips** with a message naming the family and the
+package to install. It never proceeds and reports numbers produced by an unknown font environment.
+
+Skipping is right for a developer who has not installed the fonts and wrong for a machine that is
+supposed to have them, where it would turn the benchmark into a green no-op that produces no
+report. `DOCXODUS_VISUAL_PARITY_REQUIRE_FONTS=1` turns the skip into a failure; CI sets it
+alongside `DOCXODUS_VISUAL_PARITY_HOST_FONTS=1` so the permanent `/etc/fonts/conf.d` install above
+is the thing being verified. It is deliberately separate from
+`DOCXODUS_VISUAL_PARITY_STRICT=1`, which is about the corpus verdict — several cases are
+legitimately severe today, so corpus strictness cannot be used to police the font environment.
+
+### The drift probe
+
+A generated probe document — one short, non-wrapping line and one long, wrapping paragraph per
+declared family — is rendered by both engines before the corpus. The comparison is between the two
+**engines**, not against a stored expectation:
+
+- the short line's **advance** must agree within 3 px. This is pure font resolution, so the
+  tolerance can sit just above hinting noise; a different face moves it by tens of pixels.
+- the page's total **line count** must match, which is what a different face does to a paragraph
+  long enough to wrap.
+
+Break *positions* are deliberately not compared. With the contract satisfied and both engines
+confirmed on Caladea, the Cambria paragraph's widest line still ends 34 px apart: the engines break
+identically-measured text differently. That is a real difference and worth knowing, but it is not
+font drift, and a probe that conflates the two explains nothing.
+
+A probe failure is reported as *font environment drift, not a renderer regression*, and the
+per-family advances are recorded in `summary.json` so two reports can be compared directly.
+
+`font-contract.spec.ts` runs in the ordinary browser suite (no LibreOffice needed) and pins the
+fragment against `fonts.ts`, the drift detector's sensitivity, and its noise tolerance.
+
+Committed-screenshot specs such as `tabs-visual.spec.ts` are **not** governed by this contract:
+they compare against images baked on one machine, so they remain environment-sensitive by design.
 
 ## Metrics and thresholds
 
@@ -73,8 +168,9 @@ keeps the initial baseline useful while known unsupported content is being triag
 
 ## Run locally
 
-Prerequisites: `libreoffice`, `pdftoppm`, Chromium installed for Playwright, and the repository's npm
-dependencies.
+Prerequisites: `libreoffice`, `pdftoppm`, `fontconfig`, the contract's font packages (see
+[Font-substitution contract](#font-substitution-contract)), Chromium installed for Playwright, and
+the repository's npm dependencies.
 
 ```bash
 cd npm

--- a/npm/tests/visual-parity/font-probe.ts
+++ b/npm/tests/visual-parity/font-probe.ts
@@ -1,0 +1,259 @@
+import { storedZip, xml, W_NS } from '../docx-zip.js';
+import type { RgbaImage } from './png.js';
+import { FONT_SUBSTITUTION_CONTRACT } from './fonts.js';
+
+/**
+ * The synthetic probe that tells a renderer regression apart from a change in the font
+ * environment.
+ *
+ * Both quantities it measures are functions of the glyph advances each engine actually got, so
+ * if one of them silently starts using a different face — a package removed, the fontconfig
+ * fragment not applied, a new distro default — the probe moves, and every corpus score that moved
+ * with it did not move because of this repository. It is deliberately NOT compared against a
+ * stored expectation: it compares the two engines to EACH OTHER on a document whose only variable
+ * is the font.
+ *
+ * Two halves, because they fail differently:
+ *
+ * - a short line that cannot wrap, compared by its ADVANCE. This is pure font resolution: no
+ *   line-breaking policy is involved, so the tolerance can be tight.
+ * - a long paragraph that wraps, compared by its LINE COUNT. Substituting a different face over
+ *   a paragraph this long changes how many lines it takes.
+ *
+ * The wrapping half is deliberately not compared by break POSITION. Measured on this host with
+ * the contract satisfied and both engines confirmed on Caladea, the Cambria paragraph's widest
+ * line still ended 34 px apart — the engines break identically-measured text differently. That is
+ * a real difference, and one this benchmark exists to surface, but it is not font drift, and a
+ * probe that cannot tell them apart is no better than the corpus scores it is meant to explain.
+ */
+
+/** Fixed prose: no numerals or punctuation clusters, so the metrics come from the letters. */
+const WRAPPING_TEXT = [
+  'The quick brown fox jumps over the lazy dog while the mist settles on the far river bank',
+  'and every careful compositor watches the measure fill and wonders where the line will break',
+  'before the paragraph reaches its final word.',
+].join(' ');
+
+/** Short enough to never reach the measure, in any of the declared families. */
+const ADVANCE_TEXT = 'Docxodus font substitution contract';
+
+const PAGE_WIDTH_TWIPS = 12240;
+const PAGE_HEIGHT_TWIPS = 15840;
+const MARGIN_TWIPS = 1440;
+/** Half-point units, i.e. 11 pt — the size Word's own defaults use. */
+const PROBE_SIZE_HALF_POINTS = 22;
+/**
+ * 1.5 line spacing. Single-spaced serif lines can leave no fully blank raster row between them,
+ * which merges two lines into one ink band — and a band count that depends on the font's
+ * ascenders is not a measurement of anything.
+ */
+const PROBE_LINE_TWENTIETHS = 360;
+
+/** The families the probe exercises, in the order their paragraphs appear. */
+export const PROBE_FAMILIES = FONT_SUBSTITUTION_CONTRACT.map(entry => entry.family);
+
+function paragraph(family: string, text: string): string {
+  return `<w:p><w:pPr>` +
+    `<w:spacing w:before="0" w:after="240" w:line="${PROBE_LINE_TWENTIETHS}" w:lineRule="auto"/>` +
+    `</w:pPr><w:r><w:rPr>` +
+    `<w:rFonts w:ascii="${family}" w:hAnsi="${family}" w:cs="${family}"/>` +
+    `<w:sz w:val="${PROBE_SIZE_HALF_POINTS}"/><w:szCs w:val="${PROBE_SIZE_HALF_POINTS}"/>` +
+    `</w:rPr><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+}
+
+/**
+ * The advance lines first, one per family, then the wrapping paragraphs. The order matters: the
+ * first {@link PROBE_FAMILIES}`.length` ink bands are the advance lines, which is how the
+ * comparison finds them without having to guess from their width.
+ */
+export function generateFontProbeDocx(): Uint8Array {
+  const body =
+    PROBE_FAMILIES.map(family => paragraph(family, ADVANCE_TEXT)).join('') +
+    PROBE_FAMILIES.map(family => paragraph(family, WRAPPING_TEXT)).join('');
+
+  return storedZip([
+    {
+      name: '[Content_Types].xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
+</Types>`),
+    },
+    {
+      name: '_rels/.rels',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`),
+    },
+    {
+      name: 'word/_rels/document.xml.rels',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+</Relationships>`),
+    },
+    {
+      name: 'word/styles.xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles xmlns:w="${W_NS}">
+  <w:docDefaults><w:rPrDefault><w:rPr>
+    <w:sz w:val="${PROBE_SIZE_HALF_POINTS}"/><w:szCs w:val="${PROBE_SIZE_HALF_POINTS}"/>
+  </w:rPr></w:rPrDefault></w:docDefaults>
+  <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+</w:styles>`),
+    },
+    {
+      name: 'word/document.xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="${W_NS}"><w:body>
+  ${body}
+  <w:sectPr>
+    <w:pgSz w:w="${PAGE_WIDTH_TWIPS}" w:h="${PAGE_HEIGHT_TWIPS}"/>
+    <w:pgMar w:top="${MARGIN_TWIPS}" w:right="${MARGIN_TWIPS}" w:bottom="${MARGIN_TWIPS}"
+             w:left="${MARGIN_TWIPS}" w:header="720" w:footer="720" w:gutter="0"/>
+  </w:sectPr>
+</w:body></w:document>`),
+    },
+  ]);
+}
+
+/** One rendered line of text: the extent of its ink. */
+export interface InkLine {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+}
+
+const INK_LUMINANCE_THRESHOLD = 200;
+/** Rows this close together belong to the same line; a wider gap starts a new one. */
+const LINE_GAP_ROWS = 3;
+
+/** Every horizontal band of ink in `image`, top to bottom. */
+export function inkLines(image: RgbaImage): InkLine[] {
+  const { width, height, data } = image;
+  const rows: Array<{ left: number; right: number } | null> = [];
+  for (let y = 0; y < height; y++) {
+    let left = -1;
+    let right = -1;
+    for (let x = 0; x < width; x++) {
+      const i = (y * width + x) * 4;
+      const luminance = (data[i] * 299 + data[i + 1] * 587 + data[i + 2] * 114) / 1000;
+      if (data[i + 3] > 16 && luminance < INK_LUMINANCE_THRESHOLD) {
+        if (left < 0) left = x;
+        right = x;
+      }
+    }
+    rows.push(left < 0 ? null : { left, right });
+  }
+
+  const lines: InkLine[] = [];
+  let y = 0;
+  while (y < height) {
+    if (!rows[y]) { y++; continue; }
+    let end = y;
+    let cursor = y;
+    while (cursor < height) {
+      if (rows[cursor]) { end = cursor; cursor++; continue; }
+      let gap = cursor;
+      while (gap < height && !rows[gap]) gap++;
+      if (gap - cursor <= LINE_GAP_ROWS && gap < height) { cursor = gap; continue; }
+      break;
+    }
+    const spanned = rows.slice(y, end + 1).filter((row): row is { left: number; right: number } => !!row);
+    lines.push({
+      top: y,
+      bottom: end,
+      left: Math.min(...spanned.map(row => row.left)),
+      right: Math.max(...spanned.map(row => row.right)),
+    });
+    y = end + 1;
+  }
+  return lines;
+}
+
+export interface FontProbeAdvance {
+  family: string;
+  docxodusPx: number;
+  libreofficePx: number;
+  deltaPx: number;
+}
+
+export interface FontProbeResult {
+  /** Ink lines each engine rendered across the whole probe page. */
+  docxodusLines: number;
+  libreofficeLines: number;
+  /** Per-family advance of the non-wrapping line, in pixels at 96 DPI. */
+  advances: FontProbeAdvance[];
+  maxAdvanceDeltaPx: number;
+  agreed: boolean;
+  problem: string;
+}
+
+/**
+ * Rasteriser and hinting differences move a short line's end by a pixel or two; a different face
+ * moves it by tens. The tolerance sits between them.
+ */
+export const PROBE_ADVANCE_TOLERANCE_PX = 3;
+
+export function compareProbeLines(docxodus: InkLine[], libreoffice: InkLine[]): FontProbeResult {
+  const families = PROBE_FAMILIES;
+  const base: FontProbeResult = {
+    docxodusLines: docxodus.length,
+    libreofficeLines: libreoffice.length,
+    advances: [],
+    maxAdvanceDeltaPx: 0,
+    agreed: true,
+    problem: '',
+  };
+
+  // The wrapping half: substituting a different face over paragraphs this long changes how many
+  // lines they take. Compared as a count, not as break positions — see the note at the top.
+  if (docxodus.length !== libreoffice.length) {
+    return {
+      ...base,
+      agreed: false,
+      problem: `the engines wrapped the probe into different line counts ` +
+        `(Docxodus ${docxodus.length}, LibreOffice ${libreoffice.length}); ` +
+        `they are not using the same faces`,
+    };
+  }
+  if (docxodus.length < families.length) {
+    return {
+      ...base,
+      agreed: false,
+      problem: `the probe rendered only ${docxodus.length} lines, fewer than its ` +
+        `${families.length} advance lines; the probe document did not render as authored`,
+    };
+  }
+
+  // The advance half: the first line per family cannot wrap, so its width is the face's own.
+  base.advances = families.map((family, index) => {
+    const a = docxodus[index];
+    const b = libreoffice[index];
+    const advance = {
+      family,
+      docxodusPx: a.right - a.left,
+      libreofficePx: b.right - b.left,
+      deltaPx: Math.abs((a.right - a.left) - (b.right - b.left)),
+    };
+    base.maxAdvanceDeltaPx = Math.max(base.maxAdvanceDeltaPx, advance.deltaPx);
+    return advance;
+  });
+
+  const drifted = base.advances.filter(a => a.deltaPx > PROBE_ADVANCE_TOLERANCE_PX);
+  if (drifted.length) {
+    return {
+      ...base,
+      agreed: false,
+      problem: `the engines measured ${drifted.map(a =>
+        `${a.family} ${a.deltaPx} px apart (${a.docxodusPx} vs ${a.libreofficePx})`).join(', ')} ` +
+        `against a ${PROBE_ADVANCE_TOLERANCE_PX} px tolerance; they resolved different faces`,
+    };
+  }
+  return base;
+}

--- a/npm/tests/visual-parity/fontconfig/60-docxodus-office-substitutes.conf
+++ b/npm/tests/visual-parity/fontconfig/60-docxodus-office-substitutes.conf
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+
+<!--
+  Docxodus visual-parity font-substitution contract.
+
+  Chromium and LibreOffice both resolve families through fontconfig on Linux, so binding the
+  Office families here makes the two engines substitute IDENTICALLY. That is the whole point: a
+  benchmark whose engines disagree about which font a document is set in cannot tell a renderer
+  regression from a font-environment change.
+
+  The bindings match the metric-compatible clones the distributions already package
+  (fonts-crosextra-carlito, fonts-crosextra-caladea, fonts-liberation2). No font is bundled with
+  this repository, and nothing here is used by the library at run time — it governs the benchmark
+  host only.
+
+  `binding="same"` keeps the substitute's own metrics, which is what a metric clone is for.
+  The declarations are duplicated as a `family` edit under `target="pattern"` so a request that
+  names the family directly (as fontconfig's own 30-metric-aliases.conf does) is rewritten before
+  matching, rather than only being consulted as a weak fallback.
+
+  Keep in step with FONT_SUBSTITUTION_CONTRACT in ../fonts.ts; `resolveFontContract()` verifies
+  that this file and that list agree, and the run reports the resolved file for each family.
+-->
+<fontconfig>
+
+  <alias binding="same"><family>Calibri</family><accept><family>Carlito</family></accept></alias>
+  <alias binding="same"><family>Cambria</family><accept><family>Caladea</family></accept></alias>
+  <alias binding="same"><family>Times New Roman</family><accept><family>Liberation Serif</family></accept></alias>
+  <alias binding="same"><family>Arial</family><accept><family>Liberation Sans</family></accept></alias>
+  <alias binding="same"><family>Courier New</family><accept><family>Liberation Mono</family></accept></alias>
+
+  <!--
+    Calibri Light has no metric-compatible free clone: Carlito ships no Light weight. Unbound it
+    falls through to whichever generic sans each engine happens to prefer, which is exactly the
+    non-determinism this file exists to remove. Binding it to Carlito is a choice about AGREEMENT,
+    not about fidelity — text set in Calibri Light will not wrap where Word wraps it, and that
+    difference must not be "corrected" in one renderer.
+  -->
+  <match target="pattern">
+    <test qual="any" name="family"><string>Calibri Light</string></test>
+    <edit name="family" mode="assign" binding="same"><string>Carlito</string></edit>
+  </match>
+
+</fontconfig>

--- a/npm/tests/visual-parity/fonts.ts
+++ b/npm/tests/visual-parity/fonts.ts
@@ -1,0 +1,133 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The font-substitution contract shared by both renderers.
+ *
+ * Neither Chromium nor LibreOffice ships Microsoft's Office fonts, so every Office family a
+ * fixture names is SUBSTITUTED. When the two engines substitute differently, their line breaking
+ * and baselines differ for reasons that have nothing to do with Docxodus — and a benchmark that
+ * cannot tell those apart from renderer regressions is not measuring the renderer.
+ *
+ * The fix has to be shared, not renderer-side. A Chromium-only `Calibri Light -> Carlito`
+ * fallback was tried and rejected: it made ONE engine change its mind, so the two disagreed more
+ * than before (accepted-revision SSIM 0.93177 -> 0.92905, ink F1 0.46817 -> 0.42477). Both
+ * engines read fontconfig on Linux, so ONE fontconfig fragment governs both, by construction.
+ *
+ * Nothing here bundles a font. Carlito, Caladea, and the Liberation family are the metric-
+ * compatible, freely redistributable substitutes the distributions already package; the contract
+ * only pins WHICH of them each Office family must resolve to.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export interface FontSubstitution {
+  /** The family a document names. */
+  family: string;
+  /** The family both renderers must resolve it to. */
+  substitute: string;
+  /** Where the substitute comes from, for the setup instructions and the failure message. */
+  package: string;
+  /**
+   * Whether the substitute is metrically compatible with the original. `false` means no
+   * license-safe metric clone exists, so the contract's job is agreement between the engines
+   * rather than fidelity to Word — worth stating, because such a family's wrap points are
+   * expected to differ from Word's and must not be "fixed" in one renderer.
+   */
+  metricCompatible: boolean;
+}
+
+export const FONT_SUBSTITUTION_CONTRACT: readonly FontSubstitution[] = [
+  { family: 'Calibri', substitute: 'Carlito', package: 'fonts-crosextra-carlito', metricCompatible: true },
+  { family: 'Cambria', substitute: 'Caladea', package: 'fonts-crosextra-caladea', metricCompatible: true },
+  { family: 'Times New Roman', substitute: 'Liberation Serif', package: 'fonts-liberation2', metricCompatible: true },
+  { family: 'Arial', substitute: 'Liberation Sans', package: 'fonts-liberation2', metricCompatible: true },
+  { family: 'Courier New', substitute: 'Liberation Mono', package: 'fonts-liberation2', metricCompatible: true },
+  // Carlito has no Light weight, and no freely redistributable font is metrically compatible with
+  // Calibri Light. Left unbound it falls through to whatever generic each engine prefers — here
+  // Chromium and LibreOffice both landed on Noto Sans, but that is an accident of this host, not
+  // a contract. Binding it makes the choice explicit and identical in both engines.
+  { family: 'Calibri Light', substitute: 'Carlito', package: 'fonts-crosextra-carlito', metricCompatible: false },
+];
+
+/** The apt packages a Debian/Ubuntu host needs for the whole contract. */
+export const FONT_CONTRACT_PACKAGES = [...new Set(
+  FONT_SUBSTITUTION_CONTRACT.map(entry => entry.package))].sort();
+
+/** The shipped fontconfig fragment that binds the contract for every application on the host. */
+export const FONTCONFIG_FRAGMENT = resolve(
+  __dirname, 'fontconfig', '60-docxodus-office-substitutes.conf');
+
+export interface ResolvedFont extends FontSubstitution {
+  /** The family `fc-match` actually returned. */
+  resolvedFamily: string;
+  /** The font file backing it, so a report records the exact bytes that were rendered. */
+  resolvedFile: string;
+  satisfied: boolean;
+}
+
+export interface FontContractStatus {
+  satisfied: boolean;
+  entries: ResolvedFont[];
+  /** Human-readable reason, empty when satisfied. */
+  problem: string;
+  /** The fontconfig configuration in force, so a report can be reproduced. */
+  fontconfigFile: string;
+}
+
+function fcMatch(family: string, env: NodeJS.ProcessEnv): { family: string; file: string } {
+  const result = spawnSync('fc-match', [family, '--format=%{family}\\t%{file}'],
+    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], env });
+  if (result.error || result.status !== 0) return { family: '', file: '' };
+  const [matched = '', file = ''] = result.stdout.trim().split('\t');
+  return { family: matched, file };
+}
+
+/**
+ * A fontconfig root that layers {@link FONTCONFIG_FRAGMENT} over the host's own configuration.
+ *
+ * Written outside the repository and pointed at through `FONTCONFIG_FILE`, so the contract binds
+ * the benchmark's two subprocesses WITHOUT installing anything into the developer's home
+ * directory or `/etc`. CI can install the fragment permanently instead; the effect is the same.
+ */
+export function writeFontconfigRoot(directory: string): string {
+  mkdirSync(directory, { recursive: true });
+  const path = join(directory, 'fonts.conf');
+  writeFileSync(path, `<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<!-- Generated by npm/tests/visual-parity/fonts.ts. Host configuration first, contract last. -->
+<fontconfig>
+  <include ignore_missing="yes">/etc/fonts/fonts.conf</include>
+  <include ignore_missing="yes">${FONTCONFIG_FRAGMENT}</include>
+</fontconfig>
+`);
+  return path;
+}
+
+/** Resolves every declared family through `fc-match` under `env` and reports the contract state. */
+export function resolveFontContract(env: NodeJS.ProcessEnv = process.env): FontContractStatus {
+  const entries = FONT_SUBSTITUTION_CONTRACT.map<ResolvedFont>(entry => {
+    const matched = fcMatch(entry.family, env);
+    return {
+      ...entry,
+      resolvedFamily: matched.family,
+      resolvedFile: matched.file,
+      satisfied: matched.family === entry.substitute,
+    };
+  });
+
+  const broken = entries.filter(entry => !entry.satisfied);
+  const missingPackages = [...new Set(broken.map(entry => entry.package))].sort();
+  return {
+    satisfied: broken.length === 0,
+    entries,
+    problem: broken.length === 0 ? '' :
+      `font substitution contract unsatisfied: ` +
+      broken.map(e => `${e.family} -> ${e.resolvedFamily || '(no match)'} (want ${e.substitute})`).join('; ') +
+      `. Install ${missingPackages.join(' ')} and apply ${FONTCONFIG_FRAGMENT} ` +
+      `(see npm/tests/visual-parity/README.md).`,
+    fontconfigFile: env.FONTCONFIG_FILE ?? '(host default)',
+  };
+}


### PR DESCRIPTION
Closes #378. **Stacked on #382 (issue #377)** — review that first; this PR targets its branch.

## Problem

The note area is bottom-aligned to the body text band, so the block's **height is its position**: every point of slack anywhere inside it lifts everything above it by the same amount. That is why the note text and the already-correct two-inch separator were *both* ~13 px too high, and why correcting the separator's *width* could not move it. The issue asked to "isolate the note-area vertical origin from the already-correct separator width" — the answer is that they were never independent.

Measured in Chromium against the rendered DOM (`CA008-Footnote-Reference.docx`, 1 in margins, body band bottom at y=960):

| | before | after | LibreOffice |
|---|---:|---:|---:|
| note block bottom | 960 | 960 | 960 |
| block height | 37.5 px | 20.7 px | ~24 px |
| separator rule (ink) | y 922 | y 939 | y 936–937 |
| note text (ink) | y 935–948 | y 944–955 | y 946–955 |

## Fix

Four pieces of slack, all CSS habits rather than OOXML:

1. **`.footnote-item { margin-bottom: 4pt }`** put dead space *below the last note* — beneath the very content whose bottom edge is the anchor. Spacing now falls between notes (`+ .footnote-item`), so the last note ends on the edge the block is anchored to.
2. **The separator was a bare 1 px rule** with a hard-coded 6 pt gap under it and nothing above. ECMA-376 §17.11.23 makes `w:separator` a **run** in the separator note's paragraph, so it is laid out like any line of text: the band is now one line of the note font with the rule sitting on its baseline, and the space above and below comes from the document's own metrics instead of a tuned margin.
3. **`vertical-align: super`** on the note's reference mark grows the line box it sits in, so every note carried leading the document never asked for. A relative offset raises the glyph without doing that.
4. **`line-height: 1.4`** on `.page-footnotes` overrode the note style's own spacing. Word's note paragraphs are single-spaced unless their style says otherwise, and `w:lineRule="auto"` at 240 means exactly the font's line box — `normal` in CSS.

Two more things the same model implies, and one Blink trap:

- **`w:continuationSeparator`** (§17.11.5) — full text-column width — is now drawn on a page that opens with carried-over note text. The engine drew the ordinary two-inch separator on every page.
- **The back reference** is an HTML navigation affordance; a paginated page is a facsimile of paper, where Word and LibreOffice print nothing there. Likewise the reference mark now prints alone, without the `.` Word never writes. (Both are flagged here as deliberate additions beyond "vertical placement": they are ink on a printed page that the document does not contain, and they were found by the same measurement.)
- Blink gives **no strut** to a line whose only inline-level content is an atomic inline, so a band holding just the rule collapses to the rule's own 1 px. A zero-width word joiner in generated content makes the line real. Recorded in `docs/ooxml_corner_cases.md` with the run-not-rule semantics.

## Architecture

`PaginationEngine.buildNoteArea()` is now the single builder for a page's note area, used by the renderer **and** all four measurement paths (`measureFootnotesHeight`, `measureContinuationHeight`, `splitFootnoteToFit`, `measureSingleFootnoteHeight`). Those were four separate copies of the same markup, which is precisely how "how tall are the notes" and "what do the notes look like" could drift apart — and the separator/continuation-separator choice now lives in one place instead of nowhere.

## Tests

New `npm/tests/pagination-footnote-geometry.spec.ts` (6 tests) drives a **generated** DOCX — no new tracked fixture — through the real WASM converter and the paginator, and pins the separator and the note block **separately**, so a future change to one cannot be masked by a compensating change to the other:

- the block's bottom edge is the body band's bottom, and the last note ends on it;
- the separator band is one line of the note font, with real space above *and* below the rule, and the rule below the line's midpoint (baseline, not centre);
- the rule keeps Word's two-inch default width;
- note spacing appears between notes and never after the last;
- the body band never runs into the note block;
- a page opening with carried-over note text gets the full-width continuation separator, while the page the note *starts* on keeps the two-inch one.

It fails 5/6 on the pre-fix engine. `HCO091` in `Docxodus.Tests/HtmlConversionOpsTests.cs` pins the stylesheet composition; `HCO086` (two-inch width) is unchanged and still passes.

## Results

`footnote` moves from **severe** to **close**: SSIM 0.99218 → 0.99481, tolerant ink F1 0.56597 → **0.95875**. The separator lands within 2 px of LibreOffice's and the note text's bottom edge exactly on it.

Full 12-case corpus, no case regressed: mean SSIM 0.979855 → 0.979980, mean tolerant ink F1 0.835366 → **0.854069**, case severity 4 close/1 minor/7 severe → 5 close/1 minor/6 severe.

`dotnet test` 3421/3421 pass. Playwright suite passes except the four `tabs-visual` snapshots that fail identically on `main` in this environment (font substitution — #379) and one `editor-block-drag` flake that passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Follow-up commit: two coverage gaps closed

- **The body-band anchor had no discriminating test.** The fixture emitted no footer, so reverting the note anchor to `dims.marginBottom` kept all six assertions green — the one claim that couples this PR to #377 was untested. The fixture can now carry a footer story, and a new case gives it enough lines to reach above its own margin (the only shape that separates the two anchors), asserting the block ends where the *raised* body band ends, strictly above the raw margin, and clear of the footer band. Reverting the anchor fails it.
- **`line-height: normal` had one one-line note behind it.** It is what moved the tracked case from ink F1 0.735 → 0.959, and it changes every paginated note whose style declares no spacing. A ten-note, three-line document spread across pages now pins that the block stays bottom-aligned, the last note stays flush, body never overlaps notes, and no cited note is lost.
- `buildNoteArea` now sets the same `overflow: hidden` the rendered block has, so the measured box is a BFC too — equivalent today only because the block carries no edge margins, which is exactly why it is worth stating.

Observed while writing those, and explicitly **not** changed here: crowding many notes onto one page runs into the flow loop's separate 60% note-area cap, which admits more notes than it leaves room for and clips the overflow. Reproduced identically with this branch's `pagination.ts` reverted, so it is a pre-existing question about the cap, not about the block's composition.
