### PR TITLE
Stop two IR/diff tests asserting on the wall clock and a shared runner's spare CPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,19 @@ All notable changes to this project will be documented in this file.
   pause→type→resume loop, and the save round-trip.
 
 ### Fixed
+- **Two tests failed on evidence they never meant to assert — the wall clock and a shared
+  runner's spare CPU.** `PreAcceptInputRevisionsTests` and `DocxCompareTests` each compared two
+  SEPARATELY PRODUCED packages by raw `DocumentByteArray`, but a DOCX is a ZIP that stamps every
+  entry with the time it was written: the two calls normally land in the same timestamp granule and
+  agree, and on a loaded runner they sometimes straddle one and differ on a byte unrelated to the
+  behavior under test. Both now compare the part set and each part's bytes through the new
+  `PackageEquivalence.AssertSamePackage`, which keeps the entire claim — same parts, same content —
+  and drops only container metadata; two packages produced four seconds apart fail the old
+  assertion and satisfy the new one. `IrAlignerAdversarialTests`' anti-O(n²) scale guard divided
+  two sub-30 ms CPU samples and failed at 12.41x against a 12x limit; since scheduling noise can
+  only ADD CPU time, it now takes the MINIMUM ratio over up to three independent rounds (stopping
+  at the first that passes), which cannot be tripped by one noisy round and still fails a real
+  regression — that reads ~16x in every round. The true ratio measures ~4x.
 - **Floating DrawingML text boxes now honor their OOXML anchor geometry in paginated output.**
   The converter preserves page/margin/column/paragraph/line/character origins, offsets and
   alignments, stored extents, relative sizing, wrap clearances, and internal text insets; the

--- a/Docxodus.Tests/DocxCompareTests.cs
+++ b/Docxodus.Tests/DocxCompareTests.cs
@@ -95,7 +95,7 @@ public class DocxCompareTests
     }
 
     [Fact]
-    public void DocxDiffBranch_ProducesSameBytesAsDirectDocxDiff()
+    public void DocxDiffBranch_ProducesSamePackageAsDirectDocxDiff()
     {
         var left = Doc("The quick brown fox");
         var right = Doc("The quick red fox");
@@ -104,7 +104,9 @@ public class DocxCompareTests
         var viaFacade = DocxCompare.Compare(left, right, ComparisonEngine.DocxDiff, settings);
         var direct = DocxDiff.Compare(left, right, DocxCompare.ToDocxDiffSettings(settings));
 
-        Assert.Equal(direct.DocumentByteArray, viaFacade.DocumentByteArray);
+        // Part by part, not raw package bytes: two separately produced ZIPs also differ in the entry
+        // timestamps the container writes, which says nothing about the facade. See PackageEquivalence.
+        PackageEquivalence.AssertSamePackage(direct, viaFacade);
     }
 
     [Theory]

--- a/Docxodus.Tests/Ir/Diff/IrAlignerAdversarialTests.cs
+++ b/Docxodus.Tests/Ir/Diff/IrAlignerAdversarialTests.cs
@@ -179,14 +179,32 @@ public class IrAlignerAdversarialTests
         // anchoring cost, which should scale ~linearly: 4× the blocks ⇒ well under 12× the CPU time
         // (a true O(n²) regression reads ~16×). Process CPU time keeps shared-runner scheduling noise
         // from looking like algorithmic work.
-        double small = BestSampleCpuMs(500);
-        double large = BestSampleCpuMs(2000);
-        double ratio = large / Math.Max(small, 0.0001);
+        // Best of up to three independent rounds. Scheduling noise on a shared runner can only ADD CPU
+        // time, so it can only inflate the ratio — which makes the MINIMUM across rounds the closest
+        // estimate of the true algorithmic one, and makes a single noisy round unable to fail the test.
+        // The guard keeps its teeth: a real O(n²) regression reads ~16x in EVERY round, so all three
+        // have to exceed the limit before this fails. Rounds stop as soon as one comes in under.
+        const double limit = 12.0;
+        const int rounds = 3;
 
