### PR TITLE
Flow endnotes onto paginated pages and honor Word's default endnote number format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **Paginated print layout no longer drops the endnotes section, and endnote
+  markers render in Word's default lowercase-roman format** (issue #414) — in
+  `PaginationMode.Paginated` the converter emitted `section.endnotes` as a
+  body-level sibling of the pagination staging/container divs, but the
+  paginator only flows content found inside `[data-section-index]` wrappers in
+  the staging area, so the endnotes never reached a page. The section is now
+  appended inside the last section div in the staging area and flows onto the
+  final page(s) as an ordinary block, the way Word and LibreOffice lay endnotes
+  out. Independently, footnote/endnote display numbers were hardcoded decimal:
+  the converter now resolves the effective `w:numFmt` (section-level
+  `w:footnotePr`/`w:endnotePr` over the settings-part declaration, falling back
+  to the spec defaults — decimal for footnotes, **lowerRoman for endnotes**),
+  renders citation markers and paginated-registry labels in that format, and
+  stamps the notes-section `<ol>` with the matching CSS `list-style-type`.
 - **Continuous section breaks no longer render as page breaks, and `w:cols`
   multi-column sections lay out as columns** (issue #413) — the converter now
   stamps the section wrapper with its start type (`data-section-type`, from

--- a/Docxodus.Tests/HtmlConverterTests.cs
+++ b/Docxodus.Tests/HtmlConverterTests.cs
@@ -858,6 +858,99 @@ namespace OxPt
         }
 
         [Fact]
+        public void HC008f_Endnotes_PaginatedMode_FlowInsideStagingSection()
+        {
+            // Issue #414: the paginator only flows content found inside [data-section-index]
+            // wrappers within #pagination-staging. The endnotes section used to be emitted as a
+            // body-level SIBLING of the staging/container divs, so it never reached any page and
+            // vanished from the print layout. It must be the last child of the last section div.
+            DirectoryInfo sourceDir = new DirectoryInfo("../../../../TestFiles/WC");
+            FileInfo doc = new FileInfo(Path.Combine(sourceDir.FullName, "WC036-Endnote-With-Table-Before.docx"));
+
+            byte[] byteArray = File.ReadAllBytes(doc.FullName);
+            using (MemoryStream ms = new MemoryStream())
+            {
+                ms.Write(byteArray, 0, byteArray.Length);
+                using (WordprocessingDocument wDoc = WordprocessingDocument.Open(ms, true))
+                {
+                    var settings = new WmlToHtmlConverterSettings()
+                    {
+                        FabricateCssClasses = true,
+                        RenderFootnotesAndEndnotes = true,
+                        RenderPagination = PaginationMode.Paginated,
+                    };
+
+                    XElement html = WmlToHtmlConverter.ConvertToHtml(wDoc, settings);
+
+                    var endnoteSections = html.Descendants()
+                        .Where(e => e.Name.LocalName == "section" &&
+                            (string)e.Attribute("class") == "endnotes")
+                        .ToList();
+
+                    // Exactly one endnotes section — no duplicate outside the staging area
+                    var endnotesSection = Assert.Single(endnoteSections);
+
+                    // It flows as content of a section div inside the staging area
+                    Assert.Contains(endnotesSection.Ancestors(),
+                        a => a.Attribute("data-section-index") != null);
+                    Assert.Contains(endnotesSection.Ancestors(),
+                        a => (string)a.Attribute("id") == "pagination-staging");
+                }
+            }
+        }
+
+        [Fact]
+        public void HC008g_EndnoteMarkers_DefaultLowerRoman()
+        {
+            // Issue #414: Word's default endnote w:numFmt is lowerRoman (footnotes are decimal),
+            // so with no w:endnotePr override the citation marker must render "i", not "1", and
+            // the endnotes list must number in lowercase roman.
+            DirectoryInfo sourceDir = new DirectoryInfo("../../../../TestFiles/WC");
+            FileInfo doc = new FileInfo(Path.Combine(sourceDir.FullName, "WC036-Endnote-With-Table-Before.docx"));
+
+            byte[] byteArray = File.ReadAllBytes(doc.FullName);
+            using (MemoryStream ms = new MemoryStream())
+            {
+                ms.Write(byteArray, 0, byteArray.Length);
+                using (WordprocessingDocument wDoc = WordprocessingDocument.Open(ms, true))
+                {
+                    var settings = new WmlToHtmlConverterSettings()
+                    {
+                        FabricateCssClasses = true,
+                        RenderFootnotesAndEndnotes = true,
+                    };
+
+                    XElement html = WmlToHtmlConverter.ConvertToHtml(wDoc, settings);
+
+                    // Citation marker: <a class="endnote-ref ..."><sup>i</sup></a>
+                    // (FabricateCssClasses appends a fabricated pt-* class after endnote-ref)
+                    var endnoteRef = html.Descendants()
+                        .First(e => e.Name.LocalName == "a" &&
+                            ((string)e.Attribute("class") ?? "").Contains("endnote-ref"));
+                    var sup = endnoteRef.Elements().First(e => e.Name.LocalName == "sup");
+                    Assert.Equal("i", sup.Value);
+
+                    // Endnotes section list numbers in lowercase roman
+                    var endnotesSection = html.Descendants()
+                        .First(e => e.Name.LocalName == "section" &&
+                            (string)e.Attribute("class") == "endnotes");
+                    var ol = endnotesSection.Elements().First(e => e.Name.LocalName == "ol");
+                    Assert.Contains("lower-roman", (string)ol.Attribute("style"));
+
+                    // Footnote markers keep their decimal default
+                    var footnoteRef = html.Descendants()
+                        .FirstOrDefault(e => e.Name.LocalName == "a" &&
+                            ((string)e.Attribute("class") ?? "").Contains("footnote-ref"));
+                    if (footnoteRef != null)
+                    {
+                        var fnSup = footnoteRef.Elements().First(e => e.Name.LocalName == "sup");
+                        Assert.Equal("1", fnSup.Value);
+                    }
+                }
+            }
+        }
+
+        [Fact]
         public void HC009_HeadersAndFooters_CssEnabled()
         {
             // Test that header/footer CSS is generated when RenderHeadersAndFooters is true

--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -699,6 +699,17 @@ namespace Docxodus
         /// Endnote XML IDs in document order (for rendering endnotes section).
         /// </summary>
         public List<string> EndnoteIdsInOrder { get; } = new List<string>();
+
+        /// <summary>
+        /// Effective ST_NumberFormat token for footnote markers. Word's default is decimal.
+        /// </summary>
+        public string FootnoteNumberFormat { get; set; } = "decimal";
+
+        /// <summary>
+        /// Effective ST_NumberFormat token for endnote markers. Word's default is lowerRoman
+        /// (i, ii, iii…) — endnotes do NOT share the footnotes' decimal default.
+        /// </summary>
+        public string EndnoteNumberFormat { get; set; } = "lowerRoman";
     }
 
     /// <summary>
@@ -952,6 +963,8 @@ namespace Docxodus
             if (htmlConverterSettings.RenderFootnotesAndEndnotes)
             {
                 BuildFootnoteNumberingTracker(rootElement, footnoteTracker);
+                footnoteTracker.FootnoteNumberFormat = GetNoteNumberFormat(wordDoc, W.footnotePr, "decimal");
+                footnoteTracker.EndnoteNumberFormat = GetNoteNumberFormat(wordDoc, W.endnotePr, "lowerRoman");
             }
             rootElement.AddAnnotation(footnoteTracker);
 
@@ -2695,10 +2708,16 @@ namespace Docxodus
                             bodyContent.Add(footnotesSection);
                     }
 
