### PR TITLE
Fix list-number suffix tab overshooting the text indent under estimated font metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,26 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - **List-number suffix tabs now advance to the paragraph's text indent instead
   of overshooting to the next default tab stop** (issue #415) — the
-  unknown-font text-width estimation charged a flat 0.6 em per character,
+  unknown-font text-width estimation charges a flat 0.6 em per character,
   roughly double the real width of narrow-glyph list markers like `(a)`/`(iii)`
   (Times New Roman `(a)` at 12 pt is ~0.94 em, not 1.8 em). The overestimated
   marker pushed the computed pen position past the paragraph's text-indent tab
   stop, so the marker's suffix tab resolved to the next `w:defaultTabStop`
   multiple and every numbered clause body started ~0.25" too far right — in
   exactly the hanging-indent legal-list shape (`w:ind w:left="1080"
-  w:hanging="360"`) where the marker plainly fits. `MetricsGetter` now exposes
-  a shared character-class-aware `EstimateTextWidth` (hairline / narrow / wide
-  / uppercase / CJK-fullwidth em classes modeled on Times New Roman & Calibri
-  averages, zero-width characters at 0), and all four estimation fallbacks
-  (WASM build, unavailable font, measurement error, and the HTML converter's
-  unknown-font path) route through it, so the suffix tab lands on the text
-  indent whenever the number genuinely ends before it — matching Word's rule
-  and LibreOffice's rendering.
+  w:hanging="360"`) where the marker plainly fits. Generated list-marker runs
+  now measure through a character-class-aware estimate
+  (`MetricsGetter.EstimateTextWidth`: hairline / narrow / wide / uppercase /
+  CJK-fullwidth em classes modeled on Times New Roman & Calibri averages), so
+  the suffix tab lands on the text indent whenever the number genuinely ends
+  before it — matching Word's rule and LibreOffice's rendering. The
+  character-class estimate is deliberately scoped to marker runs: general tab
+  layout reserves (stop − estimated following-text width) ahead of the
+  browser's real glyphs, and browser fallback fonts advance at ~0.6 em, so the
+  flat general estimate must stay put or column-edge tab lines (TOC entries)
+  would overflow and wrap; a marker's wrapper is (chosen stop − marker start)
+  with a flex tab absorbing any glyph-width error, so only its stop choice
+  needs realistic widths.
 - **Paginated print layout no longer drops the endnotes section, and endnote
   markers render in Word's default lowercase-roman format** (issue #414) — in
   `PaginationMode.Paginated` the converter emitted `section.endnotes` as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **List-number suffix tabs now advance to the paragraph's text indent instead
+  of overshooting to the next default tab stop** (issue #415) — the
+  unknown-font text-width estimation charged a flat 0.6 em per character,
+  roughly double the real width of narrow-glyph list markers like `(a)`/`(iii)`
+  (Times New Roman `(a)` at 12 pt is ~0.94 em, not 1.8 em). The overestimated
+  marker pushed the computed pen position past the paragraph's text-indent tab
+  stop, so the marker's suffix tab resolved to the next `w:defaultTabStop`
+  multiple and every numbered clause body started ~0.25" too far right — in
+  exactly the hanging-indent legal-list shape (`w:ind w:left="1080"
+  w:hanging="360"`) where the marker plainly fits. `MetricsGetter` now exposes
+  a shared character-class-aware `EstimateTextWidth` (hairline / narrow / wide
+  / uppercase / CJK-fullwidth em classes modeled on Times New Roman & Calibri
+  averages, zero-width characters at 0), and all four estimation fallbacks
+  (WASM build, unavailable font, measurement error, and the HTML converter's
+  unknown-font path) route through it, so the suffix tab lands on the text
+  indent whenever the number genuinely ends before it — matching Word's rule
+  and LibreOffice's rendering.
 - **Paginated print layout no longer drops the endnotes section, and endnote
   markers render in Word's default lowercase-roman format** (issue #414) — in
   `PaginationMode.Paginated` the converter emitted `section.endnotes` as a

--- a/Docxodus.Tests/HtmlConversionOpsTests.cs
+++ b/Docxodus.Tests/HtmlConversionOpsTests.cs
@@ -223,9 +223,9 @@ public class HtmlConversionOpsTests
     }
 
     [Theory]
-    [InlineData("right", "W", "3.500", "width: 3.900in")]
-    [InlineData("center", "WWWW", "3.400", "width: 3.800in")]
-    [InlineData("decimal", "12.34", "3.400", "width: 3.800in")]
+    [InlineData("right", "W", "3.692", "width: 3.859in")]
+    [InlineData("center", "WWWW", "3.550", "width: 3.717in")]
+    [InlineData("decimal", "12.34", "3.667", "width: 3.834in")]
     public void HCO088_AlignedTabWidth_MeasuresOnlyFollowingText(
         string alignment, string after, string expectedTabWidth, string expectedPrecedingWidth)
     {
@@ -281,11 +281,11 @@ public class HtmlConversionOpsTests
         var wideCurrent = Geometry("iiiiiiii", "W");
         var wideFollowing = Geometry("iiii", "WWWWW");
 
-        Assert.Equal(3.50m, narrowCurrent.TabWidth);
-        Assert.Equal(3.10m, wideCurrent.TabWidth);
+        Assert.Equal(3.69m, narrowCurrent.TabWidth);
+        Assert.Equal(3.53m, wideCurrent.TabWidth);
         Assert.Equal(narrowCurrent.PrecedingWidth, wideCurrent.PrecedingWidth);
-        Assert.Equal(3.900m, narrowCurrent.PrecedingWidth);
-        Assert.Equal(3.500m, wideFollowing.PrecedingWidth);
+        Assert.Equal(3.859m, narrowCurrent.PrecedingWidth);
+        Assert.Equal(3.293m, wideFollowing.PrecedingWidth);
     }
 
     [Fact]
@@ -304,8 +304,97 @@ public class HtmlConversionOpsTests
 
         Assert.Equal("right", (string?)leader.Attribute("data-docx-tab"));
         Assert.Empty(leader.Value);
-        Assert.Contains("width: 3.50in", (string?)leader.Attribute("style"));
+        Assert.Contains("width: 3.69in", (string?)leader.Attribute("style"));
         Assert.Contains("border-bottom: 1px dotted currentColor", (string?)leader.Attribute("style"));
+    }
+
+    [Fact]
+    public void HCO094_ListMarkerSuffixTab_AdvancesToTextIndentNotNextDefaultStop()
+    {
+        // Issue #415: on a hanging-indent numbered paragraph (marker at left − hanging, text at
+        // left), the marker's suffix tab must advance to the paragraph's text indent when the
+        // number ends before it — not to the next w:defaultTabStop multiple. The old flat
+        // 0.6 em/char width estimate nearly doubled "(a)"/"(iii)", overshooting the text-indent
+        // stop. The marker wrapper's width equals (chosen stop − marker start), so the correct
+        // stop makes every wrapper exactly hanging-width wide (360 twips = 0.25") regardless of
+        // the estimated marker width.
+        using var stream = new MemoryStream();
+        using (var doc = WordprocessingDocument.Create(stream,
+                   DocumentFormat.OpenXml.WordprocessingDocumentType.Document))
+        {
+            var main = doc.AddMainDocumentPart();
+
+            static Wp.Paragraph ListParagraph(int ilvl, string text) => new(
+                new Wp.ParagraphProperties(
+                    new Wp.NumberingProperties(
+                        new Wp.NumberingLevelReference { Val = ilvl },
+                        new Wp.NumberingId { Val = 1 })),
+                new Wp.Run(new Wp.Text(text)));
+
+            main.Document = new Wp.Document(
+                new Wp.Body(
+                    ListParagraph(0, "Confidential Information definition."),
+                    ListParagraph(1, "advisory and analysis services;"),
+                    ListParagraph(1, "implementation and configuration services; and"),
+                    ListParagraph(1, "training and knowledge-transfer services."),
+                    new Wp.SectionProperties(
+                        new Wp.PageSize { Width = 12240, Height = 15840 },
+                        new Wp.PageMargin { Top = 1440, Right = 1440, Bottom = 1440, Left = 1440 })));
+
+            static Wp.Level NumberingLevel(
+                int ilvl, Wp.NumberFormatValues format, string text, int left) => new(
+                new Wp.StartNumberingValue { Val = 1 },
+                new Wp.NumberingFormat { Val = format },
+                new Wp.LevelText { Val = text },
+                new Wp.LevelJustification { Val = Wp.LevelJustificationValues.Left },
+                new Wp.PreviousParagraphProperties(
+                    new Wp.Indentation { Left = left.ToString(), Hanging = "360" }))
+            {
+                LevelIndex = ilvl,
+            };
+
+            main.AddNewPart<NumberingDefinitionsPart>().Numbering = new Wp.Numbering(
+                new Wp.AbstractNum(
+                    NumberingLevel(0, Wp.NumberFormatValues.LowerLetter, "(%1)", 1080),
+                    NumberingLevel(1, Wp.NumberFormatValues.LowerRoman, "(%2)", 1800))
+                {
+                    AbstractNumberId = 0,
+                },
+                new Wp.NumberingInstance(
+                    new Wp.AbstractNumId { Val = 0 })
+                {
+                    NumberID = 1,
+                });
+
+            // An unavailable font forces the deterministic character-class width estimate.
+            main.AddNewPart<StyleDefinitionsPart>().Styles = new Wp.Styles(
+                new Wp.DocDefaults(
+                    new Wp.RunPropertiesDefault(
+                        new Wp.RunPropertiesBaseStyle(
+                            new Wp.RunFonts
+                            {
+                                Ascii = "MissingTabGeometryFont",
+                                HighAnsi = "MissingTabGeometryFont",
+                            },
+                            new Wp.FontSize { Val = "24" }))));
+            main.Document.Save();
+        }
+
+        string html = HtmlConversionOps.ConvertToHtml(stream.ToArray(),
+            new HtmlConversionOptions { FabricateCssClasses = false });
+        var root = XElement.Parse(html);
+
+        // The outer marker wrapper (number + suffix tab) carries the width; markers themselves
+        // render as "(a)", "(i)", "(ii)", "(iii)".
+        var wrappers = root.Descendants()
+            .Where(element => (string?)element.Attribute("data-list-marker") == "true" &&
+                ((string?)element.Attribute("style") ?? "").Contains("width:"))
+            .ToList();
+
+        Assert.Equal(4, wrappers.Count);
+        Assert.Equal(new[] { "(a)", "(i)", "(ii)", "(iii)" }, wrappers.Select(w => w.Value.Trim()));
+        Assert.All(wrappers, wrapper =>
+            Assert.Contains("width: 0.250in", (string?)wrapper.Attribute("style")));
     }
 
     [Fact]

--- a/Docxodus.Tests/HtmlConversionOpsTests.cs
+++ b/Docxodus.Tests/HtmlConversionOpsTests.cs
@@ -223,9 +223,9 @@ public class HtmlConversionOpsTests
     }
 
     [Theory]
-    [InlineData("right", "W", "3.692", "width: 3.859in")]
-    [InlineData("center", "WWWW", "3.550", "width: 3.717in")]
-    [InlineData("decimal", "12.34", "3.667", "width: 3.834in")]
+    [InlineData("right", "W", "3.500", "width: 3.900in")]
+    [InlineData("center", "WWWW", "3.400", "width: 3.800in")]
+    [InlineData("decimal", "12.34", "3.400", "width: 3.800in")]
     public void HCO088_AlignedTabWidth_MeasuresOnlyFollowingText(
         string alignment, string after, string expectedTabWidth, string expectedPrecedingWidth)
     {
@@ -281,11 +281,11 @@ public class HtmlConversionOpsTests
         var wideCurrent = Geometry("iiiiiiii", "W");
         var wideFollowing = Geometry("iiii", "WWWWW");
 
-        Assert.Equal(3.69m, narrowCurrent.TabWidth);
-        Assert.Equal(3.53m, wideCurrent.TabWidth);
+        Assert.Equal(3.50m, narrowCurrent.TabWidth);
+        Assert.Equal(3.10m, wideCurrent.TabWidth);
         Assert.Equal(narrowCurrent.PrecedingWidth, wideCurrent.PrecedingWidth);
-        Assert.Equal(3.859m, narrowCurrent.PrecedingWidth);
-        Assert.Equal(3.293m, wideFollowing.PrecedingWidth);
+        Assert.Equal(3.900m, narrowCurrent.PrecedingWidth);
+        Assert.Equal(3.500m, wideFollowing.PrecedingWidth);
     }
 
     [Fact]
@@ -304,7 +304,7 @@ public class HtmlConversionOpsTests
 
         Assert.Equal("right", (string?)leader.Attribute("data-docx-tab"));
         Assert.Empty(leader.Value);
-        Assert.Contains("width: 3.69in", (string?)leader.Attribute("style"));
+        Assert.Contains("width: 3.50in", (string?)leader.Attribute("style"));
         Assert.Contains("border-bottom: 1px dotted currentColor", (string?)leader.Attribute("style"));
     }
 
@@ -313,11 +313,12 @@ public class HtmlConversionOpsTests
     {
         // Issue #415: on a hanging-indent numbered paragraph (marker at left − hanging, text at
         // left), the marker's suffix tab must advance to the paragraph's text indent when the
-        // number ends before it — not to the next w:defaultTabStop multiple. The old flat
-        // 0.6 em/char width estimate nearly doubled "(a)"/"(iii)", overshooting the text-indent
-        // stop. The marker wrapper's width equals (chosen stop − marker start), so the correct
-        // stop makes every wrapper exactly hanging-width wide (360 twips = 0.25") regardless of
-        // the estimated marker width.
+        // number ends before it — not to the next w:defaultTabStop multiple. The flat general
+        // 0.6 em/char width estimate nearly doubles "(a)"/"(iii)", overshooting the text-indent
+        // stop; marker runs therefore measure through the character-class estimate. The marker
+        // wrapper's width equals (chosen stop − marker start), so the correct stop makes every
+        // wrapper exactly hanging-width wide (360 twips = 0.25") regardless of the estimated
+        // marker width.
         using var stream = new MemoryStream();
         using (var doc = WordprocessingDocument.Create(stream,
                    DocumentFormat.OpenXml.WordprocessingDocumentType.Document))

--- a/Docxodus/MetricsGetter.cs
+++ b/Docxodus/MetricsGetter.cs
@@ -104,16 +104,57 @@ namespace Docxodus
             return metrics;
         }
 
+        /// <summary>
+        /// Deterministic text-width estimate for text that cannot be measured with real font
+        /// metrics (WASM builds, and hosts where the requested font is not installed).
+        /// Returns width in font-size units — (summed per-character em fractions) × (sz / 2)
+        /// points — the same unit convention the measurement path returns.
+        ///
+        /// The previous estimate charged a flat 0.6 em for every character, which roughly
+        /// doubles the width of narrow-glyph strings such as the list markers "(a)"/"(iii)".
+        /// That pushed the computed pen position of a numbered paragraph past its text-indent
+        /// tab stop, so the marker's suffix tab resolved to the next default tab stop and every
+        /// clause body started ~0.25" too far right (issue #415). The per-class widths below
+        /// track Times New Roman / Calibri averages closely enough that "does the number end
+        /// before the text indent" decisions match real renderers.
+        /// </summary>
+        public static int EstimateTextWidth(decimal sz, string text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return 0;
+            float em = 0f;
+            foreach (var c in text)
+                em += EstimateCharWidthEm(c);
+            return (int)(em * (float)sz / 2f);
+        }
+
+        private static float EstimateCharWidthEm(char c)
+        {
+            switch (c)
+            {
+                case 'i': case 'j': case 'l': case '.': case ',': case '\'': case '|': case '`':
+                    return 0.25f;
+                case 't': case 'f': case 'r': case 'I': case '!': case ';': case ':':
+                case '(': case ')': case '[': case ']': case '{': case '}':
+                case '"': case '/': case '\\': case ' ': case '-':
+                    return 0.33f;
+                case 'm': case 'w': case 'M': case 'W': case '@': case '%':
+                    return 0.85f;
+                case '\u00AD': case '\u200B': case '\u200C': case '\u200D':
+                    return 0f; // soft hyphen / zero-width characters
+                default:
+                    // CJK ideographs, Hangul syllables, and fullwidth forms occupy a full em.
+                    if (c >= 0x2E80 && (c <= 0xD7A3 || (c >= 0xF900 && c <= 0xFAFF) || (c >= 0xFF01 && c <= 0xFF60)))
+                        return 1.0f;
+                    return char.IsUpper(c) ? 0.7f : 0.5f;
+            }
+        }
+
         private static int _getTextWidth(string fontName, bool bold, bool italic, decimal sz, string text)
         {
 #if WASM_BUILD
-            // In WASM builds, return an estimate based on character count and font size
-            // This is a rough approximation since we don't have SkiaSharp for text measurement
-            if (string.IsNullOrEmpty(text))
-                return 0;
-            // Approximate character width: ~0.6 of the font size for most fonts
-            float charWidth = (float)sz * 0.6f / 2f;
-            return (int)(text.Length * charWidth);
+            // In WASM builds, return an estimate since we don't have SkiaSharp for text measurement
+            return EstimateTextWidth(sz, text);
 #else
             try
             {
@@ -126,20 +167,14 @@ namespace Docxodus
 
                 // If measurement returns 0 (font unavailable), use estimation
                 if (result == 0 && !string.IsNullOrEmpty(text))
-                {
-                    float charWidth = (float)sz * 0.6f / 2f;
-                    return (int)(text.Length * charWidth);
-                }
+                    return EstimateTextWidth(sz, text);
 
                 return result;
             }
             catch
             {
                 // Fallback to estimation on any error
-                if (string.IsNullOrEmpty(text))
-                    return 0;
-                float charWidth = (float)sz * 0.6f / 2f;
-                return (int)(text.Length * charWidth);
+                return EstimateTextWidth(sz, text);
             }
 #endif
         }
