### PR TITLE
Reduce the merged-table fill/border color delta to a minimal case (#399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,36 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Border colour resolves `w:themeColor` instead of its cached literal** (issue #399,
+  `Docxodus/WmlToHtmlConverter.cs`): `w:color` on a border is a *cache* of the last
+  theme resolution, not the authority — when `w:themeColor` is present, the theme
+  entry plus any `w:themeTint`/`w:themeShade` is what the border is. Shading already
+  resolved this way, so a single table style whose fill and border reference the same
+  accent colour derived them from two different sources. For any Word-written file the
+  two agree (Word rewrites the cache when it applies the theme), so no rendered output
+  changes and no benchmark number moves; it changes documents whose theme was swapped
+  without a cache rewrite. Found while reducing the `merged-table` benchmark case,
+  which could not expose it: a generated table that makes cache and theme **disagree**
+  can.
+
 ### Changed
+- **The `merged-table` visual-parity case is attributed** (issue #399,
+  `npm/tests/visual-parity/corpus.ts`): the corpus's last `unattributed` disposition.
+  The recorded premise — "the whole perceptual delta is fill/border *color*" — is
+  wrong. Both engines paint the identical theme-derived values (`#4472C4` header,
+  `#D9E2F3` bands, `#8EAADB` borders), and the style's cached literals equal those
+  values exactly under Word's tint formula, so there is nothing to disagree about.
+  Horizontal extents match to the pixel; the residual is row **height**, ~1px per row
+  accumulating to ~3px, which large solid fills amplify perceptually — which is how the
+  case holds ink F1 1.00000 while its SSIM sits at 0.96348. That isolates to font
+  line metrics by elimination: no `w:trHeight`, `w:tblCellMar` top/bottom both 0, and
+  `w:line="240"` single spacing, so a row IS one font line box. Moves to `environment`,
+  leaving the corpus with no `unattributed` case — a tidiness result, not a gating one,
+  since strict mode fires only on *severe* cases and this one is `minor`. Also records
+  that Docxodus applies table-style conditional formatting from Word's per-row/per-cell
+  `w:cnfStyle` hints rather than deriving band membership from `w:tblLook`, so a
+  hand-authored table without them renders unshaded.
 - **TOC hyperlink styling attributed to the reference implementation, not the renderer**
   (issue #397, `npm/tests/toc-line-geometry.spec.ts` + `visual-parity/corpus.ts`):
   the `fields-and-tabs` benchmark case named two residuals, and they have opposite

--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -7890,7 +7890,14 @@ namespace Docxodus
             {
                 var sz = (int)side.Attribute(W.sz);
                 var space = (decimal?)side.Attribute(W.space) ?? 0;
-                var color = (string)side.Attribute(W.color);
+                // `w:color` is a CACHE of the last theme resolution, not the authority: when
+                // `w:themeColor` is present the theme entry (plus any tint/shade) is what the
+                // border is. Shading already resolved this way, so a table style whose fill and
+                // border both reference the same theme colour used to resolve them from two
+                // different sources — indistinguishable in a Word-written file, where the cache
+                // agrees, and wrong in one whose theme was changed without rewriting it.
+                var color = ResolveThemeColor(side, W.color, W.themeColor, W.themeTint, W.themeShade,
+                    GetThemeColorScheme(side));
                 if (color == null || color == "auto")
                     color = "windowtext";
                 else

--- a/docs/ooxml_corner_cases.md
+++ b/docs/ooxml_corner_cases.md
@@ -14,7 +14,9 @@ This document tracks edge cases and quirks in Open XML document processing where
 4. [Paragraph Layout](#paragraph-layout)
    - [`w:lineRule="auto"` is a multiple of the FONT's line box, not of font-size](#wlineruleauto-is-a-multiple-of-the-fonts-line-box-not-of-font-size)
    - [LibreOffice ignores the `Hyperlink` character style on TOC field results](#libreoffice-ignores-the-hyperlink-character-style-on-toc-field-results)
-5. [Contributing](#contributing)
+5. [Theme Colors](#theme-colors)
+   - [`w:color`/`w:fill` are a CACHE; `w:themeColor`/`w:themeFill` are the authority](#wcolorwfill-are-a-cache-wthemecolorwthemefill-are-the-authority)
+6. [Contributing](#contributing)
 
 ---
 
@@ -1311,6 +1313,80 @@ to run at all. Without `word/settings.xml`, the converter still emits the style'
 run but generates an **empty rule** for it, so `w:rStyle` silently loses every declared property and
 the reduced case appears to reproduce the LibreOffice behaviour. This is the same requirement
 CLAUDE.md notes for programmatic .NET test documents.
+
+## Theme Colors
+
+### `w:color`/`w:fill` are a CACHE; `w:themeColor`/`w:themeFill` are the authority
+
+#### Symptom
+
+None, in any file Word wrote — which is exactly what makes it worth documenting. Word rewrites the
+cached literal whenever it applies a theme, so the two always agree and a renderer that reads the
+wrong one is indistinguishable from a correct one. The divergence only surfaces in a document whose
+theme was replaced without the caches being rewritten (a template swap, a programmatic edit, or a
+producer other than Word).
+
+#### Minimal XML reproducer
+
+A table style declaring the same accent colour twice — once as a fill, once as a border — with a
+deliberately stale cache on both:
+
+```xml
+<w:tblBorders>
+  <w:top w:val="single" w:sz="4" w:color="0000FF" w:themeColor="accent5" w:themeTint="99"/>
+  <!-- … -->
+</w:tblBorders>
+<w:tblStylePr w:type="firstRow">
+  <w:tcPr><w:shd w:val="clear" w:color="auto" w:fill="FF0000" w:themeFill="accent5"/></w:tcPr>
+</w:tblStylePr>
+```
+
+with `accent5` = `4472C4` in `theme1.xml`. A conforming consumer paints the header `#4472C4` and the
+border `#8EAADB` (accent5 at tint `0x99`), ignoring both stale literals.
+
+#### The corner case
+
+ECMA-376 treats the theme reference as authoritative and the `w:color`/`w:fill` attribute as the
+last computed value, retained so a consumer that cannot resolve themes still has something to draw.
+Word's tint formula is `value × tint + 255 × (1 − tint)`, floored — `4472C4` at tint `0x99` (153/255)
+gives `8EAADB`, and at tint `0x33` (51/255) gives `D9E2F3`, which is exactly what a real file's cache
+contains.
+
+Docxodus resolved this correctly for run colour and for shading, but **border colour read the
+literal**, so one table style could derive the same accent colour from two different sources.
+Fixed; the two paths now agree.
+
+#### Renderer comparison
+
+Measured on `HC029-Table-Merged-Cells.docx`, whose colours come entirely from the
+`Grid Table 4 Accent 5` style:
+
+| Renderer | Header fill | Band fill | Border |
+|---|---|---|---|
+| Word | accent5 | accent5 tint 33 | accent5 tint 99 |
+| LibreOffice | `#4472C4` | `#D9E2F3` | `#8EAADB` |
+| Docxodus | `#4472C4` | `#D9E2F3` | `#8EAADB` |
+
+All three agree, because that file's cache is in sync — which is why the tracked benchmark case
+could not decide the question and a generated one had to.
+
+#### A second requirement the reduced case exposed
+
+Word stamps every `w:tr`/`w:tc` with a `w:cnfStyle` listing the conditional formats that apply to
+it. Docxodus applies table-style conditional formatting (`w:tblStylePr` for `firstRow`, `band1Horz`,
+…) from those hints rather than deriving band membership from `w:tblLook` and the row index, so a
+hand-authored table without them renders with **no** header or band shading at all. Real files
+always carry them; a generated regression must emit them too.
+
+#### Relevant code
+
+- `Docxodus/WmlToHtmlConverter.cs` — `ResolveThemeColor` / `ApplyTintShade`, used by
+  `CreateStyleFromShd`, run colour, and (now) `GenerateBorderStyle`.
+
+#### Tests
+
+- `npm/tests/table-style-color.spec.ts` — a generated table whose cached literals disagree with the
+  theme, asserting the theme wins for header fill, band fill, and border colour independently.
 
 ---
 

--- a/npm/tests/docx-table-color-fixture.ts
+++ b/npm/tests/docx-table-color-fixture.ts
@@ -1,0 +1,198 @@
+import { storedZip, xml } from './docx-zip.js';
+
+/**
+ * A generated table whose colours come only from a table STYLE (issue #399): conditional
+ * formatting for the header row and the banded rows, plus a table-level border colour. No cell in
+ * the document declares a colour of its own, which is exactly the shape of the tracked `HC029`
+ * benchmark case.
+ *
+ * The point of generating it is to make the theme-vs-cache question DECIDABLE. In a real Word file
+ * the cached `w:fill`/`w:color` literal and the theme resolution agree, because Word rewrites the
+ * cache whenever it applies the theme — so the tracked fixture cannot tell which one a renderer
+ * used. Here the two can be made to DISAGREE on purpose, and then the rendered pixel says which
+ * one won.
+ */
+
+const w = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const a = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+
+/** The theme's accent5, and the tints the style asks for. */
+export const THEME_ACCENT5 = '4472C4';
+/** tint 0x99 of accent5, per Word's tint formula: v*t + 255*(1-t), floored. */
+export const ACCENT5_TINT_99 = '8EAADB';
+/** tint 0x33 of accent5. */
+export const ACCENT5_TINT_33 = 'D9E2F3';
+
+/**
+ * Deliberately WRONG cached literals, one colour per property so a failure names which one
+ * regressed. A renderer painting these used the cache; one painting the theme-derived value
+ * resolved the reference. Word treats the literal as a cache of the last resolution, so the
+ * theme is what a conforming consumer must use.
+ */
+export const STALE_HEADER_FILL = 'FF0000';
+export const STALE_BAND_FILL = '00FF00';
+export const STALE_BORDER_COLOR = '0000FF';
+
+export interface TableColorFixtureOptions {
+  /**
+   * When true, the style's cached `w:fill`/`w:color` literals are replaced with a stale value
+   * that disagrees with the theme, isolating which source the renderer honours.
+   */
+  staleCache?: boolean;
+}
+
+export function generateTableColorDocx(options: TableColorFixtureOptions = {}): Uint8Array {
+  const headerFill = options.staleCache ? STALE_HEADER_FILL : THEME_ACCENT5;
+  const bandFill = options.staleCache ? STALE_BAND_FILL : ACCENT5_TINT_33;
+  const borderColor = options.staleCache ? STALE_BORDER_COLOR : ACCENT5_TINT_99;
+
+  // Word stamps each row and cell with the conditional formats that apply to it rather than
+  // leaving a consumer to derive band membership from w:tblLook and the row index. Docxodus reads
+  // those hints, so a generated table must carry them to exercise the same path a real file does.
+  const cnf = (kind: 'firstRow' | 'oddHBand' | 'none') => {
+    if (kind === 'none') return '';
+    const val = kind === 'firstRow' ? '100000000000' : '000000100000';
+    const first = kind === 'firstRow' ? '1' : '0';
+    const odd = kind === 'oddHBand' ? '1' : '0';
+    return `<w:cnfStyle w:val="${val}" w:firstRow="${first}" w:lastRow="0" w:firstColumn="0" ` +
+      `w:lastColumn="0" w:oddVBand="0" w:evenVBand="0" w:oddHBand="${odd}" w:evenHBand="0" ` +
+      `w:firstRowFirstColumn="0" w:firstRowLastColumn="0" w:lastRowFirstColumn="0" ` +
+      `w:lastRowLastColumn="0"/>`;
+  };
+
+  const cell = (text: string, kind: 'firstRow' | 'oddHBand' | 'none') =>
+    `<w:tc><w:tcPr>${cnf(kind)}<w:tcW w:w="3000" w:type="dxa"/></w:tcPr>` +
+    `<w:p><w:r><w:t>${text}</w:t></w:r></w:p></w:tc>`;
+  const row = (cells: string[], kind: 'firstRow' | 'oddHBand' | 'none' = 'none') =>
+    `<w:tr><w:trPr>${cnf(kind)}</w:trPr>${cells.map(c => cell(c, kind)).join('')}</w:tr>`;
+
+  const documentXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="${w}">
+  <w:body>
+    <w:tbl>
+      <w:tblPr>
+        <w:tblStyle w:val="GridTable4-Accent5"/>
+        <w:tblW w:w="0" w:type="auto"/>
+        <w:tblLook w:val="04A0" w:firstRow="1" w:lastRow="0" w:firstColumn="1"
+          w:lastColumn="0" w:noHBand="0" w:noVBand="1"/>
+      </w:tblPr>
+      <w:tblGrid><w:gridCol w:w="3000"/><w:gridCol w:w="3000"/><w:gridCol w:w="3000"/></w:tblGrid>
+      ${row(['Header A', 'Header B', 'Header C'], 'firstRow')}
+      ${row(['Band one A', 'Band one B', 'Band one C'], 'oddHBand')}
+      ${row(['Plain two A', 'Plain two B', 'Plain two C'])}
+      ${row(['Band three A', 'Band three B', 'Band three C'], 'oddHBand')}
+    </w:tbl>
+    <w:p/>
+    <w:sectPr>
+      <w:pgSz w:w="12240" w:h="15840"/>
+      <w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"
+        w:header="720" w:footer="720" w:gutter="0"/>
+    </w:sectPr>
+  </w:body>
+</w:document>`;
+
+  const stylesXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles xmlns:w="${w}">
+  <w:docDefaults>
+    <w:rPrDefault><w:rPr><w:rFonts w:ascii="Calibri" w:hAnsi="Calibri"/><w:sz w:val="22"/></w:rPr></w:rPrDefault>
+    <w:pPrDefault><w:pPr><w:spacing w:after="0" w:line="240" w:lineRule="auto"/></w:pPr></w:pPrDefault>
+  </w:docDefaults>
+  <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+  <w:style w:type="character" w:default="1" w:styleId="DefaultParagraphFont">
+    <w:name w:val="Default Paragraph Font"/>
+  </w:style>
+  <w:style w:type="table" w:default="1" w:styleId="TableNormal"><w:name w:val="Normal Table"/></w:style>
+  <w:style w:type="table" w:styleId="GridTable4-Accent5">
+    <w:name w:val="Grid Table 4 Accent 5"/><w:basedOn w:val="TableNormal"/>
+    <w:tblPr>
+      <w:tblStyleRowBandSize w:val="1"/><w:tblStyleColBandSize w:val="1"/>
+      <w:tblBorders>
+        <w:top w:val="single" w:sz="4" w:space="0" w:color="${borderColor}" w:themeColor="accent5" w:themeTint="99"/>
+        <w:left w:val="single" w:sz="4" w:space="0" w:color="${borderColor}" w:themeColor="accent5" w:themeTint="99"/>
+        <w:bottom w:val="single" w:sz="4" w:space="0" w:color="${borderColor}" w:themeColor="accent5" w:themeTint="99"/>
+        <w:right w:val="single" w:sz="4" w:space="0" w:color="${borderColor}" w:themeColor="accent5" w:themeTint="99"/>
+        <w:insideH w:val="single" w:sz="4" w:space="0" w:color="${borderColor}" w:themeColor="accent5" w:themeTint="99"/>
+        <w:insideV w:val="single" w:sz="4" w:space="0" w:color="${borderColor}" w:themeColor="accent5" w:themeTint="99"/>
+      </w:tblBorders>
+    </w:tblPr>
+    <w:tblStylePr w:type="firstRow">
+      <w:rPr><w:b/><w:color w:val="FFFFFF" w:themeColor="background1"/></w:rPr>
+      <w:tcPr><w:shd w:val="clear" w:color="auto" w:fill="${headerFill}" w:themeFill="accent5"/></w:tcPr>
+    </w:tblStylePr>
+    <w:tblStylePr w:type="band1Horz">
+      <w:tcPr><w:shd w:val="clear" w:color="auto" w:fill="${bandFill}" w:themeFill="accent5" w:themeFillTint="33"/></w:tcPr>
+    </w:tblStylePr>
+  </w:style>
+</w:styles>`;
+
+  const themeXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<a:theme xmlns:a="${a}" name="Generated">
+  <a:themeElements>
+    <a:clrScheme name="Generated">
+      <a:dk1><a:sysClr val="windowText" lastClr="000000"/></a:dk1>
+      <a:lt1><a:sysClr val="window" lastClr="FFFFFF"/></a:lt1>
+      <a:dk2><a:srgbClr val="44546A"/></a:dk2><a:lt2><a:srgbClr val="E7E6E6"/></a:lt2>
+      <a:accent1><a:srgbClr val="4472C4"/></a:accent1><a:accent2><a:srgbClr val="ED7D31"/></a:accent2>
+      <a:accent3><a:srgbClr val="A5A5A5"/></a:accent3><a:accent4><a:srgbClr val="FFC000"/></a:accent4>
+      <a:accent5><a:srgbClr val="${THEME_ACCENT5}"/></a:accent5><a:accent6><a:srgbClr val="70AD47"/></a:accent6>
+      <a:hlink><a:srgbClr val="0563C1"/></a:hlink><a:folHlink><a:srgbClr val="954F72"/></a:folHlink>
+    </a:clrScheme>
+    <a:fontScheme name="Generated">
+      <a:majorFont><a:latin typeface="Calibri Light"/><a:ea typeface=""/><a:cs typeface=""/></a:majorFont>
+      <a:minorFont><a:latin typeface="Calibri"/><a:ea typeface=""/><a:cs typeface=""/></a:minorFont>
+    </a:fontScheme>
+    <a:fmtScheme name="Generated">
+      <a:fillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill>
+        <a:solidFill><a:schemeClr val="phClr"/></a:solidFill>
+        <a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:fillStyleLst>
+      <a:lnStyleLst>
+        <a:ln w="6350"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:ln>
+        <a:ln w="12700"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:ln>
+        <a:ln w="19050"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:ln></a:lnStyleLst>
+      <a:effectStyleLst><a:effectStyle><a:effectLst/></a:effectStyle>
+        <a:effectStyle><a:effectLst/></a:effectStyle>
+        <a:effectStyle><a:effectLst/></a:effectStyle></a:effectStyleLst>
+      <a:bgFillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill>
+        <a:solidFill><a:schemeClr val="phClr"/></a:solidFill>
+        <a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:bgFillStyleLst>
+    </a:fmtScheme>
+  </a:themeElements>
+</a:theme>`;
+
+  return storedZip([
+    {
+      name: '[Content_Types].xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
+  <Override PartName="/word/settings.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml"/>
+  <Override PartName="/word/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>
+</Types>`),
+    },
+    {
+      name: '_rels/.rels',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`),
+    },
+    {
+      name: 'word/_rels/document.xml.rels',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/settings" Target="settings.xml"/>
+  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="theme/theme1.xml"/>
+</Relationships>`),
+    },
+    // Style resolution needs the settings part; without it a style's CSS class is emitted with an
+    // empty rule and every declared property is silently lost.
+    { name: 'word/settings.xml', data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<w:settings xmlns:w="${w}"/>`) },
+    { name: 'word/theme/theme1.xml', data: xml(themeXml) },
+    { name: 'word/styles.xml', data: xml(stylesXml) },
+    { name: 'word/document.xml', data: xml(documentXml) },
+  ]);
+}

--- a/npm/tests/table-style-color.spec.ts
+++ b/npm/tests/table-style-color.spec.ts
@@ -1,0 +1,127 @@
+import { expect, test } from '@playwright/test';
+import {
+  ACCENT5_TINT_33,
+  ACCENT5_TINT_99,
+  STALE_BAND_FILL,
+  STALE_BORDER_COLOR,
+  STALE_HEADER_FILL,
+  THEME_ACCENT5,
+  generateTableColorDocx,
+} from './docx-table-color-fixture.js';
+
+/**
+ * Issue #399 — where a table style's colours come from.
+ *
+ * The tracked `merged-table` case (HC029) draws every colour from the `Grid Table 4 Accent 5`
+ * style: a header-row fill, banded-row fills, and a border colour, each declaring BOTH a
+ * `w:themeColor`/`w:themeFill` reference and a cached literal. In a Word-written file those two
+ * always agree, because Word rewrites the cache whenever it applies the theme — so the tracked
+ * fixture cannot say which one a renderer used, and both engines paint identical pixels.
+ *
+ * This generated table makes the question decidable by letting them DISAGREE. Per ECMA-376 the
+ * theme reference is the authority and `w:color`/`w:fill` is the cached last resolution, so a
+ * document whose theme changed without a cache rewrite must follow the theme.
+ */
+
+const rgb = (hex: string) =>
+  `rgb(${parseInt(hex.slice(0, 2), 16)}, ${parseInt(hex.slice(2, 4), 16)}, ${parseInt(hex.slice(4, 6), 16)})`;
+
+interface TableColors {
+  headerFill: string;
+  bandFills: string[];
+  plainFill: string;
+  borderColor: string;
+}
+
+async function renderTable(
+  page: import('@playwright/test').Page,
+  options: { staleCache?: boolean } = {},
+): Promise<TableColors> {
+  const bytes = Array.from(generateTableColorDocx(options));
+  return page.evaluate(async (input) => {
+    const html = (window as any).Docxodus.DocumentConverter.ConvertDocxToHtmlComplete(
+      new Uint8Array(input), 'Document', 'docx-', true, '', -1, 'comment-',
+      1, 1, 'page-', false, 0, 'annot-', true, true, false, false, false);
+    document.body.innerHTML = '<main id="tbl-root"></main>';
+    (window as any).DocxodusPagination.paginateHtml(html, document.getElementById('tbl-root'), {
+      scale: 1, showPageNumbers: false, pageGap: 0, fragmentParagraphs: false,
+    });
+    await document.fonts.ready;
+    await new Promise<void>(res => requestAnimationFrame(() => requestAnimationFrame(() => res())));
+
+    const pageBox = document.querySelector('#tbl-root .page-box') as HTMLElement;
+    const rows = Array.from(pageBox.querySelectorAll('tr'));
+    const fillOf = (row: Element) => {
+      const cell = row.querySelector('td, th') as HTMLElement;
+      return getComputedStyle(cell).backgroundColor;
+    };
+    const headerCell = rows[0].querySelector('td, th') as HTMLElement;
+    return {
+      headerFill: fillOf(rows[0]),
+      bandFills: [fillOf(rows[1]), fillOf(rows[3])],
+      plainFill: fillOf(rows[2]),
+      borderColor: getComputedStyle(headerCell).borderTopColor,
+    };
+  }, bytes);
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/test-harness.html');
+  await page.waitForFunction(() => (window as any).DocxodusReady === true, undefined,
+    { timeout: 30_000 });
+  await page.addScriptTag({ url: '/pagination.bundle.js' });
+});
+
+test.describe('table-style colours', () => {
+  test('conditional formatting paints the theme-derived header, band and border colours',
+    async ({ page }) => {
+      const colors = await renderTable(page);
+
+      // These are exactly the values LibreOffice paints for the tracked HC029 fixture.
+      expect(colors.headerFill, 'first-row fill = accent5').toBe(rgb(THEME_ACCENT5));
+      for (const band of colors.bandFills) {
+        expect(band, 'banded-row fill = accent5 tint 33').toBe(rgb(ACCENT5_TINT_33));
+      }
+      expect(colors.borderColor, 'table border = accent5 tint 99').toBe(rgb(ACCENT5_TINT_99));
+    });
+
+  test('a row outside the header and the bands takes no fill', async ({ page }) => {
+    const colors = await renderTable(page);
+    // `w:tblLook` turns banding on with a band size of one row, so row 2 is unbanded. If a
+    // renderer banded every row, the fill assertions above would still pass.
+    expect(colors.plainFill).not.toBe(rgb(ACCENT5_TINT_33));
+    expect(colors.plainFill).not.toBe(rgb(THEME_ACCENT5));
+  });
+
+  /**
+   * The discriminating case. Each of the three declarations keeps its `w:themeColor`/`w:themeFill`
+   * reference but carries a deliberately WRONG cached literal, and each literal is a different
+   * colour so the failure names which property regressed.
+   */
+  test('a stale cached literal loses to the theme reference it accompanies', async ({ page }) => {
+    const colors = await renderTable(page, { staleCache: true });
+
+    expect(colors.headerFill, 'header fill must resolve w:themeFill, not the stale w:fill')
+      .toBe(rgb(THEME_ACCENT5));
+    expect(colors.headerFill).not.toBe(rgb(STALE_HEADER_FILL));
+
+    for (const band of colors.bandFills) {
+      expect(band, 'band fill must resolve w:themeFill with its tint').toBe(rgb(ACCENT5_TINT_33));
+      expect(band).not.toBe(rgb(STALE_BAND_FILL));
+    }
+
+    // Borders used to be the odd one out: shading resolved the theme while the border read the
+    // cache, so one style's fill and border disagreed about the same accent colour (issue #399).
+    expect(colors.borderColor, 'border must resolve w:themeColor, not the stale w:color')
+      .toBe(rgb(ACCENT5_TINT_99));
+    expect(colors.borderColor).not.toBe(rgb(STALE_BORDER_COLOR));
+  });
+
+  test('the resolved colours are identical whether or not the cache agrees', async ({ page }) => {
+    // The whole point of the attribution: for a Word-written file (cache in sync) the two paths
+    // are indistinguishable, which is why the tracked fixture showed no colour disagreement.
+    const fresh = await renderTable(page);
+    const stale = await renderTable(page, { staleCache: true });
+    expect(stale).toEqual(fresh);
+  });
+});

--- a/npm/tests/visual-parity/BASELINE.md
+++ b/npm/tests/visual-parity/BASELINE.md
@@ -354,6 +354,49 @@ are independent, i.e. that applying the character style does not change the line
 With this, the corpus's remaining non-`environment` work is the `merged-table` colour delta (issue
 #399), the last `unattributed` case.
 
+## The merged-table colour delta — 2026-08-11 (issue #399)
+
+The corpus's last `unattributed` case. The issue recorded that `merged-table` has perfect ink
+geometry (F1 1.00000) and that "the whole perceptual delta is fill/border *color*". **That premise
+was wrong**, and the measurement is easy once taken: sampling every non-white pixel of both renders,
+
+| Renderer | Header fill | Band fill | Border |
+|---|---|---|---|
+| LibreOffice | `#4472C4` | `#D9E2F3` | `#8EAADB` |
+| Docxodus | `#4472C4` | `#D9E2F3` | `#8EAADB` |
+
+The two engines paint the **same three colours**, and they are the theme-derived values: `HC029`
+declares no `w:shd` or border of its own, taking everything from the `Grid Table 4 Accent 5` style,
+whose cached literals equal `accent5` (`4472C4`) under Word's tint formula exactly — `tint 0x99` →
+`8EAADB`, `tint 0x33` → `D9E2F3`. There is nothing for the engines to disagree about.
+
+What differs is **geometry**. Horizontal extents are identical to the pixel (fills span x 96–719 and
+97–718 in both). Vertically the rows are about 1px taller in Docxodus, accumulating to ~3px by the
+second header band (LibreOffice 200–236, Docxodus 203–239). Because the fills are large solid
+areas, a one-pixel edge offset moves a great many pixels past the ΔE threshold, which is exactly how
+a case can hold ink F1 1.00000 — the ink masks overlap within the tolerance — while its SSIM sits at
+0.96348.
+
+That row-height difference isolates to font line metrics by elimination rather than by assumption:
+the table declares no `w:trHeight`, its `w:tblCellMar` top and bottom are both **0**, and its
+paragraphs are `w:line="240"` — exactly single spacing, which issue #396 does not touch. A row is
+therefore exactly one font line box, and the 1px is the two engines measuring that box differently
+for the same substituted font. The disposition moves `unattributed` → **`environment`**, the same
+residual the other environment cases carry. Note this changes no gating: `gatesStrictRun` fires
+only on *severe* cases, and `merged-table` is `minor`.
+
+**A real inconsistency found while reducing it.** The tracked fixture cannot say whether a renderer
+resolves `w:themeFill`/`w:themeColor` or just paints the cached `w:fill`/`w:color` literal, because
+Word keeps the two in sync. A generated table can, by making them disagree — and that exposed
+Docxodus resolving the *same* accent colour from two different sources within one style: shading
+resolved the theme, while border colour read the cache. ECMA-376 makes the theme reference the
+authority and the literal a cache of the last resolution, so border colour now resolves the theme
+like shading always did. For any Word-written file this changes nothing (which is why no corpus
+number moves); it changes documents whose theme was swapped without a cache rewrite.
+
+With this the corpus has **no `unattributed` case left**, and every remaining residual is either
+`environment` or a recorded `reference-deviation`.
+
 ## Current case results and triage
 
 `SSIM` is the mean over paired pages. `Ink F1` is the worst paired-page value, so it exposes a
@@ -364,7 +407,7 @@ attribution the strict gate reads, and these numbers are what `ratchet.json` rec
 | Case | Pages D/L | Severity | Disposition | SSIM | Ink F1 | Triage |
 |---|---:|---|---|---:|---:|---|
 | text-formatting | 1/1 | close | environment | 0.99708 | 0.96770 | Control case; fonts and small caps are close. |
-| merged-table | 1/1 | minor | unattributed | 0.96348 | 1.00000 | Ink geometry aligns; fill/border color dominates the perceptual delta and has not been reduced to a minimal case. |
+| merged-table | 1/1 | minor | environment | 0.96348 | 1.00000 | Both engines paint the SAME theme-derived colours (issue #399); the residual is row height (~1 px/row) that large solid fills amplify perceptually. |
 | numbered-lists | 1/1 | close | reference-deviation | 0.99898 | 1.00000 | The "28 px lower" reading was the accumulated auto-line-spacing error (issue #396), not a top-margin deviation: ink geometry is now exact. |
 | multi-section | 6/6 | close | environment | 0.99986 | 1.00000 | Header/body/footer bands sit at the distances `w:pgMar` declares (issue #377); ink geometry now exact. |
 | landscape-section | 1/1 | major | environment | 0.94878 | 0.95533 | Page dimensions match; improved by issue #396. Residual is same-font wrapping and rasterization. |
@@ -422,12 +465,10 @@ block vertical placement (issue #378), the font-substitution contract (issue #37
 regression ratchet (issue #395), and automatic line spacing (issue #396, which also resolved
 #397's line-box half and dissolved #398's premise) are resolved above. The remaining order is:
 
-1. Reduce the `merged-table` fill/border color delta to a minimal case and attribute it (issue
-   #399) — the corpus's last `unattributed` disposition.
-2. Reduce the two remaining `major` cases (`inline-image`, `landscape-section`) to minimal
+1. Reduce the two remaining `major` cases (`inline-image`, `landscape-section`) to minimal
    same-font layout cases (issue #404), which is what now stands between the corpus and a
    strict run.
-3. Close issue #398: the `numbered-lists` top margin was never in disagreement, so the question
+2. Close issue #398: the `numbered-lists` top margin was never in disagreement, so the question
    is whether to keep a Word-evidence procedure (issue #402) for it at all.
 
 The list-margin discrepancy should not be changed merely to imitate LibreOffice: current evidence

--- a/npm/tests/visual-parity/corpus.ts
+++ b/npm/tests/visual-parity/corpus.ts
@@ -80,9 +80,18 @@ export const VISUAL_PARITY_CORPUS: VisualCorpusEntry[] = [
     categories: ['tables'],
     rationale: 'Merged-cell borders, widths, and vertical geometry.',
     disposition: {
-      kind: 'unattributed',
-      rationale: 'Ink geometry aligns; the perceptual delta is dominated by fill/border color that has ' +
-        'not been reduced to a minimal case deciding which engine matches the OOXML color semantics.',
+      kind: 'environment',
+      rationale: 'Colour is NOT the delta (issue #399). Sampling both renders, the two engines paint ' +
+        'the identical theme-derived values — #4472C4 header, #D9E2F3 bands, #8EAADB borders — and ' +
+        'the style\'s cached literals equal those values exactly under Word\'s tint formula, so ' +
+        'there is nothing to disagree about. Horizontal extents match exactly; the residual is row ' +
+        'HEIGHT, about 1 px per row accumulating to ~3 px over the table. That isolates to font ' +
+        'line metrics by elimination: the table declares no `w:trHeight`, its `w:tblCellMar` top ' +
+        'and bottom are both 0, and its paragraphs are `w:line="240"` single spacing — so a row IS ' +
+        'exactly one font line box, and the 1 px is the two engines measuring that box differently ' +
+        'for the same substituted font. Large solid fills make a one-pixel edge offset dominate ' +
+        'the perceptual signal while ink F1 stays 1.00000.',
+      reference: 'https://github.com/JSv4/Docxodus/issues/399',
     },
   },
   {

--- a/npm/tests/visual-parity/ratchet.json
+++ b/npm/tests/visual-parity/ratchet.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "description": "Per-case visual-parity regression ratchet (issue #395). Numbers only. The scheduled run fails when any case gets worse than recorded beyond `tolerance`. Refresh this file deliberately in the PR that changes rendering, so improvements and accepted regressions are reviewed in the diff. See npm/tests/visual-parity/README.md.",
   "recordedAt": "2026-08-11",
-  "sourceCommit": "cc95e099855dff87d1f45f1b936cdb15465f4306",
+  "sourceCommit": "b6b67883789a3a860e0db56e17089ba37fab9230",
   "environment": {
     "libreoffice": "25.8",
     "chromium": "143",
@@ -70,7 +70,7 @@
     },
     {
       "id": "merged-table",
-      "disposition": "unattributed",
+      "disposition": "environment",
       "pages": {
         "docxodus": 1,
         "libreoffice": 1


### PR DESCRIPTION
Closes #399. Stacked on #407 (issue #397) → #406 (issue #396). #405 (issue #395) already merged.

The corpus's last `unattributed` disposition.

### The issue's premise is wrong, and the measurement is easy once taken

The issue records that `merged-table` has perfect ink geometry and that "the whole perceptual delta is fill/border **color**". Sampling every non-white pixel of both renders:

| Renderer | Header fill | Band fill | Border |
|---|---|---|---|
| LibreOffice | `#4472C4` | `#D9E2F3` | `#8EAADB` |
| Docxodus | `#4472C4` | `#D9E2F3` | `#8EAADB` |

**The two engines paint the same three colours.** `HC029` declares no `w:shd` or border of its own — everything comes from the `Grid Table 4 Accent 5` style, whose cached literals equal `accent5` (`4472C4`) under Word's tint formula exactly (`tint 0x99` → `8EAADB`, `tint 0x33` → `D9E2F3`). There is nothing to disagree about, so no engine can be "matching the OOXML color semantics" better than the other.

### What the delta actually is

Geometry. Horizontal extents are identical to the pixel (fills span x 96–719 and 97–718 in both). Vertically Docxodus's rows are ~1px taller, accumulating to ~3px by the second header band (LibreOffice 200–236, Docxodus 203–239). Large solid fills push a great many pixels past the ΔE threshold for a one-pixel edge offset — which is exactly how a case holds ink F1 **1.00000** (masks overlap within tolerance) while its SSIM sits at 0.96348.

That row-height difference isolates to font line metrics **by elimination, not assumption**: the table declares no `w:trHeight`, its `w:tblCellMar` top and bottom are both **0**, and its paragraphs are `w:line="240"` — exactly single spacing, which #406 does not touch. A row is therefore exactly one font line box, and the 1px is the two engines measuring that box differently for the same substituted font.

Disposition: `unattributed` → **`environment`**. To be precise about what that does and doesn't do: **it changes no gating.** `gatesStrictRun` fires only on *severe* cases and `merged-table` is `minor`, so this is a tidiness result — the corpus now has no `unattributed` case — not a closed gating hole.

### A real inconsistency the tracked fixture could not expose

Word keeps `w:color`/`w:fill` in sync with the theme, so `HC029` cannot say which source a renderer used. A generated table whose cache deliberately **disagrees** can — and it showed Docxodus deriving the same accent colour from two different sources inside one style:

| | Before | After |
|---|---|---|
| header fill (`w:themeFill`, stale cache `FF0000`) | `#4472C4` ✅ theme | `#4472C4` ✅ |
| band fill (`w:themeFill` + tint, stale `00FF00`) | `#D9E2F3` ✅ theme | `#D9E2F3` ✅ |
| border (`w:themeColor` + tint, stale `0000FF`) | **`#0000FF` ❌ cache** | `#8EAADB` ✅ theme |

(The "before" column is an actual measured run of this exact fixture prior to the fix — it is the negative control, since the corpus being byte-identical proves the change is *safe* but not that it is *live*.)

ECMA-376 makes the theme reference authoritative and `w:color`/`w:fill` a cache of the last resolution, so border colour now resolves through the same `ResolveThemeColor` path shading always used. **For any Word-written file this changes nothing** — the full corpus rerun confirms it: every per-case metric is byte-identical. It changes documents whose theme was swapped without a cache rewrite.

### Verification

- `npm/tests/table-style-color.spec.ts` (4 tests, generated DOCX — no fixture added): pins header fill, band fill and border colour **independently**, each with a *different* stale colour so a failure names which property regressed; includes an unbanded row so a renderer that shaded everything could not pass; and asserts the resolved colours are identical whether or not the cache agrees.
- **.NET suite green: 3421 passed, 0 failed.**
- Full corpus rerun: **byte-identical metrics**, 0 severe, mean ink F1 0.981644.
- Ratchet record regenerated from a clean-worktree run at the code commit; only `sourceCommit` and the one disposition differ.

### Also recorded

Docxodus applies table-style conditional formatting from Word's per-row/per-cell `w:cnfStyle` hints rather than deriving band membership from `w:tblLook` + row index. Real files always carry them; a hand-authored table without them renders **completely unshaded**, which is a trap for the next person generating a table fixture. Documented in `docs/ooxml_corner_cases.md` alongside the theme-cache semantics.

### Note on CI history

The `IrAlignerAdversarialTests.Scale_guard_500_vs_2000_cpu_ratio_within_12x` failure visible on #405's first run is a shared-runner timing flake unrelated to this stack — it passed on rerun, and #406's CI went green with the same code.