### PR TITLE
Fix continuous section breaks and render w:cols multi-column layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **Continuous section breaks no longer render as page breaks, and `w:cols`
+  multi-column sections lay out as columns** (issue #413) — the converter now
+  stamps the section wrapper with its start type (`data-section-type`, from
+  `w:type`) and column geometry (`data-cols`/`data-col-gap`, from `w:cols`,
+  with the same geometry applied inline as CSS `column-count`/`column-gap` for
+  the continuous view). The paginator groups a `w:type="continuous"` section
+  into the page run its predecessor started — provided the page box (size and
+  margins) is unchanged, Word's own condition for honoring the break — instead
+  of always opening a fresh page, and flows a multi-column section as balanced
+  CSS-multicol container blocks that split across pages at block boundaries.
+  Unequal explicit `w:col` widths collapse to the equal-column approximation,
+  and pages of a merged run carry the leading section's headers/footers and
+  page numbering.
 - **Body text now wraps around floating anchored pictures** (issue #412) —
   `WmlToHtmlConverter` renders a picture anchored with `wp:wrapSquare`,
   `wp:wrapTight`, or `wp:wrapThrough` as a CSS float instead of an inline

--- a/Docxodus.Tests/HtmlConverterTests.cs
+++ b/Docxodus.Tests/HtmlConverterTests.cs
@@ -4169,6 +4169,41 @@ namespace OxPt
         }
 
         /// <summary>
+        /// A section's start type and column geometry are properties of the document, so the
+        /// wrapper carries them in every render mode: the paginator needs w:type="continuous"
+        /// to keep filling the current page instead of opening a fresh one, and w:cols to lay
+        /// the section out as CSS columns (which the continuous view gets inline). Issue #413.
+        /// </summary>
+        [Fact]
+        public void HC062_ContinuousSectionAndColumns_StampedOnWrapper()
+        {
+            var sourceDocx = new FileInfo("../../../../TestFiles/VP/VP003-Two-Column-Section.docx");
+            var wmlDocument = new WmlDocument(sourceDocx.FullName);
+            using var streamDoc = new OpenXmlMemoryStreamDocument(wmlDocument);
+            using var wDoc = streamDoc.GetWordprocessingDocument();
+
+            var html = WmlToHtmlConverter.ConvertToHtml(wDoc, new WmlToHtmlConverterSettings());
+
+            var sectionDivs = html
+                .Descendants()
+                .Where(e => e.Attribute("data-section-index") != null)
+                .OrderBy(e => (int)e.Attribute("data-section-index"))
+                .ToList();
+            Assert.Equal(2, sectionDivs.Count);
+
+            // The single-column title section is neither typed continuous nor columned.
+            Assert.Null(sectionDivs[0].Attribute("data-section-type"));
+            Assert.Null(sectionDivs[0].Attribute("data-cols"));
+
+            // The trailing section is continuous and two-column with a 720-twip (36pt) gap,
+            // stamped for the paginator and applied inline for the continuous view.
+            Assert.Equal("continuous", (string)sectionDivs[1].Attribute("data-section-type"));
+            Assert.Equal("2", (string)sectionDivs[1].Attribute("data-cols"));
+            Assert.Equal("36.0", (string)sectionDivs[1].Attribute("data-col-gap"));
+            Assert.Equal("column-count: 2; column-gap: 36.0pt;", (string)sectionDivs[1].Attribute("style"));
+        }
+
+        /// <summary>
         /// Word's fixed table layout makes the authored column widths binding: content wraps
         /// inside a column instead of widening it. Map it to CSS's fixed layout, with the grid
         /// (not the first row) supplying the widths, exactly as Word records them.

--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -5279,6 +5279,30 @@ namespace Docxodus
                         div.Add(new XAttribute("data-footer-height", dims.FooterPt.ToString("F1", NumberFormatInfo.InvariantInfo)));
                     }
 
