### PR TITLE
Declare one font-substitution contract both renderers obey

### DIFF
--- a/.github/workflows/visual-parity.yml
+++ b/.github/workflows/visual-parity.yml
@@ -75,6 +75,10 @@ jobs:
           DOCXODUS_VISUAL_PARITY_OUTPUT: ${{ runner.temp }}/docxodus-visual-parity
           DOCXODUS_VISUAL_PARITY_FILTER: ${{ inputs.filter }}
           DOCXODUS_VISUAL_PARITY_STRICT: ${{ inputs.strict && '1' || '0' }}
+          # Measure the SYSTEM install from the previous step rather than layering the fragment
+          # again. Otherwise the run would satisfy the contract by itself and a broken system
+          # install — the path the README tells humans to use — would never be exercised.
+          DOCXODUS_VISUAL_PARITY_HOST_FONTS: '1'
         run: cd npm && npm run test:visual-parity
 
       - name: Upload visual comparison report

--- a/.github/workflows/visual-parity.yml
+++ b/.github/workflows/visual-parity.yml
@@ -40,11 +40,26 @@ jobs:
         with:
           node-version: '22'
 
+      # The font set is half the contract: Carlito, Caladea, and the Liberation family are the
+      # freely redistributable metric clones of the Office families every fixture names. No font
+      # is vendored into this repository.
       - name: Install deterministic rendering tools and fonts
         run: >-
           sudo apt-get update && sudo apt-get install -y
           libreoffice-writer poppler-utils fonts-liberation2
           fonts-crosextra-carlito fonts-crosextra-caladea
+
+      # The other half: WHICH clone each family resolves to. Chromium and LibreOffice both read
+      # fontconfig, so installing the fragment system-wide makes them substitute identically —
+      # the run then measures the renderer instead of the host. The benchmark also layers this
+      # file in itself; installing it here makes the CI machine reproduce a local run exactly.
+      - name: Apply the shared font-substitution contract
+        run: |
+          sudo cp npm/tests/visual-parity/fontconfig/60-docxodus-office-substitutes.conf /etc/fonts/conf.d/
+          fc-cache -f
+          for family in Calibri "Calibri Light" Cambria "Times New Roman" Arial "Courier New"; do
+            printf '%-16s -> ' "$family"; fc-match "$family" --format='%{family} (%{file})\n'
+          done
 
       - name: Install npm dependencies
         run: cd npm && npm ci

--- a/.github/workflows/visual-parity.yml
+++ b/.github/workflows/visual-parity.yml
@@ -79,6 +79,10 @@ jobs:
           # again. Otherwise the run would satisfy the contract by itself and a broken system
           # install — the path the README tells humans to use — would never be exercised.
           DOCXODUS_VISUAL_PARITY_HOST_FONTS: '1'
+          # And having made the run depend on that install, require it: a machine that is supposed
+          # to have the fonts must fail loudly rather than skip, or the weekly run quietly becomes
+          # a green no-op that produces no report.
+          DOCXODUS_VISUAL_PARITY_REQUIRE_FONTS: '1'
         run: cd npm && npm run test:visual-parity
 
       - name: Upload visual comparison report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,32 @@ All notable changes to this project will be documented in this file.
   `npm/tests/demo-arcade.spec.ts` drives boot, keyboard steering, the
   pause→type→resume loop, and the save round-trip.
 
+### Changed
+- **The LibreOffice visual-parity benchmark declares one font-substitution
+  contract that both renderers obey.** Neither engine ships Microsoft's Office
+  fonts, so every Office family a fixture names is substituted — and when the two
+  substitute differently, their line breaking differs for reasons that have
+  nothing to do with this repository. The policy is now a fontconfig fragment
+  (`npm/tests/visual-parity/fontconfig/`) that Chromium and LibreOffice both read,
+  binding Calibri and Calibri Light to Carlito, Cambria to Caladea, and Times New
+  Roman / Arial / Courier New to the matching Liberation faces — all freely
+  redistributable metric clones the distributions package; no font is vendored.
+  The benchmark layers the fragment over the host's configuration outside the
+  checkout (nothing is written to `$HOME` or `/etc`), resolves every declared
+  family before either engine starts, records the exact font file each one used in
+  `summary.json`, and skips — or fails under `DOCXODUS_VISUAL_PARITY_STRICT=1` —
+  with the package to install rather than reporting numbers from an unknown font
+  environment. A generated probe compares the two engines' glyph advances and
+  wrapped line counts and reports a mismatch as *font environment drift, not a
+  renderer regression*; `npm/tests/font-contract.spec.ts` pins the fragment
+  against its TypeScript declaration and the detector's sensitivity, and needs no
+  LibreOffice. The earlier Chromium-only `Calibri Light → Carlito` fallback stays
+  rejected: it changed one engine's mind and made the two disagree more.
+  `tracked-deletion` improves (SSIM 0.93177 → 0.95011, ink F1 0.46817 → 0.62634)
+  now that both engines resolve Calibri Light identically; `fields-and-tabs` ink F1
+  drops (0.30164 → 0.15913, SSIM 0.88672 → 0.89415) because the substitution had
+  been masking a real TOC line-height difference.
+
 ### Fixed
 - **The paginated footnote block sits where Word puts it.** The note area is
   bottom-aligned to the body text band, so its height IS its position — every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,11 @@ All notable changes to this project will be documented in this file.
   `npm/tests/demo-arcade.spec.ts` drives boot, keyboard steering, the
   pause→type→resume loop, and the save round-trip.
 
-### Changed
-- **The LibreOffice visual-parity benchmark declares one font-substitution
-  contract that both renderers obey.** Neither engine ships Microsoft's Office
-  fonts, so every Office family a fixture names is substituted — and when the two
+### Fixed
+- **The LibreOffice visual-parity benchmark could not tell a renderer regression
+  from a change in the font environment.** (Benchmark infrastructure; no public
+  surface changes.) Neither engine ships Microsoft's Office fonts, so every
+  Office family a fixture names is substituted — and when the two
   substitute differently, their line breaking differs for reasons that have
   nothing to do with this repository. The policy is now a fontconfig fragment
   (`npm/tests/visual-parity/fontconfig/`) that Chromium and LibreOffice both read,
@@ -55,8 +56,6 @@ All notable changes to this project will be documented in this file.
   now that both engines resolve Calibri Light identically; `fields-and-tabs` ink F1
   drops (0.30164 → 0.15913, SSIM 0.88672 → 0.89415) because the substitution had
   been masking a real TOC line-height difference.
-
-### Fixed
 - **The paginated footnote block sits where Word puts it.** The note area is
   bottom-aligned to the body text band, so its height IS its position — every
   point of slack inside it lifts everything above it, which is why the note text

