### PR TITLE
Close out issue #401: per-family generated chart regressions for the cached-data SVG projection

### DIFF
--- a/Docxodus.Tests/HtmlConversionOpsTests.cs
+++ b/Docxodus.Tests/HtmlConversionOpsTests.cs
@@ -416,49 +416,50 @@ public class HtmlConversionOpsTests
         Assert.DoesNotContain("width: 33%;", html);
     }
 
-    [Theory]
-    [InlineData("col", "column")]
-    [InlineData("bar", "bar")]
-    public void HCO087_CachedClusteredChart_RendersAccessibleSvgAtStoredExtent(
-        string barDirection, string expectedChartType)
+    // Chart namespace for the generated chart-package tests below (HCO087/HCO095-HCO098).
+    private static readonly XNamespace ChartC =
+        "http://schemas.openxmlformats.org/drawingml/2006/chart";
+
+    private static XElement GeneratedChartSeries(int index, string name, double[] values)
     {
-        // Build the package independently: chart caches are the portable OOXML display source,
-        // while the embedded workbook is optional and must not be needed by the browser renderer.
+        var c = ChartC;
+        var categories = new[] { "Alpha", "Beta", "Gamma" };
+        return new XElement(c + "ser",
+            new XElement(c + "idx", new XAttribute("val", index)),
+            new XElement(c + "order", new XAttribute("val", index)),
+            new XElement(c + "tx",
+                new XElement(c + "strRef",
+                    new XElement(c + "strCache",
+                        new XElement(c + "ptCount", new XAttribute("val", 1)),
+                        new XElement(c + "pt", new XAttribute("idx", 0),
+                            new XElement(c + "v", name))))),
+            new XElement(c + "cat",
+                new XElement(c + "strRef",
+                    new XElement(c + "strCache",
+                        new XElement(c + "ptCount", new XAttribute("val", categories.Length)),
+                        categories.Select((value, point) =>
+                            new XElement(c + "pt", new XAttribute("idx", point),
+                                new XElement(c + "v", value)))))),
+            new XElement(c + "val",
+                new XElement(c + "numRef",
+                    new XElement(c + "numCache",
+                        new XElement(c + "formatCode", "General"),
+                        new XElement(c + "ptCount", new XAttribute("val", values.Length)),
+                        values.Select((value, point) =>
+                            new XElement(c + "pt", new XAttribute("idx", point),
+                                new XElement(c + "v",
+                                    value.ToString("R", System.Globalization.CultureInfo.InvariantCulture))))))));
+    }
+
+    // Build the package independently: chart caches are the portable OOXML display source,
+    // while the embedded workbook is optional and must not be needed by the browser renderer.
+    private static byte[] GeneratedChartDocxBytes(params XElement[] plotAreaChildren)
+    {
         XNamespace w = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
         XNamespace wp = "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing";
         XNamespace a = "http://schemas.openxmlformats.org/drawingml/2006/main";
-        XNamespace c = "http://schemas.openxmlformats.org/drawingml/2006/chart";
+        var c = ChartC;
         XNamespace r = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
-
-        static XElement Series(XNamespace c, int index, string name, double[] values)
-        {
-            var categories = new[] { "Alpha", "Beta", "Gamma" };
-            return new XElement(c + "ser",
-                new XElement(c + "idx", new XAttribute("val", index)),
-                new XElement(c + "order", new XAttribute("val", index)),
-                new XElement(c + "tx",
-                    new XElement(c + "strRef",
-                        new XElement(c + "strCache",
-                            new XElement(c + "ptCount", new XAttribute("val", 1)),
-                            new XElement(c + "pt", new XAttribute("idx", 0),
-                                new XElement(c + "v", name))))),
-                new XElement(c + "cat",
-                    new XElement(c + "strRef",
-                        new XElement(c + "strCache",
-                            new XElement(c + "ptCount", new XAttribute("val", categories.Length)),
-                            categories.Select((value, point) =>
-                                new XElement(c + "pt", new XAttribute("idx", point),
-                                    new XElement(c + "v", value)))))),
-                new XElement(c + "val",
-                    new XElement(c + "numRef",
-                        new XElement(c + "numCache",
-                            new XElement(c + "formatCode", "General"),
-                            new XElement(c + "ptCount", new XAttribute("val", values.Length)),
-                            values.Select((value, point) =>
-                                new XElement(c + "pt", new XAttribute("idx", point),
-                                    new XElement(c + "v",
-                                        value.ToString("R", System.Globalization.CultureInfo.InvariantCulture))))))));
-        }
 
         using var stream = new MemoryStream();
         using (var doc = WordprocessingDocument.Create(stream,
@@ -471,15 +472,7 @@ public class HtmlConversionOpsTests
                 new XElement(c + "chartSpace",
                     new XElement(c + "chart",
                         new XElement(c + "title"),
-                        new XElement(c + "plotArea",
-                            new XElement(c + "barChart",
-                                new XElement(c + "barDir", new XAttribute("val", barDirection)),
-                                new XElement(c + "grouping", new XAttribute("val", "clustered")),
-                                Series(c, 0, "North", new[] { 2.0, 4.0, 3.0 }),
-                                Series(c, 1, "South", new[] { 3.0, 1.0, 5.0 }),
-                                new XElement(c + "gapWidth", new XAttribute("val", 150))),
-                            new XElement(c + "valAx",
-                                new XElement(c + "scaling"))),
+                        new XElement(c + "plotArea", plotAreaChildren),
                         new XElement(c + "legend")))));
             main.PutXDocument(new XDocument(
                 new XElement(w + "document",
@@ -506,11 +499,33 @@ public class HtmlConversionOpsTests
                                                     new XAttribute(r + "id", chartRelationshipId)))))))),
                         new XElement(w + "sectPr")))));
         }