-                    // Endnotes always render at document end (not per-page)
-                    var endnotesSection = RenderEndnotesSection(wordDoc, settings);
-                    if (endnotesSection != null)
-                        bodyContent.Add(endnotesSection);
+                    // Endnotes render at document end. In paginated mode CreateSectionDivs has
+                    // already placed them inside the staging area (last section div) so they
+                    // flow onto the final page(s); adding them here too would duplicate them
+                    // outside any page.
+                    if (!usePaginatedFootnotes)
+                    {
+                        var endnotesSection = RenderEndnotesSection(wordDoc, settings);
+                        if (endnotesSection != null)
+                            bodyContent.Add(endnotesSection);
+                    }
                 }
 
                 // Add footers at the bottom if enabled (non-paginated mode only)
@@ -3354,11 +3373,11 @@ namespace Docxodus
             if (footnoteId == null)
                 return null;
 
-            // Get display number from tracker (sequential 1, 2, 3... based on document order)
+            // Get display number from tracker (sequential, rendered in the effective w:numFmt)
             var root = element.AncestorsAndSelf().Last();
             var tracker = root.Annotation<FootnoteNumberingTracker>();
             var displayNumber = tracker?.FootnoteIdToDisplayNumber.TryGetValue(footnoteId, out var num) == true