--- a/npm/tests/font-contract.spec.ts
+++ b/npm/tests/font-contract.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect } from '@playwright/test';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import {
+  FONT_CONTRACT_PACKAGES,
+  FONT_SUBSTITUTION_CONTRACT,
+  FONTCONFIG_FRAGMENT,
+  resolveFontContract,
+} from './visual-parity/fonts.js';
+import {
+  compareProbeLines,
+  PROBE_ADVANCE_TOLERANCE_PX,
+  PROBE_FAMILIES,
+  type InkLine,
+} from './visual-parity/font-probe.js';
+
+/**
+ * Issue #379 — the font-substitution contract itself, checked without needing LibreOffice.
+ *
+ * The visual-parity benchmark is opt-in and host-dependent; this spec is not. It pins the two
+ * things that would silently rot between benchmark runs: the shipped fontconfig fragment agreeing
+ * with the TypeScript declaration of the same contract, and the drift detector actually
+ * detecting drift.
+ */
+
+/** One ink line per entry, `right - left` wide, at an arbitrary but consistent y. */
+function lines(widths: number[]): InkLine[] {
+  return widths.map((width, index) => ({
+    top: index * 30,
+    bottom: index * 30 + 12,
+    left: 96,
+    right: 96 + width,
+  }));
+}
+
+/** The advance lines the probe compares, followed by some wrapped ones it only counts. */
+function probePage(advances: number[], wrapped = [600, 600, 400]): InkLine[] {
+  return lines([...advances, ...wrapped]);
+}
+
+const BASELINE_ADVANCES = [210, 213, 208, 226, 304, 210];
+
+test.describe('Font substitution contract', () => {
+  /** Every family→substitute binding the fragment actually declares, in either fontconfig form. */
+  function fragmentBindings(fragment: string): Map<string, string> {
+    const bindings = new Map<string, string>();
+    const aliases = fragment.matchAll(
+      /<alias[^>]*>\s*<family>([^<]+)<\/family>\s*<accept>\s*<family>([^<]+)<\/family>/g);
+    for (const [, family, substitute] of aliases) bindings.set(family, substitute);
+    const matches = fragment.matchAll(
+      /<test[^>]*name="family"[^>]*>\s*<string>([^<]+)<\/string>[\s\S]*?<edit name="family"[^>]*>\s*<string>([^<]+)<\/string>/g);
+    for (const [, family, substitute] of matches) bindings.set(family, substitute);
+    return bindings;
+  }
+
+  test('the shipped fontconfig fragment binds exactly the declared families', () => {
+    // Both engines read the fragment; the TypeScript list is only how the run REPORTS the
+    // contract. If they drift apart, every report describes a policy the renderers do not follow.
+    const bindings = fragmentBindings(readFileSync(FONTCONFIG_FRAGMENT, 'utf8'));
+    const declared = new Map(FONT_SUBSTITUTION_CONTRACT.map(e => [e.family, e.substitute]));
+
+    expect(Object.fromEntries([...bindings].sort()))
+      .toEqual(Object.fromEntries([...declared].sort()));
+    expect(FONT_CONTRACT_PACKAGES.length).toBeGreaterThan(0);
+  });
+
+  test('the drift detector flags a substituted face', () => {
+    // Calibri Light resolved to Noto Sans in one engine and Carlito in the other: a 38 px
+    // difference on the probe's short line, which is what this tolerance exists to catch.
+    const drifted = [...BASELINE_ADVANCES];
+    drifted[5] += 38;
+
+    const result = compareProbeLines(probePage(BASELINE_ADVANCES), probePage(drifted));
+    expect(result.agreed).toBe(false);
+    expect(result.problem).toContain(PROBE_FAMILIES[5]);
+    expect(result.maxAdvanceDeltaPx).toBe(38);
+  });
+
+  test('the drift detector flags a different wrapped line count', () => {
+    const result = compareProbeLines(
+      probePage(BASELINE_ADVANCES, [600, 600, 400]),
+      probePage(BASELINE_ADVANCES, [600, 600, 600, 200]),
+    );
+    expect(result.agreed).toBe(false);
+    expect(result.problem).toContain('different line counts');
+  });
+
+  test('the drift detector tolerates rasterisation noise', () => {
+    // Hinting moves a short line's end by a pixel or two between engines; that is not drift.
+    const noisy = BASELINE_ADVANCES.map((width, index) =>
+      width + (index % 2 === 0 ? PROBE_ADVANCE_TOLERANCE_PX : -PROBE_ADVANCE_TOLERANCE_PX));
+
+    const result = compareProbeLines(probePage(BASELINE_ADVANCES), probePage(noisy));
+    expect(result.agreed, result.problem).toBe(true);
+    expect(result.maxAdvanceDeltaPx).toBe(PROBE_ADVANCE_TOLERANCE_PX);
+    expect(result.advances.map(a => a.family)).toEqual(PROBE_FAMILIES);
+  });
+
+  test('an unsatisfied contract reports what to install', () => {
+    test.skip(spawnSync('fc-match', ['--version']).error !== undefined,
+      'fontconfig is not installed on this host');
+
+    // Resolve against the HOST configuration, deliberately without the repository fragment. The
+    // result is whatever this machine happens to do — the assertion is about the report, not the
+    // machine: either the contract holds, or it says exactly which family and package are wrong.
+    const status = resolveFontContract({ ...process.env, FONTCONFIG_FILE: undefined });
+    expect(status.entries.map(entry => entry.family))
+      .toEqual(FONT_SUBSTITUTION_CONTRACT.map(entry => entry.family));
+
+    if (status.satisfied) {
+      expect(status.problem).toBe('');
+      for (const entry of status.entries) expect(entry.resolvedFile).not.toBe('');
+    } else {
+      const broken = status.entries.filter(entry => !entry.satisfied);
+      expect(broken.length).toBeGreaterThan(0);
+      for (const entry of broken) {
+        expect(status.problem).toContain(entry.family);
+        expect(status.problem).toContain(entry.package);
+      }
+      expect(status.problem).toContain('README.md');
+    }
+  });
+});

--- a/npm/tests/visual-parity.spec.ts
+++ b/npm/tests/visual-parity.spec.ts
@@ -17,6 +17,20 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { REQUIRED_VISUAL_CATEGORIES, VISUAL_PARITY_CORPUS, type VisualCorpusEntry } from './visual-parity/corpus.js';
 import { compareImages, VISUAL_THRESHOLDS, type PageMetrics, type VisualSeverity } from './visual-parity/metrics.js';
 import { decodePng, encodePng } from './visual-parity/png.js';
+import {
+  FONT_CONTRACT_PACKAGES,
+  FONTCONFIG_FRAGMENT,
+  resolveFontContract,
+  writeFontconfigRoot,
+  type FontContractStatus,
+} from './visual-parity/fonts.js';
+import {
+  compareProbeLines,
+  generateFontProbeDocx,
+  inkLines,
+  PROBE_FAMILIES,
+  type FontProbeResult,
+} from './visual-parity/font-probe.js';
 
 test.skip(process.env.DOCXODUS_VISUAL_PARITY !== '1',
   'set DOCXODUS_VISUAL_PARITY=1 on a host with libreoffice and pdftoppm');
@@ -24,6 +38,28 @@ test.skip(process.env.DOCXODUS_VISUAL_PARITY !== '1',
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '../..');
 const severityOrder: VisualSeverity[] = ['close', 'minor', 'major', 'severe'];
