### PR TITLE
Correct TOC line height and hyperlink styling in print layout (#397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **TOC hyperlink styling attributed to the reference implementation, not the renderer**
+  (issue #397, `npm/tests/toc-line-geometry.spec.ts` + `visual-parity/corpus.ts`):
+  the `fields-and-tabs` benchmark case named two residuals, and they have opposite
+  answers. Entry line-box height was a renderer bug and is fixed (issue #396 —
+  entries were displaced by a growing 7.3/11.0/14.7px and now land within 0.12px of
+  LibreOffice). Hyperlink appearance is not: the entry runs carry
+  `<w:rStyle w:val="Hyperlink"/>` and that character style declares `w:color="0563C1"`
+  with `w:u w:val="single"`. Docxodus paints the declared colour byte for byte;
+  LibreOffice paints the entries black, dropping a style the run explicitly
+  references. `w:hyperlink` is a link, not a style, so the output is **not** changed
+  to match the comparison implementation and the case's disposition moves
+  `renderer-bug` → `reference-deviation`. A generated regression pins entry line
+  geometry and hyperlink appearance **separately**, and — because "we match Word"
+  would otherwise be indistinguishable from decorating every hyperlink by default —
+  includes an otherwise identical entry with no `w:rStyle` that must come out
+  undecorated. Documented in `docs/ooxml_corner_cases.md`.
+
 ### Fixed
 - **Automatic line spacing is a multiple of the font's line box, not of font-size**
   (issue #396, `Docxodus/WmlToHtmlConverter.cs`): OOXML's `w:lineRule="auto"` gives

--- a/docs/ooxml_corner_cases.md
+++ b/docs/ooxml_corner_cases.md
@@ -13,6 +13,7 @@ This document tracks edge cases and quirks in Open XML document processing where
    - [Misleading Deflate Hints Cause Compression Loss](#misleading-deflate-hints-cause-compression-loss)
 4. [Paragraph Layout](#paragraph-layout)
    - [`w:lineRule="auto"` is a multiple of the FONT's line box, not of font-size](#wlineruleauto-is-a-multiple-of-the-fonts-line-box-not-of-font-size)
+   - [LibreOffice ignores the `Hyperlink` character style on TOC field results](#libreoffice-ignores-the-hyperlink-character-style-on-toc-field-results)
 5. [Contributing](#contributing)
 
 ---
@@ -1240,6 +1241,76 @@ PR #372 introduced the native-line-box model but enabled it only for *empty* par
 which is what pagination parity needed at the time; populated paragraphs kept the percentage
 fallback. Issues #396 (DrawingML textbox auto-fit height) and #397 (TOC line height) were both
 traced to that remaining fallback.
+
+### LibreOffice ignores the `Hyperlink` character style on TOC field results
+
+#### Symptom
+
+A generated table of contents renders blue and underlined in Docxodus (and in Word) but plain black
+in LibreOffice, making a pixel comparison of any TOC document look like a Docxodus colour bug.
+
+#### Minimal XML reproducer
+
+```xml
+<w:hyperlink w:anchor="_Toc425251205" w:history="1">
+  <w:r>
+    <w:rPr><w:rStyle w:val="Hyperlink"/><w:noProof/></w:rPr>
+    <w:t>The first heading</w:t>
+  </w:r>
+</w:hyperlink>
+```
+
+with, in `styles.xml`:
+
+```xml
+<w:style w:type="character" w:styleId="Hyperlink">
+  <w:name w:val="Hyperlink"/><w:basedOn w:val="DefaultParagraphFont"/>
+  <w:rPr><w:color w:val="0563C1" w:themeColor="hyperlink"/><w:u w:val="single"/></w:rPr>
+</w:style>
+```
+
+#### The corner case
+
+`w:hyperlink` is a *link*, not a style — nothing about it implies an appearance. The appearance
+comes from the run's explicit `w:rStyle w:val="Hyperlink"` reference, and the referenced character
+style declares the colour and the underline. Word writes exactly this when it builds a TOC with the
+`\h` switch, which is why "my table of contents came out blue and underlined" is such a common Word
+question.
+
+Measured over the TOC entry rows of `HC022-Table-Of-Contents.docx` at 96 DPI:
+
+| Renderer | Dominant entry-text colour |
+|---|---|
+| Word | `Hyperlink` style applied (blue, underlined) |
+| Docxodus | `#0563C1` — the declared value, byte for byte |
+| LibreOffice | `#000000` — the character style is dropped |
+
+#### Analysis
+
+LibreOffice's writer import appears to treat a TOC field result as generated content it re-styles
+itself, discarding the character style the run references. The direction of the deviation is
+decisive: Docxodus emits the value the file declares, so no renderer change is warranted. The
+visual-parity corpus records `fields-and-tabs` as `reference-deviation` on this evidence.
+
+#### Relevant code
+
+- `Docxodus/WmlToHtmlConverter.cs` — character-style resolution emits `span.docx-Hyperlink` with
+  the declared `color`/`text-decoration`.
+
+#### Tests
+
+- `npm/tests/toc-line-geometry.spec.ts` — asserts a `w:rStyle`-carrying entry gets the declared
+  colour and underline, AND that an otherwise identical entry *without* `w:rStyle` gets neither.
+  The second half is what proves the renderer reads the style rather than decorating every
+  hyperlink; without it, "we match Word" would be indistinguishable from a lucky default.
+
+#### A trap when reducing this to a generated document
+
+A programmatically built package needs a **`DocumentSettingsPart`** for character-style resolution
+to run at all. Without `word/settings.xml`, the converter still emits the style's CSS *class* on the
+run but generates an **empty rule** for it, so `w:rStyle` silently loses every declared property and
+the reduced case appears to reproduce the LibreOffice behaviour. This is the same requirement
+CLAUDE.md notes for programmatic .NET test documents.
 
 ---
 

--- a/npm/tests/docx-toc-fixture.ts
+++ b/npm/tests/docx-toc-fixture.ts
@@ -1,0 +1,143 @@
+import { storedZip, xml } from './docx-zip.js';
+
+/**
+ * A generated table of contents (issue #397) — heading, dotted-leader entries, right-aligned page
+ * numbers, and hyperlink runs — reduced to the two things the case is about: how tall a TOC entry's
+ * line box is, and where its hyperlink appearance comes from.
+ *
+ * The interesting property is that the entry text carries `w:rStyle w:val="Hyperlink"`, and the
+ * `Hyperlink` character style declares a color and an underline. That is the ONLY source of
+ * hyperlink appearance in the file: `w:hyperlink` is a link, not a style. A renderer that paints a
+ * hyperlink blue without being told to is fabricating, and one that ignores the declared style is
+ * dropping — the fixture can tell the two apart because it emits both kinds of entry.
+ */
+
+const w = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const r = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+
+/** The `Hyperlink` character style's declared appearance — Word's own default values. */
+export const TOC_HYPERLINK_COLOR = '0563C1';
+export const TOC_HYPERLINK_RGB = 'rgb(5, 99, 193)';
+
+/** docDefaults automatic line spacing, in 240ths of a line. Word's default since Word 2013. */
+export const TOC_LINE_TWIPS = 259;
+/** `w:after` on the TOC1 style, in twips. */
+export const TOC_AFTER_TWIPS = 100;
+/** Body font size in half-points. */
+export const TOC_SIZE_HALF_POINTS = 22;
+/** Right tab stop for the page number, in twips. */
+export const TOC_TAB_TWIPS = 9350;
+
+export interface TocEntry {
+  text: string;
+  page: string;
+  /** Apply the `Hyperlink` character style to the entry text, as Word's `\h` TOC does. */
+  styled: boolean;
+}
+
+export const TOC_ENTRIES: TocEntry[] = [
+  { text: 'The first heading of the generated document', page: '1', styled: true },
+  { text: 'The second heading of the generated document', page: '2', styled: true },
+  { text: 'The third heading of the generated document', page: '3', styled: true },
+  // The control: identical markup MINUS w:rStyle. Nothing in the file asks for hyperlink
+  // appearance here, so anything blue or underlined would be the renderer's invention.
+  { text: 'An entry whose run carries no character style', page: '4', styled: false },
+];
+
+function entryXml(entry: TocEntry, index: number): string {
+  const rStyle = entry.styled ? '<w:rStyle w:val="Hyperlink"/>' : '';
+  // `w:webHidden` on the leader/page-number runs is what Word writes; they stay visible in print.
+  return `<w:p><w:pPr><w:pStyle w:val="TOC1"/>` +
+    `<w:tabs><w:tab w:val="right" w:leader="dot" w:pos="${TOC_TAB_TWIPS}"/></w:tabs>` +
+    `</w:pPr>` +
+    `<w:hyperlink w:anchor="_Toc${index}" w:history="1">` +
+    `<w:r><w:rPr>${rStyle}<w:noProof/></w:rPr><w:t xml:space="preserve">${entry.text}</w:t></w:r>` +
+    `<w:r><w:rPr><w:noProof/><w:webHidden/></w:rPr><w:tab/></w:r>` +
+    `<w:r><w:rPr><w:noProof/><w:webHidden/></w:rPr><w:t>${entry.page}</w:t></w:r>` +
+    `</w:hyperlink></w:p>`;
+}
+
+export function generateTocDocx(): Uint8Array {
+  const body = TOC_ENTRIES.map(entryXml).join('\n    ');
+
+  const documentXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="${w}" xmlns:r="${r}">
+  <w:body>
+    <w:p><w:pPr><w:pStyle w:val="TOCHeading"/></w:pPr><w:r><w:t>Contents</w:t></w:r></w:p>
+    ${body}
+    <w:sectPr>
+      <w:pgSz w:w="12240" w:h="15840"/>
+      <w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"
+        w:header="720" w:footer="720" w:gutter="0"/>
+    </w:sectPr>
+  </w:body>
+</w:document>`;
+
+  const stylesXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles xmlns:w="${w}">
+  <w:docDefaults>
+    <w:rPrDefault><w:rPr>
+      <w:rFonts w:ascii="Calibri" w:hAnsi="Calibri"/>
+      <w:sz w:val="${TOC_SIZE_HALF_POINTS}"/><w:szCs w:val="${TOC_SIZE_HALF_POINTS}"/>
+    </w:rPr></w:rPrDefault>
+    <w:pPrDefault><w:pPr>
+      <w:spacing w:after="160" w:line="${TOC_LINE_TWIPS}" w:lineRule="auto"/>
+    </w:pPr></w:pPrDefault>
+  </w:docDefaults>
+  <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+  <w:style w:type="character" w:default="1" w:styleId="DefaultParagraphFont">
+    <w:name w:val="Default Paragraph Font"/>
+  </w:style>
+  <w:style w:type="character" w:styleId="Hyperlink">
+    <w:name w:val="Hyperlink"/><w:basedOn w:val="DefaultParagraphFont"/>
+    <w:rPr><w:color w:val="${TOC_HYPERLINK_COLOR}"/><w:u w:val="single"/></w:rPr>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="TOCHeading">
+    <w:name w:val="TOC Heading"/><w:basedOn w:val="Normal"/>
+    <w:pPr><w:outlineLvl w:val="9"/></w:pPr>
+    <w:rPr><w:sz w:val="32"/><w:szCs w:val="32"/></w:rPr>
+  </w:style>
+  <w:style w:type="paragraph" w:styleId="TOC1">
+    <w:name w:val="toc 1"/><w:basedOn w:val="Normal"/>
+    <w:pPr><w:spacing w:after="${TOC_AFTER_TWIPS}"/></w:pPr>
+  </w:style>
+</w:styles>`;
+
+  return storedZip([
+    {
+      name: '[Content_Types].xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
+  <Override PartName="/word/settings.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml"/>
+</Types>`),
+    },
+    {
+      name: '_rels/.rels',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`),
+    },
+    {
+      name: 'word/_rels/document.xml.rels',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/settings" Target="settings.xml"/>
+</Relationships>`),
+    },
+    // Style resolution needs the settings part: without it the converter emits the character
+    // style's CLASS but an empty rule, so `w:rStyle` silently loses its declared properties.
+    {
+      name: 'word/settings.xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:settings xmlns:w="${w}"/>`),
+    },
+    { name: 'word/styles.xml', data: xml(stylesXml) },
+    { name: 'word/document.xml', data: xml(documentXml) },
+  ]);
+}

--- a/npm/tests/toc-line-geometry.spec.ts
+++ b/npm/tests/toc-line-geometry.spec.ts
@@ -1,0 +1,195 @@
+import { expect, test } from '@playwright/test';
+import {
+  TOC_AFTER_TWIPS,
+  TOC_ENTRIES,
+  TOC_HYPERLINK_RGB,
+  TOC_LINE_TWIPS,
+  generateTocDocx,
+} from './docx-toc-fixture.js';
+
+/**
+ * Issue #397 — TOC entry line geometry and hyperlink appearance in print layout.
+ *
+ * The issue named two things, and they turned out to have different answers, so they are pinned
+ * SEPARATELY here and neither can hide behind the other:
+ *
+ *  - **Line-box height was a renderer bug.** TOC entries drifted further down the page with every
+ *    entry because automatic line spacing was measured against font-size instead of the font's own
+ *    line box (issue #396). Fixed; on the tracked HC022 fixture entries now land within 0.12px of
+ *    LibreOffice, where they were off by up to 14.7px.
+ *  - **Hyperlink appearance is NOT a renderer bug.** The entry run carries
+ *    `w:rStyle w:val="Hyperlink"`, and that character style declares `w:color` and `w:u`. Docxodus
+ *    paints exactly the declared color; LibreOffice paints the entries black, ignoring the style it
+ *    was given. Docxodus follows the file, so the difference is a reference deviation and the
+ *    output must not be changed to match the comparison implementation.
+ *
+ * The second point only means anything if the renderer is proven to be READING the style rather
+ * than decorating every `w:hyperlink` it sees. The fixture therefore also contains an entry with
+ * identical markup minus `w:rStyle`, and the test requires that one to be undecorated.
+ */
+
+const PT_TO_PX = 4 / 3;
+const TWIPS_PER_PT = 20;
+/** Sub-pixel tolerance: spacing is authored in twips, emitted in pt, and read back in px. */
+const TOL = 0.75;
+
+interface EntryGeometry {
+  text: string;
+  top: number;
+  bottom: number;
+  lineBox: number;
+  color: string;
+  textDecorationLine: string;
+  fontSize: number;
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/test-harness.html');
+  await page.waitForFunction(() => (window as any).DocxodusReady === true, undefined,
+    { timeout: 30_000 });
+  await page.addScriptTag({ url: '/pagination.bundle.js' });
+});
+
+async function renderToc(page: import('@playwright/test').Page) {
+  const bytes = Array.from(generateTocDocx());
+  return page.evaluate(async (input) => {
+    const html = (window as any).Docxodus.DocumentConverter.ConvertDocxToHtmlComplete(
+      new Uint8Array(input), 'Document', 'docx-', true, '', -1, 'comment-',
+      1, 1, 'page-', false, 0, 'annot-', true, true, false, false, false);
+    document.body.style.cssText = 'margin:0;padding:0;background:white;';
+    document.body.innerHTML = '<main id="toc-root"></main>';
+    (window as any).DocxodusPagination.paginateHtml(html, document.getElementById('toc-root'), {
+      scale: 1, showPageNumbers: false, pageGap: 0, fragmentParagraphs: false,
+    });
+    await document.fonts.ready;
+    await new Promise<void>(res => requestAnimationFrame(() => requestAnimationFrame(() => res())));
+
+    // The RENDERED page box only: pagination keeps a hidden staging copy with zero client rects.
+    const pageBox = document.querySelector('#toc-root .page-box') as HTMLElement;
+    const paragraphs = Array.from(pageBox.querySelectorAll('p'));
+    const entries = paragraphs
+      .filter(p => (p.textContent || '').includes('heading of the generated document') ||
+        (p.textContent || '').includes('no character style'))
+      .map(p => {
+        const rect = p.getBoundingClientRect();
+        // The entry's own text run — NOT the leader/page-number runs, whose appearance is a
+        // separate question. Runs nest (the converter wraps them), and querySelectorAll is in
+        // document order, so the LAST span carrying the entry text is the innermost one: the run
+        // that actually holds the character style.
+        const carriers = Array.from(p.querySelectorAll('span'))
+          .filter(span => (span.textContent || '').includes('generated document') ||
+            (span.textContent || '').includes('no character style'));
+        const run = carriers[carriers.length - 1] as HTMLElement;
+        const runStyle = getComputedStyle(run);
+        return {
+          text: (p.textContent || '').slice(0, 30),
+          top: rect.top, bottom: rect.bottom,
+          // Every entry is one line and `w:after` becomes a margin, which is outside the border
+          // box — so the paragraph's own height IS the line box. (The run's client rect is the
+          // glyph box, which is a different and smaller thing.)
+          lineBox: rect.height,
+          color: runStyle.color,
+          textDecorationLine: runStyle.textDecorationLine,
+          fontSize: parseFloat(runStyle.fontSize),
+        };
+      });
+
+    // A one-line paragraph with no auto-spacing multiplier gives the font's NATIVE line box, which
+    // is the base the OOXML multiple is applied to. The heading is a different size, so measure the
+    // base from a probe at the entry's own size instead of hard-coding a font metric.
+    const probe = document.createElement('p');
+    probe.style.cssText = 'line-height: normal; margin: 0; position: absolute; visibility: hidden;';
+    probe.textContent = 'Probe';
+    const entryRun = pageBox.querySelector('p:nth-of-type(2) span') as HTMLElement;
+    const runStyle = getComputedStyle(entryRun);
+    // Copy the font WITHOUT the `font` shorthand: that shorthand carries line-height, which would
+    // hand the probe the very multiplied value it is supposed to provide the base for.
+    probe.style.fontFamily = runStyle.fontFamily;
+    probe.style.fontSize = runStyle.fontSize;
+    probe.style.fontWeight = runStyle.fontWeight;
+    probe.style.fontStyle = runStyle.fontStyle;
+    probe.style.lineHeight = 'normal';
+    pageBox.appendChild(probe);
+    const nativeLineBox = probe.getBoundingClientRect().height;
+    probe.remove();
+
+    return { entries: entries as EntryGeometry[], nativeLineBox };
+  }, bytes);
+}
+
+test.describe('TOC entry line geometry', () => {
+  test('an entry line box is the OOXML multiple of the FONT line box, not of font-size',
+    async ({ page }) => {
+      const { entries, nativeLineBox } = await renderToc(page);
+      expect(entries.length).toBe(TOC_ENTRIES.length);
+
+      const multiple = TOC_LINE_TWIPS / 240;
+      const expected = nativeLineBox * multiple;
+      for (const entry of entries) {
+        expect(entry.lineBox, `${entry.text}: line box`).toBeCloseTo(expected, 0);
+        // The failure mode this replaces: a percentage of the em square, which is materially
+        // smaller because the font's natural line box is taller than 1 em.
+        expect(entry.lineBox).toBeGreaterThan(entry.fontSize * multiple + 1);
+      }
+    });
+
+  test('entries are evenly spaced, so displacement cannot accumulate down the page',
+    async ({ page }) => {
+      const { entries, nativeLineBox } = await renderToc(page);
+      const step = nativeLineBox * (TOC_LINE_TWIPS / 240) +
+        (TOC_AFTER_TWIPS / TWIPS_PER_PT) * PT_TO_PX;
+
+      const steps = entries.slice(1).map((entry, index) => entry.top - entries[index].top);
+      for (const [index, measured] of steps.entries()) {
+        expect(measured, `entry ${index + 1} to ${index + 2}`).toBeCloseTo(step, 0);
+      }
+      // Any per-entry error compounds; the last entry is where it is loudest.
+      const drift = Math.abs((entries[entries.length - 1].top - entries[0].top) -
+        step * (entries.length - 1));
+      expect(drift, 'accumulated drift across the whole TOC').toBeLessThan(TOL);
+    });
+});
+
+test.describe('TOC hyperlink appearance', () => {
+  /**
+   * The reference deviation, pinned as a positive statement about our own output: the declared
+   * character style is applied. LibreOffice renders these entries black — see BASELINE.md — but it
+   * is a comparison implementation, not the correctness oracle, and the file says otherwise.
+   */
+  test('an entry run styled `Hyperlink` gets the character style\'s declared color and underline',
+    async ({ page }) => {
+      const { entries } = await renderToc(page);
+      const styled = entries.filter((_, index) => TOC_ENTRIES[index].styled);
+      expect(styled.length).toBeGreaterThan(0);
+
+      for (const entry of styled) {
+        expect(entry.color, `${entry.text}: color`).toBe(TOC_HYPERLINK_RGB);
+        expect(entry.textDecorationLine, `${entry.text}: decoration`).toContain('underline');
+      }
+    });
+
+  /**
+   * The control that makes the assertion above meaningful. `w:hyperlink` is a link, not a style: a
+   * renderer that decorated every hyperlink would pass the previous test while actually ignoring
+   * the style, and LibreOffice would then be the one following the file.
+   */
+  test('an identical entry WITHOUT the character style is not decorated', async ({ page }) => {
+    const { entries } = await renderToc(page);
+    const unstyledIndex = TOC_ENTRIES.findIndex(entry => !entry.styled);
+    expect(unstyledIndex).toBeGreaterThanOrEqual(0);
+    const unstyled = entries[unstyledIndex];
+
+    expect(unstyled.color, 'an unstyled hyperlink run must not be painted hyperlink blue')
+      .not.toBe(TOC_HYPERLINK_RGB);
+    expect(unstyled.textDecorationLine,
+      'an unstyled hyperlink run must not be underlined by the renderer')
+      .not.toContain('underline');
+  });
+
+  test('hyperlink appearance is independent of line geometry', async ({ page }) => {
+    const { entries } = await renderToc(page);
+    const boxes = new Set(entries.map(entry => Math.round(entry.lineBox * 100)));
+    // Styled and unstyled entries share one line box: colour and underline must not change height.
+    expect(boxes.size, 'the character style must not alter the line box').toBe(1);
+  });
+});

--- a/npm/tests/visual-parity/BASELINE.md
+++ b/npm/tests/visual-parity/BASELINE.md
@@ -316,6 +316,44 @@ No severe case remains and the strict-gating set is empty, but strict mode is NO
 that is a separate decision, and two `major` cases still sit above the threshold a strict run
 would eventually want.
 
+## TOC hyperlink styling — 2026-08-11 (issue #397)
+
+Issue #397 named two residuals in the `fields-and-tabs` case, and they turned out to have opposite
+answers. Pinning them separately is what the issue asked for, and it is what the evidence supports.
+
+**Line-box height was ours.** TOC entries drifted further down the page with every entry — 7.3px,
+11.0px, 14.7px for the first three — because automatic line spacing was measured against font-size
+instead of the font's own line box. Fixed in issue #396 above; entries now land within **0.12px**
+of LibreOffice and the case's ink F1 is 0.99775.
+
+**Hyperlink styling is not.** The entry run in `HC022` carries `<w:rStyle w:val="Hyperlink"/>`, and
+the document's `Hyperlink` character style declares `w:color="0563C1"` with `w:u w:val="single"`.
+Sampling the two renders over the TOC entry rows:
+
+| Renderer | Dominant entry-text colour |
+|---|---|
+| Docxodus | **`#0563C1`** — the declared value, byte for byte |
+| LibreOffice | **`#000000`** — no hyperlink colour at all |
+
+Docxodus renders what the file declares. LibreOffice drops a character style that the run
+explicitly references, which is a deviation from the OOXML, not a Docxodus defect — and "the TOC
+came out blue and underlined" is the well-known consequence of Word's own `\h` table of contents
+applying this style. LibreOffice is a comparison implementation, not the correctness oracle, so the
+output is **not** changed to match it and the disposition moves `renderer-bug` →
+`reference-deviation`. This is the same standard applied when the `numbered-lists` margin was
+kept over LibreOffice's import.
+
+The claim only means something if the renderer is reading the style rather than decorating every
+hyperlink it sees, so `npm/tests/toc-line-geometry.spec.ts` generates a TOC containing both kinds
+of entry: one with `w:rStyle` and an otherwise identical one without. The styled entry must carry
+the declared colour and underline; the unstyled one must carry neither. Line geometry is pinned by
+separate assertions — the entry line box equals the OOXML multiple of the font's line box, and the
+entries are evenly spaced so displacement cannot accumulate — and one assertion pins that the two
+are independent, i.e. that applying the character style does not change the line box.
+
+With this, the corpus's remaining non-`environment` work is the `merged-table` colour delta (issue
+#399), the last `unattributed` case.
+
 ## Current case results and triage
 
 `SSIM` is the mean over paired pages. `Ink F1` is the worst paired-page value, so it exposes a
@@ -334,7 +372,7 @@ attribution the strict gate reads, and these numbers are what `ratchet.json` rec
 | inline-image | 1/1 | major | environment | 0.93255 | 0.77340 | Improved by issue #396 (ink F1 0.64760 to 0.77340). Residual is indentation/wrapping of the same fonts, not an inline-flow failure. |
 | chart | 1/1 | close | environment | 0.98687 | 0.96817 | Cached clustered column data renders as accessible inline SVG at the stored extent. Other chart families remain unsupported. |
 | shape | 1/1 | close | renderer-bug | 0.98599 | 1.00000 | Auto-fit height now follows the laid-out text (issue #396): height error -16.0 px to +2.7 px, ink geometry exact. Residual is the CSS border adding to an auto height where DrawingML strokes `a:ln` on the shape boundary. |
-| fields-and-tabs | 1/1 | minor | renderer-bug | 0.96026 | 0.99775 | Tab targets and leaders correct since PR #380; entry line height correct since issue #396 (within 0.12 px). Remaining difference is hyperlink styling — issue #397. |
+| fields-and-tabs | 1/1 | minor | reference-deviation | 0.96026 | 0.99775 | Tab targets and leaders correct since PR #380; entry line height correct since issue #396 (within 0.12 px). The residual is hyperlink styling: the run references the `Hyperlink` character style, Docxodus paints its declared `#0563C1`, LibreOffice paints black (issue #397). |
 | footnote | 1/1 | close | environment | 0.99502 | 0.99064 | Note placement fixed (issue #378); issue #396 stopped the superscript reference inflating its line box. Residual is substituted-font rasterization and LibreOffice-24.2 separator width. |
 | tracked-deletion | 1/1 | minor | environment | 0.97950 | 0.99667 | Identical accepted-revision bytes are compared. Improved by the font contract (issue #379) and issue #396; residual is same-font heading metrics and wrapping. |
 
@@ -384,14 +422,12 @@ block vertical placement (issue #378), the font-substitution contract (issue #37
 regression ratchet (issue #395), and automatic line spacing (issue #396, which also resolved
 #397's line-box half and dissolved #398's premise) are resolved above. The remaining order is:
 
-1. Attribute the `fields-and-tabs` hyperlink styling difference (issue #397) — the last piece of
-   that case now that its line geometry is within 0.12 px.
-2. Reduce the `merged-table` fill/border color delta to a minimal case and attribute it (issue
+1. Reduce the `merged-table` fill/border color delta to a minimal case and attribute it (issue
    #399) — the corpus's last `unattributed` disposition.
-3. Reduce the two remaining `major` cases (`inline-image`, `landscape-section`) to minimal
+2. Reduce the two remaining `major` cases (`inline-image`, `landscape-section`) to minimal
    same-font layout cases (issue #404), which is what now stands between the corpus and a
    strict run.
-4. Close issue #398: the `numbered-lists` top margin was never in disagreement, so the question
+3. Close issue #398: the `numbered-lists` top margin was never in disagreement, so the question
    is whether to keep a Word-evidence procedure (issue #402) for it at all.
 
 The list-margin discrepancy should not be changed merely to imitate LibreOffice: current evidence

--- a/npm/tests/visual-parity/corpus.ts
+++ b/npm/tests/visual-parity/corpus.ts
@@ -176,11 +176,14 @@ export const VISUAL_PARITY_CORPUS: VisualCorpusEntry[] = [
     categories: ['fields', 'text'],
     rationale: 'Field results, tab leaders, and right-aligned page numbers.',
     disposition: {
-      kind: 'renderer-bug',
+      kind: 'reference-deviation',
       rationale: 'Tab targets and leaders are correct since PR #380, and TOC entry line height is ' +
-        'correct since issue #396 — entries now land within 0.12 px of LibreOffice, where they ' +
-        'were displaced by up to 15 px. The remaining difference is hyperlink styling, whose ' +
-        'attribution is issue #397.',
+        'correct since issue #396 — entries land within 0.12 px of LibreOffice, where they were ' +
+        'displaced by up to 14.7 px, and ink F1 is 0.99775. The residual is hyperlink styling, ' +
+        'attributed in issue #397: the entry runs carry `w:rStyle w:val="Hyperlink"`, and that ' +
+        'character style declares `w:color 0563C1` and `w:u single`. Docxodus paints exactly the ' +
+        'declared colour; LibreOffice paints the entries black, ignoring the style the file ' +
+        'applies. Docxodus follows the OOXML, so the output is not changed to match.',
       reference: 'https://github.com/JSv4/Docxodus/issues/397',
     },
   },

--- a/npm/tests/visual-parity/ratchet.json
+++ b/npm/tests/visual-parity/ratchet.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "description": "Per-case visual-parity regression ratchet (issue #395). Numbers only. The scheduled run fails when any case gets worse than recorded beyond `tolerance`. Refresh this file deliberately in the PR that changes rendering, so improvements and accepted regressions are reviewed in the diff. See npm/tests/visual-parity/README.md.",
   "recordedAt": "2026-08-11",
-  "sourceCommit": "6a88ffaa76f5895b38552800fca7191efb8ab91e",
+  "sourceCommit": "cc95e099855dff87d1f45f1b936cdb15465f4306",
   "environment": {
     "libreoffice": "25.8",
     "chromium": "143",
@@ -26,7 +26,7 @@
     },
     {
       "id": "fields-and-tabs",
-      "disposition": "renderer-bug",
+      "disposition": "reference-deviation",
       "pages": {
         "docxodus": 1,
         "libreoffice": 1


### PR DESCRIPTION
Closes #397. Re-opens the path to `main` for work that was merged into a dead-end branch.

### Why this PR exists

PR #407 carried issue #397. It was merged into `shape-autofit-height` about 25 seconds *after* that branch's own PR (#406) had already merged to `main` — so #397's commits landed on a branch with no remaining path to `main`, and never reached it. Issue #397 is correspondingly still open, and GitHub silently retargeted the downstream #408 onto this branch.

This PR is that branch → `main`. Its diff is **exactly #397's work**: the #396 commits underneath are content-identical to main's squash `8e4e746`, so they contribute nothing.

### What it contains (unchanged from #407)

The issue named two residuals in the `fields-and-tabs` case, and **they have opposite answers**, so they are pinned separately.

**Line-box height was ours — fixed by #396.** TOC entries drifted further down the page with every entry (7.3px, 11.0px, 14.7px for the first three). They now land within **0.12px** of LibreOffice:

| Entry | LibreOffice | Before | After |
|---|---:|---:|---:|
| 1 | 140.17 | 132.83 | **140.05** |
| 2 | 166.17 | 155.17 | **166.13** |
| 3 | 192.17 | 177.52 | **192.20** |

Case ink F1 0.15913 → **0.99775**; SSIM 0.89415 → **0.96026**; severity `severe` → `minor`.

**Hyperlink styling is not ours — attributed, not changed.** The entry run carries `<w:rStyle w:val="Hyperlink"/>`, and that character style declares `w:color="0563C1"` with `w:u w:val="single"`. Sampling the TOC entry rows at 96 DPI:

| Renderer | Dominant entry-text colour |
|---|---|
| Docxodus | **`#0563C1`** — the declared value, byte for byte |
| LibreOffice | **`#000000`** — the character style is dropped |

`w:hyperlink` is a *link*, not a style. Word's own `\h` TOC writes exactly this markup, which is why "my table of contents came out blue and underlined" is such a common Word question. Docxodus renders what the file declares, so per the issue's reference policy the output is **not** changed to match the comparison implementation; the disposition moves `renderer-bug` → **`reference-deviation`**.

### The control that makes the attribution honest

"We match Word" is indistinguishable from "we decorate every hyperlink by default" — and if it were the latter, LibreOffice would be the one following the file. So the generated TOC contains **both kinds of entry**: one with `w:rStyle` and an otherwise identical one without. The styled entry must carry the declared colour and underline; the unstyled one must carry neither.

### Verification

`npm/tests/toc-line-geometry.spec.ts` (5 tests, generated DOCX via `docx-zip.ts` — no fixture added): entry line box == the OOXML multiple of the **font's** line box; entries evenly spaced with sub-pixel accumulated drift; declared colour + underline present when `w:rStyle` is; absent when it isn't; and the character style does not alter the line box.

**The ratchet record was regenerated and every measurement is byte-identical** — only `sourceCommit` and the one disposition differ, which is the evidence that this changes attribution and not rendering.

`docs/ooxml_corner_cases.md` records the LibreOffice deviation, including the trap that cost real time while reducing it: a programmatically built package needs a **`DocumentSettingsPart`** for character-style resolution to run at all. Without `word/settings.xml` the converter emits the style's CSS *class* but an **empty rule**, so `w:rStyle` silently loses every declared property — and the reduced case then appears to reproduce the LibreOffice behaviour, which would have inverted the attribution.

### Stack

#408 (issue #399) is based on this branch and is now conflict-free.