### PR TITLE
Render stacked, pie, line, and area chart families from cached data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Chart families beyond clustered bar/column render from cached data**
+  (issue #411) — `WmlToHtmlConverter` now projects stacked and percent-stacked
+  bar/column charts, pie and doughnut charts (per-point `c:dPt` colors,
+  `c:firstSliceAng`/`c:holeSize` honored), line charts, and area charts into
+  inline SVG, with 3-D variants (`bar3DChart`, `pie3DChart`, `line3DChart`,
+  `area3DChart`) rendered as their 2-D projection. Previously everything but a
+  clustered `c:barChart` rendered as a blank extent. Line-series colors are
+  read from the stroke (`a:ln/a:solidFill`), date axes (`c:dateAx`) format
+  cached serial day numbers as dates, dense category axes thin their labels to
+  fit, and a percent-stacked value axis pins at 100% with `%`-suffixed ticks.
+  New SVG element classes `docx-chart-slice`, `docx-chart-line`, and
+  `docx-chart-area` join `docx-chart-bar`; `data-chart-type` gains
+  `column-stacked`/`bar-stacked`/`-percent-stacked` suffixes plus `pie`,
+  `doughnut`, `line`, and `area`.
 - **Visual-parity corpus second wave** (issue #400) — nine new tracked cases
   covering the shapes one-fixture-per-category coverage had left invisible:
   stacked/pie/line chart families, floating square- and tight-wrapped images,

--- a/Docxodus.Tests/HtmlConversionOpsTests.cs
+++ b/Docxodus.Tests/HtmlConversionOpsTests.cs
@@ -437,6 +437,73 @@ public class HtmlConversionOpsTests
         Assert.Contains(bars, bar => (string?)bar.Attribute("fill") == "#ED7D31");
     }
 
+    private static XElement ConvertFixtureChartSvg(string fixture)
+    {
+        var bytes = File.ReadAllBytes(Path.Combine("..", "..", "..", "..", "TestFiles",
+            Path.Combine(fixture.Split('/'))));
+        string html = HtmlConversionOps.ConvertToHtml(bytes,
+            new HtmlConversionOptions { FabricateCssClasses = false });
+        var root = XElement.Parse(html);
+        return root.Descendants().Single(element => element.Name.LocalName == "svg");
+    }
+
+    [Fact]
+    public void HCO088_CachedStackedColumnChart_RendersOneStackPerCategory()
+    {
+        var svg = ConvertFixtureChartSvg("VP/VP001-Chart-Stacked-Column.docx");
+        var bars = svg.Descendants()
+            .Where(element => (string?)element.Attribute("class") == "docx-chart-bar")
+            .ToList();
+
+        Assert.Equal("column-stacked", (string?)svg.Attribute("data-chart-type"));
+        // Three series across four categories, cached fully: 12 stacked segments.
+        Assert.Equal(12, bars.Count);
+        // Segments of one category stack on a single x, one on top of another.
+        var firstCategory = bars
+            .Where(bar => (string?)bar.Attribute("data-chart-category") == "0")
+            .ToList();
+        Assert.Equal(3, firstCategory.Count);
+        Assert.Single(firstCategory.Select(bar => (string?)bar.Attribute("x")).Distinct());
+        Assert.Equal(3, firstCategory.Select(bar => (string?)bar.Attribute("y")).Distinct().Count());
+        Assert.Contains("Series 1", svg.Value);
+    }
+
+    [Fact]
+    public void HCO089_CachedPie3DChart_RendersSlicesWithPerPointColors()
+    {
+        var svg = ConvertFixtureChartSvg("CU002-Chart-Cached-Data-02.docx");
+        var slices = svg.Descendants()
+            .Where(element => (string?)element.Attribute("class") == "docx-chart-slice")
+            .ToList();
+
+        Assert.Equal("pie", (string?)svg.Attribute("data-chart-type"));
+        Assert.Equal(4, slices.Count);
+        // Each data point carries its own accent color, so all slices differ.
+        Assert.Equal(4, slices.Select(slice => (string?)slice.Attribute("fill")).Distinct().Count());
+        Assert.Equal("320", (string?)slices[0].Attribute("data-chart-value"));
+        // The pie legend lists categories, not the single series.
+        Assert.Contains("Cars", svg.Value);
+        Assert.Contains("Boats", svg.Value);
+    }
+
+    [Fact]
+    public void HCO090_CachedLineChart_RendersOnePolylinePerSeriesWithDateCategories()
+    {
+        var svg = ConvertFixtureChartSvg("CU004-Chart-Cached-Data-04.docx");
+        var lines = svg.Descendants()
+            .Where(element => (string?)element.Attribute("class") == "docx-chart-line")
+            .ToList();
+
+        Assert.Equal("line", (string?)svg.Attribute("data-chart-type"));
+        Assert.Equal(3, lines.Count);
+        Assert.All(lines, line => Assert.Equal(20,
+            ((string?)line.Attribute("points"))!.Split(' ').Length));
+        Assert.Equal(3, lines.Select(line => (string?)line.Attribute("stroke")).Distinct().Count());
+        // The date axis caches serial day numbers (41518 = 9/1/2013); labels render as dates.
+        Assert.Contains("9/1/2013", svg.Value);
+        Assert.Contains("Car", svg.Value);
+    }
+
     [Fact]
     public void HCO020_BulletListMarker_RendersUnicodeBullet()
     {

--- a/Docxodus/WmlToHtmlConverter.Charts.cs
+++ b/Docxodus/WmlToHtmlConverter.Charts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -14,21 +14,29 @@ namespace Docxodus
     {
         private static readonly XNamespace Svg = "http://www.w3.org/2000/svg";
 
-        private sealed class CachedChartSeries
+        // Chart families that can be projected from cached data. 3-D variants carry the same
+        // cached series as their 2-D counterparts, so they project to the flat rendering.
+        private static readonly Dictionary<XName, string> SupportedChartPlots = new Dictionary<XName, string>
         {
-            public string Name { get; init; }
-
-            public string Color { get; init; }
-
-            public Dictionary<int, double> Values { get; init; }
-        }
+            [C.barChart] = "bar",
+            [C.bar3DChart] = "bar",
+            [C.lineChart] = "line",
+            [C.line3DChart] = "line",
+            [C.areaChart] = "area",
+            [C.area3DChart] = "area",
+            [C.pieChart] = "pie",
+            [C.pie3DChart] = "pie",
+            [C.doughnutChart] = "doughnut",
+        };
 
         /// <summary>
-        /// Projects the cached data of a standard clustered Word bar/column chart into inline SVG.
-        /// Word stores those values in the chart part specifically so consumers can display the
-        /// chart without recalculating its embedded workbook. Keeping this projection in the DOCX
-        /// converter makes charts visible in both standalone and WASM output without a JS runtime
-        /// dependency or a server-side Office process.
+        /// Projects the cached data of a Word chart into inline SVG. Covers the bar/column
+        /// (clustered, stacked, percent-stacked), line, area, pie, and doughnut families, with
+        /// 3-D variants rendered as their 2-D projection. Word stores cached values in the chart
+        /// part specifically so consumers can display the chart without recalculating its embedded
+        /// workbook. Keeping this projection in the DOCX converter makes charts visible in both
+        /// standalone and WASM output without a JS runtime dependency or a server-side Office
+        /// process.
         /// </summary>
         private static XElement ProcessChart(WordprocessingDocument wordDoc, XElement drawing)
         {
@@ -54,13 +62,14 @@ namespace Docxodus
             var chartSpace = chartPart?.GetXDocument().Root;
             var chart = chartSpace?.Element(C.chart);
             var plotArea = chart?.Element(C.plotArea);
-            var barChart = plotArea?.Element(C.barChart);
-            if (barChart == null)
+            var plot = plotArea?.Elements()
+                .FirstOrDefault(element => SupportedChartPlots.ContainsKey(element.Name));
+            if (plot == null)
                 return null;
 
-            var grouping = (string)barChart.Element(C.grouping)?.Attribute("val");
-            if (!string.IsNullOrEmpty(grouping) && grouping != "clustered")
-                return null;
+            var family = SupportedChartPlots[plot.Name];
+            var grouping = (string)plot.Element(C.grouping)?.Attribute("val")
+                ?? (family == "bar" ? "clustered" : "standard");
 
             var container = drawing.Elements().FirstOrDefault(e => e.Name == WP.inline || e.Name == WP.anchor);
             var extent = container?.Element(WP.extent);
@@ -75,7 +84,7 @@ namespace Docxodus
                 return null;
 
             var theme = LoadThemeColorScheme(wordDoc);
-            var series = barChart.Elements(C.ser)
+            var series = plot.Elements(C.ser)
                 .Select((element, index) => ReadCachedChartSeries(element, index, theme))
                 .Where(item => item != null && item.Values.Count > 0)
                 .ToList();
@@ -86,17 +95,17 @@ namespace Docxodus
             if (categoryCount <= 0)
                 return null;
 
-            var categories = ReadCachedCategories(barChart.Elements(C.ser).First(), categoryCount);
+            var categories = ReadCachedCategories(plot.Elements(C.ser).First(), categoryCount);
             var title = ReadChartTitle(chart);
             var titleFontSize = ReadChartFontSize(chart.Element(C.title), 14 * 96 / 72.0);
             var legend = chart.Element(C.legend);
             var showLegend = legend != null && !IsDeleted(legend);
             var legendFontSize = ReadChartFontSize(legend, 9 * 96 / 72.0);
-            var horizontal = (string)barChart.Element(C.barDir)?.Attribute("val") == "bar";
-            var gapWidth = ReadIntAttribute(barChart.Element(C.gapWidth), "val", 150, 0, 500);
-            var overlap = ReadIntAttribute(barChart.Element(C.overlap), "val", 0, -100, 100);
+            var horizontal = family == "bar" && (string)plot.Element(C.barDir)?.Attribute("val") == "bar";
+            var gapWidth = ReadIntAttribute(plot.Element(C.gapWidth), "val", 150, 0, 500);
+            var overlap = ReadIntAttribute(plot.Element(C.overlap), "val", 0, -100, 100);
 
-            var categoryAxis = plotArea.Element(C.catAx);
+            var categoryAxis = plotArea.Element(C.catAx) ?? plotArea.Element(C.dateAx);
             var valueAxis = plotArea.Element(C.valAx);
             var categoryFontSize = ReadChartFontSize(categoryAxis, 9 * 96 / 72.0);
             var valueFontSize = ReadChartFontSize(valueAxis, 9 * 96 / 72.0);
@@ -104,6 +113,20 @@ namespace Docxodus
             var explicitMinimum = ReadDoubleAttribute(scaling?.Element(C.min), "val");
             var explicitMaximum = ReadDoubleAttribute(scaling?.Element(C.max), "val");
             var explicitMajorUnit = ReadDoubleAttribute(valueAxis?.Element(C.majorUnit), "val");
+
+            var groupingSuffix = grouping switch
+            {
+                "stacked" => "-stacked",
+                "percentStacked" => "-percent-stacked",
+                _ => string.Empty,
+            };
+            var chartType = family switch
+            {
+                "bar" => (horizontal ? "bar" : "column") + groupingSuffix,
+                "line" => "line" + groupingSuffix,
+                "area" => "area" + groupingSuffix,
+                _ => family,
+            };
 
             var altText = (string)container?.Element(WP.docPr)?.Attribute("descr")
                 ?? (string)container?.Element(WP.docPr)?.Attribute("name")
@@ -113,7 +136,7 @@ namespace Docxodus
                 new XAttribute("viewBox", $"0 0 {Format(width)} {Format(height)}"),
                 new XAttribute("role", "img"),
                 new XAttribute("aria-label", altText),
-                new XAttribute("data-chart-type", horizontal ? "bar" : "column"),
+                new XAttribute("data-chart-type", chartType),
                 new XAttribute("style", string.Format(CultureInfo.InvariantCulture,
                     "display: inline-block; width: {0:0.##}pt; height: {1:0.##}pt; vertical-align: top;",
                     widthEmu.Value / 12700.0, heightEmu.Value / 12700.0)),
@@ -131,19 +154,65 @@ namespace Docxodus
                 AddSvgText(svg, width / 2, Math.Max(titleFontSize, height * 0.105), title,
                     "middle", titleFontSize);
 
-            var values = series.SelectMany(item => item.Values.Values).ToList();
-            var scale = BuildChartScale(values, explicitMinimum, explicitMaximum, explicitMajorUnit);
-            if (horizontal)
+            if (family is "pie" or "doughnut")
+            {
+                var sliceColors = RenderPieChart(svg, width, height, title, showLegend, plot,
+                    series[0], categoryCount, family == "doughnut", theme);
+                if (showLegend)
+                    RenderChartLegend(svg, width, height,
+                        Enumerable.Range(0, categoryCount)
+                            .Select(index => (categories[index], sliceColors[index]))
+                            .ToList(),
+                        legendFontSize);
+                return svg;
+            }
+
+            var stacked = grouping is "stacked" or "percentStacked";
+            var axisSuffix = string.Empty;
+            if (grouping == "percentStacked")
+            {
+                series = NormalizeSeriesToPercentages(series, categoryCount);
+                axisSuffix = "%";
+            }
+
+            var scaleValues = stacked
+                ? StackedExtents(series, categoryCount)
+                : series.SelectMany(item => item.Values.Values).ToList();
+            if (grouping == "percentStacked")
+            {
+                // Word pins a percent-stacked axis to 100% rather than adding tick headroom.
+                explicitMinimum ??= Math.Min(0, scaleValues.Min());
+                explicitMaximum ??= 100;
+            }
+            var scale = BuildChartScale(scaleValues, explicitMinimum, explicitMaximum, explicitMajorUnit);
+
+            if (family is "line" or "area")
+                RenderLineOrAreaChart(svg, width, height, title, showLegend, series, categories,
+                    categoryCount, family == "area", stacked, scale, categoryFontSize, valueFontSize,
+                    axisSuffix);
+            else if (horizontal)
                 RenderHorizontalBarChart(svg, width, height, title, showLegend, series, categories,
-                    categoryCount, gapWidth, overlap, scale, categoryFontSize, valueFontSize);
+                    categoryCount, gapWidth, overlap, stacked, scale, categoryFontSize, valueFontSize,
+                    axisSuffix);
             else
                 RenderColumnChart(svg, width, height, title, showLegend, series, categories,
-                    categoryCount, gapWidth, overlap, scale, categoryFontSize, valueFontSize);
+                    categoryCount, gapWidth, overlap, stacked, scale, categoryFontSize, valueFontSize,
+                    axisSuffix);
 
             if (showLegend)
-                RenderChartLegend(svg, width, height, series, legendFontSize);
+                RenderChartLegend(svg, width, height,
+                    series.Select(item => (item.Name, item.Color)).ToList(), legendFontSize);
 
             return svg;
+        }
+
+        private sealed class CachedChartSeries
+        {
+            public string Name { get; init; }
+
+            public string Color { get; init; }
+
+            public Dictionary<int, double> Values { get; init; }
         }
 
         private sealed class ChartScale
