### PR TITLE
Add a regression ratchet to the weekly visual-parity run (#395)

### DIFF
--- a/.github/workflows/visual-parity.yml
+++ b/.github/workflows/visual-parity.yml
@@ -12,6 +12,11 @@ on:
         required: false
         default: false
         type: boolean
+      ratchet:
+        description: Fail if any case got worse than the committed record
+        required: false
+        default: true
+        type: boolean
   schedule:
     - cron: '41 8 * * 1'
 
@@ -55,11 +60,16 @@ jobs:
       - name: Install Chromium
         run: cd npm && npx playwright install --with-deps chromium
 
+      # The regression ratchet (issue #395) compares this run against the committed record and
+      # fails when any case got worse. A scheduled run has no `inputs`, so the expression falls
+      # through to '1' — the weekly run is the one that most needs the gate, because nobody is
+      # watching it. Refresh the record deliberately in the PR that changes rendering.
       - name: Compare stratified corpus with LibreOffice
         env:
           DOCXODUS_VISUAL_PARITY_OUTPUT: ${{ runner.temp }}/docxodus-visual-parity
           DOCXODUS_VISUAL_PARITY_FILTER: ${{ inputs.filter }}
           DOCXODUS_VISUAL_PARITY_STRICT: ${{ inputs.strict && '1' || '0' }}
+          DOCXODUS_VISUAL_PARITY_RATCHET: ${{ github.event_name == 'workflow_dispatch' && !inputs.ratchet && '0' || '1' }}
         run: cd npm && npm run test:visual-parity
 
       - name: Upload visual comparison report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Visual-parity regression ratchet** (issue #395,
+  `npm/tests/visual-parity/ratchet.ts` + `ratchet.json`): the weekly scheduled run
+  now compares itself against a committed, numbers-only per-case record — page
+  counts, severity, mean SSIM, worst ink F1, disposition; no images, no paths, no
+  artifact hashes — and fails when any case gets worse beyond a documented
+  tolerance (0.0005 SSIM, 0.001 ink F1). Previously the run uploaded an artifact
+  that expired in 14 days and nothing compared one run against the previous, so a
+  renderer regression was caught only if someone downloaded and eyeballed it in
+  time. The ratchet is deliberately **broader than strict mode**: strict gates only
+  severe cases the renderer owns, while the ratchet covers every case at every
+  severity, so a `close` case sliding to `minor` is caught. Because CI installs
+  LibreOffice from unpinned `ubuntu-latest` apt (issue #403), the record carries an
+  environment fingerprint (LibreOffice major.minor, Chromium major, `fonts.conf`
+  SHA-256); a mismatch reports `environment-changed` and demands a refresh rather
+  than blaming Docxodus for a reference-renderer release. Refresh the record
+  deliberately with `DOCXODUS_VISUAL_PARITY_UPDATE_RECORD=1` in the PR that changes
+  rendering, so improvements and accepted regressions are reviewed in the diff; a
+  passing run still lists every improvement it measured, so a stale record
+  announces itself. The comparison layer is pure and `visual-parity-ratchet.spec.ts`
+  exercises it on every pull request without LibreOffice or a renderer, which keeps
+  "a deliberately introduced regression fails, naming the case and the signal" a
+  continuously proven property. The full artifact upload is unchanged.
 - **Visual-parity font-substitution contract** (issue #379,
   `npm/tests/visual-parity/fonts.conf` + `font-contract.ts`): font policy for the
   LibreOffice benchmark is now a shared contract instead of a host observation.

--- a/npm/tests/visual-parity-ratchet.spec.ts
+++ b/npm/tests/visual-parity-ratchet.spec.ts
@@ -1,0 +1,343 @@
+import { test, expect } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { VISUAL_PARITY_CORPUS } from './visual-parity/corpus.js';
+import {
+  RATCHET_PRECISION,
+  RATCHET_RECORD_FILE,
+  RATCHET_SCHEMA_VERSION,
+  RATCHET_TOLERANCE,
+  buildRecord,
+  chromiumFingerprint,
+  compareToRecord,
+  libreofficeFingerprint,
+  readRecord,
+  serializeRecord,
+  type RatchetSummary,
+  type RatchetSummaryCase,
+} from './visual-parity/ratchet.js';
+
+/**
+ * The ratchet's own regression suite (issue #395).
+ *
+ * Deliberately NOT gated behind `DOCXODUS_VISUAL_PARITY`: the comparison layer is pure, so it runs
+ * on every pull request without LibreOffice, Poppler, or a renderer. That is what makes the first
+ * acceptance criterion — "a deliberately introduced regression fails the run naming the case and
+ * signal" — a continuously proven property rather than a claim demonstrated once by hand. Breaking
+ * a renderer on purpose to test the alarm is neither repeatable nor safe; feeding the comparator a
+ * deliberately worsened summary is both.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '../..');
+
+const ENVIRONMENT = {
+  chromium: '143.0.7499.4',
+  libreoffice: 'LibreOffice 25.8.7.3 580(Build:3)',
+  fontContract: { sha256: 'abc123' },
+};
+
+function summaryCase(overrides: Partial<RatchetSummaryCase> = {}): RatchetSummaryCase {
+  return {
+    id: 'shape',
+    disposition: { kind: 'renderer-bug' },
+    docxodusPages: 1,
+    libreofficePages: 1,
+    severity: 'severe',
+    pages: [{ ssim: 0.97428, tolerantInkF1: 0.63049 }],
+    ...overrides,
+  };
+}
+
+function summaryOf(cases: RatchetSummaryCase[]): RatchetSummary {
+  return { gitCommit: 'deadbeef', environment: ENVIRONMENT, cases };
+}
+
+const BASELINE_SUMMARY = summaryOf([
+  summaryCase(),
+  summaryCase({
+    id: 'multi-section',
+    disposition: { kind: 'environment' },
+    docxodusPages: 6,
+    libreofficePages: 6,
+    severity: 'close',
+    // A worst-page aggregation must not average a bad page away.
+    pages: [
+      { ssim: 0.99934, tolerantInkF1: 0.99797 },
+      { ssim: 0.99940, tolerantInkF1: 0.99900 },
+    ],
+  }),
+]);
+
+const BASELINE_RECORD = buildRecord(BASELINE_SUMMARY, '2026-08-11');
+
+test.describe('visual parity ratchet', () => {
+  test('an unchanged run holds against its own record', () => {
+    const comparison = compareToRecord(BASELINE_RECORD, BASELINE_SUMMARY);
+    expect(comparison.status).toBe('ok');
+    expect(comparison.findings).toEqual([]);
+    expect(comparison.improvements).toEqual([]);
+  });
+
+  test('records mean SSIM and WORST ink F1, not the mean of both', () => {
+    const multiSection = BASELINE_RECORD.cases.find(entry => entry.id === 'multi-section')!;
+    expect(multiSection.ssim).toBeCloseTo((0.99934 + 0.99940) / 2, RATCHET_PRECISION);
+    expect(multiSection.worstInkF1).toBe(0.99797);
+  });
+
+  test('a deliberately worsened SSIM fails, naming the case and the signal', () => {
+    const regressed = summaryOf([
+      summaryCase({ pages: [{ ssim: 0.95000, tolerantInkF1: 0.63049 }] }),
+      BASELINE_SUMMARY.cases[1],
+    ]);
+    const comparison = compareToRecord(BASELINE_RECORD, regressed);
+
+    expect(comparison.status).toBe('regressed');
+    expect(comparison.findings).toHaveLength(1);
+    expect(comparison.findings[0].caseId).toBe('shape');
+    expect(comparison.findings[0].signal).toBe('ssim');
+    expect(comparison.message).toContain('shape');
+    expect(comparison.message).toContain('mean SSIM');
+    expect(comparison.message).toContain('0.97428');
+    expect(comparison.message).toContain('0.95000');
+  });
+
+  test('a deliberately worsened ink F1 fails, naming the case and the signal', () => {
+    const regressed = summaryOf([
+      summaryCase({ pages: [{ ssim: 0.97428, tolerantInkF1: 0.40000 }] }),
+      BASELINE_SUMMARY.cases[1],
+    ]);
+    const comparison = compareToRecord(BASELINE_RECORD, regressed);
+
+    expect(comparison.status).toBe('regressed');
+    expect(comparison.findings.map(finding => finding.signal)).toEqual(['inkF1']);
+    expect(comparison.findings[0].caseId).toBe('shape');
+    expect(comparison.message).toContain('worst ink F1');
+  });
+
+  test('a worsened severity fails even when SSIM and ink F1 hold', () => {
+    const regressed = summaryOf([
+      summaryCase(),
+      { ...BASELINE_SUMMARY.cases[1], severity: 'minor' as const },
+    ]);
+    const comparison = compareToRecord(BASELINE_RECORD, regressed);
+
+    expect(comparison.status).toBe('regressed');
+    expect(comparison.findings.map(finding => finding.signal)).toEqual(['severity']);
+    expect(comparison.message).toContain('multi-section');
+    expect(comparison.message).toContain('close to minor');
+  });
+
+  test('a page-count change fails — the loudest regression signal', () => {
+    const regressed = summaryOf([
+      summaryCase({ docxodusPages: 2 }),
+      BASELINE_SUMMARY.cases[1],
+    ]);
+    const comparison = compareToRecord(BASELINE_RECORD, regressed);
+
+    expect(comparison.status).toBe('regressed');
+    expect(comparison.findings.map(finding => finding.signal)).toEqual(['pages']);
+    expect(comparison.message).toContain('page count changed from 1/1');
+  });
+
+  test('a new conversion error fails and suppresses its now-meaningless numbers', () => {
+    const regressed = summaryOf([
+      summaryCase({ error: 'LibreOffice did not produce a PDF', pages: [] }),
+      BASELINE_SUMMARY.cases[1],
+    ]);
+    const comparison = compareToRecord(BASELINE_RECORD, regressed);
+
+    expect(comparison.status).toBe('regressed');
+    expect(comparison.findings.map(finding => finding.signal)).toEqual(['error']);
+    expect(comparison.message).toContain('LibreOffice did not produce a PDF');
+  });
+
+  test('an improved case does NOT fail, and is reported so the refresh is informed', () => {
+    const improved = summaryOf([
+      summaryCase({ severity: 'close', pages: [{ ssim: 0.99000, tolerantInkF1: 0.96000 }] }),
+      BASELINE_SUMMARY.cases[1],
+    ]);
+    const comparison = compareToRecord(BASELINE_RECORD, improved);
+
+    expect(comparison.status).toBe('ok');
+    expect(comparison.findings).toEqual([]);
+    expect(comparison.improvements.map(finding => finding.signal).sort())
+      .toEqual(['inkF1', 'severity', 'ssim']);
+    expect(comparison.message).toContain('refresh the record to bank them');
+  });
+
+  test('movement within tolerance is neither a regression nor an improvement', () => {
+    const jittered = summaryOf([
+      summaryCase({
+        pages: [{
+          ssim: 0.97428 - RATCHET_TOLERANCE.ssim / 2,
+          tolerantInkF1: 0.63049 - RATCHET_TOLERANCE.inkF1 / 2,
+        }],
+      }),
+      BASELINE_SUMMARY.cases[1],
+    ]);
+    const comparison = compareToRecord(BASELINE_RECORD, jittered);
+
+    expect(comparison.status).toBe('ok');
+    expect(comparison.improvements).toEqual([]);
+  });
+
+  test('movement just beyond tolerance is a regression', () => {
+    const regressed = summaryOf([
+      summaryCase({
+        pages: [{ ssim: 0.97428 - RATCHET_TOLERANCE.ssim * 2, tolerantInkF1: 0.63049 }],
+      }),
+      BASELINE_SUMMARY.cases[1],
+    ]);
+    expect(compareToRecord(BASELINE_RECORD, regressed).status).toBe('regressed');
+  });
+
+  /**
+   * The false-accusation guard. CI installs LibreOffice from unpinned `ubuntu-latest` apt (pinning
+   * it is issue #403), and BASELINE.md documents how far a reference change moves the numbers —
+   * LibreOffice 24.2 draws a different footnote separator than 25.8. Comparing across that would
+   * blame Docxodus for someone else's release.
+   */
+  test('a reference-environment change is reported as such, never as a renderer regression', () => {
+    const upgraded: RatchetSummary = {
+      ...BASELINE_SUMMARY,
+      environment: { ...ENVIRONMENT, libreoffice: 'LibreOffice 26.2.0.1 100(Build:1)' },
+      // Numbers that WOULD read as a severe regression if compared naively.
+      cases: [
+        summaryCase({ severity: 'severe', pages: [{ ssim: 0.10000, tolerantInkF1: 0.10000 }] }),
+        BASELINE_SUMMARY.cases[1],
+      ],
+    };
+    const comparison = compareToRecord(BASELINE_RECORD, upgraded);
+
+    expect(comparison.status).toBe('environment-changed');
+    expect(comparison.findings).toEqual([]);
+    expect(comparison.message).toContain('NOT a renderer regression');
+    expect(comparison.message).toContain('record refresh required');
+    expect(comparison.environmentDrift.join(' ')).toContain('recorded 25.8, measured 26.2');
+  });
+
+  test('a font-contract edit is an environment change, since it moves both renderers', () => {
+    const comparison = compareToRecord(BASELINE_RECORD, {
+      ...BASELINE_SUMMARY,
+      environment: { ...ENVIRONMENT, fontContract: { sha256: 'different' } },
+    });
+    expect(comparison.status).toBe('environment-changed');
+    expect(comparison.environmentDrift.join(' ')).toContain('fontContractSha256');
+  });
+
+  test('a LibreOffice patch release inside one minor stays comparable', () => {
+    const comparison = compareToRecord(BASELINE_RECORD, {
+      ...BASELINE_SUMMARY,
+      environment: { ...ENVIRONMENT, libreoffice: 'LibreOffice 25.8.9.1 580(Build:9)' },
+    });
+    expect(comparison.status).toBe('ok');
+  });
+
+  test('fingerprints reduce versions to their layout-relevant boundary', () => {
+    expect(libreofficeFingerprint('LibreOffice 25.8.7.3 580(Build:3)')).toBe('25.8');
+    expect(libreofficeFingerprint(undefined)).toBe('unknown');
+    expect(chromiumFingerprint('143.0.7499.4')).toBe('143');
+    expect(chromiumFingerprint(undefined)).toBe('unknown');
+  });
+
+  test('a case dropped from an unfiltered run fails, but not from a filtered one', () => {
+    const partial = summaryOf([summaryCase()]);
+
+    expect(compareToRecord(BASELINE_RECORD, partial, { expectComplete: true }).status)
+      .toBe('regressed');
+    expect(compareToRecord(BASELINE_RECORD, partial, { expectComplete: true })
+      .findings.map(finding => finding.signal)).toEqual(['missing']);
+    expect(compareToRecord(BASELINE_RECORD, partial, { expectComplete: false }).status).toBe('ok');
+  });
+
+  test('a corpus case with no record entry fails until the record is refreshed', () => {
+    const extended = summaryOf([
+      ...BASELINE_SUMMARY.cases,
+      summaryCase({ id: 'nested-table', disposition: { kind: 'unattributed' } }),
+    ]);
+    const comparison = compareToRecord(BASELINE_RECORD, extended);
+
+    expect(comparison.status).toBe('regressed');
+    expect(comparison.findings.map(finding => finding.signal)).toEqual(['unrecorded']);
+    expect(comparison.message).toContain('nested-table');
+  });
+
+  test('an unreadable schema version demands regeneration instead of comparing', () => {
+    const comparison = compareToRecord(
+      { ...BASELINE_RECORD, schemaVersion: RATCHET_SCHEMA_VERSION + 1 }, BASELINE_SUMMARY);
+    expect(comparison.status).toBe('record-mismatch');
+    expect(comparison.message).toContain('DOCXODUS_VISUAL_PARITY_UPDATE_RECORD=1');
+  });
+
+  test('the record serializes stably, so a rerun produces no diff churn', () => {
+    const again = buildRecord(BASELINE_SUMMARY, '2026-08-11');
+    expect(serializeRecord(again)).toBe(serializeRecord(BASELINE_RECORD));
+    expect(serializeRecord(BASELINE_RECORD).endsWith('\n')).toBe(true);
+    // Sorted by id so corpus reordering cannot churn the committed diff.
+    expect(BASELINE_RECORD.cases.map(entry => entry.id)).toEqual(['multi-section', 'shape']);
+  });
+});
+
+test.describe('the committed ratchet record', () => {
+  test('exists, is current-schema, and is a numbers-only file', () => {
+    const record = readRecord();
+    expect(record, `${RATCHET_RECORD_FILE} must be committed`).not.toBeNull();
+    expect(record!.schemaVersion).toBe(RATCHET_SCHEMA_VERSION);
+    expect(record!.tolerance).toEqual({
+      ssim: RATCHET_TOLERANCE.ssim,
+      inkF1: RATCHET_TOLERANCE.inkF1,
+    });
+
+    // No image, path, or per-artifact hash may leak into the record: it is reviewed as a diff, and
+    // artifact naming must never churn it. The only digest is the font contract's.
+    const serialized = readFileSync(RATCHET_RECORD_FILE, 'utf8');
+    expect(serialized).not.toContain('.png');
+    expect(serialized).not.toContain('artifact');
+    expect(serialized.match(/[0-9a-f]{64}/g) ?? []).toEqual([record!.environment.fontContractSha256]);
+    for (const entry of record!.cases) {
+      expect(Object.keys(entry).sort()).toEqual(
+        entry.error === undefined
+          ? ['disposition', 'id', 'pages', 'severity', 'ssim', 'worstInkF1']
+          : ['disposition', 'error', 'id', 'pages', 'severity', 'ssim', 'worstInkF1']);
+    }
+  });
+
+  test('covers exactly the corpus, so adding a case cannot skip the ratchet', () => {
+    const record = readRecord()!;
+    expect(record.cases.map(entry => entry.id).sort())
+      .toEqual(VISUAL_PARITY_CORPUS.map(entry => entry.id).sort());
+  });
+
+  test('agrees with corpus.ts about every disposition', () => {
+    const record = readRecord()!;
+    for (const entry of record.cases) {
+      const corpusEntry = VISUAL_PARITY_CORPUS.find(candidate => candidate.id === entry.id)!;
+      expect(entry.disposition, `${entry.id} disposition drifted from corpus.ts`)
+        .toBe(corpusEntry.disposition.kind);
+    }
+  });
+
+  /**
+   * The record's environment fingerprint must describe the environment it was measured in.
+   * `fonts.conf` is the one component that lives in the repository, so it is the one a PR can
+   * silently desynchronize — editing the contract without rerunning the benchmark would leave
+   * numbers attributed to a substitution set that no longer exists.
+   */
+  test('pins the font contract actually committed alongside it', () => {
+    const record = readRecord()!;
+    const contract = resolve(__dirname, 'visual-parity/fonts.conf');
+    expect(record.environment.fontContractSha256)
+      .toBe(createHash('sha256').update(readFileSync(contract)).digest('hex'));
+  });
+
+  test('is tracked by Git and lives outside any ignored path', () => {
+    execFileSync('git', ['ls-files', '--error-unmatch', relative(repoRoot, RATCHET_RECORD_FILE)], {
+      cwd: repoRoot,
+      stdio: 'pipe',
+    });
+  });
+});