@@ -175,10 +210,7 @@ namespace Docxodus
             {
                 // This happened on Azure but interestingly enough not while testing locally.
                 // Use estimation instead of returning 0
-                if (string.IsNullOrEmpty(text))
-                    return 0;
-                float charWidth = (float)sz * 0.6f / 2f;
-                return (int)(text.Length * charWidth);
+                return EstimateTextWidth(sz, text);
             }
         }
 

--- a/Docxodus/MetricsGetter.cs
+++ b/Docxodus/MetricsGetter.cs
@@ -105,18 +105,25 @@ namespace Docxodus
         }
 
         /// <summary>
-        /// Deterministic text-width estimate for text that cannot be measured with real font
-        /// metrics (WASM builds, and hosts where the requested font is not installed).
+        /// Character-class-aware text-width estimate for LIST-MARKER runs whose font cannot be
+        /// measured with real metrics (WASM builds, and hosts where the font is not installed).
         /// Returns width in font-size units — (summed per-character em fractions) × (sz / 2)
         /// points — the same unit convention the measurement path returns.
         ///
-        /// The previous estimate charged a flat 0.6 em for every character, which roughly
-        /// doubles the width of narrow-glyph strings such as the list markers "(a)"/"(iii)".
-        /// That pushed the computed pen position of a numbered paragraph past its text-indent
-        /// tab stop, so the marker's suffix tab resolved to the next default tab stop and every
-        /// clause body started ~0.25" too far right (issue #415). The per-class widths below
-        /// track Times New Roman / Calibri averages closely enough that "does the number end
-        /// before the text indent" decisions match real renderers.
+        /// The general fallback (a flat 0.6 em per character) roughly doubles the width of
+        /// narrow-glyph markers such as "(a)"/"(iii)", pushing the computed pen position of a
+        /// numbered paragraph past its text-indent tab stop so the marker's suffix tab resolved
+        /// to the next default tab stop — every clause body ~0.25" too far right (issue #415).
+        /// The per-class widths below track Times New Roman / Calibri averages closely enough
+        /// that "does the number end before the text indent" decisions match real renderers.
+        ///
+        /// This is deliberately NOT the general text fallback. For ordinary tab runs the HTML
+        /// layout reserves (tab stop − estimated following-text width) and the browser paints
+        /// the real glyphs after that reservation, so the flat 0.6 em estimate must stay at or
+        /// above browser fallback-font advances (monospace fixtures and DejaVu-class fallbacks
+        /// sit at ~0.6 em) or lines near the column edge overflow and wrap. A list marker is
+        /// safe: its wrapper is (chosen stop − marker start) with a flex tab absorbing any
+        /// glyph-width error, so only the stop choice needs realistic widths.
         /// </summary>
         public static int EstimateTextWidth(decimal sz, string text)
         {
@@ -153,8 +160,13 @@ namespace Docxodus
         private static int _getTextWidth(string fontName, bool bold, bool italic, decimal sz, string text)
         {
 #if WASM_BUILD
-            // In WASM builds, return an estimate since we don't have SkiaSharp for text measurement
-            return EstimateTextWidth(sz, text);
+            // In WASM builds, return an estimate based on character count and font size
+            // This is a rough approximation since we don't have SkiaSharp for text measurement
+            if (string.IsNullOrEmpty(text))
+                return 0;
+            // Approximate character width: ~0.6 of the font size for most fonts
+            float charWidth = (float)sz * 0.6f / 2f;
+            return (int)(text.Length * charWidth);
 #else
             try
             {
@@ -167,14 +179,20 @@ namespace Docxodus
 
                 // If measurement returns 0 (font unavailable), use estimation
                 if (result == 0 && !string.IsNullOrEmpty(text))
-                    return EstimateTextWidth(sz, text);
+                {
+                    float charWidth = (float)sz * 0.6f / 2f;
+                    return (int)(text.Length * charWidth);
+                }
 
                 return result;
             }
             catch
             {
                 // Fallback to estimation on any error
-                return EstimateTextWidth(sz, text);
+                if (string.IsNullOrEmpty(text))
+                    return 0;
+                float charWidth = (float)sz * 0.6f / 2f;
+                return (int)(text.Length * charWidth);
             }
 #endif
         }
@@ -210,7 +228,10 @@ namespace Docxodus
             {
                 // This happened on Azure but interestingly enough not while testing locally.
                 // Use estimation instead of returning 0
-                return EstimateTextWidth(sz, text);
+                if (string.IsNullOrEmpty(text))
+                    return 0;
+                float charWidth = (float)sz * 0.6f / 2f;
+                return (int)(text.Length * charWidth);
             }
         }
 

