### PR TITLE
Wrap body text around floating anchored pictures (wrapSquare/wrapTight/wrapThrough)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Body text now wraps around floating anchored pictures** (issue #412) —
+  `WmlToHtmlConverter` renders a picture anchored with `wp:wrapSquare`,
+  `wp:wrapTight`, or `wp:wrapThrough` as a CSS float instead of an inline
+  object, so surrounding lines flow beside the image the way Word and
+  LibreOffice lay them out rather than resuming below it. The float side comes
+  from a one-sided `wrapText`, the anchor's `wp:align` token, or the
+  offset-placed object's center against the governing section's column (or
+  page) center; the anchor's `distT/R/B/L` clearances become margins.
+  `wrapTight`'s polygon degrades to its bounding box; `wrapTopAndBottom`,
+  `wrapNone`, and a centered object keep their previous placement.
+
 ### Added
 - **Chart families beyond clustered bar/column render from cached data**
   (issue #411) — `WmlToHtmlConverter` now projects stacked and percent-stacked

--- a/Docxodus.Tests/HtmlConversionOpsTests.cs
+++ b/Docxodus.Tests/HtmlConversionOpsTests.cs
@@ -1288,6 +1288,40 @@ public class HtmlConversionOpsTests
         Assert.Contains("position: absolute", html);
     }
 
+    // A floating picture anchored with wp:wrapSquare must exclude body text from its rect
+    // (issue #412): Word wraps the paragraph's lines beside the picture, while an inline
+    // <img> pushes every following line below it. The picture in DB007 is offset-placed
+    // against the column with its center past the column midpoint, so it floats right; the
+    // anchor's 114300 EMU distL/distR become 9pt clearance margins.
+    [Fact]
+    public void HCO092_AnchoredPictureWithSquareWrap_FloatsRight()
+    {
+        byte[] bytes = File.ReadAllBytes(Path.Combine("..", "..", "..", "..", "TestFiles",
+            "DB007-WhitePaper.docx"));
+
+        string html = HtmlConversionOps.ConvertToHtml(bytes,
+            new HtmlConversionOptions { FabricateCssClasses = false });
+
+        Assert.Contains("float: right", html);
+        Assert.Contains("margin-left: 9pt", html);
+        Assert.Contains("margin-right: 9pt", html);
+    }
+
+    // wrapTight's polygon degrades to its bounding box. This picture sits at column offset 0,
+    // so its center is left of the column midpoint and it floats left.
+    [Fact]
+    public void HCO093_AnchoredPictureWithTightWrap_FloatsLeft()
+    {
+        byte[] bytes = File.ReadAllBytes(Path.Combine("..", "..", "..", "..", "TestFiles",
+            "VP", "VP002-Image-Wrap-Tight.docx"));
+
+        string html = HtmlConversionOps.ConvertToHtml(bytes,
+            new HtmlConversionOptions { FabricateCssClasses = false });
+
+        Assert.Contains("float: left", html);
+        Assert.DoesNotContain("float: right", html);
+    }
+
     // Some legacy Word documents keep the modern DrawingML text-box body in a related XML
     // part. The synthetic package deliberately uses a distinct VML fallback so this verifies
     // that the supported choice gains its external body without rendering both copies.

--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -9014,11 +9014,11 @@ namespace Docxodus
                         var imgElement2 = imageHandler(imageInfo);
                         if (hyperlinkUri != null)
                         {
-                            return new XElement(XhtmlNoNamespace.a,
+                            return ApplyAnchorTextWrap(new XElement(XhtmlNoNamespace.a,
                                 new XAttribute(XhtmlNoNamespace.href, hyperlinkUri),
-                                imgElement2);
+                                imgElement2), containerElement);
                         }
-                        return imgElement2;
+                        return ApplyAnchorTextWrap(imgElement2, containerElement);
                     }
 
                     var imageInfo2 = new ImageInfo()
@@ -9034,11 +9034,11 @@ namespace Docxodus
                     var imgElement = imageHandler(imageInfo2);
                     if (hyperlinkUri != null)
                     {
-                        return new XElement(XhtmlNoNamespace.a,
+                        return ApplyAnchorTextWrap(new XElement(XhtmlNoNamespace.a,
                             new XAttribute(XhtmlNoNamespace.href, hyperlinkUri),
-                            imgElement);
+                            imgElement), containerElement);
                     }
-                    return imgElement;
+                    return ApplyAnchorTextWrap(imgElement, containerElement);
                 }
                 finally
                 {
@@ -9047,6 +9047,84 @@ namespace Docxodus
 #endif
                 }
             }
