### PR TITLE
Pin one font-substitution contract for both visual-parity renderers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Visual-parity font-substitution contract** (issue #379,
+  `npm/tests/visual-parity/fonts.conf` + `font-contract.ts`): font policy for the
+  LibreOffice benchmark is now a shared contract instead of a host observation.
+  `fonts.conf` pins each declared Office family to a license-safe metric-compatible
+  substitute (Calibri/Calibri Light → Carlito, Cambria → Caladea, Times New
+  Roman/Arial/Courier New → Liberation), and BOTH renderers load it via
+  `FONTCONFIG_FILE` — LibreOffice per subprocess, Chromium at browser launch
+  (scoped to the benchmark opt-in in `playwright.config.ts`, so ordinary specs and
+  committed snapshots keep host fonts). Enforcement is layered: an fc-match
+  assertion fails the run naming the package to install, an in-browser
+  canvas-width check catches a browser launched without the contract, and a
+  cross-renderer wrapping probe (one generated paragraph per family; line counts
+  must match) detects drift the other layers can't — negatively validated, since
+  Calibri Light wraps differently without the contract on a stock host. Every
+  `summary.json` records the resolved family/file/version set and the contract
+  file's SHA-256, so baseline deltas trace to the renderer or a declared contract
+  change, never silent host-font drift. On the corpus: nine cases byte-identical,
+  `tracked-deletion` improved (the shared Calibri Light pinning succeeds where the
+  rejected renderer-only fallback failed), `fields-and-tabs` now measures its
+  honest, lower score.
 - **Visual-parity attribution dispositions** (`npm/tests/visual-parity/corpus.ts`):
   every benchmark corpus case now carries a reviewed `disposition` — `renderer-bug`,
   `environment`, `reference-deviation`, `unsupported-feature`, or `unattributed` —