--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -7524,8 +7524,7 @@ namespace Docxodus
                 // Character-based estimation starts in point space (w:sz is half-points), while
                 // the rest of this method consumes CSS-pixel widths. Normalize it to the same
                 // 96-DPI coordinate space before converting the result to twips below.
-                float charWidth = (float)sz * 0.6f / 2f;
-                w = (int)(runText.Length * charWidth * 96f / 72f);
+                w = MetricsGetter.EstimateTextWidth(sz, runText) * 96 / 72;
             }
             else
             {

--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -7401,7 +7401,10 @@ namespace Docxodus
                     var dummyRun3 = new XElement(W.r, fontNameAtt, languageTypeAtt,
                         runContainingTabToReplace.Elements(W.rPr),
                         currentElement);
-                    var widthOfText = CalcWidthOfRunInTwips(dummyRun3);
+                    // A generated list-number run measures with the narrow-glyph-aware estimate
+                    // so its suffix tab resolves against a realistic pen position (issue #415).
+                    var widthOfText = CalcWidthOfRunInTwips(dummyRun3,
+                        isListMarker: runContainingTabToReplace.Attribute(PtOpenXml.ListItemRun) != null);
 
                     currentElement.Add(new XAttribute(PtOpenXml.TabWidth,
                         string.Format(NumberFormatInfo.InvariantInfo, "{0:0.000}", (decimal) widthOfText/1440m)));
@@ -7467,7 +7470,7 @@ namespace Docxodus
 
         private static HashSet<string> KnownFamilies => FontFamilyHelper.KnownFamilies;
 
-        private static int CalcWidthOfRunInTwips(XElement r)
+        private static int CalcWidthOfRunInTwips(XElement r, bool isListMarker = false)
         {
             var fontName = (string)r.Attribute(PtOpenXml.pt + "FontName") ??
                            (string)r.Ancestors(W.p).First().Attribute(PtOpenXml.pt + "FontName");
@@ -7524,7 +7527,24 @@ namespace Docxodus
                 // Character-based estimation starts in point space (w:sz is half-points), while
                 // the rest of this method consumes CSS-pixel widths. Normalize it to the same
                 // 96-DPI coordinate space before converting the result to twips below.
-                w = MetricsGetter.EstimateTextWidth(sz, runText) * 96 / 72;
+                //
+                // List-marker runs use the character-class estimate: the flat 0.6 em/char
+                // average roughly doubles narrow-glyph markers like "(a)", which pushed the
+                // suffix tab past the paragraph's text-indent stop (issue #415). General text
+                // must KEEP the flat average — HTML tab layout reserves (stop − this estimate)
+                // ahead of the browser's real glyphs, and browser fallback fonts advance at
+                // ~0.6 em, so a lower general estimate makes column-edge tab lines overflow
+                // and wrap. A marker's wrapper is (chosen stop − marker start) with a flex tab
+                // absorbing the difference, so only its stop CHOICE needs realistic widths.
+                if (isListMarker)
+                {
+                    w = MetricsGetter.EstimateTextWidth(sz, runText) * 96 / 72;
+                }
+                else
+                {
+                    float charWidth = (float)sz * 0.6f / 2f;
+                    w = (int)(runText.Length * charWidth * 96f / 72f);
+                }
             }
             else
             {

--- a/npm/tests/tab-geometry.spec.ts
+++ b/npm/tests/tab-geometry.spec.ts
@@ -77,7 +77,8 @@ test.describe('generated tab-stop geometry', () => {
     expect(narrowCurrent.followingRight).toBeCloseTo(TAB_TARGET_PX, 0);
     expect(wideCurrent.followingRight).toBeCloseTo(TAB_TARGET_PX, 0);
     expect(wideFollowing.followingRight).toBeCloseTo(TAB_TARGET_PX, 0);
-    expect(narrowCurrent.tabWidth - wideCurrent.tabWidth).toBeCloseTo(0.4 * 96, 0);
+    // Four extra 'i' characters at the estimator's 0.25 em/char and 12 pt: 4 × 4px.
+    expect(narrowCurrent.tabWidth - wideCurrent.tabWidth).toBeCloseTo(16, 0);
     expect(narrowCurrent.followingLeft - wideFollowing.followingLeft)
       .toBeCloseTo(wideFollowing.followingWidth - narrowCurrent.followingWidth, 0);
   });

--- a/npm/tests/tab-geometry.spec.ts
+++ b/npm/tests/tab-geometry.spec.ts
@@ -77,8 +77,7 @@ test.describe('generated tab-stop geometry', () => {
     expect(narrowCurrent.followingRight).toBeCloseTo(TAB_TARGET_PX, 0);
     expect(wideCurrent.followingRight).toBeCloseTo(TAB_TARGET_PX, 0);
     expect(wideFollowing.followingRight).toBeCloseTo(TAB_TARGET_PX, 0);
-    // Four extra 'i' characters at the estimator's 0.25 em/char and 12 pt: 4 × 4px.
-    expect(narrowCurrent.tabWidth - wideCurrent.tabWidth).toBeCloseTo(16, 0);
+    expect(narrowCurrent.tabWidth - wideCurrent.tabWidth).toBeCloseTo(0.4 * 96, 0);
     expect(narrowCurrent.followingLeft - wideFollowing.followingLeft)
       .toBeCloseTo(wideFollowing.followingWidth - narrowCurrent.followingWidth, 0);
   });


### PR DESCRIPTION
Fixes #415.

## Root cause

The suffix-tab resolution rule was already Word's rule: `CalculateSpanWidthTransform` puts a tab stop at the paragraph's left (text) indent and advances the marker's suffix tab to the first stop past the pen position. What was broken was the **width oracle** feeding that decision. Whenever real font metrics are unavailable — always in the WASM build (the surface the visual-parity corpus measures), and on any host without the document's font — the estimation fallback charges a flat **0.6 em per character**. That is roughly double the real width of narrow-glyph list markers: Times New Roman `(a)` at 12 pt is ~0.94 em, but the estimate said 1.8 em (432 twips).

On VP004's `w:ind w:left="1080" w:hanging="360"` sub-clause lists the marker starts at 720 twips, so the estimated pen position reached 720 + 432 = 1152 > 1080, skipping the text-indent stop and resolving to the next `w:defaultTabStop` multiple (1440 twips). Because the rendered marker wrapper's width is `chosen stop − marker start`, the error is baked into the HTML regardless of the browser's real glyph widths — text at 193 px instead of the declared 168 px, on every numbered clause. The deeper `(i)`/`(ii)`/`(iii)` roman level (text indent 1800) overshot the same way.

## Fix — scoped to list-marker measurement

The first commit retuned the estimator globally; CI showed why that is wrong: for **ordinary** tab runs the HTML layout reserves `(tab stop − estimated following-text width)` ahead of the browser's real glyphs, and the browsers' actual fonts (Liberation Mono in the tab-geometry fixtures, DejaVu-class fallbacks for Calibri in the TOC fixture) advance at ~0.6 em — so lowering the general estimate under-reserves the line, and column-edge tab lines (TOC entries) overflow and wrap. The flat 0.6 em general estimate is load-bearing there.

A list marker has no such coupling: its wrapper is `(chosen stop − marker start)` with a flex tab that absorbs glyph-width error, so only the **stop choice** needs realistic widths. The final shape:

- `MetricsGetter.EstimateTextWidth` — a character-class-aware estimator (hairline 0.25 em / narrow 0.33 em / wide 0.85 em / uppercase 0.7 em / default 0.5 em, modeled on Times New Roman & Calibri averages; full-em CJK/fullwidth; zero-width characters at 0), documented as the **list-marker** estimate.
- `WmlToHtmlConverter.CalcWidthOfRunInTwips` gains an `isListMarker` flag, set only when the measured run carries `PtOpenXml.ListItemRun` (FormattingAssembler's generated number/bullet run). Marker runs use the character-class estimate in the unknown-font branch; everything else keeps the flat 0.6 em byte-for-byte.

With honest marker widths, `(a)` measures 278 twips → pen 998 < 1080 → the suffix tab lands on the text indent, matching LibreOffice and the declared OOXML. Genuinely-too-wide numbers still fall through to the next default stop, which is Word's else-branch.

## Tests

- **HCO094** (new): hanging-indent `lowerLetter`/`lowerRoman` numbered document with an unavailable font; asserts every marker wrapper is exactly `0.250in` — the wrapper width equals *chosen stop − marker start*, so the assertion is measurement-independent and pins the stop choice itself, through `(iii)`, the tightest fit.
- HCO088/HCO089/HCO090 and the Playwright tab-geometry pins are **unchanged from main** (the scoped fix does not touch general tab geometry).
- .NET suite: 3430 passed, 0 failed. The seven Playwright specs that failed on the first commit (`tab-geometry`, `toc-line-geometry`) pass locally against the rebuilt WASM, plus full local Playwright run.

Verified end-to-end on `TestFiles/VP/VP004-Legal-Contract.docx`: every `(a)`–`(d)`/`(i)`–`(iii)` marker wrapper is `0.250in` (text at the declared text indent — 168 px, LibreOffice parity). The corpus `legal-contract` numbers in `BASELINE.md` are measured artifacts of the harness rerun and are left for the next rerun to update.