+                    // The section's start type (w:type). The paginated view needs it to know a
+                    // "continuous" section keeps filling the page its predecessor started
+                    // instead of opening a fresh one; absent means Word's default, nextPage.
+                    var sectionType = (string)sectAnnotation?.SectionElement.Element(W.type)?.Attribute(W.val);
+                    if (sectionType != null)
+                        div.Add(new XAttribute("data-section-type", sectionType));
+
+                    // The section's column geometry (w:cols). Word lays a multi-column section
+                    // out as N equal columns separated by w:space; CSS multicol reproduces that,
+                    // so the count/gap are stamped for the paginator and the same geometry is
+                    // applied inline for the continuous view. (Unequal explicit w:col widths
+                    // collapse to the equal-column approximation.)
+                    var cols = sectAnnotation?.SectionElement.Element(W.cols);
+                    var colsNum = (int?)cols?.Attribute(W.num) ?? 1;
+                    if (colsNum > 1)
+                    {
+                        var colGapPt = ((int?)cols.Attribute(W.space) ?? 720) / 20m;
+                        var colGap = colGapPt.ToString("F1", NumberFormatInfo.InvariantInfo);
+                        div.Add(new XAttribute("data-cols", colsNum));
+                        div.Add(new XAttribute("data-col-gap", colGap));
+                        div.Add(new XAttribute("style",
+                            $"column-count: {colsNum}; column-gap: {colGap}pt;"));
+                    }
+
                     // The section's page numbering (w:pgNumType), which is what an unswitched
                     // PAGE field renders through. Emitted per attribute: absent means "continue
                     // the previous section" / "Word's default format", not a value.