--- a/npm/tests/visual-parity.spec.ts
+++ b/npm/tests/visual-parity.spec.ts
@@ -34,6 +34,13 @@ import {
   probeMarker,
 } from './visual-parity/font-contract.js';
 import { decodePng, encodePng } from './visual-parity/png.js';
+import {
+  RATCHET_RECORD_FILE,
+  buildRecord,
+  compareToRecord,
+  readRecord,
+  serializeRecord,
+} from './visual-parity/ratchet.js';
 
 test.skip(process.env.DOCXODUS_VISUAL_PARITY !== '1',
   'set DOCXODUS_VISUAL_PARITY=1 on a host with libreoffice and pdftoppm');
@@ -466,6 +473,32 @@ test('stratified tracked corpus matches LibreOffice at pixel level', async ({ pa
   const summaryPath = join(outputRoot, 'summary.json');
   writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
   console.log(`Visual parity report: ${summaryPath}`);
+
+  // The regression ratchet (issue #395). Broader than strict mode: it covers every case at every
+  // severity, so a `close` case sliding to `minor` is caught rather than merely archived in an
+  // artifact that expires in 14 days.
+  const complete = !process.env.DOCXODUS_VISUAL_PARITY_FILTER;
+  if (process.env.DOCXODUS_VISUAL_PARITY_UPDATE_RECORD === '1') {
+    if (!complete) {
+      throw new Error('Refusing to write a partial ratchet record: unset ' +
+        'DOCXODUS_VISUAL_PARITY_FILTER so every case is measured in the same run.');
+    }
+    const record = buildRecord(summary, new Date().toISOString().slice(0, 10));
+    writeFileSync(RATCHET_RECORD_FILE, serializeRecord(record));
+    console.log(`Ratchet record refreshed: ${RATCHET_RECORD_FILE}`);
+  } else {
+    const record = readRecord();
+    if (!record) {
+      console.log('No ratchet record yet; create one with DOCXODUS_VISUAL_PARITY_UPDATE_RECORD=1.');
+    } else {
+      const comparison = compareToRecord(record, summary, { expectComplete: complete });
+      console.log(`Ratchet [${comparison.status}]: ${comparison.message}`);
+      // Opt-out rather than opt-in: a ratchet nobody enables is the artifact nobody downloaded.
+      if (process.env.DOCXODUS_VISUAL_PARITY_RATCHET !== '0') {
+        expect(comparison.status, comparison.message).toBe('ok');
+      }
+    }
+  }
 
   if (process.env.DOCXODUS_VISUAL_PARITY_STRICT === '1') {
     expect(cases.filter(gatesStrictRun).map(result =>

--- a/npm/tests/visual-parity/BASELINE.md
+++ b/npm/tests/visual-parity/BASELINE.md
@@ -206,6 +206,40 @@ Severity counts, strict gating (`shape`, `fields-and-tabs`), and every dispositi
 `environment` now has a sharper meaning: the engines lay out the SAME fonts differently
 (line breaking, justification, rasterization) — never that they picked different fonts.
 
+## Regression ratchet — 2026-08-11 (issue #395)
+
+Every measurement above was a snapshot nothing defended. The scheduled run uploaded an artifact
+that expired in 14 days, and no run was compared against the previous one, so a renderer
+regression was caught only if a human downloaded and eyeballed the report in time.
+
+`ratchet.json` is now a committed, numbers-only record — one row per case carrying page counts,
+severity, mean SSIM, worst ink F1, and the disposition — and every run compares against it. It is
+deliberately broader than strict mode: strict gates only severe cases the renderer owns, whereas
+"no case may get worse than recorded" covers all twelve at every severity. Full-strict remains
+unreachable while two renderer-attributable severe cases stand; this is the part that is
+enforceable today.
+
+The record is seeded from a clean-worktree full-corpus run at `c4bf105` (the merge of issue #379)
+in the environment the baseline contract names: LibreOffice 25.8.7.3, Chromium 143.0.7499.4,
+Poppler 25.03.0. The `shape` and `chart` figures reproduce that run's recorded values to five
+decimal places; `footnote` and `tracked-deletion` differ from the 2026-08-11 *local* table below
+exactly as documented, because that table was measured under LibreOffice 24.2 with its legacy
+footnote separator.
+
+Two properties set the tolerances. Within one environment the benchmark is deterministic — two
+clean passes produced identical normalized metrics and identical SHA-256s for all 60 images — so
+0.0005 SSIM and 0.001 ink F1 are an order of magnitude below the smallest movement any recorded
+fix produced (the two-inch footnote separator, +0.000128 SSIM and +0.003537 ink F1). Across
+environments the numbers move materially, and CI's LibreOffice comes from unpinned
+`ubuntu-latest` apt (issue #403), so the record carries an environment fingerprint. A fingerprint
+mismatch reports `environment-changed` and demands a deliberate refresh — it is never reported as
+a renderer regression, because attributing a LibreOffice release to Docxodus is precisely the
+false accusation the font contract and the disposition field were built to prevent.
+
+The alarm itself is verified continuously rather than by anecdote: the comparison layer is pure,
+so `visual-parity-ratchet.spec.ts` feeds it deliberately worsened summaries on every pull request
+— no LibreOffice, no renderer, and no need to break rendering on purpose to prove the gate fires.
+
 ## Current case results and triage
 
 `SSIM` is the mean over paired pages. `Ink F1` is the worst paired-page value, so it exposes a
@@ -269,8 +303,8 @@ renderer heuristic.
 
 The former first priority (blank charts), the PR #372 rerun, aligned tab geometry,
 header/body/footer vertical placement (issue #377), DrawingML textbox anchor geometry, footnote
-block vertical placement (issue #378), and the font-substitution contract (issue #379) are
-resolved above. The remaining order is:
+block vertical placement (issue #378), the font-substitution contract (issue #379), and the
+regression ratchet (issue #395) are resolved above. The remaining order is:
 
 1. Model auto-fit text/line height for DrawingML textboxes (`shape`, strict-gating).
 2. TOC line height and hyperlink styling (`fields-and-tabs`, strict-gating — now honestly

--- a/npm/tests/visual-parity/README.md
+++ b/npm/tests/visual-parity/README.md
@@ -102,10 +102,64 @@ Severity is assigned by the worst signal:
 | major | ≥ 0.85 | ≥ 0.75 | ≤ 0.15 | ≤ 1 px |
 | severe | below major | below major | above major | > 1 px |
 
-A page-count mismatch is always severe. Default runs are observational and succeed after producing
-the complete report; `DOCXODUS_VISUAL_PARITY_STRICT=1` turns renderer-attributable severe cases into
-a failing gate (see the disposition contract below). This keeps the baseline useful while known
-environment deltas and reference deviations are tracked without blocking.
+A page-count mismatch is always severe. `DOCXODUS_VISUAL_PARITY_STRICT=1` turns renderer-attributable
+severe cases into a failing gate (see the disposition contract below). This keeps the baseline useful
+while known environment deltas and reference deviations are tracked without blocking. Independently
+of strict mode, every run compares itself against the committed regression record described next.
+
+## Regression ratchet
+
+Full-strict mode stays unreachable while renderer-attributable severe cases remain, but *"no case
+may get worse than recorded"* is enforceable today (issue #395). `ratchet.json` is a committed,
+numbers-only record — one row per case: page counts, severity, mean SSIM, worst ink F1, and the
+disposition. No images, no paths, no artifact hashes, so it stays reviewable as a diff.
+
+The ratchet is deliberately **broader than strict mode**: strict gates only severe cases the
+renderer owns, while the ratchet covers every case at every severity. A `close` case sliding to
+`minor` is exactly the drift the weekly run existed to catch and previously could not — its
+artifact expired in 14 days and nothing compared one run to the next.
+
+| Signal | Fails when |
+|---|---|
+| page count | either engine's page count changes at all |
+| severity | the case moves down the severity ladder |
+| mean SSIM | falls more than `tolerance.ssim` (0.0005) below the record |
+| worst ink F1 | falls more than `tolerance.inkF1` (0.001) below the record |
+| conversion | the case errors where the record has none |
+| coverage | a recorded case is missing, or a measured case is unrecorded |
+
+The tolerances are tight because within one environment the benchmark is *deterministic* — two
+clean passes produced identical metrics and identical SHA-256s for all 60 images. They are not
+zero because the environment fingerprint is coarser than the environment itself. Every renderer
+movement BASELINE.md records for a real fix is at least an order of magnitude larger; the smallest
+is the two-inch footnote separator at +0.000128 SSIM and +0.003537 ink F1.
+
+**Environment fingerprint.** Across environments the numbers move materially — LibreOffice 24.2
+draws a different footnote separator than 25.8 — and CI installs LibreOffice from unpinned
+`ubuntu-latest` apt (pinning it is issue #403). The record therefore carries the LibreOffice
+major.minor, the Chromium major, and `fonts.conf`'s SHA-256. When they do not match, the run
+reports **`environment-changed`** and demands a refresh instead of claiming a regression, so a
+reference-renderer release can never be blamed on Docxodus. That outcome still fails the run: a
+stale record silently comparing across environments is worse than an explicit demand to refresh it.
+
+**Updating the record** is a deliberate act in the PR that changes rendering, so improvements and
+accepted regressions are reviewed in the diff:
+
+```bash
+DOCXODUS_VISUAL_PARITY_OUTPUT=/tmp/docxodus-visual-parity \
+DOCXODUS_VISUAL_PARITY_UPDATE_RECORD=1 \
+npm run test:visual-parity
+```
+
+The update path refuses a filtered run, so a partial record cannot be committed. A passing run
+still lists every improvement it measured, so a stale record announces itself. Set
+`DOCXODUS_VISUAL_PARITY_RATCHET=0` to observe without gating; the comparison is reported either
+way. A filtered run compares only the cases it measured.
+
+The comparison layer (`ratchet.ts`) is pure, and `visual-parity-ratchet.spec.ts` exercises it on
+**every** pull request — no LibreOffice, no renderer. That is what keeps "a deliberately introduced
+regression fails, naming the case and the signal" a continuously proven property instead of a
+claim demonstrated once by hand.
 
 ## Attribution dispositions
 

--- a/npm/tests/visual-parity/ratchet.json
+++ b/npm/tests/visual-parity/ratchet.json
@@ -1,0 +1,149 @@
+{
+  "schemaVersion": 1,
+  "description": "Per-case visual-parity regression ratchet (issue #395). Numbers only. The scheduled run fails when any case gets worse than recorded beyond `tolerance`. Refresh this file deliberately in the PR that changes rendering, so improvements and accepted regressions are reviewed in the diff. See npm/tests/visual-parity/README.md.",
+  "recordedAt": "2026-08-11",
+  "sourceCommit": "c4bf10521c08cdd56f9c4f578b5b1927c2f2b430",
+  "environment": {
+    "libreoffice": "25.8",
+    "chromium": "143",
+    "fontContractSha256": "65e32c507ebaa14eef364f04036f26c6853ab900779889d29b2f3d427c9937db"
+  },
+  "tolerance": {
+    "ssim": 0.0005,
+    "inkF1": 0.001
+  },
+  "cases": [
+    {
+      "id": "chart",
+      "disposition": "environment",
+      "pages": {
+        "docxodus": 1,
+        "libreoffice": 1
+      },
+      "severity": "close",
+      "ssim": 0.98687,
+      "worstInkF1": 0.96817
+    },
+    {
+      "id": "fields-and-tabs",
+      "disposition": "renderer-bug",
+      "pages": {
+        "docxodus": 1,
+        "libreoffice": 1
+      },
+      "severity": "severe",
+      "ssim": 0.89415,
+      "worstInkF1": 0.15913
+    },
+    {
+      "id": "footnote",
+      "disposition": "environment",
+      "pages": {
+        "docxodus": 1,
+        "libreoffice": 1
+      },
+      "severity": "severe",
+      "ssim": 0.99249,
+      "worstInkF1": 0.7033
+    },
+    {
+      "id": "inline-image",
+      "disposition": "environment",
+      "pages": {
+        "docxodus": 1,
+        "libreoffice": 1
+      },
+      "severity": "severe",
+      "ssim": 0.9366,
+      "worstInkF1": 0.6476
+    },
+    {
+      "id": "landscape-section",
+      "disposition": "environment",
+      "pages": {
+        "docxodus": 1,
+        "libreoffice": 1
+      },
+      "severity": "severe",
+      "ssim": 0.92607,
+      "worstInkF1": 0.60042
+    },
+    {
+      "id": "merged-table",
+      "disposition": "unattributed",
+      "pages": {
+        "docxodus": 1,
+        "libreoffice": 1
+      },
+      "severity": "minor",
+      "ssim": 0.96348,
+      "worstInkF1": 1
+    },
+    {
+      "id": "multi-section",
+      "disposition": "environment",
+      "pages": {
+        "docxodus": 6,
+        "libreoffice": 6
+      },
+      "severity": "close",
+      "ssim": 0.99934,
+      "worstInkF1": 0.99797
+    },
+    {
+      "id": "numbered-lists",
+      "disposition": "reference-deviation",
+      "pages": {
+        "docxodus": 1,
+        "libreoffice": 1
+      },
+      "severity": "severe",
+      "ssim": 0.99426,
+      "worstInkF1": 0.5558
+    },
+    {
+      "id": "running-content",
+      "disposition": "environment",
+      "pages": {
+        "docxodus": 5,
+        "libreoffice": 5
+      },
+      "severity": "close",
+      "ssim": 0.99921,
+      "worstInkF1": 0.96486
+    },
+    {
+      "id": "shape",
+      "disposition": "renderer-bug",
+      "pages": {
+        "docxodus": 1,
+        "libreoffice": 1
+      },
+      "severity": "severe",
+      "ssim": 0.97428,
+      "worstInkF1": 0.63049
+    },
+    {
+      "id": "text-formatting",
+      "disposition": "environment",
+      "pages": {
+        "docxodus": 1,
+        "libreoffice": 1
+      },
+      "severity": "close",
+      "ssim": 0.99725,
+      "worstInkF1": 0.9677
+    },
+    {
+      "id": "tracked-deletion",
+      "disposition": "environment",
+      "pages": {
+        "docxodus": 1,
+        "libreoffice": 1
+      },
+      "severity": "severe",
+      "ssim": 0.95011,
+      "worstInkF1": 0.62634
+    }
+  ]
+}

--- a/npm/tests/visual-parity/ratchet.ts
+++ b/npm/tests/visual-parity/ratchet.ts
@@ -1,0 +1,425 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { VisualSeverity } from './metrics.js';
+
+/**
+ * The regression ratchet (issue #395).
+ *
+ * The scheduled run used to upload an artifact nobody compared against anything: a renderer
+ * regression was caught only if a human downloaded and eyeballed the report inside the 14-day
+ * retention window. Full-strict mode stays unreachable while renderer-attributable severe cases
+ * remain, but "no case may get worse than recorded" is enforceable today.
+ *
+ * This module is the pure comparison layer: it turns a run's `summary.json` into a numbers-only
+ * per-case record, and compares a fresh summary against a committed record. It deliberately holds
+ * no I/O so the spec can exercise it against synthetic summaries on every CI run, without
+ * LibreOffice, without a renderer, and without actually breaking one.
+ *
+ * Two properties make a tight tolerance honest:
+ *
+ *  - Within one environment the benchmark is deterministic. BASELINE.md records two clean full
+ *    passes producing identical normalized metrics and identical PNG SHA-256s for all 60 images,
+ *    so in-environment noise is zero rather than merely small.
+ *  - Across environments it is not: LibreOffice, Chromium, and the substituted fonts each move
+ *    the numbers materially. The record therefore carries an environment fingerprint, and a
+ *    mismatch is reported as `environment-changed` — never as a renderer regression.
+ *
+ * The ratchet is deliberately BROADER than strict mode. Strict mode gates only severe cases whose
+ * disposition attributes them to the renderer; the ratchet covers every case at every severity,
+ * because a `close` case silently sliding to `minor` is exactly the drift the weekly run existed
+ * to catch and never did.
+ */
+
+export const RATCHET_SCHEMA_VERSION = 1;
+
+/**
+ * The committed record. It lives beside the corpus it describes so a rendering PR touches the
+ * corpus, the record, and the baseline narrative in one reviewable diff.
+ */
+export const RATCHET_RECORD_FILE =
+  resolve(dirname(fileURLToPath(import.meta.url)), 'ratchet.json');
+
+/**
+ * Movement a run may show against the record without being called a regression.
+ *
+ * Zero would be defensible on the determinism evidence above, but the fingerprint is coarser than
+ * the environment: it pins LibreOffice to major.minor and Chromium to its major, so a patch-level
+ * update inside one fingerprint can still perturb rasterization slightly. These values absorb that
+ * and nothing more — every renderer movement BASELINE.md records for a real fix is at least an
+ * order of magnitude larger, the smallest being the two-inch footnote separator at +0.000128 SSIM
+ * and +0.003537 ink F1.
+ *
+ * Loosening these needs the same evidence bar as any other threshold change: a reproduced
+ * false positive, not a run that was inconvenient to explain.
+ */
+export const RATCHET_TOLERANCE = {
+  ssim: 0.0005,
+  inkF1: 0.001,
+} as const;
+
+/** Decimal places the record stores, so float summation order cannot churn the committed diff. */
+export const RATCHET_PRECISION = 5;
+
+const SEVERITY_ORDER: VisualSeverity[] = ['close', 'minor', 'major', 'severe'];
+
+export interface RatchetEnvironment {
+  /** LibreOffice major.minor — the reference renderer, unpinned in CI until issue #403. */
+  libreoffice: string;
+  /** Chromium major. */
+  chromium: string;
+  /** SHA-256 of `fonts.conf`; changing the contract is a deliberate, reviewable act. */
+  fontContractSha256: string;
+}
+
+export interface RatchetCase {
+  id: string;
+  /** Recorded so a disposition edit shows up in the record's diff, not only in `corpus.ts`. */
+  disposition: string;
+  pages: { docxodus: number; libreoffice: number };
+  severity: VisualSeverity;
+  /** Mean SSIM over paired pages — the same aggregation BASELINE.md's per-case table reports. */
+  ssim: number;
+  /** WORST paired-page ink F1, so one blank or disjoint page cannot be averaged away. */
+  worstInkF1: number;
+  /** Present only when the case failed to convert; a run may never introduce one. */
+  error?: true;
+}
+
+export interface RatchetRecord {
+  schemaVersion: number;
+  description: string;
+  recordedAt: string;
+  sourceCommit: string;
+  environment: RatchetEnvironment;
+  tolerance: { ssim: number; inkF1: number };
+  cases: RatchetCase[];
+}
+
+/** The subset of `summary.json` the ratchet reads. */
+export interface RatchetSummaryCase {
+  id: string;
+  disposition: { kind: string };
+  docxodusPages: number;
+  libreofficePages: number;
+  severity: VisualSeverity;
+  pages: { ssim: number; tolerantInkF1: number }[];
+  error?: string;
+}
+
+export interface RatchetSummary {
+  gitCommit?: string;
+  environment: {
+    chromium?: string;
+    libreoffice?: string;
+    fontContract?: { sha256?: string };
+  };
+  cases: RatchetSummaryCase[];
+}
+
+export type RatchetStatus = 'ok' | 'regressed' | 'environment-changed' | 'record-mismatch';
+
+export interface RatchetOptions {
+  /**
+   * Whether the run covered the whole corpus. A `DOCXODUS_VISUAL_PARITY_FILTER` run legitimately
+   * measures a subset, so its absent cases are not findings; an unfiltered run's are.
+   */
+  expectComplete: boolean;
+}
+
+export interface RatchetFinding {
+  caseId: string;
+  /** The signal that moved, so the failure names both the case and what got worse. */
+  signal: 'severity' | 'ssim' | 'inkF1' | 'pages' | 'error' | 'missing' | 'unrecorded';
+  recorded: string;
+  measured: string;
+  detail: string;
+}
+
+export interface RatchetComparison {
+  status: RatchetStatus;
+  findings: RatchetFinding[];
+  /** Cases that measurably IMPROVED — reported so the record refresh is an informed act. */
+  improvements: RatchetFinding[];
+  environmentDrift: string[];
+  message: string;
+}
+
+export function round(value: number): number {
+  const factor = 10 ** RATCHET_PRECISION;
+  return Math.round(value * factor) / factor;
+}
+
+const format = (value: number): string => value.toFixed(RATCHET_PRECISION);
+
+/**
+ * LibreOffice reports e.g. `LibreOffice 25.8.7.3 580(Build:3)`. Only major.minor participates in
+ * the fingerprint: a patch bump inside one minor is a bugfix release the tolerance absorbs, while
+ * a minor bump is the kind of change that redrew the footnote separator between 24.2 and 25.8.
+ */
+export function libreofficeFingerprint(version: string | undefined): string {
+  const match = (version ?? '').match(/(\d+)\.(\d+)/);
+  return match ? `${match[1]}.${match[2]}` : 'unknown';
+}
+
+/** Chromium reports e.g. `143.0.7499.4`; the major is the meaningful layout boundary. */
+export function chromiumFingerprint(version: string | undefined): string {
+  const match = (version ?? '').match(/(\d+)/);
+  return match ? match[1] : 'unknown';
+}
+
+export function environmentOf(summary: RatchetSummary): RatchetEnvironment {
+  return {
+    libreoffice: libreofficeFingerprint(summary.environment?.libreoffice),
+    chromium: chromiumFingerprint(summary.environment?.chromium),
+    fontContractSha256: summary.environment?.fontContract?.sha256 ?? 'unknown',
+  };
+}
+
+/** Mean SSIM over paired pages; 1 for a case with no comparable page (a conversion error). */
+export function meanSsim(entry: RatchetSummaryCase): number {
+  if (!entry.pages.length) return 0;
+  return entry.pages.reduce((sum, page) => sum + page.ssim, 0) / entry.pages.length;
+}
+
+/** Worst (minimum) paired-page ink F1 — the aggregation BASELINE.md's table uses. */
+export function worstInkF1(entry: RatchetSummaryCase): number {
+  if (!entry.pages.length) return 0;
+  return entry.pages.reduce((min, page) => Math.min(min, page.tolerantInkF1), Number.POSITIVE_INFINITY);
+}
+
+export function recordCase(entry: RatchetSummaryCase): RatchetCase {
+  return {
+    id: entry.id,
+    disposition: entry.disposition.kind,
+    pages: { docxodus: entry.docxodusPages, libreoffice: entry.libreofficePages },
+    severity: entry.severity,
+    ssim: round(meanSsim(entry)),
+    worstInkF1: round(worstInkF1(entry)),
+    ...(entry.error !== undefined ? { error: true as const } : {}),
+  };
+}
+
+/**
+ * Builds the committed record from a completed run. Numbers only: no image, no path, no hash, so
+ * the file stays reviewable as a diff and cannot drift with artifact naming.
+ */
+export function buildRecord(summary: RatchetSummary, recordedAt: string): RatchetRecord {
+  return {
+    schemaVersion: RATCHET_SCHEMA_VERSION,
+    description:
+      'Per-case visual-parity regression ratchet (issue #395). Numbers only. The scheduled run ' +
+      'fails when any case gets worse than recorded beyond `tolerance`. Refresh this file ' +
+      'deliberately in the PR that changes rendering, so improvements and accepted regressions ' +
+      'are reviewed in the diff. See npm/tests/visual-parity/README.md.',
+    recordedAt,
+    sourceCommit: summary.gitCommit ?? 'unknown',
+    environment: environmentOf(summary),
+    tolerance: { ssim: RATCHET_TOLERANCE.ssim, inkF1: RATCHET_TOLERANCE.inkF1 },
+    cases: [...summary.cases].sort((a, b) => a.id.localeCompare(b.id)).map(recordCase),
+  };
+}
+
+/** Stable, human-readable serialization; the record is reviewed as a diff. */
+export function serializeRecord(record: RatchetRecord): string {
+  return `${JSON.stringify(record, null, 2)}\n`;
+}
+
+/** The committed record, or null before one exists. The only I/O in this module. */
+export function readRecord(file: string = RATCHET_RECORD_FILE): RatchetRecord | null {
+  if (!existsSync(file)) return null;
+  return JSON.parse(readFileSync(file, 'utf8')) as RatchetRecord;
+}
+
+function environmentDrift(record: RatchetRecord, measured: RatchetEnvironment): string[] {
+  const drift: string[] = [];
+  for (const key of ['libreoffice', 'chromium', 'fontContractSha256'] as const) {
+    if (record.environment[key] !== measured[key]) {
+      drift.push(`${key}: recorded ${record.environment[key]}, measured ${measured[key]}`);
+    }
+  }
+  return drift;
+}
+
+/**
+ * Compares a run against the committed record.
+ *
+ * Ordering matters. An environment change is reported BEFORE any numeric comparison, because
+ * comparing numbers measured under a different LibreOffice against numbers measured under this
+ * one would attribute a reference-renderer change to Docxodus — the exact false accusation the
+ * fingerprint exists to prevent. That outcome still fails the run: a stale record silently
+ * comparing across environments is worse than an explicit demand to refresh it.
+ */
+export function compareToRecord(
+  record: RatchetRecord,
+  summary: RatchetSummary,
+  options: RatchetOptions = { expectComplete: true },
+): RatchetComparison {
+  if (record.schemaVersion !== RATCHET_SCHEMA_VERSION) {
+    return {
+      status: 'record-mismatch',
+      findings: [],
+      improvements: [],
+      environmentDrift: [],
+      message: `Ratchet record schema ${record.schemaVersion} is not the expected ` +
+        `${RATCHET_SCHEMA_VERSION}; regenerate it with DOCXODUS_VISUAL_PARITY_UPDATE_RECORD=1.`,
+    };
+  }
+
+  const measuredEnvironment = environmentOf(summary);
+  const drift = environmentDrift(record, measuredEnvironment);
+  if (drift.length) {
+    return {
+      status: 'environment-changed',
+      findings: [],
+      improvements: [],
+      environmentDrift: drift,
+      message:
+        'Reference environment changed, record refresh required — NOT a renderer regression.\n  ' +
+        drift.join('\n  ') +
+        '\nThe recorded numbers were measured under a different reference environment, so ' +
+        'comparing against them would attribute that change to Docxodus. Rerun the benchmark ' +
+        'in the new environment with DOCXODUS_VISUAL_PARITY_UPDATE_RECORD=1 and commit the ' +
+        'refreshed record.',
+    };
+  }
+
+  const findings: RatchetFinding[] = [];
+  const improvements: RatchetFinding[] = [];
+  const measuredById = new Map(summary.cases.map(entry => [entry.id, entry]));
+
+  for (const recorded of record.cases) {
+    const measured = measuredById.get(recorded.id);
+    if (!measured) {
+      if (!options.expectComplete) continue;
+      findings.push({
+        caseId: recorded.id,
+        signal: 'missing',
+        recorded: recorded.severity,
+        measured: '(absent)',
+        detail: `${recorded.id} is in the record but was not measured by this run`,
+      });
+      continue;
+    }
+    findings.push(...compareCase(recorded, measured, record.tolerance, improvements));
+  }
+
+  for (const measured of summary.cases) {
+    if (record.cases.some(recorded => recorded.id === measured.id)) continue;
+    findings.push({
+      caseId: measured.id,
+      signal: 'unrecorded',
+      recorded: '(absent)',
+      measured: measured.severity,
+      detail: `${measured.id} was measured but is not in the record; add it with ` +
+        'DOCXODUS_VISUAL_PARITY_UPDATE_RECORD=1',
+    });
+  }
+
+  if (findings.length) {
+    return {
+      status: 'regressed',
+      findings,
+      improvements,
+      environmentDrift: [],
+      message: `Visual parity regressed against the record in ${findings.length} signal(s):\n  ` +
+        findings.map(finding => finding.detail).join('\n  '),
+    };
+  }
+
+  const improved = improvements.length
+    ? ` ${improvements.length} signal(s) improved; refresh the record to bank them:\n  ` +
+      improvements.map(finding => finding.detail).join('\n  ')
+    : '';
+  const compared = record.cases.filter(recorded => measuredById.has(recorded.id)).length;
+  return {
+    status: 'ok',
+    findings: [],
+    improvements,
+    environmentDrift: [],
+    message: `Visual parity holds against the record for ${compared} case(s).${improved}`,
+  };
+}
+
+function compareCase(
+  recorded: RatchetCase,
+  measured: RatchetSummaryCase,
+  tolerance: { ssim: number; inkF1: number },
+  improvements: RatchetFinding[],
+): RatchetFinding[] {
+  const findings: RatchetFinding[] = [];
+
+  if (measured.error !== undefined && !recorded.error) {
+    findings.push({
+      caseId: recorded.id,
+      signal: 'error',
+      recorded: 'converted',
+      measured: 'conversion error',
+      detail: `${recorded.id}: conversion error where the record has none — ${measured.error}`,
+    });
+    // Every other signal is meaningless once the case failed to render at all.
+    return findings;
+  }
+
+  if (measured.docxodusPages !== recorded.pages.docxodus ||
+      measured.libreofficePages !== recorded.pages.libreoffice) {
+    findings.push({
+      caseId: recorded.id,
+      signal: 'pages',
+      recorded: `${recorded.pages.docxodus}/${recorded.pages.libreoffice}`,
+      measured: `${measured.docxodusPages}/${measured.libreofficePages}`,
+      detail: `${recorded.id}: page count changed from ` +
+        `${recorded.pages.docxodus}/${recorded.pages.libreoffice} (Docxodus/LibreOffice) to ` +
+        `${measured.docxodusPages}/${measured.libreofficePages}`,
+    });
+  }
+
+  const severityDelta = SEVERITY_ORDER.indexOf(measured.severity) -
+    SEVERITY_ORDER.indexOf(recorded.severity);
+  if (severityDelta > 0) {
+    findings.push({
+      caseId: recorded.id,
+      signal: 'severity',
+      recorded: recorded.severity,
+      measured: measured.severity,
+      detail: `${recorded.id}: severity worsened from ${recorded.severity} to ${measured.severity}`,
+    });
+  } else if (severityDelta < 0) {
+    improvements.push({
+      caseId: recorded.id,
+      signal: 'severity',
+      recorded: recorded.severity,
+      measured: measured.severity,
+      detail: `${recorded.id}: severity improved from ${recorded.severity} to ${measured.severity}`,
+    });
+  }
+
+  const signals = [
+    { signal: 'ssim' as const, recorded: recorded.ssim, measured: meanSsim(measured), tolerance: tolerance.ssim, label: 'mean SSIM' },
+    { signal: 'inkF1' as const, recorded: recorded.worstInkF1, measured: worstInkF1(measured), tolerance: tolerance.inkF1, label: 'worst ink F1' },
+  ];
+  for (const entry of signals) {
+    const delta = entry.measured - entry.recorded;
+    if (delta < -entry.tolerance) {
+      findings.push({
+        caseId: recorded.id,
+        signal: entry.signal,
+        recorded: format(entry.recorded),
+        measured: format(entry.measured),
+        detail: `${recorded.id}: ${entry.label} fell from ${format(entry.recorded)} to ` +
+          `${format(entry.measured)} (${format(delta)}, tolerance ${entry.tolerance})`,
+      });
+    } else if (delta > entry.tolerance) {
+      improvements.push({
+        caseId: recorded.id,
+        signal: entry.signal,
+        recorded: format(entry.recorded),
+        measured: format(entry.measured),
+        detail: `${recorded.id}: ${entry.label} rose from ${format(entry.recorded)} to ` +
+          `${format(entry.measured)} (+${format(delta)})`,
+      });
+    }
+  }
+
+  return findings;
+}


### PR DESCRIPTION
Closes #395.

The weekly scheduled run uploaded an artifact that expires in 14 days, and nothing compared one run against the previous — a renderer regression was caught only if someone downloaded and eyeballed the report in time. Full-strict mode stays unreachable while two renderer-attributable severe cases remain, but **"no case may get worse than recorded" is enforceable today**, and the font contract (#379) removed the environment drift that would have made it noisy.

### The record

`npm/tests/visual-parity/ratchet.json` — one row per case: page counts, severity, mean SSIM, worst ink F1, and the disposition. No images, no paths, no artifact hashes, so it reads as a diff in review and cannot churn with artifact naming. Aggregations match BASELINE.md's per-case table exactly (SSIM is the mean over paired pages, ink F1 the **worst**, so one blank page is not averaged away).

It is seeded from a clean-worktree full-corpus run at `c4bf105` in the environment the baseline contract names (LibreOffice 25.8.7.3, Chromium 143.0.7499.4, Poppler 25.03.0). `shape` and `chart` reproduce that run's recorded figures to 5 dp.

### Broader than strict mode

Strict mode gates only *severe* cases whose disposition attributes them to the renderer. The ratchet covers **all twelve cases at every severity**, so a `close` case sliding to `minor` is caught — that is its main value-add over the existing gate, and it is why it runs independently of `DOCXODUS_VISUAL_PARITY_STRICT`.

| Signal | Fails when |
|---|---|
| page count | either engine's page count changes at all |
| severity | the case moves down the severity ladder |
| mean SSIM | falls more than 0.0005 below the record |
| worst ink F1 | falls more than 0.001 below the record |
| conversion | the case errors where the record has none |
| coverage | a recorded case is missing, or a measured case is unrecorded |

Tolerances are tight because **within one environment the benchmark is deterministic** — BASELINE.md records two clean passes producing identical metrics and identical SHA-256s for all 60 images. They are not zero because the fingerprint is coarser than the environment. Every renderer movement recorded for a real fix is at least an order of magnitude larger; the smallest is the two-inch footnote separator at +0.000128 SSIM / +0.003537 ink F1.

### The false-accusation guard

CI installs LibreOffice from unpinned `ubuntu-latest` apt (pinning it is #403), and BASELINE.md documents how far a reference change moves the numbers — LibreOffice 24.2 draws a different footnote separator than 25.8. The record therefore carries an environment fingerprint (LibreOffice major.minor, Chromium major, `fonts.conf` SHA-256). On mismatch the run reports **`environment-changed`** and demands a refresh rather than claiming a regression, so a reference-renderer release is never blamed on Docxodus.

That outcome still *fails* the run: a stale record silently comparing across environments is worse than an explicit demand to refresh it.

### Updating the record

Deliberate, in the PR that changes rendering, so improvements and accepted regressions are reviewed in the diff:

```bash
DOCXODUS_VISUAL_PARITY_OUTPUT=/tmp/docxodus-visual-parity \
DOCXODUS_VISUAL_PARITY_UPDATE_RECORD=1 \
npm run test:visual-parity
```

The update path refuses a filtered run, so a partial record cannot be committed. A passing run still lists every improvement it measured, so a stale record announces itself. `DOCXODUS_VISUAL_PARITY_RATCHET=0` observes without gating; a filtered run compares only what it measured.

### Verification

- `visual-parity-ratchet.spec.ts` — 23 tests, **not** gated behind `DOCXODUS_VISUAL_PARITY`. The comparison layer is pure, so it runs on every PR with no LibreOffice, no Poppler and no renderer, feeding the comparator deliberately worsened summaries instead of breaking rendering on purpose. That keeps acceptance criterion 1 continuously proven rather than demonstrated once by hand. It also pins the committed record against `corpus.ts` (coverage + dispositions) and against the committed `fonts.conf` digest.
- End-to-end through the real benchmark: a filtered run reproduced the record exactly (`Ratchet [ok]`), and with a deliberately worsened record the same run failed with

  ```
  Ratchet [regressed]: Visual parity regressed against the record in 2 signal(s):
    merged-table: severity worsened from close to minor
    text-formatting: mean SSIM fell from 0.99900 to 0.99725 (-0.00175, tolerance 0.0005)
  ```

- `npx tsc -p tsconfig.tests.json` clean.

The full artifact upload is unchanged, as the issue requires.

### Acceptance criteria

- [x] a deliberately introduced regression fails the run naming the case and signal — proven both by the pure-layer spec on every PR and end-to-end above
- [x] an improved case does not fail; the record update path is documented (README + BASELINE.md + this PR)
- [x] the record lives in the repository and is human-readable in review