+
+/**
+ * The font-substitution contract has to be in force before EITHER engine starts, and Chromium's
+ * fontconfig is read when the browser process launches — which happens when the first test
+ * requests a page, after this module is evaluated. So the layered fontconfig root is written
+ * here, at import time, and handed to the browser through `test.use` below and to every
+ * LibreOffice subprocess through its env.
+ *
+ * `DOCXODUS_VISUAL_PARITY_HOST_FONTS=1` opts out and measures the host as it is, which is how you
+ * reproduce a report from a machine that installed the fragment permanently instead.
+ */
+const useHostFonts = process.env.DOCXODUS_VISUAL_PARITY_HOST_FONTS === '1';
+const fontconfigRoot = useHostFonts || process.env.DOCXODUS_VISUAL_PARITY !== '1'
+  ? undefined
+  : writeFontconfigRoot(mkdtempSync(join(tmpdir(), 'docxodus-visual-fontconfig-')));
+const fontEnv: NodeJS.ProcessEnv = fontconfigRoot
+  ? { ...process.env, FONTCONFIG_FILE: fontconfigRoot }
+  : process.env;
+
+if (fontconfigRoot) {
+  test.use({ launchOptions: { env: { ...process.env, FONTCONFIG_FILE: fontconfigRoot } } });
+}
 
 interface PageResult extends PageMetrics {
   page: number;
@@ -121,7 +157,7 @@ function renderLibreOffice(docxPath: string, work: string): string[] {
   for (const directory of [pdfDir, profileDir, runtimeDir, homeDir]) mkdirSync(directory, { mode: 0o700 });
 
   const deterministicEnv = {
-    ...process.env,
+    ...fontEnv,
     HOME: homeDir,
     XDG_RUNTIME_DIR: runtimeDir,
     LANG: 'C.UTF-8',
@@ -240,6 +276,46 @@ async function renderDocxodus(page: Page, docxPath: string, output: string): Pro
   return paths;
 }
 
+/**
+ * Renders the synthetic wrapping probe through both engines and reports whether they agree.
+ *
+ * This is the signal that separates a renderer regression from a font-environment change: the
+ * probe's only variable is which face each engine resolved, so when its lines stop matching, the
+ * corpus numbers that moved with them did not move because of this repository.
+ */
+async function runFontProbe(page: Page, outputRoot: string): Promise<FontProbeResult & {
+  families: string[];
+  artifacts: { docxodus: string; libreoffice: string };
+}> {
+  const probeOutput = join(outputRoot, 'font-probe');
+  mkdirSync(probeOutput, { recursive: true });
+  const work = mkdtempSync(join(tmpdir(), 'docxodus-font-probe-'));
+  try {
+    const probePath = join(work, 'font-probe.docx');
+    writeFileSync(probePath, generateFontProbeDocx());
+
+    const libreofficePages = renderLibreOffice(probePath, work);
+    const libreofficePng = join(probeOutput, 'libreoffice-1.png');
+    writeFileSync(libreofficePng, readFileSync(libreofficePages[0]));
+    const docxodusPages = await renderDocxodus(page, probePath, probeOutput);
+
+    const comparison = compareProbeLines(
+      inkLines(decodePng(readFileSync(docxodusPages[0]))),
+      inkLines(decodePng(readFileSync(libreofficePng))),
+    );
+    return {
+      ...comparison,
+      families: PROBE_FAMILIES,
+      artifacts: {
+        docxodus: relative(outputRoot, docxodusPages[0]),
+        libreoffice: relative(outputRoot, libreofficePng),
+      },
+    };
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
+}
+
 function worse(a: VisualSeverity, b: VisualSeverity): VisualSeverity {
   return severityOrder.indexOf(a) >= severityOrder.indexOf(b) ? a : b;
 }
@@ -276,11 +352,26 @@ test('stratified tracked corpus matches LibreOffice at pixel level', async ({ pa
   }
   mkdirSync(outputRoot, { recursive: true, mode: 0o700 });
 
+  // The font contract gates the whole run: without it the two engines can be set in different
+  // faces, and every number below would be measuring the host rather than the renderer.
+  const fontContract: FontContractStatus = resolveFontContract(fontEnv);
+  if (!fontContract.satisfied) {
+    const message = `${fontContract.problem}\nRequired packages: ${FONT_CONTRACT_PACKAGES.join(' ')}`;
+    if (process.env.DOCXODUS_VISUAL_PARITY_STRICT === '1') throw new Error(message);
+    test.skip(true, message);
+  }
+
   await page.setViewportSize({ width: 1400, height: 1000 });
   await page.emulateMedia({ reducedMotion: 'reduce' });
   await page.goto('/test-harness.html');
   await page.waitForFunction(() => (window as any).DocxodusReady === true, { timeout: 90000 });
   await page.addScriptTag({ url: '/pagination.bundle.js' });
+
+  const fontProbe = await runFontProbe(page, outputRoot);
+  console.log(fontProbe.agreed
+    ? `Font probe: engines agree on ${fontProbe.docxodusLines} lines ` +
+      `(worst advance delta ${fontProbe.maxAdvanceDeltaPx} px)`
+    : `Font probe: FONT ENVIRONMENT DRIFT — ${fontProbe.problem}`);
 
   const cases: CaseResult[] = [];
   for (const [caseIndex, entry] of corpus.entries()) {
@@ -374,12 +465,17 @@ test('stratified tracked corpus matches LibreOffice at pixel level', async ({ pa
       chromium: page.context().browser()?.version() ?? 'unknown',
       libreoffice: commandVersion('libreoffice', ['--version']),
       pdftoppm: commandVersion('pdftoppm', ['-v']).split('\n')[0],
-      calibriMatch: commandVersion('fc-match', ['Calibri', '--format=%{family} %{file}']),
-      calibriLightMatch: commandVersion('fc-match', ['Calibri Light', '--format=%{family} %{file}']),
-      timesNewRomanMatch: commandVersion('fc-match', ['Times New Roman', '--format=%{family} %{file}']),
       locale: 'C.UTF-8',
       timezone: 'UTC',
     },
+    // The exact faces both engines rendered with, so a rerun can tell a renderer change from a
+    // font-environment change instead of guessing.
+    fontContract: {
+      ...fontContract,
+      fragment: relative(repoRoot, FONTCONFIG_FRAGMENT),
+      source: useHostFonts ? 'host fontconfig (DOCXODUS_VISUAL_PARITY_HOST_FONTS=1)' : 'repository fragment',
+    },
+    fontProbe,
     coverage: Object.fromEntries(REQUIRED_VISUAL_CATEGORIES.map(category => [
       category,
       VISUAL_PARITY_CORPUS.filter(entry => entry.categories.includes(category)).map(entry => entry.id),
@@ -390,6 +486,11 @@ test('stratified tracked corpus matches LibreOffice at pixel level', async ({ pa
   const summaryPath = join(outputRoot, 'summary.json');
   writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
   console.log(`Visual parity report: ${summaryPath}`);
+
+  // Reported before the corpus verdict on purpose: when the probe fails, the corpus numbers are
+  // not evidence about the renderer, and saying so first keeps the two from being confused.
+  expect(fontProbe.agreed, `font environment drift, not a renderer regression: ${fontProbe.problem}`)
+    .toBe(true);
 
   if (process.env.DOCXODUS_VISUAL_PARITY_STRICT === '1') {
     expect(cases.filter(result => result.severity === 'severe'),

--- a/npm/tests/visual-parity.spec.ts
+++ b/npm/tests/visual-parity.spec.ts
@@ -354,10 +354,19 @@ test('stratified tracked corpus matches LibreOffice at pixel level', async ({ pa
 
   // The font contract gates the whole run: without it the two engines can be set in different
   // faces, and every number below would be measuring the host rather than the renderer.
+  //
+  // Skipping is right for a developer who has not installed the fonts, and wrong for a machine
+  // that is supposed to have them: there, a contract that silently stops holding turns the whole
+  // benchmark into a green no-op that produces no report. `REQUIRE_FONTS` is separate from
+  // `STRICT` on purpose — strictness is about the corpus verdict, several cases are legitimately
+  // severe today, and a host that cannot even set up its fonts must fail for that reason alone.
   const fontContract: FontContractStatus = resolveFontContract(fontEnv);
   if (!fontContract.satisfied) {
     const message = `${fontContract.problem}\nRequired packages: ${FONT_CONTRACT_PACKAGES.join(' ')}`;
-    if (process.env.DOCXODUS_VISUAL_PARITY_STRICT === '1') throw new Error(message);
+    if (process.env.DOCXODUS_VISUAL_PARITY_REQUIRE_FONTS === '1' ||
+        process.env.DOCXODUS_VISUAL_PARITY_STRICT === '1') {
+      throw new Error(message);
+    }
     test.skip(true, message);
   }
 

--- a/npm/tests/visual-parity/BASELINE.md
+++ b/npm/tests/visual-parity/BASELINE.md
@@ -191,6 +191,11 @@ shared font-substitution contract (issue #379) are resolved above. The remaining
 2. Investigate the paragraph line-height differences the font contract now exposes on
    `fields-and-tabs`, `landscape-section`, and `inline-image` — with the fonts pinned, these are
    renderer signals rather than environment noise.
+3. Make the paginator's 60% note-area cap defer rather than clip. A page whose citations would
+   fill more than that share admits more notes than it leaves room for, and the surplus is cut off
+   by the note block's `overflow: hidden` — 187 px on a generated twelve-note page, reproduced
+   identically before issue #378's changes, so it is a question about the cap and not about the
+   note block's composition.
 
 The list-margin discrepancy should not be changed merely to imitate LibreOffice: current evidence
 supports Docxodus's use of the declared OOXML margin. LibreOffice is a comparison implementation, not

--- a/npm/tests/visual-parity/BASELINE.md
+++ b/npm/tests/visual-parity/BASELINE.md
@@ -33,8 +33,12 @@ does not replace the fast committed snapshots or the arcade export test.
 - False-positive controls: wait for fonts/images/two animation frames; disable animation, carets,
   shadows, labels, and page gaps; search only a +/-2 px translation; report page geometry
   independently; use no masks.
-- Environment: Chromium 143.0.7499.4; LibreOffice 25.8.7.3; Poppler 25.03.0; Calibri mapped by
-  fontconfig to Carlito, Calibri Light to Noto Sans, and Times New Roman to Liberation Serif.
+- Environment: Chromium 143.0.7499.4; LibreOffice 25.8.7.3; Poppler 25.03.0. Fonts are governed by
+  the shared substitution contract (issue #379): one fontconfig fragment both engines read, mapping
+  Calibri and Calibri Light to Carlito, Cambria to Caladea, and Times New Roman / Arial / Courier
+  New to the matching Liberation faces. The run resolves every declared family before either engine
+  starts, records the exact font file each one used, and skips (or fails, under strict mode) rather
+  than reporting numbers from an unknown font environment.
 
 Two clean full render passes produced identical normalized metrics and all 60 Docxodus,
 LibreOffice, and overlay PNG SHA-256 hashes. The final ink-F1 edge-case correction changed no image
@@ -76,8 +80,8 @@ were added to the repository.
 | Page-count mismatches | 1 | 0 | 0 |
 | Case severity | 1 close, 1 minor, 0 major, 10 severe | 2 close, 1 minor, 0 major, 9 severe | 5 close, 1 minor, 0 major, 6 severe |
 | Page severity | 1 close, 1 minor, 2 major, 16 severe | 2 close, 1 minor, 1 major, 17 severe | 14 close, 1 minor, 0 major, 6 severe |
-| Mean SSIM | 0.974586 | 0.978298 | 0.979980 |
-| Mean tolerant ink F1 | 0.394106 | 0.412753 | 0.854069 |
+| Mean SSIM | 0.974586 | 0.978298 | 0.981207 |
+| Mean tolerant ink F1 | 0.394106 | 0.412753 | 0.854815 |
 
 Resolved items:
 
@@ -111,6 +115,16 @@ Resolved items:
    mark, and a fixed 1.4 line-height overriding the note style's single spacing) lands the
    separator within 2 px of LibreOffice's and the note text's bottom edge exactly on it. The case
    moves from severe (SSIM 0.99218, ink F1 0.56597) to **close** (0.99481 / 0.95875).
+6. **Shared font-substitution contract (issue #379).** One fontconfig fragment now governs both
+   engines, so a family cannot be set in different faces on the two sides of the comparison. The
+   run resolves every declared family before starting, records the font file each one used, and
+   skips or fails rather than reporting numbers from an unknown environment; a generated probe
+   compares the engines' advances and wrapped line counts and labels a mismatch as font-environment
+   drift rather than a renderer regression. `tracked-deletion` improves markedly (SSIM 0.93177 →
+   0.95011, ink F1 0.46817 → 0.62634) because Chromium and LibreOffice previously disagreed about
+   Calibri Light. `fields-and-tabs` moves the other way on ink F1 (0.30164 → 0.15913, SSIM
+   0.88672 → 0.89415): the substitution had been masking a real TOC line-height difference, which
+   is now visible as the renderer signal it always was.
 
 ## Current case results and triage
 
@@ -128,9 +142,9 @@ single blank or disjoint page rather than averaging it away.
 | inline-image | 1/1 | severe | 0.93660 | 0.64760 | Image and text are separate source paragraphs; the discrepancy is indentation/font/wrapping, not an inline-flow failure. |
 | chart | 1/1 | close | 0.98687 | 0.96817 | Cached clustered column data now renders as accessible inline SVG at the stored extent; bars, grid, colors, labels, title, and bottom legend align closely. Other chart families and stacked groupings remain unsupported. |
 | shape | 1/1 | severe | 0.96967 | 0.50719 | Textbox content exists but is roughly 5 px right and 13 px down with a small size difference: drawing-anchor geometry. |
-| fields-and-tabs | 1/1 | severe | 0.88672 | 0.30164 | Right-tab page numbers now reach the declared 9350-twip target and leaders fill the rendered remainder. The whole-page score falls slightly because the corrected leader adds ink at the still-mismatched TOC line height; hyperlink styling, font metrics, and paragraph spacing remain separate differences. |
+| fields-and-tabs | 1/1 | severe | 0.89415 | 0.15913 | Right-tab page numbers now reach the declared 9350-twip target and leaders fill the rendered remainder. The whole-page score falls slightly because the corrected leader adds ink at the still-mismatched TOC line height; hyperlink styling, font metrics, and paragraph spacing remain separate differences. |
 | footnote | 1/1 | close | 0.99481 | 0.95875 | Note block composition corrected (issue #378): the separator is a line with the rule on its baseline, spacing falls between notes, and the last note ends on the body band's bottom edge. |
-| tracked-deletion | 1/1 | severe | 0.93177 | 0.46817 | Identical accepted-revision bytes are now compared. Remaining differences cluster around Calibri Light substitution, heading metrics, and wrapping rather than revision semantics. |
+| tracked-deletion | 1/1 | severe | 0.95011 | 0.62634 | Identical accepted-revision bytes, and both engines now resolve Calibri Light the same way (issue #379). Remaining differences are heading metrics and wrapping, not revision semantics. |
 
 ## Fixes justified by the baseline
 
@@ -161,18 +175,22 @@ single blank or disjoint page rather than averaging it away.
 
 An attempted explicit `Calibri Light -> Carlito` browser fallback was rejected: it worsened the
 accepted-revision case (SSIM 0.93177 to 0.92905; ink F1 0.46817 to 0.42477) despite a small SSIM gain
-on the TOC. Font substitution therefore remains an observed environment variable, not a hidden
-renderer heuristic.
+on the TOC. That result was the diagnosis, not a dead end — changing ONE engine's mind made the two
+disagree more, because LibreOffice was already resolving Calibri Light through its own substitution
+table. Issue #379 resolves it where it belongs: a fontconfig fragment both engines read, which moves
+the same case to SSIM 0.95011 / ink F1 0.62634. Font substitution is now a declared, verified
+contract rather than either an observed variable or a hidden renderer heuristic.
 
 ## Prioritized next work
 
 The former first priority (blank charts), the PR #372 rerun, aligned tab geometry,
-header/body/footer vertical placement (issue #377), and footnote block placement (issue #378) are
-resolved above. The remaining order is:
+header/body/footer vertical placement (issue #377), footnote block placement (issue #378), and the
+shared font-substitution contract (issue #379) are resolved above. The remaining order is:
 
 1. Correct drawing-anchor offsets with a generated textbox geometry regression.
-2. Define and provision one font-substitution contract shared by Chromium and LibreOffice CI before
-   treating paragraph-wrap differences as renderer regressions (issue #379).
+2. Investigate the paragraph line-height differences the font contract now exposes on
+   `fields-and-tabs`, `landscape-section`, and `inline-image` — with the fonts pinned, these are
+   renderer signals rather than environment noise.
 
 The list-margin discrepancy should not be changed merely to imitate LibreOffice: current evidence
 supports Docxodus's use of the declared OOXML margin. LibreOffice is a comparison implementation, not

--- a/npm/tests/visual-parity/README.md
+++ b/npm/tests/visual-parity/README.md
@@ -28,11 +28,9 @@ output directory so stale pages cannot contaminate a rerun.
   raster pixel.
 - LibreOffice exports PDF from a fresh per-document user profile. Poppler rasterizes the PDF at
   exactly 96 DPI.
-- Both processes use `C.UTF-8`, UTC, and the host fontconfig installation. The summary records the
-  Chromium, LibreOffice, Poppler, Calibri/Calibri Light substitutes, and Times New Roman substitute.
-  A missing Office font remains a triage signal rather than something the benchmark masks: for
-  example, a host may map Calibri Light to Noto Sans while LibreOffice applies its own substitution,
-  changing line wraps even when the renderer's OOXML geometry is correct.
+- Both processes use `C.UTF-8`, UTC, and the **shared font-substitution contract** below. The
+  summary records the Chromium, LibreOffice, and Poppler versions, and the exact font file each
+  declared family resolved to in this run.
 - The comparison uses final-revision view: insertions are included and deletions/move markup are not
   rendered. LibreOffice's headless PDF filter follows the file's saved redline-display state and
   provides no final-view switch, so manifest cases marked `revisionMode: 'accepted'` are accepted
@@ -46,6 +44,96 @@ output directory so stale pages cannot contaminate a rerun.
   chosen offset is always reported.
 - No masks are applied. A future mask must be a bounded rectangle tied to one manifest case/page and
   carry a specific justification; a document-wide or text-wide mask is not acceptable.
+
+## Font-substitution contract
+
+Neither engine ships Microsoft's Office fonts, so every Office family a fixture names is
+substituted. When the two engines substitute *differently*, their line breaking and baselines
+differ for reasons that have nothing to do with Docxodus — and a benchmark that cannot tell that
+apart from a renderer regression is not measuring the renderer.
+
+The policy is therefore **shared by both engines**, not implemented in one of them. A
+Chromium-only `Calibri Light → Carlito` fallback was tried and rejected: it made one engine change
+its mind, so the two disagreed *more* than before (accepted-revision SSIM 0.93177 → 0.92905, ink F1
+0.46817 → 0.42477). Chromium and LibreOffice both resolve families through fontconfig on Linux, so
+one fontconfig fragment governs both by construction.
+
+| Family | Substitute | Package | Metric clone |
+|---|---|---|---|
+| Calibri | Carlito | `fonts-crosextra-carlito` | yes |
+| Cambria | Caladea | `fonts-crosextra-caladea` | yes |
+| Times New Roman | Liberation Serif | `fonts-liberation2` | yes |
+| Arial | Liberation Sans | `fonts-liberation2` | yes |
+| Courier New | Liberation Mono | `fonts-liberation2` | yes |
+| Calibri Light | Carlito | `fonts-crosextra-carlito` | **no** |
+
+Calibri Light has no metric-compatible free clone — Carlito ships no Light weight. Left unbound it
+falls through to whichever generic sans each engine happens to prefer, which is exactly the
+non-determinism the contract removes. Binding it is a choice about *agreement*, not fidelity: text
+set in Calibri Light will not wrap where Word wraps it, and that must not be "corrected" in one
+renderer.
+
+The contract lives in exactly two places, and `font-contract.spec.ts` fails if they drift apart:
+
+- `fontconfig/60-docxodus-office-substitutes.conf` — what the engines read.
+- `fonts.ts` — what the run reports and verifies (`FONT_SUBSTITUTION_CONTRACT`).
+
+No font is bundled with this repository, and nothing here affects the library at run time.
+
+### Applying it
+
+The benchmark applies the fragment itself: it writes a fontconfig root outside the checkout that
+layers the fragment over the host's own configuration, and points both Chromium (through the
+browser launch environment) and every LibreOffice subprocess at it. Nothing is written into your
+home directory or `/etc`. You only need the packages:
+
+```bash
+sudo apt-get install -y fonts-liberation2 fonts-crosextra-carlito fonts-crosextra-caladea
+```
+
+To install the contract permanently instead — which is what CI does, and what makes other tools on
+the machine agree too:
+
+```bash
+sudo cp npm/tests/visual-parity/fontconfig/60-docxodus-office-substitutes.conf /etc/fonts/conf.d/
+fc-cache -f
+fc-match "Calibri Light"   # => Carlito
+```
+
+Then run with `DOCXODUS_VISUAL_PARITY_HOST_FONTS=1` to measure the host configuration as it is,
+rather than layering the fragment again.
+
+### When the contract is unavailable
+
+The run resolves every declared family through `fc-match` before either engine starts. If any
+family resolves to the wrong substitute the run **skips** with a message naming the family and the
+package to install — and **fails** instead under `DOCXODUS_VISUAL_PARITY_STRICT=1`. It never
+proceeds and reports numbers produced by an unknown font environment.
+
+### The drift probe
+
+A generated probe document — one short, non-wrapping line and one long, wrapping paragraph per
+declared family — is rendered by both engines before the corpus. The comparison is between the two
+**engines**, not against a stored expectation:
+
+- the short line's **advance** must agree within 3 px. This is pure font resolution, so the
+  tolerance can sit just above hinting noise; a different face moves it by tens of pixels.
+- the page's total **line count** must match, which is what a different face does to a paragraph
+  long enough to wrap.
+
+Break *positions* are deliberately not compared. With the contract satisfied and both engines
+confirmed on Caladea, the Cambria paragraph's widest line still ends 34 px apart: the engines break
+identically-measured text differently. That is a real difference and worth knowing, but it is not
+font drift, and a probe that conflates the two explains nothing.
+
+A probe failure is reported as *font environment drift, not a renderer regression*, and the
+per-family advances are recorded in `summary.json` so two reports can be compared directly.
+
+`font-contract.spec.ts` runs in the ordinary browser suite (no LibreOffice needed) and pins the
+fragment against `fonts.ts`, the drift detector's sensitivity, and its noise tolerance.
+
+Committed-screenshot specs such as `tabs-visual.spec.ts` are **not** governed by this contract:
+they compare against images baked on one machine, so they remain environment-sensitive by design.
 
 ## Metrics and thresholds
 
@@ -73,8 +161,9 @@ keeps the initial baseline useful while known unsupported content is being triag
 
 ## Run locally
 
-Prerequisites: `libreoffice`, `pdftoppm`, Chromium installed for Playwright, and the repository's npm
-dependencies.
+Prerequisites: `libreoffice`, `pdftoppm`, `fontconfig`, the contract's font packages (see
+[Font-substitution contract](#font-substitution-contract)), Chromium installed for Playwright, and
+the repository's npm dependencies.
 
 ```bash
 cd npm

--- a/npm/tests/visual-parity/README.md
+++ b/npm/tests/visual-parity/README.md
@@ -107,8 +107,15 @@ rather than layering the fragment again.
 
 The run resolves every declared family through `fc-match` before either engine starts. If any
 family resolves to the wrong substitute the run **skips** with a message naming the family and the
-package to install — and **fails** instead under `DOCXODUS_VISUAL_PARITY_STRICT=1`. It never
-proceeds and reports numbers produced by an unknown font environment.
+package to install. It never proceeds and reports numbers produced by an unknown font environment.
+
+Skipping is right for a developer who has not installed the fonts and wrong for a machine that is
+supposed to have them, where it would turn the benchmark into a green no-op that produces no
+report. `DOCXODUS_VISUAL_PARITY_REQUIRE_FONTS=1` turns the skip into a failure; CI sets it
+alongside `DOCXODUS_VISUAL_PARITY_HOST_FONTS=1` so the permanent `/etc/fonts/conf.d` install above
+is the thing being verified. It is deliberately separate from
+`DOCXODUS_VISUAL_PARITY_STRICT=1`, which is about the corpus verdict — several cases are
+legitimately severe today, so corpus strictness cannot be used to police the font environment.
 
 ### The drift probe
 

--- a/npm/tests/visual-parity/font-probe.ts
+++ b/npm/tests/visual-parity/font-probe.ts
@@ -1,0 +1,259 @@
+import { storedZip, xml, W_NS } from '../docx-zip.js';
+import type { RgbaImage } from './png.js';
+import { FONT_SUBSTITUTION_CONTRACT } from './fonts.js';
+
+/**
+ * The synthetic probe that tells a renderer regression apart from a change in the font
+ * environment.
+ *
+ * Both quantities it measures are functions of the glyph advances each engine actually got, so
+ * if one of them silently starts using a different face — a package removed, the fontconfig
+ * fragment not applied, a new distro default — the probe moves, and every corpus score that moved
+ * with it did not move because of this repository. It is deliberately NOT compared against a
+ * stored expectation: it compares the two engines to EACH OTHER on a document whose only variable
+ * is the font.
+ *
+ * Two halves, because they fail differently:
+ *
+ * - a short line that cannot wrap, compared by its ADVANCE. This is pure font resolution: no
+ *   line-breaking policy is involved, so the tolerance can be tight.
+ * - a long paragraph that wraps, compared by its LINE COUNT. Substituting a different face over
+ *   a paragraph this long changes how many lines it takes.
+ *
+ * The wrapping half is deliberately not compared by break POSITION. Measured on this host with
+ * the contract satisfied and both engines confirmed on Caladea, the Cambria paragraph's widest
+ * line still ended 34 px apart — the engines break identically-measured text differently. That is
+ * a real difference, and one this benchmark exists to surface, but it is not font drift, and a
+ * probe that cannot tell them apart is no better than the corpus scores it is meant to explain.
+ */
+
+/** Fixed prose: no numerals or punctuation clusters, so the metrics come from the letters. */
+const WRAPPING_TEXT = [
+  'The quick brown fox jumps over the lazy dog while the mist settles on the far river bank',
+  'and every careful compositor watches the measure fill and wonders where the line will break',
+  'before the paragraph reaches its final word.',
+].join(' ');
+
+/** Short enough to never reach the measure, in any of the declared families. */
+const ADVANCE_TEXT = 'Docxodus font substitution contract';
+
+const PAGE_WIDTH_TWIPS = 12240;
+const PAGE_HEIGHT_TWIPS = 15840;
+const MARGIN_TWIPS = 1440;
+/** Half-point units, i.e. 11 pt — the size Word's own defaults use. */
+const PROBE_SIZE_HALF_POINTS = 22;
+/**
+ * 1.5 line spacing. Single-spaced serif lines can leave no fully blank raster row between them,
+ * which merges two lines into one ink band — and a band count that depends on the font's
+ * ascenders is not a measurement of anything.
+ */
+const PROBE_LINE_TWENTIETHS = 360;
+
+/** The families the probe exercises, in the order their paragraphs appear. */
+export const PROBE_FAMILIES = FONT_SUBSTITUTION_CONTRACT.map(entry => entry.family);
+
+function paragraph(family: string, text: string): string {
+  return `<w:p><w:pPr>` +
+    `<w:spacing w:before="0" w:after="240" w:line="${PROBE_LINE_TWENTIETHS}" w:lineRule="auto"/>` +
+    `</w:pPr><w:r><w:rPr>` +
+    `<w:rFonts w:ascii="${family}" w:hAnsi="${family}" w:cs="${family}"/>` +
+    `<w:sz w:val="${PROBE_SIZE_HALF_POINTS}"/><w:szCs w:val="${PROBE_SIZE_HALF_POINTS}"/>` +
+    `</w:rPr><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+}
+
+/**
+ * The advance lines first, one per family, then the wrapping paragraphs. The order matters: the
+ * first {@link PROBE_FAMILIES}`.length` ink bands are the advance lines, which is how the
+ * comparison finds them without having to guess from their width.
+ */
+export function generateFontProbeDocx(): Uint8Array {
+  const body =
+    PROBE_FAMILIES.map(family => paragraph(family, ADVANCE_TEXT)).join('') +
+    PROBE_FAMILIES.map(family => paragraph(family, WRAPPING_TEXT)).join('');
+
+  return storedZip([
+    {
+      name: '[Content_Types].xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
+</Types>`),
+    },
+    {
+      name: '_rels/.rels',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`),
+    },
+    {
+      name: 'word/_rels/document.xml.rels',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+</Relationships>`),
+    },
+    {
+      name: 'word/styles.xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles xmlns:w="${W_NS}">
+  <w:docDefaults><w:rPrDefault><w:rPr>
+    <w:sz w:val="${PROBE_SIZE_HALF_POINTS}"/><w:szCs w:val="${PROBE_SIZE_HALF_POINTS}"/>
+  </w:rPr></w:rPrDefault></w:docDefaults>
+  <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+</w:styles>`),
+    },
+    {
+      name: 'word/document.xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="${W_NS}"><w:body>
+  ${body}
+  <w:sectPr>
+    <w:pgSz w:w="${PAGE_WIDTH_TWIPS}" w:h="${PAGE_HEIGHT_TWIPS}"/>
+    <w:pgMar w:top="${MARGIN_TWIPS}" w:right="${MARGIN_TWIPS}" w:bottom="${MARGIN_TWIPS}"
+             w:left="${MARGIN_TWIPS}" w:header="720" w:footer="720" w:gutter="0"/>
+  </w:sectPr>
+</w:body></w:document>`),
+    },
+  ]);
+}
+
+/** One rendered line of text: the extent of its ink. */
+export interface InkLine {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+}
+
+const INK_LUMINANCE_THRESHOLD = 200;
+/** Rows this close together belong to the same line; a wider gap starts a new one. */
+const LINE_GAP_ROWS = 3;
+
+/** Every horizontal band of ink in `image`, top to bottom. */
+export function inkLines(image: RgbaImage): InkLine[] {
+  const { width, height, data } = image;
+  const rows: Array<{ left: number; right: number } | null> = [];
+  for (let y = 0; y < height; y++) {
+    let left = -1;
+    let right = -1;
+    for (let x = 0; x < width; x++) {
+      const i = (y * width + x) * 4;
+      const luminance = (data[i] * 299 + data[i + 1] * 587 + data[i + 2] * 114) / 1000;
+      if (data[i + 3] > 16 && luminance < INK_LUMINANCE_THRESHOLD) {
+        if (left < 0) left = x;
+        right = x;
+      }
+    }
+    rows.push(left < 0 ? null : { left, right });
+  }
+
+  const lines: InkLine[] = [];
+  let y = 0;
+  while (y < height) {
+    if (!rows[y]) { y++; continue; }
+    let end = y;
+    let cursor = y;
+    while (cursor < height) {
+      if (rows[cursor]) { end = cursor; cursor++; continue; }
+      let gap = cursor;
+      while (gap < height && !rows[gap]) gap++;
+      if (gap - cursor <= LINE_GAP_ROWS && gap < height) { cursor = gap; continue; }
+      break;
+    }
+    const spanned = rows.slice(y, end + 1).filter((row): row is { left: number; right: number } => !!row);
+    lines.push({
+      top: y,
+      bottom: end,
+      left: Math.min(...spanned.map(row => row.left)),
+      right: Math.max(...spanned.map(row => row.right)),
+    });
+    y = end + 1;
+  }
+  return lines;
+}
+
+export interface FontProbeAdvance {
+  family: string;
+  docxodusPx: number;
+  libreofficePx: number;
+  deltaPx: number;
+}
+
+export interface FontProbeResult {
+  /** Ink lines each engine rendered across the whole probe page. */
+  docxodusLines: number;
+  libreofficeLines: number;
+  /** Per-family advance of the non-wrapping line, in pixels at 96 DPI. */
+  advances: FontProbeAdvance[];
+  maxAdvanceDeltaPx: number;
+  agreed: boolean;
+  problem: string;
+}
+
+/**
+ * Rasteriser and hinting differences move a short line's end by a pixel or two; a different face
+ * moves it by tens. The tolerance sits between them.
+ */
+export const PROBE_ADVANCE_TOLERANCE_PX = 3;
+
+export function compareProbeLines(docxodus: InkLine[], libreoffice: InkLine[]): FontProbeResult {
+  const families = PROBE_FAMILIES;
+  const base: FontProbeResult = {
+    docxodusLines: docxodus.length,
+    libreofficeLines: libreoffice.length,
+    advances: [],
+    maxAdvanceDeltaPx: 0,
+    agreed: true,
+    problem: '',
+  };
+
+  // The wrapping half: substituting a different face over paragraphs this long changes how many
+  // lines they take. Compared as a count, not as break positions — see the note at the top.
+  if (docxodus.length !== libreoffice.length) {
+    return {
+      ...base,
+      agreed: false,
+      problem: `the engines wrapped the probe into different line counts ` +
+        `(Docxodus ${docxodus.length}, LibreOffice ${libreoffice.length}); ` +
+        `they are not using the same faces`,
+    };
+  }
+  if (docxodus.length < families.length) {
+    return {
+      ...base,
+      agreed: false,
+      problem: `the probe rendered only ${docxodus.length} lines, fewer than its ` +
+        `${families.length} advance lines; the probe document did not render as authored`,
+    };
+  }
+
+  // The advance half: the first line per family cannot wrap, so its width is the face's own.
+  base.advances = families.map((family, index) => {
+    const a = docxodus[index];
+    const b = libreoffice[index];
+    const advance = {
+      family,
+      docxodusPx: a.right - a.left,
+      libreofficePx: b.right - b.left,
+      deltaPx: Math.abs((a.right - a.left) - (b.right - b.left)),
+    };
+    base.maxAdvanceDeltaPx = Math.max(base.maxAdvanceDeltaPx, advance.deltaPx);
+    return advance;
+  });
+
+  const drifted = base.advances.filter(a => a.deltaPx > PROBE_ADVANCE_TOLERANCE_PX);
+  if (drifted.length) {
+    return {
+      ...base,
+      agreed: false,
+      problem: `the engines measured ${drifted.map(a =>
+        `${a.family} ${a.deltaPx} px apart (${a.docxodusPx} vs ${a.libreofficePx})`).join(', ')} ` +
+        `against a ${PROBE_ADVANCE_TOLERANCE_PX} px tolerance; they resolved different faces`,
+    };
+  }
+  return base;
+}

--- a/npm/tests/visual-parity/fontconfig/60-docxodus-office-substitutes.conf
+++ b/npm/tests/visual-parity/fontconfig/60-docxodus-office-substitutes.conf
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+
+<!--
+  Docxodus visual-parity font-substitution contract.
+
+  Chromium and LibreOffice both resolve families through fontconfig on Linux, so binding the
+  Office families here makes the two engines substitute IDENTICALLY. That is the whole point: a
+  benchmark whose engines disagree about which font a document is set in cannot tell a renderer
+  regression from a font-environment change.
+
+  The bindings match the metric-compatible clones the distributions already package
+  (fonts-crosextra-carlito, fonts-crosextra-caladea, fonts-liberation2). No font is bundled with
+  this repository, and nothing here is used by the library at run time — it governs the benchmark
+  host only.
+
+  `binding="same"` keeps the substitute's own metrics, which is what a metric clone is for.
+  The declarations are duplicated as a `family` edit under `target="pattern"` so a request that
+  names the family directly (as fontconfig's own 30-metric-aliases.conf does) is rewritten before
+  matching, rather than only being consulted as a weak fallback.
+
+  Keep in step with FONT_SUBSTITUTION_CONTRACT in ../fonts.ts; `resolveFontContract()` verifies
+  that this file and that list agree, and the run reports the resolved file for each family.
+-->
+<fontconfig>
+
+  <alias binding="same"><family>Calibri</family><accept><family>Carlito</family></accept></alias>
+  <alias binding="same"><family>Cambria</family><accept><family>Caladea</family></accept></alias>
+  <alias binding="same"><family>Times New Roman</family><accept><family>Liberation Serif</family></accept></alias>
+  <alias binding="same"><family>Arial</family><accept><family>Liberation Sans</family></accept></alias>
+  <alias binding="same"><family>Courier New</family><accept><family>Liberation Mono</family></accept></alias>
+
+  <!--
+    Calibri Light has no metric-compatible free clone: Carlito ships no Light weight. Unbound it
+    falls through to whichever generic sans each engine happens to prefer, which is exactly the
+    non-determinism this file exists to remove. Binding it to Carlito is a choice about AGREEMENT,
+    not about fidelity — text set in Calibri Light will not wrap where Word wraps it, and that
+    difference must not be "corrected" in one renderer.
+  -->
+  <match target="pattern">
+    <test qual="any" name="family"><string>Calibri Light</string></test>
+    <edit name="family" mode="assign" binding="same"><string>Carlito</string></edit>
+  </match>
+
+</fontconfig>

--- a/npm/tests/visual-parity/fonts.ts
+++ b/npm/tests/visual-parity/fonts.ts
@@ -1,0 +1,133 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The font-substitution contract shared by both renderers.
+ *
+ * Neither Chromium nor LibreOffice ships Microsoft's Office fonts, so every Office family a
+ * fixture names is SUBSTITUTED. When the two engines substitute differently, their line breaking
+ * and baselines differ for reasons that have nothing to do with Docxodus — and a benchmark that
+ * cannot tell those apart from renderer regressions is not measuring the renderer.
+ *
+ * The fix has to be shared, not renderer-side. A Chromium-only `Calibri Light -> Carlito`
+ * fallback was tried and rejected: it made ONE engine change its mind, so the two disagreed more
+ * than before (accepted-revision SSIM 0.93177 -> 0.92905, ink F1 0.46817 -> 0.42477). Both
+ * engines read fontconfig on Linux, so ONE fontconfig fragment governs both, by construction.
+ *
+ * Nothing here bundles a font. Carlito, Caladea, and the Liberation family are the metric-
+ * compatible, freely redistributable substitutes the distributions already package; the contract
+ * only pins WHICH of them each Office family must resolve to.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export interface FontSubstitution {
+  /** The family a document names. */
+  family: string;
+  /** The family both renderers must resolve it to. */
+  substitute: string;
+  /** Where the substitute comes from, for the setup instructions and the failure message. */
+  package: string;
+  /**
+   * Whether the substitute is metrically compatible with the original. `false` means no
+   * license-safe metric clone exists, so the contract's job is agreement between the engines
+   * rather than fidelity to Word — worth stating, because such a family's wrap points are
+   * expected to differ from Word's and must not be "fixed" in one renderer.
+   */
+  metricCompatible: boolean;
+}
+
+export const FONT_SUBSTITUTION_CONTRACT: readonly FontSubstitution[] = [
+  { family: 'Calibri', substitute: 'Carlito', package: 'fonts-crosextra-carlito', metricCompatible: true },
+  { family: 'Cambria', substitute: 'Caladea', package: 'fonts-crosextra-caladea', metricCompatible: true },
+  { family: 'Times New Roman', substitute: 'Liberation Serif', package: 'fonts-liberation2', metricCompatible: true },
+  { family: 'Arial', substitute: 'Liberation Sans', package: 'fonts-liberation2', metricCompatible: true },
+  { family: 'Courier New', substitute: 'Liberation Mono', package: 'fonts-liberation2', metricCompatible: true },
+  // Carlito has no Light weight, and no freely redistributable font is metrically compatible with
+  // Calibri Light. Left unbound it falls through to whatever generic each engine prefers — here
+  // Chromium and LibreOffice both landed on Noto Sans, but that is an accident of this host, not
+  // a contract. Binding it makes the choice explicit and identical in both engines.
+  { family: 'Calibri Light', substitute: 'Carlito', package: 'fonts-crosextra-carlito', metricCompatible: false },
+];
+
+/** The apt packages a Debian/Ubuntu host needs for the whole contract. */
+export const FONT_CONTRACT_PACKAGES = [...new Set(
+  FONT_SUBSTITUTION_CONTRACT.map(entry => entry.package))].sort();
+
+/** The shipped fontconfig fragment that binds the contract for every application on the host. */
+export const FONTCONFIG_FRAGMENT = resolve(
+  __dirname, 'fontconfig', '60-docxodus-office-substitutes.conf');
+
+export interface ResolvedFont extends FontSubstitution {
+  /** The family `fc-match` actually returned. */
+  resolvedFamily: string;
+  /** The font file backing it, so a report records the exact bytes that were rendered. */
+  resolvedFile: string;
+  satisfied: boolean;
+}
+
+export interface FontContractStatus {
+  satisfied: boolean;
+  entries: ResolvedFont[];
+  /** Human-readable reason, empty when satisfied. */
+  problem: string;
+  /** The fontconfig configuration in force, so a report can be reproduced. */
+  fontconfigFile: string;
+}
+
+function fcMatch(family: string, env: NodeJS.ProcessEnv): { family: string; file: string } {
+  const result = spawnSync('fc-match', [family, '--format=%{family}\\t%{file}'],
+    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], env });
+  if (result.error || result.status !== 0) return { family: '', file: '' };
+  const [matched = '', file = ''] = result.stdout.trim().split('\t');
+  return { family: matched, file };
+}
+
+/**
+ * A fontconfig root that layers {@link FONTCONFIG_FRAGMENT} over the host's own configuration.
+ *
+ * Written outside the repository and pointed at through `FONTCONFIG_FILE`, so the contract binds
+ * the benchmark's two subprocesses WITHOUT installing anything into the developer's home
+ * directory or `/etc`. CI can install the fragment permanently instead; the effect is the same.
+ */
+export function writeFontconfigRoot(directory: string): string {
+  mkdirSync(directory, { recursive: true });
+  const path = join(directory, 'fonts.conf');
+  writeFileSync(path, `<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<!-- Generated by npm/tests/visual-parity/fonts.ts. Host configuration first, contract last. -->
+<fontconfig>
+  <include ignore_missing="yes">/etc/fonts/fonts.conf</include>
+  <include ignore_missing="yes">${FONTCONFIG_FRAGMENT}</include>
+</fontconfig>
+`);
+  return path;
+}
+
+/** Resolves every declared family through `fc-match` under `env` and reports the contract state. */
+export function resolveFontContract(env: NodeJS.ProcessEnv = process.env): FontContractStatus {
+  const entries = FONT_SUBSTITUTION_CONTRACT.map<ResolvedFont>(entry => {
+    const matched = fcMatch(entry.family, env);
+    return {
+      ...entry,
+      resolvedFamily: matched.family,
+      resolvedFile: matched.file,
+      satisfied: matched.family === entry.substitute,
+    };
+  });
+
+  const broken = entries.filter(entry => !entry.satisfied);
+  const missingPackages = [...new Set(broken.map(entry => entry.package))].sort();
+  return {
+    satisfied: broken.length === 0,
+    entries,
+    problem: broken.length === 0 ? '' :
+      `font substitution contract unsatisfied: ` +
+      broken.map(e => `${e.family} -> ${e.resolvedFamily || '(no match)'} (want ${e.substitute})`).join('; ') +
+      `. Install ${missingPackages.join(' ')} and apply ${FONTCONFIG_FRAGMENT} ` +
+      `(see npm/tests/visual-parity/README.md).`,
+    fontconfigFile: env.FONTCONFIG_FILE ?? '(host default)',
+  };
+}


### PR DESCRIPTION
Closes #379. **Stacked on #383 (issue #378), which is stacked on #382 (issue #377)** — review in that order; this PR targets #383's branch.

## Problem

Neither Chromium nor LibreOffice ships Microsoft's Office fonts, so every Office family a fixture names is **substituted**. When the two substitute *differently*, their line breaking and baselines differ for reasons that have nothing to do with this repository — and a benchmark that cannot tell that apart from a renderer regression is not measuring the renderer.

The issue records that a Chromium-only `Calibri Light → Carlito` fallback was tested and rejected for worsening the accepted-revision case. That result was the **diagnosis**, not a dead end: changing one engine's mind made the two disagree *more*, because LibreOffice was already resolving Calibri Light through its own substitution table. The policy has to be shared.

## Fix

Both engines resolve families through fontconfig on Linux, so **one fontconfig fragment governs both by construction**.

| Family | Substitute | Package | Metric clone |
|---|---|---|---|
| Calibri | Carlito | `fonts-crosextra-carlito` | yes |
| Cambria | Caladea | `fonts-crosextra-caladea` | yes |
| Times New Roman | Liberation Serif | `fonts-liberation2` | yes |
| Arial | Liberation Sans | `fonts-liberation2` | yes |
| Courier New | Liberation Mono | `fonts-liberation2` | yes |
| Calibri Light | Carlito | `fonts-crosextra-carlito` | **no** |

Calibri Light has no metric-compatible free clone — Carlito ships no Light weight. Unbound it falls through to whichever generic sans each engine happens to prefer, which is exactly the non-determinism this removes. Binding it is a choice about **agreement**, not fidelity, and the fragment says so: text set in Calibri Light will not wrap where Word wraps it, and that must not be "corrected" in one renderer.

All substitutes are freely redistributable clones the distributions already package. **No font is vendored**, and nothing here touches the library at run time.

- `fontconfig/60-docxodus-office-substitutes.conf` — what the engines read.
- `fonts.ts` — the same contract as data. It layers the fragment over the host's configuration **outside the checkout** (nothing is written to `$HOME` or `/etc`) and hands it to the browser launch and to every LibreOffice subprocess, so a developer needs only the packages.
- CI installs the fragment into `/etc/fonts/conf.d/` and prints the resolved faces, so the CI machine reproduces a local run exactly.

**Fail or skip, never guess.** The run resolves every declared family through `fc-match` before either engine starts. If any family resolves wrongly it **skips** with the family and the package named — and **fails** under `DOCXODUS_VISUAL_PARITY_STRICT=1`. `summary.json` records the exact font file each family used, so two reports can be compared without trusting the machines.

**The drift probe.** A generated document — one short non-wrapping line and one long wrapping paragraph per family — is rendered by both engines before the corpus, and the comparison is between the two **engines**, not against a stored expectation:

- the short line's **advance** must agree within 3 px (pure font resolution, so the tolerance sits just above hinting noise; a different face moves it by tens of pixels);
- the page's total **line count** must match (what a different face does to a paragraph long enough to wrap).

Break *positions* are deliberately not compared, and the code says why: with the contract satisfied and both engines confirmed on Caladea, the Cambria paragraph's widest line still ends 34 px apart. That is a real renderer difference worth knowing — but it is not font drift, and a probe that conflates them explains nothing. A failure is reported as *font environment drift, not a renderer regression*.

## Tests

`npm/tests/font-contract.spec.ts` (5 tests) runs in the **ordinary** browser suite — no LibreOffice needed — and pins:

- the shipped fragment binding *exactly* the families `fonts.ts` declares, parsed from the XML in both fontconfig forms (two owners of one contract);
- the detector flagging a substituted face (the real 38 px Calibri Light case);
- the detector flagging a changed wrapped line count;
- the detector tolerating rasterisation noise at exactly the tolerance;
- an unsatisfied contract naming the family, the package, and the setup doc.

The end-to-end drift path was verified by pointing LibreOffice at a deliberately divergent fontconfig: the probe reported *"the engines measured Calibri Light 38 px apart (210 vs 248) against a 3 px tolerance; they resolved different faces"* and failed the run. The skip and strict-fail paths were verified with `DOCXODUS_VISUAL_PARITY_HOST_FONTS=1` on a host whose Calibri Light resolves to Noto Sans.

## Results

The contract is not a score-improving change; it makes scores **attributable**. Both directions, reported honestly:

| Case | SSIM | Ink F1 | Why |
|---|---|---|---|
| tracked-deletion | 0.93177 → **0.95011** | 0.46817 → **0.62634** | the engines had disagreed about Calibri Light |
| fields-and-tabs | 0.88672 → 0.89415 | 0.30164 → **0.15913** | substitution had been masking a real TOC line-height difference, now a renderer signal |

Corpus means: SSIM 0.979980 → 0.981207, tolerant ink F1 0.854069 → 0.854815. No other case moved. Probe: 25 lines in both engines, worst advance delta 2 px.

Playwright suite passes except the four `tabs-visual` snapshot comparisons, which fail identically on `main` in this environment — committed screenshots are baked on one machine and are explicitly **not** governed by this contract, which the README now states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Follow-up commit

- **CI now exercises the documented install path.** The workflow installed the fragment into `/etc/fonts/conf.d/` and then let the benchmark layer it again, so a broken system install would still have passed and the path the README tells humans to use was never checked. CI runs with `DOCXODUS_VISUAL_PARITY_HOST_FONTS=1`, which makes the preflight verify the real install.
- **CHANGELOG entry re-filed under `### Fixed`.** This is benchmark infrastructure with no public surface; `### Changed` would make the next release cut a spurious minor per the repo's release table.

- **`DOCXODUS_VISUAL_PARITY_REQUIRE_FONTS=1`.** Making CI measure the system install created a way for the weekly run to go green with no report: an install that doesn't take effect leaves the contract unsatisfied, the preflight skips, and the workflow passes. The new flag turns that skip into a failure and CI sets it alongside `HOST_FONTS=1`, so the permanent `/etc/fonts/conf.d` install is the thing being verified. Deliberately separate from `STRICT=1` — strictness is about the corpus verdict, six cases are legitimately severe today, so it can't be used to police the font environment. Skipping stays right for a developer who hasn't installed the fonts.
- `BASELINE.md`'s prioritized work records the finding that surfaced while testing the note area: a page whose citations would exceed the paginator's 60% note-area cap admits more notes than it leaves room for and clips the surplus (187 px on a generated twelve-note page, reproduced identically before #378).