+        }
+
+        /// <summary>
+        /// Word flows body text around a floating picture whose anchor requests wrapSquare,
+        /// wrapTight, or wrapThrough; without a flow exclusion the picture behaves as an inline
+        /// object and every following line resumes below it. A CSS float is the closest
+        /// flow-level equivalent: it excludes the anchored rect from the line layout of the
+        /// current and following blocks in both continuous and paginated rendering. wrapTight's
+        /// polygon degrades to its bounding box (identical for the rectangular polygons Word
+        /// writes for photos); wrapTopAndBottom and wrapNone keep the existing placement.
+        /// </summary>
+        private static XElement ApplyAnchorTextWrap(XElement imageHtml, XElement drawingContainer)
+        {
+            if (imageHtml == null || drawingContainer == null || drawingContainer.Name != WP.anchor)
+                return imageHtml;
+
+            var wrap = drawingContainer.Elements().FirstOrDefault(e =>
+                e.Name == WP.wrapSquare || e.Name == WP.wrapTight || e.Name == WP.wrapThrough);
+            if (wrap == null)
+                return imageHtml;
+
+            var side = GetAnchorFloatSide(drawingContainer, wrap);
+            if (side == null)
+                return imageHtml;
+
+            // The anchor's dist* attributes are text clearance around the object, which is
+            // exactly what CSS margins are on a float.
+            var style = new Dictionary<string, string> { { "float", side } };
+            AddEmuPadding(style, "margin-top", (long?)drawingContainer.Attribute(NoNamespace.distT));
+            AddEmuPadding(style, "margin-right", (long?)drawingContainer.Attribute(NoNamespace.distR));
+            AddEmuPadding(style, "margin-bottom", (long?)drawingContainer.Attribute(NoNamespace.distB));
+            AddEmuPadding(style, "margin-left", (long?)drawingContainer.Attribute(NoNamespace.distL));
+
+            var wrapper = new XElement(Xhtml.span, imageHtml);
+            wrapper.AddAnnotation(style);
+            return wrapper;
+        }
+
+        /// <summary>
+        /// Picks the edge the floated object hugs. An explicitly one-sided wrapText names where
+        /// the TEXT goes, so the object floats to the opposite edge; otherwise the anchor's own
+        /// horizontal position decides — an alignment token directly, or an offset-placed
+        /// object's center measured against the governing section's column (or page) center.
+        /// A centered object has no float equivalent and keeps its inline placement.
+        /// </summary>
+        private static string GetAnchorFloatSide(XElement anchor, XElement wrap)
+        {
+            var wrapText = (string)wrap.Attribute(NoNamespace.wrapText);
+            if (wrapText == "left")
+                return "right";
+            if (wrapText == "right")
+                return "left";
+
+            var positionH = anchor.Element(WP.positionH);
+            switch (positionH?.Element(WP.align)?.Value)
+            {
+                case "left":
+                case "inside":
+                    return "left";
+                case "right":
+                case "outside":
+                    return "right";
+                case "center":
+                    return null;
+            }
+
+            var offsetEmu = (long?)positionH?.Element(WP.posOffset) ?? 0L;
+            var extentEmu = (long?)anchor.Elements(WP.extent)
+                .Attributes(NoNamespace.cx).FirstOrDefault() ?? 0L;
+
+            var sectPr = anchor.Annotation<SectionAnnotation>()?.SectionElement;
+            var dims = PageDimensions.FromSectionProperties(sectPr);
+            var referencePt = (string)positionH?.Attribute(NoNamespace.relativeFrom) == "page"
+                ? dims.PageWidthPt
+                : dims.ContentWidthPt;
+
+            var objectCenterEmu = offsetEmu + extentEmu / 2.0;
+            return objectCenterEmu <= referencePt * 12700.0 / 2.0 ? "left" : "right";
         }
 
         private static XElement ProcessPictureOrObject(WordprocessingDocument wordDoc,


### PR DESCRIPTION
Fixes #412.

## Root cause

`WmlToHtmlConverter.ProcessDrawing` never inspects a floating picture's wrap mode. Anchored *text boxes* get the full anchor treatment (`AddDrawingTextBoxStyle` → `AddDrawingAnchorMetadata`, absolute positioning under pagination), but an anchored *picture* falls straight through to the `imageHandler` and is emitted as a plain inline `<img>` — so on `DB007-WhitePaper.docx` the five lines LibreOffice wraps beside the picture instead resume below it, displacing the page's whole lower half (ink F1 0.394 square / 0.512 tight).

## Fix

When the drawing container is a `wp:anchor` carrying `wp:wrapSquare`, `wp:wrapTight`, or `wp:wrapThrough`, the rendered image (hyperlinked or not) is wrapped in a floated span — the CSS flow-level equivalent of Word's text-flow exclusion, effective in both continuous and paginated rendering since a float excludes line boxes of the current *and following* blocks:

- **Float side**: a one-sided `wrapText` names where the *text* goes, so the object floats opposite; else the `wp:align` token (`left`/`inside`, `right`/`outside`) decides directly; else the offset-placed object's center is measured against the governing section's column (or page, per `relativeFrom`) center via the existing `SectionAnnotation`/`PageDimensions` machinery.
- **Clearance**: the anchor's `distT/distR/distB/distL` attributes become the float's margins (they are text-clearance values, which is exactly what margins are on a float).
- **Degradations kept honest**: `wrapTight`'s polygon degrades to its bounding box (identical for the rectangular polygons Word writes for photos); `wrapTopAndBottom`, `wrapNone`, and a centered object keep their previous placement.

Before / after on the issue's primary case (`DB007-WhitePaper.docx`): text previously resumed below the picture; it now wraps five lines beside the right-floated image, matching the LibreOffice reference. `VP002-Image-Wrap-Tight.docx` correspondingly floats left with text wrapping on the right.

## Tests

- `HCO092_AnchoredPictureWithSquareWrap_FloatsRight` — DB007 (offset-placed, center past column midpoint → `float: right`; 114300 EMU dist → 9pt margins)
- `HCO093_AnchoredPictureWithTightWrap_FloatsLeft` — VP002 (`wrapTight` + polygon at column offset 0 → `float: left`)
- Full suite: 3426 passed, 0 failed; Release build (warnings-as-errors) clean.

## Notes

- The visual-parity corpus dispositions and `ratchet.json` records for `wrapped-image-square` / `wrapped-image-tight` are intentionally untouched: the ratchet treats improvements as non-failing ("refresh the record to bank them"), and the record refresh requires the measured LibreOffice environment (`DOCXODUS_VISUAL_PARITY_UPDATE_RECORD=1`), which isn't available here. The next benchmark run should surface both cases as improvements to bank.
- WASM/npm surfaces are unaffected (bug fix, no new setting).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFH8yVgHgpCT29E2SNdUKT)_