+        return stream.ToArray();
+    }
 
-        var html = HtmlConversionOps.ConvertToHtml(stream.ToArray(),
+    private static XElement ConvertChartSvg(byte[] bytes)
+    {
+        string html = HtmlConversionOps.ConvertToHtml(bytes,
             new HtmlConversionOptions { FabricateCssClasses = false });
         var root = XElement.Parse(html);
-        var svg = root.Descendants().Single(element => element.Name.LocalName == "svg");
+        return root.Descendants().Single(element => element.Name.LocalName == "svg");
+    }
+
+    [Theory]
+    [InlineData("col", "column")]
+    [InlineData("bar", "bar")]
+    public void HCO087_CachedClusteredChart_RendersAccessibleSvgAtStoredExtent(
+        string barDirection, string expectedChartType)
+    {
+        var c = ChartC;
+        var svg = ConvertChartSvg(GeneratedChartDocxBytes(
+            new XElement(c + "barChart",
+                new XElement(c + "barDir", new XAttribute("val", barDirection)),
+                new XElement(c + "grouping", new XAttribute("val", "clustered")),
+                GeneratedChartSeries(0, "North", new[] { 2.0, 4.0, 3.0 }),
+                GeneratedChartSeries(1, "South", new[] { 3.0, 1.0, 5.0 }),
+                new XElement(c + "gapWidth", new XAttribute("val", 150))),
+            new XElement(c + "valAx",
+                new XElement(c + "scaling"))));
         var bars = svg.Descendants()
             .Where(element => (string?)element.Attribute("class") == "docx-chart-bar")
             .ToList();
@@ -527,15 +542,9 @@ public class HtmlConversionOpsTests
         Assert.Contains(bars, bar => (string?)bar.Attribute("fill") == "#ED7D31");
     }
 
-    private static XElement ConvertFixtureChartSvg(string fixture)
-    {
-        var bytes = File.ReadAllBytes(Path.Combine("..", "..", "..", "..", "TestFiles",
-            Path.Combine(fixture.Split('/'))));
-        string html = HtmlConversionOps.ConvertToHtml(bytes,
-            new HtmlConversionOptions { FabricateCssClasses = false });
-        var root = XElement.Parse(html);
-        return root.Descendants().Single(element => element.Name.LocalName == "svg");
-    }
+    private static XElement ConvertFixtureChartSvg(string fixture) =>
+        ConvertChartSvg(File.ReadAllBytes(Path.Combine("..", "..", "..", "..", "TestFiles",
+            Path.Combine(fixture.Split('/')))));
 
     [Fact]
     public void HCO088_CachedStackedColumnChart_RendersOneStackPerCategory()
@@ -592,6 +601,97 @@ public class HtmlConversionOpsTests
         // The date axis caches serial day numbers (41518 = 9/1/2013); labels render as dates.
         Assert.Contains("9/1/2013", svg.Value);
         Assert.Contains("Car", svg.Value);
+    }
+
+    [Fact]
+    public void HCO095_CachedPercentStackedColumnChart_NormalizesEveryCategoryTo100()
+    {
+        var c = ChartC;
+        var svg = ConvertChartSvg(GeneratedChartDocxBytes(
+            new XElement(c + "barChart",
+                new XElement(c + "barDir", new XAttribute("val", "col")),
+                new XElement(c + "grouping", new XAttribute("val", "percentStacked")),
+                GeneratedChartSeries(0, "North", new[] { 1.0, 3.0, 2.0 }),
+                GeneratedChartSeries(1, "South", new[] { 3.0, 1.0, 6.0 })),
+            new XElement(c + "valAx",
+                new XElement(c + "scaling"))));
+        var bars = svg.Descendants()
+            .Where(element => (string?)element.Attribute("class") == "docx-chart-bar")
+            .ToList();
+
+        Assert.Equal("column-percent-stacked", (string?)svg.Attribute("data-chart-type"));
+        Assert.Equal(6, bars.Count);
+        // Unequal raw totals per category all normalize to a full-height 100% stack.
+        foreach (var category in bars.GroupBy(bar => (string?)bar.Attribute("data-chart-category")))
+            Assert.Equal(100.0, category.Sum(bar => double.Parse(
+                (string)bar.Attribute("data-chart-value")!,
+                System.Globalization.CultureInfo.InvariantCulture)), 6);
+        // The value axis pins at 100% with %-suffixed ticks instead of adding tick headroom.
+        Assert.Contains(svg.Descendants().Where(element => element.Name.LocalName == "text"),
+            text => text.Value == "100%");
+    }
+
+    [Fact]
+    public void HCO096_CachedDoughnutChart_RendersRingSlicesWithHole()
+    {
+        var c = ChartC;
+        var svg = ConvertChartSvg(GeneratedChartDocxBytes(
+            new XElement(c + "doughnutChart",
+                GeneratedChartSeries(0, "Share", new[] { 5.0, 3.0, 2.0 }),
+                new XElement(c + "holeSize", new XAttribute("val", 50)))));
+        var slices = svg.Descendants()
+            .Where(element => (string?)element.Attribute("class") == "docx-chart-slice")
+            .ToList();
+
+        Assert.Equal("doughnut", (string?)svg.Attribute("data-chart-type"));
+        Assert.Equal(3, slices.Count);
+        // A doughnut slice is a ring segment (outer arc + inner hole arc), never a wedge
+        // reaching the center like a pie slice.
+        Assert.All(slices, slice =>
+            Assert.Equal(2, ((string)slice.Attribute("d")!).Split('A').Length - 1));
+        // The pie-family legend lists categories, not the single series.
+        Assert.Contains("Alpha", svg.Value);
+        Assert.Contains("Gamma", svg.Value);
+    }
+
+    [Fact]
+    public void HCO097_CachedStackedAreaChart_StacksSecondBandOnFirst()
+    {
+        var c = ChartC;
+        var svg = ConvertChartSvg(GeneratedChartDocxBytes(
+            new XElement(c + "areaChart",
+                new XElement(c + "grouping", new XAttribute("val", "stacked")),
+                GeneratedChartSeries(0, "North", new[] { 2.0, 4.0, 3.0 }),
+                GeneratedChartSeries(1, "South", new[] { 3.0, 1.0, 5.0 })),
+            new XElement(c + "valAx",
+                new XElement(c + "scaling"))));
+        var areas = svg.Descendants()
+            .Where(element => (string?)element.Attribute("class") == "docx-chart-area")
+            .ToList();
+
+        Assert.Equal("area-stacked", (string?)svg.Attribute("data-chart-type"));
+        Assert.Equal(2, areas.Count);
+        static string[] Points(XElement area) => ((string)area.Attribute("points")!).Split(' ');
+        Assert.All(areas, area => Assert.Equal(6, Points(area).Length));
+        // The second band's bottom edge is the first band's top edge: stacked, not overlaid.
+        Assert.Equal(Points(areas[0]).Take(3),
+            Points(areas[1]).Skip(3).Reverse());
+    }
+
+    [Fact]
+    public void HCO098_UnsupportedChartFamily_DegradesToBlankExtentWithoutCrash()
+    {
+        // Scatter has no cached-values projection; the drawing must degrade to the established
+        // no-chart output (blank extent) rather than fail the whole conversion.
+        var c = ChartC;
+        string html = HtmlConversionOps.ConvertToHtml(GeneratedChartDocxBytes(
+                new XElement(c + "scatterChart",
+                    new XElement(c + "scatterStyle", new XAttribute("val", "lineMarker")),
+                    GeneratedChartSeries(0, "North", new[] { 2.0, 4.0, 3.0 }))),
+            new HtmlConversionOptions { FabricateCssClasses = false });
+
+        Assert.DoesNotContain(XElement.Parse(html).Descendants(),
+            element => element.Name.LocalName == "svg");
     }
 
     [Fact]