-                ? num.ToString()
+                ? FormatNoteNumber(num, tracker.FootnoteNumberFormat)
                 : footnoteId; // Fallback to XML ID if not found
 
             // Put <sup> inside anchor like LibreOffice does for clean inline rendering
@@ -3384,11 +3403,12 @@ namespace Docxodus
             if (endnoteId == null)
                 return null;
 
-            // Get display number from tracker (sequential 1, 2, 3... based on document order)
+            // Get display number from tracker (sequential, rendered in the effective w:numFmt —
+            // Word's default for endnotes is lowerRoman, so an unconfigured document shows i, ii…)
             var root = element.AncestorsAndSelf().Last();
             var tracker = root.Annotation<FootnoteNumberingTracker>();
             var displayNumber = tracker?.EndnoteIdToDisplayNumber.TryGetValue(endnoteId, out var num) == true
-                ? num.ToString()
+                ? FormatNoteNumber(num, tracker.EndnoteNumberFormat)
                 : endnoteId; // Fallback to XML ID if not found
 
             // Put <sup> inside anchor like LibreOffice does for clean inline rendering
@@ -3442,6 +3462,7 @@ namespace Docxodus
                 new XAttribute("class", "footnotes"),
                 new XElement(Xhtml.hr),
                 new XElement(Xhtml.ol,
+                    new XAttribute("style", $"list-style-type: {NoteListStyleType(tracker?.FootnoteNumberFormat ?? "decimal")};"),
                     orderedFootnotes.Select(fn => RenderFootnoteItem(wordDoc, settings, fn, "fn", tracker))));
 
             return footnotesSection;
@@ -3488,6 +3509,7 @@ namespace Docxodus
                 new XAttribute("class", "endnotes"),
                 new XElement(Xhtml.hr),
                 new XElement(Xhtml.ol,
+                    new XAttribute("style", $"list-style-type: {NoteListStyleType(tracker?.EndnoteNumberFormat ?? "lowerRoman")};"),
                     orderedEndnotes.Select(en => RenderFootnoteItem(wordDoc, settings, en, "en", tracker))));
 
             return endnotesSection;
@@ -3606,9 +3628,9 @@ namespace Docxodus
                 if (footnoteId == null)
                     continue;
 
-                // Get display number from tracker
+                // Get display number from tracker, rendered in the effective w:numFmt
                 var displayNumber = tracker?.FootnoteIdToDisplayNumber.TryGetValue(footnoteId, out var num) == true
-                    ? num.ToString()
+                    ? FormatNoteNumber(num, tracker.FootnoteNumberFormat)
                     : footnoteId;
 
                 // Convert the content of the footnote
@@ -5337,6 +5359,21 @@ namespace Docxodus
                     var footnoteRegistry = RenderPaginatedFootnoteRegistry(wordDoc, settings);
                     if (footnoteRegistry != null)
                         stagingContent.Add(footnoteRegistry);
+
+                    // Endnotes are document content and must FLOW after the last body block —
+                    // Word and LibreOffice both lay them out at the end of the document, on a
+                    // page. The paginator only pages content found inside [data-section-index]
+                    // wrappers within the staging area, so the non-paginated placement (a
+                    // body-level sibling of the staging/container divs) never reaches any page
+                    // and the endnotes silently vanish from the print layout. Appending the
+                    // section to the LAST section div makes it an ordinary measured block that
+                    // lands on the final page(s).
+                    if (divList.Count > 0)
+                    {
+                        var endnotesSection = RenderEndnotesSection(wordDoc, settings);
+                        if (endnotesSection != null)
+                            divList[divList.Count - 1].Add(endnotesSection);
+                    }
                 }
 
                 // Add section content