@@ -153,6 +222,48 @@ namespace Docxodus
             public double Maximum { get; init; }
 
             public double MajorUnit { get; init; }
+        }
+
+        private static List<CachedChartSeries> NormalizeSeriesToPercentages(
+            IReadOnlyList<CachedChartSeries> series, int categoryCount)
+        {
+            var totals = new double[categoryCount];
+            foreach (var item in series)
+                foreach (var pair in item.Values)
+                    totals[pair.Key] += Math.Abs(pair.Value);
+            return series
+                .Select(item => new CachedChartSeries
+                {
+                    Name = item.Name,
+                    Color = item.Color,
+                    Values = item.Values.ToDictionary(pair => pair.Key,
+                        pair => totals[pair.Key] > 0 ? pair.Value / totals[pair.Key] * 100 : 0),
+                })
+                .ToList();
+        }
+
+        private static List<double> StackedExtents(IReadOnlyList<CachedChartSeries> series,
+            int categoryCount)
+        {
+            // A stacked axis spans the per-category totals, with positive and negative values
+            // accumulating on their own sides of zero.
+            var extents = new List<double>();
+            for (var categoryIndex = 0; categoryIndex < categoryCount; categoryIndex++)
+            {
+                double positive = 0, negative = 0;
+                foreach (var item in series)
+                {
+                    if (!item.Values.TryGetValue(categoryIndex, out var value))
+                        continue;
+                    if (value >= 0)
+                        positive += value;
+                    else
+                        negative += value;
+                }
+                extents.Add(positive);
+                extents.Add(negative);
+            }
+            return extents;
         }
 
         private static ChartScale BuildChartScale(IReadOnlyCollection<double> values,
@@ -196,10 +307,11 @@ namespace Docxodus
 
         private static void RenderColumnChart(XElement svg, double width, double height, string title,
             bool showLegend, IReadOnlyList<CachedChartSeries> series, IReadOnlyList<string> categories,
-            int categoryCount, int gapWidth, int overlap, ChartScale scale,
-            double categoryFontSize, double valueFontSize)
+            int categoryCount, int gapWidth, int overlap, bool stacked, ChartScale scale,
+            double categoryFontSize, double valueFontSize, string axisSuffix)
         {
-            var plotLeft = Math.Max(22, 10 + FormatAxisValue(scale.Maximum, scale.MajorUnit).Length * 6);
+            var plotLeft = Math.Max(22,
+                10 + (FormatAxisValue(scale.Maximum, scale.MajorUnit) + axisSuffix).Length * 6);
             var plotRight = width - 12;
             var plotTop = string.IsNullOrWhiteSpace(title) ? 14 : 60;
             var plotBottom = height - (showLegend ? 54 : 28);
@@ -219,30 +331,56 @@ namespace Docxodus
                     new XAttribute("y2", Format(y)),
                     new XAttribute("stroke", "#D9D9D9"),
                     new XAttribute("stroke-width", "1")));