--- a/npm/playwright.config.ts
+++ b/npm/playwright.config.ts
@@ -1,4 +1,20 @@
 import { defineConfig, devices } from '@playwright/test';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The visual-parity benchmark pins font substitution for BOTH renderers (issue #379): the spec
+// passes the same file to LibreOffice via FONTCONFIG_FILE, and Chromium must be LAUNCHED under
+// it, which only the config can do. Scoped to the benchmark opt-in so ordinary specs and their
+// committed snapshots keep the host's default fonts.
+const visualParityLaunchEnv = process.env.DOCXODUS_VISUAL_PARITY === '1'
+  ? {
+      env: {
+        ...process.env as Record<string, string>,
+        FONTCONFIG_FILE: resolve(
+          dirname(fileURLToPath(import.meta.url)), 'tests/visual-parity/fonts.conf'),
+      },
+    }
+  : {};
 
 export default defineConfig({
   testDir: './tests',
@@ -24,7 +40,7 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: { ...devices['Desktop Chrome'], launchOptions: visualParityLaunchEnv },
     },
     {
       // Firefox is the canary for cross-contenteditable drag feedback: its native selection

--- a/npm/tests/visual-parity.spec.ts
+++ b/npm/tests/visual-parity.spec.ts
@@ -23,6 +23,16 @@ import {
   type VisualDisposition,
 } from './visual-parity/corpus.js';
 import { compareImages, VISUAL_THRESHOLDS, type PageMetrics, type VisualSeverity } from './visual-parity/metrics.js';
+import {
+  FONT_CONTRACT,
+  FONT_CONTRACT_FILE,
+  PROBE_TEXT,
+  assertFontContract,
+  fontContractReport,
+  generateFontProbeDocx,
+  probeLineCountsFromPdfText,
+  probeMarker,
+} from './visual-parity/font-contract.js';
 import { decodePng, encodePng } from './visual-parity/png.js';
 
 test.skip(process.env.DOCXODUS_VISUAL_PARITY !== '1',
@@ -138,36 +148,70 @@ function numericPngs(directory: string, prefix: string): string[] {
     .map(item => join(directory, item.name));
 }
 
-function renderLibreOffice(docxPath: string, work: string): string[] {
-  const pdfDir = join(work, 'pdf');
-  const profileDir = join(work, 'profile');
+function libreofficeEnv(work: string): NodeJS.ProcessEnv {
   const runtimeDir = join(work, 'runtime');
   const homeDir = join(work, 'home');
-  for (const directory of [pdfDir, profileDir, runtimeDir, homeDir]) mkdirSync(directory, { mode: 0o700 });
-
-  const deterministicEnv = {
+  for (const directory of [runtimeDir, homeDir]) mkdirSync(directory, { recursive: true, mode: 0o700 });
+  return {
     ...process.env,
     HOME: homeDir,
     XDG_RUNTIME_DIR: runtimeDir,
     LANG: 'C.UTF-8',
     LC_ALL: 'C.UTF-8',
     TZ: 'UTC',
+    // The same font-substitution contract Chromium runs under (playwright.config.ts).
+    FONTCONFIG_FILE: FONT_CONTRACT_FILE,
   };
+}
+
+function libreofficePdf(docxPath: string, work: string): string {
+  const pdfDir = join(work, 'pdf');
+  const profileDir = join(work, 'profile');
+  for (const directory of [pdfDir, profileDir]) mkdirSync(directory, { recursive: true, mode: 0o700 });
+
   execFileSync('libreoffice', [
     `-env:UserInstallation=${pathToFileURL(profileDir).href}`,
     '--headless', '--nologo', '--nodefault', '--nofirststartwizard', '--norestore',
     '--convert-to', 'pdf', '--outdir', pdfDir, docxPath,
-  ], { env: deterministicEnv, stdio: 'pipe', timeout: 120000 });
+  ], { env: libreofficeEnv(work), stdio: 'pipe', timeout: 120000 });
 
   const pdfPath = join(pdfDir, `${docxPath.split('/').pop()!.replace(/\.docx$/i, '')}.pdf`);
   if (!existsSync(pdfPath)) throw new Error(`LibreOffice did not produce ${pdfPath}`);
+  return pdfPath;
+}
+
+function renderLibreOffice(docxPath: string, work: string): string[] {
+  const pdfPath = libreofficePdf(docxPath, work);
   const prefix = 'libreoffice-page';
   execFileSync('pdftoppm', [
     '-r', '96', '-png', pdfPath, join(work, prefix),
-  ], { env: deterministicEnv, stdio: 'pipe', timeout: 120000 });
+  ], { env: libreofficeEnv(work), stdio: 'pipe', timeout: 120000 });
   const pages = numericPngs(work, prefix);
   if (!pages.length) throw new Error(`pdftoppm produced no pages for ${docxPath}`);
   return pages;
+}
+
+/**
+ * Chromium must actually be running under the contract, not merely have it on disk — the config
+ * injects FONTCONFIG_FILE only at browser launch. Calibri Light is the discriminator: without
+ * the contract a host resolves it to whatever it has (Noto Sans, DejaVu Sans), whose advance
+ * widths differ from the substitute's.
+ */
+async function assertBrowserFontContract(page: Page): Promise<void> {
+  const mismatches = await page.evaluate((entries) => {
+    const context = document.createElement('canvas').getContext('2d')!;
+    const width = (family: string) => {
+      context.font = `16px "${family}"`;
+      return context.measureText('Sphinx of black quartz, judge my vow 0123456789').width;
+    };
+    return entries
+      .filter(([family, substitute]) => Math.abs(width(family) - width(substitute)) > 0.5)
+      .map(([family, substitute]) => `${family} does not measure as ${substitute}`);
+  }, FONT_CONTRACT.map(entry => [entry.family, entry.substitute] as [string, string]));
+  if (mismatches.length) {
+    throw new Error(`Chromium is not applying the font contract (${FONT_CONTRACT_FILE}):\n  ` +
+      mismatches.join('\n  '));
+  }
 }
 
 async function materializeComparisonFixture(
@@ -294,6 +338,7 @@ function summarizeCases(cases: CaseResult[]) {
 test('stratified tracked corpus matches LibreOffice at pixel level', async ({ page, browserName }) => {
   test.setTimeout(20 * 60 * 1000);
   assertTrackedCorpus(VISUAL_PARITY_CORPUS);
+  const fontContract = fontContractReport(repoRoot); // throws if the host misses the contract
   const corpus = selectedCorpus();
   const outputRoot = resolve(process.env.DOCXODUS_VISUAL_PARITY_OUTPUT ??
     join(tmpdir(), 'docxodus-visual-parity'));
@@ -311,6 +356,7 @@ test('stratified tracked corpus matches LibreOffice at pixel level', async ({ pa
   await page.emulateMedia({ reducedMotion: 'reduce' });
   await page.goto('/test-harness.html');
   await page.waitForFunction(() => (window as any).DocxodusReady === true, { timeout: 90000 });
+  await assertBrowserFontContract(page);
   await page.addScriptTag({ url: '/pagination.bundle.js' });
 
   const cases: CaseResult[] = [];
@@ -406,9 +452,7 @@ test('stratified tracked corpus matches LibreOffice at pixel level', async ({ pa
       chromium: page.context().browser()?.version() ?? 'unknown',
       libreoffice: commandVersion('libreoffice', ['--version']),
       pdftoppm: commandVersion('pdftoppm', ['-v']).split('\n')[0],
-      calibriMatch: commandVersion('fc-match', ['Calibri', '--format=%{family} %{file}']),
-      calibriLightMatch: commandVersion('fc-match', ['Calibri Light', '--format=%{family} %{file}']),
-      timesNewRomanMatch: commandVersion('fc-match', ['Times New Roman', '--format=%{family} %{file}']),
+      fontContract,
       locale: 'C.UTF-8',
       timezone: 'UTC',
     },
@@ -429,5 +473,78 @@ test('stratified tracked corpus matches LibreOffice at pixel level', async ({ pa
       'strict mode rejects severe cases attributed to the renderer (renderer-bug or unattributed) ' +
       'and conversion errors; environment and reference-deviation severes are reported, not gated',
     ).toEqual([]);
+  }
+});
+
+/**
+ * The contract drift probe (issue #379): one generated paragraph per declared family, wrapped in
+ * a 6.5in column by both renderers. Wrapping is the metric-sensitive observable — if either
+ * engine resolves a family to a different font, advance widths change and the paragraph wraps to
+ * a different number of lines. fc-match proves what fontconfig WOULD resolve; this proves what
+ * the two renderers actually DID.
+ */
+test('declared font families wrap identically in Chromium and LibreOffice', async ({ page }) => {
+  test.setTimeout(5 * 60 * 1000);
+  assertFontContract();
+
+  const work = mkdtempSync(join(tmpdir(), 'docxodus-font-probe-'));
+  try {
+    const docxPath = join(work, 'font-probe.docx');
+    writeFileSync(docxPath, Buffer.from(generateFontProbeDocx()));
+    const pdfText = execFileSync('pdftotext', ['-layout', libreofficePdf(docxPath, work), '-'], {
+      encoding: 'utf8',
+      env: libreofficeEnv(work),
+      timeout: 120000,
+    });
+    const libreofficeLines = probeLineCountsFromPdfText(pdfText);
+
+    await page.goto('/test-harness.html');
+    await page.waitForFunction(() => (window as any).DocxodusReady === true, { timeout: 90000 });
+    await assertBrowserFontContract(page);
+    await page.addScriptTag({ url: '/pagination.bundle.js' });
+
+    const chromiumLines = await page.evaluate(
+      ({ bytes, markers }: { bytes: number[]; markers: string[] }) => {
+        const html = (window as any).Docxodus.DocumentConverter.ConvertDocxToHtmlComplete(
+          new Uint8Array(bytes), 'Document', 'docx-', true, '', -1, 'comment-',
+          1, 1, 'page-', false, 0, 'annot-', true, true, false, false, false,
+        );
+        if (html.startsWith('{') && html.includes('"Error"')) throw new Error(html);
+        document.body.innerHTML = '<main id="font-probe-root"></main>';
+        (window as any).DocxodusPagination.paginateHtml(
+          html, document.getElementById('font-probe-root'),
+          { scale: 1, showPageNumbers: false, pageGap: 0, fragmentParagraphs: false });
+        return document.fonts.ready.then(() => markers.map(marker => {
+          // Only rendered pages — the hidden pagination staging copy has no client rects.
+          const paragraph = Array.from(document.querySelectorAll('#font-probe-root .page-box p'))
+            .find(candidate => (candidate.textContent || '').includes(marker));
+          if (!paragraph) return -1;
+          const range = document.createRange();
+          range.selectNodeContents(paragraph);
+          const lineTops = new Set(Array.from(range.getClientRects())
+            .filter(rect => rect.width > 1 && rect.height > 1)
+            .map(rect => Math.round(rect.top)));
+          return lineTops.size;
+        }));
+      },
+      {
+        bytes: Array.from(generateFontProbeDocx()),
+        markers: FONT_CONTRACT.map((_, index) => probeMarker(index)),
+      });
+
+    for (const [index, entry] of FONT_CONTRACT.entries()) {
+      expect(chromiumLines[index], `${entry.family} paragraph missing from Chromium render`)
+        .toBeGreaterThan(1);
+      expect(libreofficeLines[index], `${entry.family} paragraph missing from LibreOffice render`)
+        .toBeGreaterThan(1);
+      expect(
+        chromiumLines[index],
+        `${entry.family} (contract: ${entry.substitute}) wraps to ${chromiumLines[index]} lines ` +
+        `in Chromium but ${libreofficeLines[index]} in LibreOffice — the substitution contract ` +
+        `has drifted between the renderers. Probe text: "${PROBE_TEXT.slice(0, 40)}…"`,
+      ).toBe(libreofficeLines[index]);
+    }
+  } finally {
+    rmSync(work, { recursive: true, force: true });
   }
 });

--- a/npm/tests/visual-parity/BASELINE.md
+++ b/npm/tests/visual-parity/BASELINE.md
@@ -178,6 +178,34 @@ Chromium, and Calibri Light substitutes); the per-case table below carries the c
 figures. The headline number is no longer the raw severe count but the strict-gating set: two
 renderer-attributable severe cases remain.
 
+## Font-substitution contract — 2026-08-11 (issue #379)
+
+Font policy is now a shared contract, not a host observation: `fonts.conf` pins each declared
+Office family to a license-safe metric-compatible substitute (Calibri/Calibri Light → Carlito,
+Cambria → Caladea, Times New Roman/Arial/Courier New → Liberation), and both renderers load it via
+`FONTCONFIG_FILE` — LibreOffice per subprocess, Chromium at launch through `playwright.config.ts`.
+Enforcement is layered (fc-match assertion with install hints, in-browser canvas-width check,
+cross-renderer wrapping probe), and the resolved family/file/version set plus the contract file's
+SHA-256 are recorded in every `summary.json`. The probe is negatively validated: without the
+contract, Calibri Light wraps 5 lines instead of 4 on a stock Ubuntu host (DejaVu Sans vs
+Carlito). See the README's contract section for the full mechanism.
+
+Corpus effect, against the immediately preceding run in the same environment:
+
+- **Nine of twelve cases byte-identical** — this host's defaults already matched the contract for
+  their families, confirming the pinning changes nothing except what it claims to pin.
+- **`tracked-deletion` improved** (SSIM 0.94833, +0.01688; ink F1 0.58271, +0.04299). The
+  renderer-only `Calibri Light → Carlito` fallback was rejected in the initial baseline because it
+  worsened this exact case; the SAME mapping shared by both engines improves it — the contract's
+  thesis, demonstrated.
+- **`fields-and-tabs` measured lower** (ink F1 0.15994, −0.19971): with Calibri Light pinned in
+  both engines the TOC line-height mismatch no longer partially overlaps by accident. The case was
+  already strict-gating `renderer-bug`; the pinned number is the honest one.
+
+Severity counts, strict gating (`shape`, `fields-and-tabs`), and every disposition are unchanged.
+`environment` now has a sharper meaning: the engines lay out the SAME fonts differently
+(line breaking, justification, rasterization) — never that they picked different fonts.
+
 ## Current case results and triage
 
 `SSIM` is the mean over paired pages. `Ink F1` is the worst paired-page value, so it exposes a
@@ -195,9 +223,9 @@ rerun (environment above); `Disposition` is the corpus attribution the strict ga
 | inline-image | 1/1 | severe | environment | 0.93585 | 0.64828 | Image and text are separate source paragraphs; the discrepancy is indentation/font/wrapping, not an inline-flow failure. Re-triage after issue #379. |
 | chart | 1/1 | close | environment | 0.98651 | 0.96816 | Cached clustered column data now renders as accessible inline SVG at the stored extent. Other chart families and stacked groupings remain unsupported and are not yet in the corpus. |
 | shape | 1/1 | severe | renderer-bug | 0.97418 | 0.63170 | Column centering, paragraph offset, and 40%-of-margin relative width now match: horizontal bounds are exact and the top is within 1 px. The residual is auto-fit text/line height (the Docxodus box is 15 px shorter). |
-| fields-and-tabs | 1/1 | severe | renderer-bug | 0.89143 | 0.35965 | Right-tab page numbers now reach the declared 9350-twip target and leaders fill the rendered remainder. TOC line height and hyperlink styling remain renderer-side, entangled with font metrics. |
-| footnote | 1/1 | severe | environment | 0.99277 | 0.73700 | Note placement fixed (issue #378): note-text bottom flush with LibreOffice's, separator-to-note gap matches. Residual is substituted-font line metrics (issue #379) and LibreOffice-24.2's legacy separator width. |
-| tracked-deletion | 1/1 | severe | environment | 0.93145 | 0.53972 | Identical accepted-revision bytes are now compared. Remaining differences cluster around Calibri Light substitution, heading metrics, and wrapping rather than revision semantics. Re-triage after issue #379. |
+| fields-and-tabs | 1/1 | severe | renderer-bug | 0.89412 | 0.15994 | Right-tab page numbers now reach the declared 9350-twip target and leaders fill the rendered remainder. TOC line height and hyperlink styling remain renderer-side; the font contract made this measurement honest and lower. |
+| footnote | 1/1 | severe | environment | 0.99277 | 0.73700 | Note placement fixed (issue #378): note-text bottom flush with LibreOffice's, separator-to-note gap matches. Residual is same-font line-box metrics and LibreOffice-24.2's legacy separator width. |
+| tracked-deletion | 1/1 | severe | environment | 0.94833 | 0.58271 | Identical accepted-revision bytes are now compared. Improved by the shared Calibri Light pinning (issue #379); the residual is heading metrics and wrapping of the same fonts. |
 
 ## Fixes justified by the baseline
 
@@ -240,17 +268,15 @@ renderer heuristic.
 ## Prioritized next work
 
 The former first priority (blank charts), the PR #372 rerun, aligned tab geometry,
-header/body/footer vertical placement (issue #377), DrawingML textbox anchor geometry, and footnote
-block vertical placement (issue #378) are resolved above. The remaining order is:
+header/body/footer vertical placement (issue #377), DrawingML textbox anchor geometry, footnote
+block vertical placement (issue #378), and the font-substitution contract (issue #379) are
+resolved above. The remaining order is:
 
-1. Define and provision one font-substitution contract shared by Chromium and LibreOffice CI
-   (issue #379). This is the gate for everything attributed `environment`: four severe cases
-   (`landscape-section`, `inline-image`, `footnote` residual, `tracked-deletion`) cannot be
-   triaged further until wrap and line-metric differences stop being environment noise.
-2. Model auto-fit text/line height for DrawingML textboxes (`shape`, strict-gating).
-3. TOC line height and hyperlink styling (`fields-and-tabs`, strict-gating; re-measure after 1).
-4. Reduce the `merged-table` fill/border color delta to a minimal case and attribute it.
-5. Obtain Word evidence for the `numbered-lists` top margin to close or reclassify the
+1. Model auto-fit text/line height for DrawingML textboxes (`shape`, strict-gating).
+2. TOC line height and hyperlink styling (`fields-and-tabs`, strict-gating — now honestly
+   measured under the pinned contract).
+3. Reduce the `merged-table` fill/border color delta to a minimal case and attribute it.
+4. Obtain Word evidence for the `numbered-lists` top margin to close or reclassify the
    reference-deviation.
 
 The list-margin discrepancy should not be changed merely to imitate LibreOffice: current evidence

--- a/npm/tests/visual-parity/README.md
+++ b/npm/tests/visual-parity/README.md
@@ -28,11 +28,10 @@ output directory so stale pages cannot contaminate a rerun.
   raster pixel.
 - LibreOffice exports PDF from a fresh per-document user profile. Poppler rasterizes the PDF at
   exactly 96 DPI.
-- Both processes use `C.UTF-8`, UTC, and the host fontconfig installation. The summary records the
-  Chromium, LibreOffice, Poppler, Calibri/Calibri Light substitutes, and Times New Roman substitute.
-  A missing Office font remains a triage signal rather than something the benchmark masks: for
-  example, a host may map Calibri Light to Noto Sans while LibreOffice applies its own substitution,
-  changing line wraps even when the renderer's OOXML geometry is correct.
+- Both processes use `C.UTF-8`, UTC, and the **font-substitution contract** below instead of the
+  host's default fontconfig, so line wraps cannot drift with whatever fonts a host happens to
+  carry. The summary records the Chromium, LibreOffice, and Poppler versions plus every contract
+  resolution (family, file, font version, contract-file SHA-256).
 - The comparison uses final-revision view: insertions are included and deletions/move markup are not
   rendered. LibreOffice's headless PDF filter follows the file's saved redline-display state and
   provides no final-view switch, so manifest cases marked `revisionMode: 'accepted'` are accepted
@@ -46,6 +45,42 @@ output directory so stale pages cannot contaminate a rerun.
   chosen offset is always reported.
 - No masks are applied. A future mask must be a bounded rectangle tied to one manifest case/page and
   carry a specific justification; a document-wide or text-wide mask is not acceptable.
+
+## Font-substitution contract
+
+Documents declare proprietary Office families no CI host may install. Which substitute each
+family resolves to changes wrapping and line metrics, and a renderer-only fallback was tried and
+rejected — it moved one engine without the other. Font policy is therefore a **shared contract**
+(issue #379): `fonts.conf` pins each declared family to a license-safe metric-compatible
+substitute, and both renderers load it via `FONTCONFIG_FILE` — LibreOffice through the runner's
+subprocess environment, Chromium at browser launch through `playwright.config.ts` (scoped to the
+benchmark opt-in so ordinary specs keep host fonts).
+
+| Declared family | Substitute | Package | Metric-compatible |
+|---|---|---|---|
+| Calibri | Carlito | fonts-crosextra-carlito | yes |
+| Calibri Light | Carlito | fonts-crosextra-carlito | no — documented approximation, no open metric clone exists |
+| Cambria | Caladea | fonts-crosextra-caladea | yes |
+| Times New Roman | Liberation Serif | fonts-liberation2 | yes |
+| Arial | Liberation Sans | fonts-liberation2 | yes |
+| Courier New | Liberation Mono | fonts-liberation2 | yes |
+
+Enforcement is layered, and each layer fails with a message naming what to fix:
+
+- `assertFontContract()` fails the run when `fc-match` under the contract does not resolve every
+  family to its substitute, naming the package to install.
+- An in-browser check fails when Chromium was launched without the contract (canvas advance
+  widths of each family must equal its substitute's).
+- A **wrapping probe** (`declared font families wrap identically…` in `visual-parity.spec.ts`)
+  renders one generated paragraph per family through both engines and requires identical
+  line counts — fc-match proves what fontconfig would resolve; the probe proves what the two
+  renderers actually did. It is negatively validated: without the contract, Calibri Light wraps
+  differently on a stock Ubuntu host.
+
+With the contract pinned and recorded, a baseline delta traces to either the renderer or a
+declared contract change — never to silent host-font drift. `environment` dispositions now mean
+"the two engines lay out the SAME substitute differently" (rasterization, justification, line
+breaking), not "the two engines picked different fonts".
 
 ## Metrics and thresholds
 
@@ -96,8 +131,10 @@ evidence bar as a renderer fix: OOXML semantics, Word behavior where available, 
 ## Run locally
 
 Prerequisites: `libreoffice-writer` (a bare `libreoffice-core` install fails every case with
-"source file could not be loaded"), `pdftoppm` (poppler-utils), Chromium installed for Playwright,
-and the repository's npm dependencies.
+"source file could not be loaded"), `poppler-utils` (`pdftoppm`/`pdftotext`), the contract fonts
+(`fonts-crosextra-carlito`, `fonts-crosextra-caladea`, `fonts-liberation2` — the run fails with
+install instructions when missing), Chromium installed for Playwright, and the repository's npm
+dependencies.
 
 ```bash
 cd npm

--- a/npm/tests/visual-parity/corpus.ts
+++ b/npm/tests/visual-parity/corpus.ts
@@ -114,10 +114,8 @@ export const VISUAL_PARITY_CORPUS: VisualCorpusEntry[] = [
     rationale: 'Landscape dimensions and margin placement.',
     disposition: {
       kind: 'environment',
-      rationale: 'Page dimensions match exactly; the residual is paragraph spacing and wrapping under ' +
-        'different Chromium/LibreOffice font substitution. Re-triage once a shared substitution ' +
-        'contract exists.',
-      reference: 'https://github.com/JSv4/Docxodus/issues/379',
+      rationale: 'Page dimensions match exactly; unchanged by the font contract, so the residual is ' +
+        'paragraph spacing and line breaking of the SAME fonts differing between the two engines.',
     },
   },
   {
@@ -138,9 +136,8 @@ export const VISUAL_PARITY_CORPUS: VisualCorpusEntry[] = [
     disposition: {
       kind: 'environment',
       rationale: 'The image and text are separate source paragraphs; the discrepancy is ' +
-        'indentation/font/wrapping under differing font substitution, not an inline-flow failure. ' +
-        'Re-triage once a shared substitution contract exists.',
-      reference: 'https://github.com/JSv4/Docxodus/issues/379',
+        'indentation/font/wrapping, not an inline-flow failure. Unchanged by the font contract, ' +
+        'so the engines lay out the same fonts differently.',
     },
   },
   {
@@ -174,8 +171,9 @@ export const VISUAL_PARITY_CORPUS: VisualCorpusEntry[] = [
     disposition: {
       kind: 'renderer-bug',
       rationale: 'Tab targets and leaders are correct since PR #380; TOC line height and hyperlink ' +
-        'styling remain renderer-side differences, entangled with font-substitution wrapping.',
-      reference: 'https://github.com/JSv4/Docxodus/issues/379',
+        'styling remain renderer-side differences. The font contract made the measurement honest ' +
+        'and lower: with Calibri Light pinned to Carlito in both engines, the line-height ' +
+        'mismatch no longer partially overlaps by accident.',
     },
   },
   {
@@ -186,10 +184,9 @@ export const VISUAL_PARITY_CORPUS: VisualCorpusEntry[] = [
     disposition: {
       kind: 'environment',
       rationale: 'Note placement is fixed (issue #378): the last note line ends on the bottom margin ' +
-        'in both engines and the separator-to-note gap matches. The residual is body/note line ' +
-        'metrics of the substituted font differing between Chromium and LibreOffice, and older ' +
-        'LibreOffice drawing its 25%-column separator instead of the two-inch default.',
-      reference: 'https://github.com/JSv4/Docxodus/issues/379',
+        'in both engines and the separator-to-note gap matches. The residual is line-box metrics ' +
+        'of the same font differing between the engines, and older LibreOffice drawing its ' +
+        '25%-column separator instead of the two-inch default.',
     },
   },
   {
@@ -200,10 +197,10 @@ export const VISUAL_PARITY_CORPUS: VisualCorpusEntry[] = [
     revisionMode: 'accepted',
     disposition: {
       kind: 'environment',
-      rationale: 'Identical accepted bytes go to both engines; the differences cluster around Calibri ' +
-        'Light substitution, heading metrics, and wrapping rather than revision semantics. Re-triage ' +
-        'once a shared substitution contract exists.',
-      reference: 'https://github.com/JSv4/Docxodus/issues/379',
+      rationale: 'Identical accepted bytes go to both engines; the differences cluster around heading ' +
+        'metrics and wrapping rather than revision semantics. The font contract improved this case ' +
+        '(shared Calibri Light pinning) — the residual is the engines laying out the same fonts ' +
+        'differently.',
     },
   },
 ];

--- a/npm/tests/visual-parity/font-contract.ts
+++ b/npm/tests/visual-parity/font-contract.ts
@@ -1,0 +1,166 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { storedZip, xml, R_NS, W_NS } from '../docx-zip.js';
+
+/**
+ * The font-substitution contract (issue #379): the proprietary Office families the corpus uses,
+ * each pinned to a license-safe metric-compatible substitute by `fonts.conf`, which both
+ * renderers load via FONTCONFIG_FILE. This module owns declaring the contract, verifying the
+ * host satisfies it, and recording the resolved fonts in the report.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Absolute path both renderers must receive as FONTCONFIG_FILE. */
+export const FONT_CONTRACT_FILE = resolve(__dirname, 'fonts.conf');
+
+export interface FontContractEntry {
+  /** The family documents declare. */
+  family: string;
+  /** The substitute the contract assigns. */
+  substitute: string;
+  /** Debian package providing the substitute, for the failure message. */
+  package: string;
+  /** True when the substitute is metric-compatible with the declared family by design. */
+  metricCompatible: boolean;
+}
+
+export const FONT_CONTRACT: FontContractEntry[] = [
+  { family: 'Calibri', substitute: 'Carlito', package: 'fonts-crosextra-carlito', metricCompatible: true },
+  // No open metric clone of the Light cut exists; the contract's job is that BOTH engines make
+  // the same approximation, not that the approximation is metrically exact.
+  { family: 'Calibri Light', substitute: 'Carlito', package: 'fonts-crosextra-carlito', metricCompatible: false },
+  { family: 'Cambria', substitute: 'Caladea', package: 'fonts-crosextra-caladea', metricCompatible: true },
+  { family: 'Times New Roman', substitute: 'Liberation Serif', package: 'fonts-liberation2', metricCompatible: true },
+  { family: 'Arial', substitute: 'Liberation Sans', package: 'fonts-liberation2', metricCompatible: true },
+  { family: 'Courier New', substitute: 'Liberation Mono', package: 'fonts-liberation2', metricCompatible: true },
+];
+
+export interface ResolvedFont {
+  family: string;
+  substitute: string;
+  resolvedFamily: string;
+  file: string;
+  fontVersion: string;
+  metricCompatible: boolean;
+}
+
+/** What each declared family resolves to under the contract, per fc-match. */
+export function resolveContractFonts(): ResolvedFont[] {
+  return FONT_CONTRACT.map(entry => {
+    const out = execFileSync('fc-match', ['-f', '%{family}\t%{file}\t%{fontversion}', entry.family], {
+      encoding: 'utf8',
+      env: { ...process.env, FONTCONFIG_FILE: FONT_CONTRACT_FILE },
+    });
+    const [resolvedFamily = '', file = '', fontVersion = ''] = out.split('\t');
+    return {
+      family: entry.family,
+      substitute: entry.substitute,
+      // fc-match may report a family list; the substitute must be one of its names.
+      resolvedFamily,
+      file,
+      fontVersion,
+      metricCompatible: entry.metricCompatible,
+    };
+  });
+}
+
+/**
+ * Fails clearly when the host cannot satisfy the contract, naming the packages to install.
+ * Returns the resolutions for the report on success.
+ */
+export function assertFontContract(): ResolvedFont[] {
+  let resolved: ResolvedFont[];
+  try {
+    resolved = resolveContractFonts();
+  } catch (error) {
+    throw new Error(`fc-match is unavailable; the font contract cannot be verified: ${error}`);
+  }
+  const broken = resolved.filter(r =>
+    !r.resolvedFamily.split(',').some(name => name.trim() === r.substitute));
+  if (broken.length) {
+    const detail = broken.map(r => {
+      const pkg = FONT_CONTRACT.find(e => e.family === r.family)!.package;
+      return `  ${r.family} -> ${r.resolvedFamily || '(nothing)'} (contract: ${r.substitute}; install ${pkg})`;
+    }).join('\n');
+    throw new Error(`Font-substitution contract not satisfied:\n${detail}`);
+  }
+  return resolved;
+}
+
+/** The report block `summary.json` records for the environment. */
+export function fontContractReport(repoRoot: string) {
+  return {
+    file: relative(repoRoot, FONT_CONTRACT_FILE),
+    sha256: createHash('sha256').update(readFileSync(FONT_CONTRACT_FILE)).digest('hex'),
+    families: assertFontContract(),
+  };
+}
+
+/**
+ * The drift probe document: one multi-line paragraph per contract family, in that family, at
+ * 11pt in a 6.5in column. Wrapping is the metric-sensitive observable — if either renderer
+ * resolves a family differently, advance widths change and the paragraph wraps to a different
+ * number of lines. The pangram mixes widths so a substitution cannot hide behind quantization.
+ */
+export const PROBE_TEXT =
+  'Sphinx of black quartz, judge my vow; 0123456789 — pack my box with five dozen liquor jugs. '
+    .repeat(4)
+    .trim();
+
+/** Marker prefixing each family's paragraph so both renderers' output can be attributed. */
+export const probeMarker = (index: number): string => `@@F${index}@@`;
+
+export function generateFontProbeDocx(): Uint8Array {
+  const paragraphs = FONT_CONTRACT.map((entry, index) =>
+    `<w:p><w:pPr><w:spacing w:before="0" w:after="120" w:line="240" w:lineRule="auto"/></w:pPr>` +
+    `<w:r><w:rPr><w:rFonts w:ascii="${entry.family}" w:hAnsi="${entry.family}"/><w:sz w:val="22"/></w:rPr>` +
+    `<w:t xml:space="preserve">${probeMarker(index)} ${PROBE_TEXT}</w:t></w:r></w:p>`).join('\n  ');
+
+  return storedZip([
+    {
+      name: '[Content_Types].xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`),
+    },
+    {
+      name: '_rels/.rels',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${R_NS}/officeDocument" Target="word/document.xml"/>
+</Relationships>`),
+    },
+    {
+      name: 'word/document.xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="${W_NS}" xmlns:r="${R_NS}"><w:body>
+  ${paragraphs}
+  <w:sectPr>
+    <w:pgSz w:w="12240" w:h="15840"/>
+    <w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"
+      w:header="720" w:footer="720" w:gutter="0"/>
+    <w:cols w:space="720"/>
+  </w:sectPr>
+</w:body></w:document>`),
+    },
+  ]);
+}
+
+/** Lines per probe paragraph in a `pdftotext -layout` dump, attributed by marker order. */
+export function probeLineCountsFromPdfText(text: string): number[] {
+  const lines = text.split('\n').map(line => line.trim()).filter(Boolean);
+  const starts = FONT_CONTRACT.map((_, index) =>
+    lines.findIndex(line => line.includes(probeMarker(index))));
+  if (starts.some(start => start < 0)) {
+    throw new Error(`probe markers missing from pdftotext output:\n${text.slice(0, 500)}`);
+  }
+  return starts.map((start, index) =>
+    (index + 1 < starts.length ? starts[index + 1] : lines.length) - start);
+}

--- a/npm/tests/visual-parity/fonts.conf
+++ b/npm/tests/visual-parity/fonts.conf
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<!--
+  The visual-parity font-substitution contract (issue #379).
+
+  Both renderers link fontconfig, so pointing FONTCONFIG_FILE at this file gives Chromium and
+  LibreOffice the SAME resolution for the proprietary Office families neither host may install:
+  each family is assigned to its license-safe metric-compatible substitute. A renderer-only
+  fallback was tried and rejected (it moved one engine without the other); the contract exists so
+  font policy can never again live in one code path.
+
+  Calibri Light has no open metric clone; assigning it to Carlito is a documented approximation —
+  what matters for the benchmark is that BOTH engines make the same approximation.
+
+  The system config is included first for font directories and caches; the assignments below then
+  override any weak metric aliases it ships, so resolution does not depend on the host distro.
+-->
+<fontconfig>
+  <include ignore_missing="yes">/etc/fonts/fonts.conf</include>
+
+  <match target="pattern">
+    <test name="family"><string>Calibri</string></test>
+    <edit name="family" mode="assign" binding="same"><string>Carlito</string></edit>
+  </match>
+  <match target="pattern">
+    <test name="family"><string>Calibri Light</string></test>
+    <edit name="family" mode="assign" binding="same"><string>Carlito</string></edit>
+  </match>
+  <match target="pattern">
+    <test name="family"><string>Cambria</string></test>
+    <edit name="family" mode="assign" binding="same"><string>Caladea</string></edit>
+  </match>
+  <match target="pattern">
+    <test name="family"><string>Times New Roman</string></test>
+    <edit name="family" mode="assign" binding="same"><string>Liberation Serif</string></edit>
+  </match>
+  <match target="pattern">
+    <test name="family"><string>Arial</string></test>
+    <edit name="family" mode="assign" binding="same"><string>Liberation Sans</string></edit>
+  </match>
+  <match target="pattern">
+    <test name="family"><string>Courier New</string></test>
+    <edit name="family" mode="assign" binding="same"><string>Liberation Mono</string></edit>
+  </match>
+</fontconfig>


### PR DESCRIPTION
Font policy for the LibreOffice benchmark becomes a **shared contract** instead of a host observation. A renderer-only `Calibri Light → Carlito` fallback was tried and rejected in the initial baseline because it moved one engine without the other; this closes that gap the way issue #379 prescribes — one fontconfig file, loaded by **both** renderers.

## The contract

`npm/tests/visual-parity/fonts.conf` assigns each declared Office family a license-safe metric-compatible substitute:

| Declared | Substitute | Metric-compatible |
|---|---|---|
| Calibri | Carlito | yes |
| Calibri Light | Carlito | no — documented approximation, no open metric clone exists |
| Cambria | Caladea | yes |
| Times New Roman / Arial / Courier New | Liberation Serif / Sans / Mono | yes |

Both renderers load it via `FONTCONFIG_FILE`: LibreOffice through the runner's subprocess environment, Chromium at browser launch through `playwright.config.ts` — scoped to the `DOCXODUS_VISUAL_PARITY=1` opt-in so ordinary specs and their committed snapshots keep host fonts.

## Enforcement (each layer fails naming what to fix)

- `assertFontContract()` — fc-match under the contract must resolve every family to its substitute; failure names the Debian package to install.
- In-browser canvas-width check — catches a Chromium launched without the contract (Calibri Light is the discriminator).
- **Wrapping probe** — a generated paragraph per family rendered through both engines; line counts must match. fc-match proves what fontconfig *would* resolve; the probe proves what the two renderers actually *did*. Negatively validated: without the contract, Calibri Light wraps 5 lines instead of 4 on a stock Ubuntu host (DejaVu Sans vs Carlito).

`summary.json` records every resolution (family, file, font version) plus the contract file's SHA-256, so a baseline delta traces to the renderer or a declared contract change — never silent host-font drift.

## Corpus effect (vs the immediately preceding same-environment run)

- **9/12 cases byte-identical** — the pinning changes nothing except what it claims to pin.
- **`tracked-deletion` improved** (SSIM +0.017, ink F1 +0.043): the same Calibri Light mapping that was rejected as a renderer-only change *improves* the case when shared — the contract's thesis, demonstrated.
- **`fields-and-tabs` now measures its honest, lower score** (ink F1 0.360 → 0.160): with fonts pinned in both engines, the TOC line-height mismatch no longer partially overlaps by accident. Already strict-gating `renderer-bug`.
- Severity counts, strict gating (`shape`, `fields-and-tabs`), and all dispositions unchanged; `environment` now sharply means "the engines lay out the SAME fonts differently".

CI needs no workflow change — it already installs the contract fonts and poppler-utils.

## Testing

- Wrapping probe + full corpus run under the contract: pass (0 errors, 0 page-count mismatches)
- Probe negative validation: drift detected when the contract is absent
- `tsc -p tsconfig.tests.json`: clean
- `tabs-visual` (committed snapshots, no benchmark flag): pass — ordinary specs unaffected

Closes #379.

---
_Generated by [Claude Code](https://claude.ai/code/session_0198sMhLG9bomXkxRUYGvANo)_