@@ -6522,6 +6559,52 @@ namespace Docxodus
                 }
             }
         }
+
+        /// <summary>
+        /// Resolves the effective ST_NumberFormat token for footnote or endnote markers.
+        /// A w:numFmt inside a section's w:footnotePr/w:endnotePr wins over the document-wide
+        /// declaration in settings.xml; with neither present, Word's spec defaults apply —
+        /// decimal for footnotes but lowerRoman for endnotes (ECMA-376 §17.11.17/§17.11.19).
+        /// </summary>
+        private static string GetNoteNumberFormat(WordprocessingDocument wordDoc, XName notePrName, string specDefault)
+        {
+            var body = wordDoc.MainDocumentPart?.GetXDocument().Root?.Element(W.body);
+            var sectionFormat = body?.Descendants(W.sectPr)
+                .Select(sectPr => (string)sectPr.Element(notePrName)?.Element(W.numFmt)?.Attribute(W.val))
+                .FirstOrDefault(v => v != null);
+            if (sectionFormat != null)
+                return sectionFormat;
+
+            var settingsFormat = (string)GetSettingsXDocumentOrDefault(wordDoc)?.Root
+                ?.Element(notePrName)?.Element(W.numFmt)?.Attribute(W.val);
+            return settingsFormat ?? specDefault;
+        }
+
+        /// <summary>
+        /// Renders a note's sequential display number in the given ST_NumberFormat token
+        /// (e.g. 1 → "i" for lowerRoman). Tokens without a numbering algorithm fall back
+        /// to the decimal spelling so a marker never renders as empty text.
+        /// </summary>
+        private static string FormatNoteNumber(int number, string numFmt)
+        {
+            var text = ListItemTextGetter_Default.GetListItemText("en-US", number, numFmt);
+            return string.IsNullOrEmpty(text) ? number.ToString() : text;
+        }
+
+        /// <summary>
+        /// CSS list-style-type equivalent of an ST_NumberFormat token, for the footnotes/endnotes
+        /// section &lt;ol&gt; — the li elements carry numeric value attributes, and the browser
+        /// renders those values in this style. Unmapped tokens fall back to decimal.
+        /// </summary>
+        private static string NoteListStyleType(string numFmt) => numFmt switch
+        {
+            "lowerRoman" => "lower-roman",
+            "upperRoman" => "upper-roman",
+            "lowerLetter" => "lower-alpha",
+            "upperLetter" => "upper-alpha",
+            "decimalZero" => "decimal-leading-zero",
+            _ => "decimal",
+        };
 
         /// <summary>
         /// Maps Windows system color names to hex values.

--- a/docs/ooxml_corner_cases.md
+++ b/docs/ooxml_corner_cases.md
@@ -1015,6 +1015,50 @@ saved package.
 
 ---
 