-                AddSvgText(svg, plotLeft - 5, y, FormatAxisValue(value, scale.MajorUnit), "end",
-                    valueFontSize, true);
+                AddSvgText(svg, plotLeft - 5, y, FormatAxisValue(value, scale.MajorUnit) + axisSuffix,
+                    "end", valueFontSize, true);
             }
 
             var slot = plotWidth / categoryCount;
-            var negativeOverlapGap = Math.Max(0, -overlap / 100.0);
-            var positiveOverlap = Math.Max(0, overlap / 100.0);
-            var denominator = series.Count + gapWidth / 100.0 +
-                              (series.Count - 1) * (negativeOverlapGap - positiveOverlap);
-            var barWidth = Math.Max(1, slot / Math.Max(1, denominator));
-            var barStep = barWidth * (1 + negativeOverlapGap - positiveOverlap);
-            var groupWidth = barWidth + Math.Max(0, series.Count - 1) * barStep;
+            double barWidth, barStep, groupWidth;
+            if (stacked)
+            {
+                barWidth = Math.Max(1, slot / (1 + gapWidth / 100.0));
+                barStep = 0;
+                groupWidth = barWidth;
+            }
+            else
+            {
+                var negativeOverlapGap = Math.Max(0, -overlap / 100.0);
+                var positiveOverlap = Math.Max(0, overlap / 100.0);
+                var denominator = series.Count + gapWidth / 100.0 +
+                                  (series.Count - 1) * (negativeOverlapGap - positiveOverlap);
+                barWidth = Math.Max(1, slot / Math.Max(1, denominator));
+                barStep = barWidth * (1 + negativeOverlapGap - positiveOverlap);
+                groupWidth = barWidth + Math.Max(0, series.Count - 1) * barStep;
+            }
             var zeroY = Y(0);
 
             for (var categoryIndex = 0; categoryIndex < categoryCount; categoryIndex++)
             {
                 var groupLeft = plotLeft + categoryIndex * slot + (slot - groupWidth) / 2;
+                double positive = 0, negative = 0;
                 for (var seriesIndex = 0; seriesIndex < series.Count; seriesIndex++)
                 {
                     if (!series[seriesIndex].Values.TryGetValue(categoryIndex, out var value))
                         continue;
-                    var valueY = Y(value);
-                    var top = Math.Min(zeroY, valueY);
-                    var barHeight = Math.Max(0.5, Math.Abs(zeroY - valueY));
+                    double top, barHeight;
+                    if (stacked)
+                    {
+                        var from = value >= 0 ? positive : negative;
+                        var to = from + value;
+                        top = Math.Min(Y(from), Y(to));
+                        barHeight = Math.Max(0.5, Math.Abs(Y(from) - Y(to)));
+                        if (value >= 0)
+                            positive = to;
+                        else
+                            negative = to;
+                    }
+                    else
+                    {
+                        var valueY = Y(value);
+                        top = Math.Min(zeroY, valueY);
+                        barHeight = Math.Max(0.5, Math.Abs(zeroY - valueY));
+                    }
                     svg.Add(ChartBar(groupLeft + seriesIndex * barStep, top, barWidth, barHeight,
                         series[seriesIndex], seriesIndex, categoryIndex, value));
                 }
@@ -254,8 +392,8 @@ namespace Docxodus
 
         private static void RenderHorizontalBarChart(XElement svg, double width, double height, string title,
             bool showLegend, IReadOnlyList<CachedChartSeries> series, IReadOnlyList<string> categories,
-            int categoryCount, int gapWidth, int overlap, ChartScale scale,
-            double categoryFontSize, double valueFontSize)
+            int categoryCount, int gapWidth, int overlap, bool stacked, ChartScale scale,
+            double categoryFontSize, double valueFontSize, string axisSuffix)
         {
             var longestCategory = categories.DefaultIfEmpty(string.Empty).Max(item => item?.Length ?? 0);
             var plotLeft = Math.Min(width * 0.38, Math.Max(40, 12 + longestCategory * 6));
@@ -278,18 +416,28 @@ namespace Docxodus
                     new XAttribute("y2", Format(plotBottom)),
                     new XAttribute("stroke", "#D9D9D9"),
                     new XAttribute("stroke-width", "1")));