### PR DESCRIPTION
Closes #401.

## Root cause

Issue #401's symptom — stacked, percent-stacked, pie/doughnut, line, and area chart families rendering a blank extent — was rooted in `ProcessChart` (`Docxodus/WmlToHtmlConverter.Charts.cs`) hard-gating the cached-data → SVG projection on `c:barChart` + `grouping="clustered"` and returning null for every other family.

That root cause was already remediated on `main` by PR #417, which generalized the projection to all the families #401 lists (plus 3-D variants and date axes). #417 closed issue #411 — a later duplicate of #401 filed from the second-wave visual-parity corpus — but was never linked to #401, which stayed open.

## What this PR adds

Auditing #401's scope and acceptance criteria against `main` left one unmet item: **"independently generated DOCX regressions per family (semantic SVG assertions, no embedded workbook), mirroring HCO087."** HCO088–HCO090 cover stacked-column, pie, and line via committed fixtures, but percent-stacked, doughnut, and area had no regression at all, and nothing pinned the never-crash degrade path for a still-unsupported family.

This PR extracts HCO087's generated chart-package builder into shared helpers (`GeneratedChartSeries` / `GeneratedChartDocxBytes` / `ConvertChartSvg`; HCO087's assertions unchanged) and adds four regressions with no fixture or embedded-workbook dependency:

- **HCO095** percent-stacked column: every category normalizes to a full-height 100% stack; the value axis pins at 100% with %-suffixed ticks
- **HCO096** doughnut: ring slices (outer arc + inner-hole arc), never a wedge to the center; the pie-family legend lists categories
- **HCO097** stacked area: the second band's bottom edge is exactly the first band's top edge — stacked, not overlaid
- **HCO098** scatter (unsupported family): the drawing degrades to the established blank-extent output instead of failing the conversion

New IDs start at HCO095 because HCO091–HCO094 are already taken by later tests in the file (the repo previously had to repair exactly this kind of duplicate-ID collision).

## Remaining acceptance criterion

"The rank-6 corpus chart cases stop being blank and get measured dispositions" requires the visual-parity benchmark rerun under its pinned environment contract (production WASM bundle + recorded Chromium/LibreOffice/Poppler versions); `npm/tests/visual-parity/BASELINE.md` still records `chart-stacked`/`chart-pie`/`chart-line` as `unsupported-feature` from the pre-#417 run. That re-triage belongs to the benchmark's scheduled/manual workflow rather than this test-only change.

## Testing

- `dotnet test --filter "FullyQualifiedName~HtmlConversionOpsTests"` — 62 passed, 0 failed (includes the four new tests and the refactored HCO087)
- `dotnet build -c Release Docxodus.Tests` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tGxpDBSC1EQxGYYHgw4d7

---
_Generated by [Claude Code](https://claude.ai/code/session_017tGxpDBSC1EQxGYYHgw4d7)_