+## Endnotes: the default `w:numFmt` is lowerRoman, not decimal
+
+### The behavior
+
+Footnote and endnote markers do **not** share a default numbering format. With no `w:numFmt`
+declared anywhere — no `w:footnotePr`/`w:endnotePr` in the settings part, none in any `w:sectPr` —
+Word and LibreOffice number footnotes `1, 2, 3…` but endnotes `i, ii, iii…` (lowercase roman).
+ECMA-376 pins this: `w:numFmt`'s default is `decimal` in a footnote context (§17.11.17/§17.11.18)
+but `lowerRoman` in an endnote context (§17.11.17/§17.11.19). A typical Word-authored package
+carries a `w:endnotePr` in settings.xml that declares only the two reserved separator notes and
+**no** `w:numFmt` at all, so the spec default is what actually renders.
+
+Precedence when the format IS declared: a `w:numFmt` inside a section's `w:sectPr/w:endnotePr`
+overrides the document-wide declaration in settings.xml for that section.
+
+### Minimal reproducer
+
+```xml
+<!-- word/settings.xml — Word's usual shape: endnotePr present, numFmt absent -->
+<w:endnotePr>
+  <w:endnote w:id="-1"/>
+  <w:endnote w:id="0"/>
+</w:endnotePr>
+```
+
+Cite one endnote from the body (`TestFiles/WC/WC036-Endnote-With-Table-Before.docx` is exactly
+this shape).
+
+### Renderer comparison
+
+| Renderer | Endnote marker | Footnote marker |
+|----------|----------------|-----------------|
+| Word | `i` | `1` |
+| LibreOffice | `i` | `1` |
+| Docxodus (before fix) | `1` | `1` |
+| Docxodus (issue #414 fix) | `i` | `1` |
+
+### Relevant code
+
+`WmlToHtmlConverter.GetNoteNumberFormat` resolves the effective token (sectPr-level `notePr` →
+settings-part `notePr` → spec default), `FormatNoteNumber` renders the glyph via
+`ListItemTextGetter_Default.GetListItemText`, and the footnotes/endnotes section `<ol>` carries
+the matching CSS `list-style-type` (`NoteListStyleType`).
+
 ## Layout: Word's line breaking and table sizing have no matching CSS default
 
 ### The behavior


### PR DESCRIPTION
Fixes #414 (visual-parity corpus case `endnote`, `TestFiles/WC/WC036-Endnote-With-Table-Before.docx`).

## Root causes

**1. The endnotes section never reached a page in print layout.** In `PaginationMode.Paginated` the converter emitted `section.endnotes` as a body-level *sibling* of the `#pagination-staging`/`#pagination-container` divs (the "Endnotes always render at document end" branch). But `PaginationEngine.paginate()` only flows content found inside `[data-section-index]` wrappers within the staging area — so the section was never measured, never assigned to a page, and ended up stranded below the page stack on the container background, invisible to the page-screenshot parity harness.

**2. Endnote markers rendered decimal.** Display numbers were hardcoded `num.ToString()` and the notes-section `<ol>` used the browser's decimal default. ECMA-376's default `w:numFmt` differs per note kind: decimal for footnotes but **lowerRoman** for endnotes — and the fixture (like most Word documents) carries a `w:endnotePr` with no `w:numFmt`, so the spec default is what Word/LibreOffice render (`i`).

## Fix

- `CreateSectionDivs` now appends the endnotes section inside the **last section div in the staging area** (paginated mode only), where the paginator measures and flows it as an ordinary block at the end of the document — the way Word and LibreOffice lay endnotes out. The body-transform site skips the old sibling placement in paginated mode so the section isn't duplicated. No `pagination.ts` change needed.
- New `GetNoteNumberFormat` resolves the effective `ST_NumberFormat` token (section-level `w:footnotePr`/`w:endnotePr` › settings-part declaration › spec default), stored on the existing `FootnoteNumberingTracker`. Citation markers (`ProcessFootnoteReference`/`ProcessEndnoteReference`), the paginated footnote-registry labels, and the notes-section `<ol>` (via a `list-style-type` mapping) all render through it, delegating glyph generation to the existing `ListItemTextGetter_Default`.

## Verification

- New tests `HC008f` (endnotes section is unique and lives inside a `[data-section-index]` wrapper in `#pagination-staging`) and `HC008g` (marker `<sup>` renders `i`, endnotes `<ol>` is lower-roman, footnote markers stay `1`).
- Full .NET suite: **3429 passed, 0 failed**.
- Browser-verified with Chromium + the real `pagination.ts` engine on WC036: before — endnotes in no page box, marker `1`; after — endnotes (separator, `i.` label, and the note's table) on the final page, marker `i`, matching LibreOffice.

Also documents the endnote-default corner case in `docs/ooxml_corner_cases.md` and adds a CHANGELOG entry.

Known follow-up (out of scope): the browser editor's `renumberNoteChrome` rewrites marker text with decimal ordinals after note edits; carrying the format to that client-side path is an editor concern, not a converter one.

---
_Generated by [Claude Code](https://claude.ai/code/session_019AwvHn97eQV2bWWME1N8GB)_