-                AddSvgText(svg, x, plotBottom + 15, FormatAxisValue(value, scale.MajorUnit), "middle",
-                    valueFontSize);
+                AddSvgText(svg, x, plotBottom + 15, FormatAxisValue(value, scale.MajorUnit) + axisSuffix,
+                    "middle", valueFontSize);
             }
 
             var slot = plotHeight / categoryCount;
-            var negativeOverlapGap = Math.Max(0, -overlap / 100.0);
-            var positiveOverlap = Math.Max(0, overlap / 100.0);
-            var denominator = series.Count + gapWidth / 100.0 +
-                              (series.Count - 1) * (negativeOverlapGap - positiveOverlap);
-            var barHeight = Math.Max(1, slot / Math.Max(1, denominator));
-            var barStep = barHeight * (1 + negativeOverlapGap - positiveOverlap);
-            var groupHeight = barHeight + Math.Max(0, series.Count - 1) * barStep;
+            double barHeight, barStep, groupHeight;
+            if (stacked)
+            {
+                barHeight = Math.Max(1, slot / (1 + gapWidth / 100.0));
+                barStep = 0;
+                groupHeight = barHeight;
+            }
+            else
+            {
+                var negativeOverlapGap = Math.Max(0, -overlap / 100.0);
+                var positiveOverlap = Math.Max(0, overlap / 100.0);
+                var denominator = series.Count + gapWidth / 100.0 +
+                                  (series.Count - 1) * (negativeOverlapGap - positiveOverlap);
+                barHeight = Math.Max(1, slot / Math.Max(1, denominator));
+                barStep = barHeight * (1 + negativeOverlapGap - positiveOverlap);
+                groupHeight = barHeight + Math.Max(0, series.Count - 1) * barStep;
+            }
             var zeroX = X(0);
 
             for (var categoryIndex = 0; categoryIndex < categoryCount; categoryIndex++)