-        _out.WriteLine($"Scale guard CPU: 500-para = {small:F2} ms, 2000-para = {large:F2} ms, ratio = {ratio:F2}x (n=4x)");
-        Assert.True(ratio <= 12.0,
-            $"Align CPU-time ratio {ratio:F2}x for 4x input exceeds the 12x anti-O(n²) guard " +
-            $"(500={small:F2}ms, 2000={large:F2}ms).");
+        double bestRatio = double.MaxValue, bestSmall = 0, bestLarge = 0;
+        for (int round = 0; round < rounds; round++)
+        {
+            double small = BestSampleCpuMs(500);
+            double large = BestSampleCpuMs(2000);
+            double ratio = large / Math.Max(small, 0.0001);
+            _out.WriteLine($"Scale guard CPU round {round + 1}: 500-para = {small:F2} ms, " +
+                $"2000-para = {large:F2} ms, ratio = {ratio:F2}x (n=4x)");
+
+            if (ratio < bestRatio)
+                (bestRatio, bestSmall, bestLarge) = (ratio, small, large);
+            if (bestRatio <= limit)
+                break;
+        }
+
+        Assert.True(bestRatio <= limit,
+            $"Align CPU-time ratio {bestRatio:F2}x for 4x input exceeds the {limit:F0}x anti-O(n²) guard " +
+            $"in every one of {rounds} rounds (best round: 500={bestSmall:F2}ms, 2000={bestLarge:F2}ms).");
     }
 
     /// <summary>

--- a/Docxodus.Tests/Ir/Diff/PreAcceptInputRevisionsTests.cs
+++ b/Docxodus.Tests/Ir/Diff/PreAcceptInputRevisionsTests.cs
@@ -40,7 +40,7 @@ public class PreAcceptInputRevisionsTests
     // ---- oracle (b): the flag IS the wrapper ----------------------------------------------------
 
     [Fact]
-    public void Flag_on_is_byte_identical_to_accept_all_then_compare_wrapper()
+    public void Flag_on_produces_the_same_package_as_accept_all_then_compare_wrapper()
     {
         var left = MultiScopeRevisionDoc(
             "Body alpha", "Alice", "alpha-ins", "alpha-del", "PriorBob", "hdr-prior", "fn-prior");
@@ -53,8 +53,11 @@ public class PreAcceptInputRevisionsTests
             new DocxDiffSettings { AuthorForRevisions = "NewDiff" });
 
         // The flag is, by construction, exactly "accept-all both inputs, then compare" — so the produced
-        // tracked-changes packages are byte-for-byte identical.
-        Assert.Equal(wrapper.DocumentByteArray, flagOn.DocumentByteArray);
+        // tracked-changes packages hold the same parts with byte-for-byte identical content. Compared part
+        // by part rather than as raw package bytes: the ZIP container stamps each entry with the time it
+        // was written, which makes whole-package equality a race between these two calls rather than a
+        // statement about the flag. See PackageEquivalence.
+        PackageEquivalence.AssertSamePackage(wrapper, flagOn);
     }
 
     [Fact]

--- a/Docxodus.Tests/PackageEquivalence.cs
+++ b/Docxodus.Tests/PackageEquivalence.cs
@@ -1,0 +1,89 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using Docxodus;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+/// <summary>
+/// Compares two SEPARATELY PRODUCED DOCX packages for equivalence, part by part.
+///
+/// <para>Raw <see cref="DocxodusDocument.DocumentByteArray"/> equality cannot express this. A DOCX is a
+/// ZIP, and every entry carries the wall-clock time at which it was written, so two packages built from
+/// identical content a moment apart differ in those header bytes — and once a stored timestamp changes,
+/// the surrounding compressed stream shifts with it. The two calls under test run milliseconds apart and
+/// so USUALLY land in the same timestamp granule; on a loaded CI runner they sometimes straddle one, and
+/// the assertion fails on a single byte with no relation to the behavior being tested.</para>
+///
+/// <para>Comparing the part set and each part's bytes keeps the whole claim — same parts, same content,
+/// same relationships — while dropping only the container metadata that no test means to assert. Verified
+/// against the failure mode directly: two packages produced four seconds apart differ in raw bytes and
+/// agree on every part.</para>
+/// </summary>
+internal static class PackageEquivalence
+{
+    /// <summary>Asserts that <paramref name="actual"/> holds exactly the parts of <paramref name="expected"/>, byte for byte.</summary>
+    public static void AssertSamePackage(WmlDocument expected, WmlDocument actual)
+    {
+        Dictionary<string, byte[]> expectedParts = ReadParts(expected);
+        Dictionary<string, byte[]> actualParts = ReadParts(actual);
+
+        Assert.Equal(
+            expectedParts.Keys.OrderBy(uri => uri, StringComparer.Ordinal),
+            actualParts.Keys.OrderBy(uri => uri, StringComparer.Ordinal));
+
+        foreach (string uri in expectedParts.Keys.OrderBy(uri => uri, StringComparer.Ordinal))
+        {
+            byte[] expectedPart = expectedParts[uri];
+            byte[] actualPart = actualParts[uri];
+            if (expectedPart.AsSpan().SequenceEqual(actualPart))
+                continue;
+
+            Assert.Fail($"package part {uri} differs: {DescribeDifference(expectedPart, actualPart)}");
+        }
+    }
+
+    private static Dictionary<string, byte[]> ReadParts(WmlDocument document)
+    {
+        using var stream = new MemoryStream(document.DocumentByteArray.ToArray());
+        using var wordDocument = WordprocessingDocument.Open(stream, false);
+
+        var parts = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+        foreach (var part in wordDocument.GetPackage().GetParts())
+        {
+            using var partStream = part.GetStream(FileMode.Open, FileAccess.Read);
+            using var buffer = new MemoryStream();
+            partStream.CopyTo(buffer);
+            parts[part.Uri.ToString()] = buffer.ToArray();
+        }
+        return parts;
+    }
+
+    /// <summary>The first differing offset plus a short window either side, mirroring xUnit's byte-collection report.</summary>
+    private static string DescribeDifference(byte[] expected, byte[] actual)
+    {
+        int shared = Math.Min(expected.Length, actual.Length);
+        int position = 0;
+        while (position < shared && expected[position] == actual[position])
+            position++;
+
+        if (position == shared)
+            return $"lengths {expected.Length} and {actual.Length}, identical through byte {shared}";
+
+        return $"first difference at byte {position} " +
+            $"(expected {Window(expected, position)}, actual {Window(actual, position)}); " +
+            $"lengths {expected.Length} and {actual.Length}";
+    }
+
+    private static string Window(byte[] bytes, int position)
+    {
+        int start = Math.Max(0, position - 2);
+        int end = Math.Min(bytes.Length, position + 3);
+        return "[" + string.Join(", ", bytes[start..end]) + "]";
+    }
+}