--- a/npm/src/pagination.ts
+++ b/npm/src/pagination.ts
@@ -20,6 +20,22 @@ import type { PageBands, PageDimensions } from "./page-geometry.js";
 export type { PageBands, PageDimensions } from "./page-geometry.js";
 
 /**
+ * Whether two sections describe the same physical page box. A continuous section
+ * break is only honorable when it does — a changed page size or margin set forces
+ * a real page break, which is Word's behavior too.
+ */
+function samePageBox(a: PageDimensions, b: PageDimensions): boolean {
+  return (
+    a.pageWidth === b.pageWidth &&
+    a.pageHeight === b.pageHeight &&
+    a.marginTop === b.marginTop &&
+    a.marginRight === b.marginRight &&
+    a.marginBottom === b.marginBottom &&
+    a.marginLeft === b.marginLeft
+  );
+}
+
+/**
  * Headers and footers for a specific section.
  */
 export interface SectionHeaderFooter {
@@ -246,24 +262,65 @@ export class PaginationEngine {
     const sectionsToProcess =
       sections.length > 0 ? Array.from(sections) : [this.stagingElement];
 
+    // Group adjacent sections into page runs. A `w:type="continuous"` section keeps
+    // filling the page its predecessor started rather than opening a fresh one, so it
+    // joins the previous run — provided the page box (size and margins) is unchanged,
+    // which is also Word's own condition for honoring a continuous break. Pages of a
+    // merged run carry the run's leading section index, so its headers/footers and
+    // page numbering govern the shared pages.
+    interface PageRun {
+      sections: HTMLElement[];
+      sectionIndex: number;
+      dims: PageDimensions;
+    }
+    const runs: PageRun[] = [];
     for (const section of sectionsToProcess) {
-      const sectionIndex = parseInt(section.dataset.sectionIndex || "0", 10);
       const dims = parseSectionDimensions(section);
+      const previous = runs[runs.length - 1];
+      if (
+        previous &&
+        section.dataset.sectionType === "continuous" &&
+        samePageBox(previous.dims, dims)
+      ) {
+        previous.sections.push(section);
+      } else {
+        runs.push({
+          sections: [section],
+          sectionIndex: parseInt(section.dataset.sectionIndex || "0", 10),
+          dims,
+        });
+      }
+    }
 
+    for (const run of runs) {
       // Make staging visible for measurement
       this.stagingElement.style.visibility = "hidden";
       this.stagingElement.style.position = "absolute";
       this.stagingElement.style.left = "-9999px";
       this.stagingElement.style.display = "block";
 
-      // Set width for accurate line wrapping
-      section.style.width = `${dims.contentWidth}pt`;
+      const blocks: MeasuredBlock[] = [];
+      for (const section of run.sections) {
+        // Set width for accurate line wrapping
+        section.style.width = `${run.dims.contentWidth}pt`;
 
-      // Measure all blocks in this section
-      const blocks = this.measureBlocks(section, dims);
+        const columnCount = parseInt(section.dataset.cols || "1", 10);
+        if (columnCount > 1) {
+          const gap = parseFloat(section.dataset.colGap || "");
+          blocks.push(...this.buildColumnBlocks(
+            section,
+            run.dims,
+            run.sectionIndex,
+            columnCount,
+            Number.isFinite(gap) ? gap : 36
+          ));
+        } else {
+          blocks.push(...this.measureBlocks(section, run.dims));
+        }
+      }
 
       // Flow blocks into pages
-      const sectionPages = this.flowToPages(blocks, dims, pageNumber, sectionIndex);
+      const sectionPages = this.flowToPages(blocks, run.dims, pageNumber, run.sectionIndex);
       pages.push(...sectionPages);
       pageNumber += sectionPages.length;
     }
@@ -380,6 +437,80 @@ export class PaginationEngine {
         pageBreakBefore: child.dataset.pageBreakBefore === "true",
         isPageBreak,
       });
+    }
+
+    return blocks;
+  }
+
+  /**
+   * Flows a multi-column (`w:cols`) section's children into CSS-multicol container
+   * blocks. Word lays such a section out as N columns inside the same body extent;
+   * a balanced `column-count` container reproduces that geometry, and the paginator
+   * then places each container as one ordinary measured block. A container grows
+   * greedily until its balanced height would exceed the smallest page body available
+   * to the section, so a long columned section still splits across pages at block
+   * boundaries. Each child lands in exactly one container, so anchors never
+   * duplicate. An explicit page break child passes through as its own block, which
+   * ends the current container and lets the normal flow logic turn the page.
+   */
+  private buildColumnBlocks(
+    section: HTMLElement,
+    dims: PageDimensions,
+    sectionIndex: number,
+    columnCount: number,
+    columnGapPt: number
+  ): MeasuredBlock[] {
+    const children = Array.from(section.children) as HTMLElement[];
+    const blocks: MeasuredBlock[] = [];
+    const maxFragmentHeight = this.smallestEffectiveContentHeight(dims, sectionIndex);
+
+    const isBreak = (child: HTMLElement) =>
+      child.dataset.pageBreak === "true" ||
+      child.classList.contains(`${this.cssPrefix}break`);
+
+    const makeContainer = (slice: HTMLElement[]): HTMLElement => {
+      const container = document.createElement("div");
+      container.style.columnCount = String(columnCount);
+      container.style.columnGap = `${columnGapPt}pt`;
+      for (const child of slice) {
+        container.appendChild(child.cloneNode(true));
+      }
+      return container;
+    };
+
+    let start = 0;
+    while (start < children.length) {
+      if (isBreak(children[start])) {
+        blocks.push(this.measureElement(children[start], dims));
+        start++;
+        continue;
+      }
+
+      // Grow the container one child at a time. Even a single oversized child is
+      // emitted alone, preserving the established oversized-block fallback.
+      let end = start + 1;
+      let container = makeContainer(children.slice(start, end));
+      let measured = this.measureElement(container, dims);
+      while (end < children.length && !isBreak(children[end])) {
+        const candidate = makeContainer(children.slice(start, end + 1));
+        const candidateMeasured = this.measureElement(candidate, dims);
+        if (candidateMeasured.heightPt > maxFragmentHeight) break;
+        container = candidate;
+        measured = candidateMeasured;
+        end++;
+      }
+
+      blocks.push({
+        element: container,
+        heightPt: measured.heightPt,
+        marginTopPt: measured.marginTopPt,
+        marginBottomPt: measured.marginBottomPt,
+        keepWithNext: false,
+        keepLines: false,
+        pageBreakBefore: false,
+        isPageBreak: false,
+      });
+      start = end;
     }
 
     return blocks;

--- a/npm/tests/pagination-continuous-section.spec.ts
+++ b/npm/tests/pagination-continuous-section.spec.ts
@@ -1,0 +1,203 @@
+import { test, expect, Page } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const TEST_FILES_DIR = path.join(__dirname, '../../TestFiles');
+
+/**
+ * Continuous section breaks and w:cols column geometry (issue #413).
+ *
+ * A `w:type="continuous"` section keeps filling the page its predecessor started;
+ * the paginator used to open a fresh page for EVERY section wrapper, promoting the
+ * continuous break to a page break. A `w:cols` section lays out as balanced CSS
+ * columns instead of one full-width column.
+ */
+
+const PAGE_GEOMETRY = `
+  data-page-width="102" data-page-height="102"
+  data-content-width="100" data-content-height="100"
+  data-margin-top="1" data-margin-right="1"
+  data-margin-bottom="1" data-margin-left="1"`;
+
+function staging(sections: string): string {
+  return `
+    <style>
+      #staging { font: 12px/12px Arial; }
+      #staging p { box-sizing: border-box; margin: 0; padding: 0; width: 100%; }
+    </style>
+    <div id="staging">${sections}</div>
+    <div id="container"></div>`;
+}
+
+interface PaginatedShape {
+  /** Per page, the text of each top-level block. */
+  content: string[][];
+  /** Per page, each top-level block's inline column-count ('' when none). */
+  columnCounts: string[][];
+}
+
+async function paginate(page: Page): Promise<PaginatedShape> {
+  await page.addScriptTag({ path: path.join(__dirname, '../dist/pagination.bundle.js') });
+
+  return page.evaluate(() => {
+    const staging = document.getElementById('staging') as HTMLElement;
+    const container = document.getElementById('container') as HTMLElement;
+    const { PaginationEngine } = (window as any).DocxodusPagination;
+    new PaginationEngine(staging, container, { showPageNumbers: false }).paginate();
+
+    const pages = Array.from(container.querySelectorAll<HTMLElement>('.page-content'));
+    return {
+      content: pages.map(content =>
+        Array.from(content.children).map(block => (block.textContent || '').trim())
+      ),
+      columnCounts: pages.map(content =>
+        Array.from(content.children).map(
+          block => (block as HTMLElement).style.columnCount || ''
+        )
+      ),
+    };
+  });
+}
+
+test.describe('Continuous section breaks', () => {
+  test('a continuous section continues on the current page', async ({ page }) => {
+    await page.setContent(staging(`
+      <div data-section-index="0" ${PAGE_GEOMETRY}>
+        <p style="height: 30pt">title</p>
+      </div>
+      <div data-section-index="1" data-section-type="continuous" ${PAGE_GEOMETRY}>
+        <p style="height: 30pt">body</p>
+      </div>`));
+
+    const { content } = await paginate(page);
+
+    expect(content).toEqual([['title', 'body']]);
+  });
+
+  test('a default (nextPage) section still starts a fresh page', async ({ page }) => {
+    await page.setContent(staging(`
+      <div data-section-index="0" ${PAGE_GEOMETRY}>
+        <p style="height: 30pt">title</p>
+      </div>
+      <div data-section-index="1" ${PAGE_GEOMETRY}>
+        <p style="height: 30pt">body</p>
+      </div>`));
+
+    const { content } = await paginate(page);
+
+    expect(content).toEqual([['title'], ['body']]);
+  });
+
+  test('a continuous section with a different page box starts a fresh page, as Word does', async ({ page }) => {
+    await page.setContent(staging(`
+      <div data-section-index="0" ${PAGE_GEOMETRY}>
+        <p style="height: 30pt">title</p>
+      </div>
+      <div data-section-index="1" data-section-type="continuous"
+           data-page-width="204" data-page-height="204"
+           data-content-width="200" data-content-height="200"
+           data-margin-top="2" data-margin-right="2"
+           data-margin-bottom="2" data-margin-left="2">
+        <p style="height: 30pt">body</p>
+      </div>`));
+
+    const { content } = await paginate(page);
+
+    expect(content).toEqual([['title'], ['body']]);
+  });
+
+  test('an overfilled shared page still turns normally', async ({ page }) => {
+    await page.setContent(staging(`
+      <div data-section-index="0" ${PAGE_GEOMETRY}>
+        <p style="height: 60pt">title</p>
+      </div>
+      <div data-section-index="1" data-section-type="continuous" ${PAGE_GEOMETRY}>
+        <p style="height: 30pt">first</p>
+        <p style="height: 30pt">second</p>
+      </div>`));
+
+    const { content } = await paginate(page);
+
+    expect(content).toEqual([['title', 'first'], ['second']]);
+  });
+});
+
+test.describe('w:cols column geometry', () => {
+  test('a columned continuous section shares the page as one balanced multicol block', async ({ page }) => {
+    await page.setContent(staging(`
+      <div data-section-index="0" ${PAGE_GEOMETRY}>
+        <p style="height: 20pt">title</p>
+      </div>
+      <div data-section-index="1" data-section-type="continuous"
+           data-cols="2" data-col-gap="10" ${PAGE_GEOMETRY}>
+        <p style="height: 20pt">alpha</p>
+        <p style="height: 20pt">beta</p>
+      </div>`));
+
+    const { content, columnCounts } = await paginate(page);
+
+    // One page: the 20pt title plus a balanced two-column container (~20pt tall
+    // instead of 40pt stacked). Each source block lands in the container exactly once.
+    expect(content).toEqual([['title', 'alphabeta']]);
+    expect(columnCounts).toEqual([['', '2']]);
+  });
+
+  test('a long columned section splits across pages at block boundaries', async ({ page }) => {
+    await page.setContent(staging(`
+      <div data-section-index="0" data-cols="2" data-col-gap="10" ${PAGE_GEOMETRY}>
+        <p style="height: 60pt">alpha</p>
+        <p style="height: 60pt">beta</p>
+        <p style="height: 60pt">gamma</p>
+        <p style="height: 60pt">delta</p>
+      </div>`));
+
+    const { content, columnCounts } = await paginate(page);
+
+    // Balancing may split a paragraph across columns, as Word does: three 60pt
+    // blocks balance to ~90pt and fit the 100pt body, while a fourth would need
+    // 120pt — so the section fragments at that block boundary.
+    expect(content).toEqual([['alphabetagamma'], ['delta']]);
+    expect(columnCounts).toEqual([['2'], ['2']]);
+  });
+});
+
+test.describe('VP003 end-to-end (issue #413)', () => {
+  test('title and two-column body share one page, laid out in columns', async ({ page }) => {
+    await page.goto('/test-harness.html');
+    await page.waitForFunction(() => (window as any).DocxodusReady === true, { timeout: 30000 });
+
+    const bytes = new Uint8Array(
+      fs.readFileSync(path.join(TEST_FILES_DIR, 'VP/VP003-Two-Column-Section.docx')));
+    const conversion = await page.evaluate(
+      input => (window as any).DocxodusTests.convertToHtmlWithPagination(
+        new Uint8Array(input), 1, 1),
+      Array.from(bytes)
+    );
+    expect(conversion.error).toBeUndefined();
+
+    await page.setContent(conversion.html!);
+    await page.addScriptTag({ path: path.join(__dirname, '../dist/pagination.bundle.js') });
+
+    const result = await page.evaluate(() => {
+      const staging = document.getElementById('pagination-staging') as HTMLElement;
+      const container = document.getElementById('pagination-container') as HTMLElement;
+      const { PaginationEngine } = (window as any).DocxodusPagination;
+      const { totalPages } = new PaginationEngine(staging, container, {
+        showPageNumbers: false,
+      }).paginate();
+
+      const columnBlocks = Array.from(
+        container.querySelectorAll<HTMLElement>('.page-content > div')
+      ).filter(block => block.style.columnCount === '2');
+      return { totalPages, columnBlockCount: columnBlocks.length };
+    });
+
+    // LibreOffice and Word lay this fixture out on ONE page: the continuous
+    // section starts on the title's page and its body balances into two columns.
+    expect(result.totalPages).toBe(1);
+    expect(result.columnBlockCount).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Fixes #413.

## Root cause

Both failures were renderer-owned, split across the two layers:

1. **Continuous break promoted to a page break** — `WmlToHtmlConverter.CreateSectionDivs` stamps page geometry on every section wrapper but never emitted the section **start type** (`w:type`), and `pagination.ts#paginate()` unconditionally flowed each section wrapper onto fresh pages. Every section break therefore became a page break, continuous or not.
2. **`w:cols` ignored** — the converter emitted no column geometry at all, and the paginator had no concept of columns, so a two-column body rendered as one full-width column.

## Fix

**Converter (`WmlToHtmlConverter.cs`)** — the section wrapper now carries:
- `data-section-type` (from `w:type`; absent means Word's default, `nextPage`),
- `data-cols` / `data-col-gap` (from `w:cols` `@w:num`/`@w:space`, gap in points), with the same geometry applied inline as CSS `column-count`/`column-gap` so the continuous (non-paginated) view lays columns out too. Unequal explicit `w:col` widths collapse to the equal-column approximation.

**Paginator (`npm/src/pagination.ts`)** —
- Adjacent sections are grouped into *page runs*: a `w:type="continuous"` section joins the run its predecessor started instead of opening a fresh page — provided the page box (size + margins) is unchanged, which is Word's own condition for honoring a continuous break. Pages of a merged run carry the leading section's index, so its headers/footers and page numbering govern the shared pages.
- A multi-column section flows as balanced CSS-multicol container blocks (`buildColumnBlocks`): containers grow greedily until the balanced height would exceed the smallest page body, so a long columned section still splits across pages at block boundaries; each child lands in exactly one container (no duplicated anchors), and an explicit page break inside the section still turns the page.

## Result

`VP003-Two-Column-Section.docx` now paginates to **one page with the body balanced into two 36pt-gapped columns**, matching LibreOffice's layout (previously 2/1 pages with a full-width body — SSIM 0.80838, ink F1 0.07207).

## Tests

- `HC062_ContinuousSectionAndColumns_StampedOnWrapper` (.NET) — asserts the wrapper stamping on the VP003 fixture, including that the single-column title section stays unstamped. Full suite: 3427 passed / 0 failed.
- `npm/tests/pagination-continuous-section.spec.ts` (Playwright, 7 tests) — continuous sections share the page; default sections still break; a changed page box forces a break (Word behavior); overfilled shared pages turn normally; columned sections balance and split at block boundaries; plus a WASM end-to-end test proving VP003 converts + paginates to 1 page with a two-column block. All pagination/editor regression specs pass.

## Note on the visual-parity ratchet

`ratchet.json` still records `two-column-section` at 2/1 pages. The record must be refreshed (`DOCXODUS_VISUAL_PARITY_UPDATE_RECORD=1`) in the recorded reference environment (LibreOffice 25.8 + Poppler + the pinned font contract) to bank the improvement — this container has LibreOffice 24.2 and no Poppler, so a local refresh would misattribute an environment change. Until then a measured parity run will flag the page-count improvement as a finding; ordinary PR CI (the pure comparator specs) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7L3B7hk1xthWgKFcUWVSn

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7L3B7hk1xthWgKFcUWVSn)_