@@ -297,17 +445,203 @@ namespace Docxodus
                 var groupTop = plotTop + categoryIndex * slot + (slot - groupHeight) / 2;
                 AddSvgText(svg, plotLeft - 6, plotTop + (categoryIndex + 0.5) * slot,
                     categories[categoryIndex], "end", categoryFontSize, true);
+                double positive = 0, negative = 0;
                 for (var seriesIndex = 0; seriesIndex < series.Count; seriesIndex++)
                 {
                     if (!series[seriesIndex].Values.TryGetValue(categoryIndex, out var value))
                         continue;
-                    var valueX = X(value);
-                    var left = Math.Min(zeroX, valueX);
-                    var barWidth = Math.Max(0.5, Math.Abs(zeroX - valueX));
+                    double left, barWidth;
+                    if (stacked)
+                    {
+                        var from = value >= 0 ? positive : negative;
+                        var to = from + value;
+                        left = Math.Min(X(from), X(to));
+                        barWidth = Math.Max(0.5, Math.Abs(X(from) - X(to)));
+                        if (value >= 0)
+                            positive = to;
+                        else
+                            negative = to;
+                    }
+                    else
+                    {
+                        var valueX = X(value);
+                        left = Math.Min(zeroX, valueX);
+                        barWidth = Math.Max(0.5, Math.Abs(zeroX - valueX));
+                    }
                     svg.Add(ChartBar(left, groupTop + seriesIndex * barStep, barWidth, barHeight,
                         series[seriesIndex], seriesIndex, categoryIndex, value));
                 }
             }