### PR DESCRIPTION
Three tests in the IR/diff suite could fail on evidence they never meant to assert. Both failures showed up on PR #382, whose diff cannot reach `Ir/` at all — the same job passed on rerun with a *different* test failing, which is the signature of flakes rather than breakage.

## The clock

`PreAcceptInputRevisionsTests.Flag_on_is_byte_identical_to_accept_all_then_compare_wrapper` and `DocxCompareTests.DocxDiffBranch_ProducesSameBytesAsDirectDocxDiff` compared two **separately produced** packages with raw `DocumentByteArray` equality.

A DOCX is a ZIP, and the container stamps every entry with the time it was written. The two calls run milliseconds apart and so normally land in the same timestamp granule and agree; on a loaded runner they sometimes straddle one, and the assertion fails on a byte with no relation to the behavior under test. That is what CI reported — a binary byte differing by 1 at a fixed offset:

```
Expected: [···, 8, 0, 22, 186, 10, ···]
Actual:   [···, 8, 0, 21, 186, 10, ···]
```

Probed directly rather than assumed: two packages produced **four seconds apart** differ in raw bytes and agree on **every part**.

Both now use the new `PackageEquivalence.AssertSamePackage`, comparing the part set and each part's bytes. That keeps the entire claim — same parts, same content, same relationships — and drops only the container metadata no test means to assert. Verified against the real failure mode: across a forced straddle, the old assertion fails and the new one holds.

Only these two tests had the defect. The other `DocumentByteArray` comparisons in the suite assert an exact *clone* of one package (`ByteIdenticalInputs_ReturnDetachedExactClone…`, `Compare_StrictSelfCompare_PreservesExactPackageBytes`), which is deterministic and left alone.

## The spare CPU

`IrAlignerAdversarialTests.Scale_guard_500_vs_2000_cpu_ratio_within_12x` divides two sub-30 ms CPU samples against a 12x anti-O(n²) cliff. CI read **12.41x** on 2.16 ms / 26.85 ms.

The test was already careful — best-of-5 samples, batched aligns, forced GC, warm-up, non-parallel collection, process CPU time. The remaining problem is structural: at that scale a shared runner's scheduling noise is a large fraction of the measurement.

Scheduling noise can only **add** CPU time, so it can only **inflate** the ratio. That makes the minimum across independent rounds the closest estimate of the true one. The guard now takes the best of up to three rounds, stopping at the first that passes:

- one noisy round can no longer fail it;
- a real regression still does — that reads ~16x in **every** round, so all three must exceed the limit.

The threshold is unchanged at 12x. The true ratio measures **~4x**, so the CI reading was roughly 3x noise inflation.

I verified the guard still fires by temporarily lowering the limit to 1.0: it failed with the expected message after exhausting all three rounds.

## Verification

- `dotnet build -c Release Docxodus.sln` — 0 errors
- `dotnet test` — **3420 passed**, 0 failed, 3 skipped
- Both fixes probed against their actual failure modes, not just re-run until green

## Notes

Branched fresh off `main` as requested; #382 and #383 rebase onto it afterwards. No library code changes — tests and one test helper only.