+        }
+
+        private static void RenderLineOrAreaChart(XElement svg, double width, double height, string title,
+            bool showLegend, IReadOnlyList<CachedChartSeries> series, IReadOnlyList<string> categories,
+            int categoryCount, bool area, bool stacked, ChartScale scale,
+            double categoryFontSize, double valueFontSize, string axisSuffix)
+        {
+            var plotLeft = Math.Max(22,
+                10 + (FormatAxisValue(scale.Maximum, scale.MajorUnit) + axisSuffix).Length * 6);
+            var plotRight = width - 12;
+            var plotTop = string.IsNullOrWhiteSpace(title) ? 14 : 60;
+            var plotBottom = height - (showLegend ? 54 : 28);
+            var plotWidth = Math.Max(1, plotRight - plotLeft);
+            var plotHeight = Math.Max(1, plotBottom - plotTop);
+            var range = scale.Maximum - scale.Minimum;
+            double Y(double value) => plotBottom - (value - scale.Minimum) / range * plotHeight;
+
+            for (var value = scale.Minimum; value <= scale.Maximum + scale.MajorUnit * 0.0001;
+                 value += scale.MajorUnit)
+            {
+                var y = Y(value);
+                svg.Add(new XElement(Svg + "line",
+                    new XAttribute("x1", Format(plotLeft)),
+                    new XAttribute("x2", Format(plotRight)),
+                    new XAttribute("y1", Format(y)),
+                    new XAttribute("y2", Format(y)),
+                    new XAttribute("stroke", "#D9D9D9"),
+                    new XAttribute("stroke-width", "1")));
+                AddSvgText(svg, plotLeft - 5, y, FormatAxisValue(value, scale.MajorUnit) + axisSuffix,
+                    "end", valueFontSize, true);
+            }
+
+            var slot = plotWidth / categoryCount;
+            double X(int index) => plotLeft + (index + 0.5) * slot;
+
+            // A dense category axis (e.g. daily data) cannot fit every label; thin to what the
+            // plot width can hold given the widest label.
+            var labelWidth = Math.Max(30,
+                categories.DefaultIfEmpty(string.Empty).Max(item => item?.Length ?? 0) * 6 + 12);
+            var labelStep = Math.Max(1, (int)Math.Ceiling(categoryCount * labelWidth / plotWidth));
+            for (var index = 0; index < categoryCount; index += labelStep)
+                AddSvgText(svg, X(index), plotBottom + 15, categories[index], "middle",
+                    categoryFontSize);
+
+            var baseline = new double[categoryCount];
+            for (var seriesIndex = 0; seriesIndex < series.Count; seriesIndex++)
+            {
+                var item = series[seriesIndex];
+                double ValueAt(int index) => item.Values.TryGetValue(index, out var v) ? v : 0;
+                if (area)
+                {
+                    var points = new List<string>();
+                    for (var index = 0; index < categoryCount; index++)
+                        points.Add(Format(X(index)) + "," + Format(Y(baseline[index] + ValueAt(index))));
+                    for (var index = categoryCount - 1; index >= 0; index--)
+                        points.Add(Format(X(index)) + "," + Format(Y(stacked ? baseline[index] : 0)));
+                    svg.Add(new XElement(Svg + "polygon",
+                        new XAttribute("class", "docx-chart-area"),
+                        new XAttribute("data-chart-series", seriesIndex),
+                        new XAttribute("points", string.Join(" ", points)),
+                        new XAttribute("fill", item.Color),
+                        stacked ? null : new XAttribute("fill-opacity", "0.75"),
+                        new XAttribute("stroke", "#FFFFFF"),
+                        new XAttribute("stroke-width", "1")));
+                }
+                else
+                {
+                    // Word's default for a blank point is a gap; without stacking, simply skip it.
+                    var points = Enumerable.Range(0, categoryCount)
+                        .Where(index => stacked || item.Values.ContainsKey(index))
+                        .Select(index => Format(X(index)) + "," +
+                                         Format(Y(baseline[index] + ValueAt(index))))
+                        .ToList();
+                    if (points.Count > 0)
+                        svg.Add(new XElement(Svg + "polyline",
+                            new XAttribute("class", "docx-chart-line"),
+                            new XAttribute("data-chart-series", seriesIndex),
+                            new XAttribute("points", string.Join(" ", points)),
+                            new XAttribute("fill", "none"),
+                            new XAttribute("stroke", item.Color),
+                            new XAttribute("stroke-width", "2"),
+                            new XAttribute("stroke-linejoin", "round"),
+                            new XAttribute("stroke-linecap", "round")));
+                }
+
+                if (stacked)
+                    for (var index = 0; index < categoryCount; index++)
+                        baseline[index] += ValueAt(index);
+            }
+        }
+
+        private static IReadOnlyList<string> RenderPieChart(XElement svg, double width, double height,
+            string title, bool showLegend, XElement plot, CachedChartSeries series, int categoryCount,
+            bool doughnut, ThemeColorScheme theme)
+        {
+            var plotTop = string.IsNullOrWhiteSpace(title) ? 14 : 60;
+            var plotBottom = height - (showLegend ? 54 : 20);
+            var centerX = width / 2;
+            var centerY = (plotTop + plotBottom) / 2;
+            var radius = Math.Max(8, Math.Min(width - 40, plotBottom - plotTop) / 2 - 4);
+            var innerRadius = doughnut
+                ? radius * ReadIntAttribute(plot.Element(C.holeSize), "val", 50, 10, 90) / 100.0
+                : 0;
+
+            var colors = ReadPieSliceColors(plot.Elements(C.ser).First(), categoryCount, theme);
+            var total = 0.0;
+            for (var index = 0; index < categoryCount; index++)
+                if (series.Values.TryGetValue(index, out var value))
+                    total += Math.Abs(value);
+            if (total <= 0)
+                return colors;
+
+            // Slices run clockwise from 12 o'clock (plus any explicit first-slice rotation),
+            // matching Word. Negative values plot at their absolute size, also matching Word.
+            var angle = (ReadIntAttribute(plot.Element(C.firstSliceAng), "val", 0, 0, 360) - 90)
+                * Math.PI / 180;
+            for (var index = 0; index < categoryCount; index++)
+            {
+                if (!series.Values.TryGetValue(index, out var value) || value == 0)
+                    continue;
+                var sweep = Math.Min(Math.Abs(value) / total * Math.PI * 2, Math.PI * 2 - 1e-4);
+                svg.Add(PieSlice(centerX, centerY, radius, innerRadius, angle, angle + sweep,
+                    colors[index], index, value));
+                angle += sweep;
+            }
+            return colors;
+        }
+
+        private static XElement PieSlice(double centerX, double centerY, double outerRadius,
+            double innerRadius, double start, double end, string color, int categoryIndex, double value)
+        {
+            var largeArc = end - start > Math.PI ? 1 : 0;
+            string Point(double radius, double angle) =>
+                Format(centerX + radius * Math.Cos(angle)) + " " +
+                Format(centerY + radius * Math.Sin(angle));
+            var path = innerRadius > 0
+                ? $"M {Point(outerRadius, start)} " +
+                  $"A {Format(outerRadius)} {Format(outerRadius)} 0 {largeArc} 1 {Point(outerRadius, end)} " +
+                  $"L {Point(innerRadius, end)} " +
+                  $"A {Format(innerRadius)} {Format(innerRadius)} 0 {largeArc} 0 {Point(innerRadius, start)} Z"
+                : $"M {Format(centerX)} {Format(centerY)} " +
+                  $"L {Point(outerRadius, start)} " +
+                  $"A {Format(outerRadius)} {Format(outerRadius)} 0 {largeArc} 1 {Point(outerRadius, end)} Z";
+            return new XElement(Svg + "path",
+                new XAttribute("class", "docx-chart-slice"),
+                new XAttribute("data-chart-category", categoryIndex),
+                new XAttribute("data-chart-value", value.ToString("R", CultureInfo.InvariantCulture)),
+                new XAttribute("d", path),
+                new XAttribute("fill", color),
+                new XAttribute("stroke", "#FFFFFF"),
+                new XAttribute("stroke-width", "1"));
+        }
+
+        private static IReadOnlyList<string> ReadPieSliceColors(XElement series, int categoryCount,
+            ThemeColorScheme theme)
+        {
+            var explicitColors = series.Elements(C.dPt)
+                .Select(point => new
+                {
+                    Index = ReadIntAttribute(point.Element(C.idx), "val", -1, -1, int.MaxValue),
+                    Properties = point.Element(C.spPr),
+                })
+                .Where(point => point.Index >= 0 && point.Properties != null)
+                .GroupBy(point => point.Index)
+                .ToDictionary(group => group.Key, group => group.First().Properties);
+            return Enumerable.Range(0, categoryCount)
+                .Select(index => ReadChartColor(
+                    explicitColors.TryGetValue(index, out var properties) ? properties : null,
+                    index, theme))
+                .ToList();
         }
 
         private static XElement ChartBar(double x, double y, double width, double height,
@@ -324,23 +658,24 @@ namespace Docxodus
                 new XAttribute("fill", series.Color));
 
         private static void RenderChartLegend(XElement svg, double width, double height,
-            IReadOnlyList<CachedChartSeries> series, double fontSize)
+            IReadOnlyList<(string Name, string Color)> items, double fontSize)
         {
             const double interItemGap = 7.5;
-            var widths = series.Select(item => 20.5 + Math.Max(1, item.Name.Length) * fontSize * 0.375)
+            var widths = items
+                .Select(item => 20.5 + Math.Max(1, item.Name?.Length ?? 1) * fontSize * 0.375)
                 .ToList();
             var total = widths.Sum() - interItemGap;
             var x = Math.Max(4, (width - total) / 2);
             var y = height - 11;
-            for (var index = 0; index < series.Count; index++)
+            for (var index = 0; index < items.Count; index++)
             {
                 svg.Add(new XElement(Svg + "rect",
                     new XAttribute("x", Format(x)),
                     new XAttribute("y", Format(y - 4)),
                     new XAttribute("width", "8"),
                     new XAttribute("height", "8"),
-                    new XAttribute("fill", series[index].Color)));
-                AddSvgText(svg, x + 12, y, series[index].Name, "start", fontSize, true);
+                    new XAttribute("fill", items[index].Color)));
+                AddSvgText(svg, x + 12, y, items[index].Name, "start", fontSize, true);
                 x += widths[index];
             }
         }
@@ -380,7 +715,13 @@ namespace Docxodus
 
         private static IReadOnlyList<string> ReadCachedCategories(XElement firstSeries, int count)
         {
-            var points = firstSeries.Element(C.cat)?.Descendants(C.pt)
+            var cache = firstSeries.Element(C.cat);
+            // A date axis caches serial day numbers; surface them as dates, the way every
+            // renderer with the embedded workbook would.
+            var formatCode = cache?.Descendants(C.formatCode).FirstOrDefault()?.Value;
+            var isDate = formatCode != null && formatCode.Contains('y') &&
+                (cache.Descendants(C.numCache).Any() || cache.Descendants(C.numLit).Any());
+            var points = cache?.Descendants(C.pt)
                 .Select(point => new
                 {
                     Index = ReadIntAttribute(point, "idx", -1, -1, int.MaxValue),
@@ -391,9 +732,17 @@ namespace Docxodus
                 .ToDictionary(group => group.Key, group => group.First().Value ?? string.Empty)
                 ?? new Dictionary<int, string>();
             return Enumerable.Range(0, count)
-                .Select(index => points.TryGetValue(index, out var value) && !string.IsNullOrWhiteSpace(value)
-                    ? value
-                    : (index + 1).ToString(CultureInfo.InvariantCulture))
+                .Select(index =>
+                {
+                    if (!points.TryGetValue(index, out var value) || string.IsNullOrWhiteSpace(value))
+                        return (index + 1).ToString(CultureInfo.InvariantCulture);
+                    if (isDate && double.TryParse(value, NumberStyles.Float,
+                            CultureInfo.InvariantCulture, out var serial) &&
+                        serial is >= 1 and <= 2958465)
+                        return new DateTime(1899, 12, 30).AddDays(serial)
+                            .ToString("M/d/yyyy", CultureInfo.InvariantCulture);
+                    return value;
+                })
                 .ToList();
         }
 
@@ -433,7 +782,10 @@ namespace Docxodus
         private static string ReadChartColor(XElement shapeProperties, int seriesIndex,
             ThemeColorScheme theme)
         {
-            var fill = shapeProperties?.Element(A.solidFill);
+            // A filled shape (bar, area, slice) colors via a:solidFill; a line series carries its
+            // color on the stroke (a:ln/a:solidFill) instead.
+            var fill = shapeProperties?.Element(A.solidFill)
+                ?? shapeProperties?.Element(A.ln)?.Element(A.solidFill);
             var rgb = (string)fill?.Element(A.srgbClr)?.Attribute("val");
             var schemeColor = fill?.Element(A.schemeClr);
             if (!IsHexColor(rgb) && schemeColor != null)


### PR DESCRIPTION
Fixes #411.

## Root cause

`WmlToHtmlConverter.Charts.cs` hard-gated `ProcessChart` on `plotArea` containing a `c:barChart` **and** `c:grouping val="clustered"` — any other chart family (or grouping) returned `null`, so the caller in `WmlToHtmlConverter.cs` fell through and the drawing rendered as a blank extent: no placeholder, no ink. That is exactly why the three second-wave visual-parity corpus cases (`chart-stacked`, `chart-pie`, `chart-line`) measured ink F1 0.0.

## Remediation

Generalize the existing cached-data → SVG projection instead of adding a parallel renderer. One `SupportedChartPlots` map picks the first supported plot group in the plot area, and family-specific rendering shares the extent/theme/series/axis-scale machinery the clustered path already had:

- **Stacked / percent-stacked bar and column** — segments accumulate per category on either side of zero inside the existing two bar renderers (a `stacked` flag, not a copy). The axis spans per-category totals; a percent-stacked axis pins at 100% with `%`-suffixed ticks, matching Word.
- **Pie / doughnut** — slices clockwise from 12 o'clock (`c:firstSliceAng` honored), per-point colors from `c:dPt` (theme scheme colors resolved as before), `c:holeSize` for doughnuts, and the legend lists categories rather than the single series.
- **Line** — one polyline per series; series color read from the stroke (`a:ln/a:solidFill` — line series carry no shape fill), blank points skipped as gaps (Word's `dispBlanksAs` default), dense category axes thin labels to what the plot width fits.
- **Area** — filled polygons, standard and stacked groupings.
- **3-D variants** (`bar3DChart`, `pie3DChart`, `line3DChart`, `area3DChart`) carry the same cached series as their 2-D counterparts and render as the flat projection.
- **Date axes** (`c:dateAx`) — cached serial day numbers format as dates (`41518` → `9/1/2013`), and the category-axis font lookup falls back to `c:dateAx` when `c:catAx` is absent.

Clustered bar/column output is byte-for-byte unchanged (existing `HCO087` passes untouched). New SVG element classes `docx-chart-slice` / `docx-chart-line` / `docx-chart-area` join `docx-chart-bar`, and `data-chart-type` gains `pie`, `doughnut`, `line`, `area`, and `-stacked`/`-percent-stacked` suffixes.

## Verification

- New tests `HCO088`–`HCO090` exercise the three corpus fixtures (`VP001-Chart-Stacked-Column.docx`, `CU002-Chart-Cached-Data-02.docx`, `CU004-Chart-Cached-Data-04.docx`): stack geometry, per-point slice colors, per-series polylines, date labels.
- Full suite: 3424 passed, 0 failed.
- WASM-mode build (`WASM_BUILD=true`) compiles clean.
- Headless-chromium screenshots of all three fixtures confirm the rendered output (stacked columns with legend, correctly proportioned clockwise pie, three colored polylines with thinned date labels).

Per the issue's disposition note, the three corpus entries dispositioned `unsupported-feature` can be re-triaged after the benchmark rerun.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZnnDfitKU31ktVV4LwN98)_