### PR TITLE
Fix mobile Chrome garbling the arcade with extra wrapped rows (device text inflation opt-out + canvas no-wrap pin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **Mobile Chrome no longer garbles the arcade/observatory animations with
+  extra wrapped rows, and the converter opts document text out of
+  device-driven inflation** — on Android the demo's 92-cell frame rows render
+  WIDER than authored: the system has no Courier New (Chrome substitutes a
+  wider monospace face), and mobile Chrome's text autosizer (the system "Text
+  scaling" accessibility setting) inflates text-heavy blocks outright while
+  the section's authored column width stays fixed. Once a row outgrows the
+  6.5in text column, `overflow-wrap: break-word` folds it onto a second line
+  and the frame stacks into garbage — extra lines multiplying as the animation
+  fills the grid (sparse early frames stay narrow, which is why screens
+  "initially looked good" and degraded as the logo swept in). Three layers:
+  (1) the converter's always-emitted document-layout CSS now carries
+  `-webkit-text-size-adjust: 100%; text-size-adjust: 100%` on EVERY document
+  element, not just `body` — the property is non-inherited, and the field
+  evidence shows an intermediate-ancestor rule (the ribbon chrome's existing
+  `.dxr` opt-out, present in the shipped bundle) does not protect the document
+  inside it on a real phone; a word processor never inflates document text —
+  the viewport's fit-to-width zoom is the legibility affordance. (2) The
+  GitHub Pages demo pages carry the same page-level opt-out so the live site
+  (pinned to a released engine) is fixed without waiting for a release.
+  (3) The arcade/observatory drivers pin the canvas paragraph to
+  `white-space: pre` (keyed to its stable Unid), the mechanism-agnostic
+  guarantee: a frame row can never wrap no matter what a platform does to
+  glyph widths — the worst case degrades to a clipped right edge instead of
+  stacked rows. Guarded by `demo-arcade-mobile.spec.ts` under the new
+  `chromium-pixel5` Playwright project, which recreates the phone's condition
+  directly (inflates the document text 175% past the column and asserts the
+  frame stays 26 line boxes; without the pin it measures 130+), and by HC056
+  asserting the new layout-CSS rule.
 - **List-number suffix tabs now advance to the paragraph's text indent instead
   of overshooting to the next default tab stop** (issue #415) — the
   unknown-font text-width estimation charges a flat 0.6 em per character,

--- a/Docxodus.Tests/HtmlConverterTests.cs
+++ b/Docxodus.Tests/HtmlConverterTests.cs
@@ -4232,6 +4232,9 @@ namespace OxPt
         /// A word wider than its column must break rather than overflow, and a table must never
         /// exceed the text column. CSS's defaults do the opposite of Word on both counts, so the
         /// converter emits the rules that restore Word's behavior in EVERY render mode.
+        /// Mobile Chrome's text autosizer must also be opted out on every document element
+        /// (text-size-adjust is non-inherited and Blink consults its own cluster roots), or the
+        /// device re-breaks lines the document authored at a fixed column width.
         /// </summary>
         [Fact]
         public void HC056_DocumentLayoutCss_IsAlwaysEmitted()
@@ -4241,6 +4244,9 @@ namespace OxPt
             Assert.Contains("overflow-wrap: break-word;", htmlString);
             Assert.Contains("max-width: 100%;", htmlString);
             Assert.Contains("overflow-wrap: anywhere;", htmlString);
+            Assert.Contains("body, body * {", htmlString);
+            Assert.Contains("-webkit-text-size-adjust: 100%;", htmlString);
+            Assert.Contains("text-size-adjust: 100%;", htmlString);
         }
 
         /// <summary>

--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -2477,6 +2477,18 @@ namespace Docxodus
         ///    line-height of the raised box removes it from that calculation while leaving its
         ///    own glyph untouched — the same device the converter already uses to keep the two
         ///    compacted pieces of a <c>w:br</c> from contributing a line box.
+        /// 4. <b>The device does not resize the document's text.</b> Chrome on Android runs a
+        ///    "text autosizer" (driven by the OS/browser Text-scaling accessibility setting and
+        ///    the minimum-font-size preference) that multiplies the font size of text-heavy
+        ///    blocks — while the section's authored column width stays fixed, so every line
+        ///    re-breaks and the render no longer matches what the document says (garbling
+        ///    fixed-grid content outright). A word processor never inflates document text; the
+        ///    viewer's zoom is the legibility affordance. <c>text-size-adjust: 100%</c> is the
+        ///    standard opt-out. It is a non-inherited property that Blink consults on the
+        ///    autosizing cluster ROOTS it picks itself (observed on Android: a rule on an
+        ///    intermediate ancestor such as the editor chrome's root does NOT protect the
+        ///    document inside it), so it is emitted on every element of the document rather
+        ///    than only on <c>body</c>.
         /// </remarks>
         private static string GenerateDocumentLayoutCss()
         {
@@ -2484,6 +2496,10 @@ namespace Docxodus
             sb.AppendLine("/* Document layout CSS — Word's layout invariants, which CSS defaults do not match. */");
             sb.AppendLine("body {");
             sb.AppendLine("    overflow-wrap: break-word;");
+            sb.AppendLine("}");
+            sb.AppendLine("body, body * {");
+            sb.AppendLine("    -webkit-text-size-adjust: 100%;");
+            sb.AppendLine("    text-size-adjust: 100%;");
             sb.AppendLine("}");
             sb.AppendLine("table {");
             sb.AppendLine("    max-width: 100%;");

--- a/docs/demo/app.html
+++ b/docs/demo/app.html
@@ -43,6 +43,14 @@
        dead strip the surface can never scroll into. */
     /* Matches the surface's --dxr-desk so the page never flashes a different gray. */
     body { margin: 0; height: 100dvh; background: #f1f5f9; overscroll-behavior: none; }
+    /* Chrome on Android's text autosizer (the system "Text scaling" setting)
+       inflates text-heavy blocks while the document's authored column width
+       stays fixed, re-breaking every line the document says. Opt the editor
+       surface out; the property is non-inherited and Blink consults the
+       autosizing cluster roots it picks itself, hence the universal selector.
+       Newer engines emit this inside the document render too; page-level
+       covers the pinned engine today. */
+    html, body * { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
     #app { height: 100%; }
 
     /* A single "back to the landing page" affordance, docked over the ribbon's own

--- a/docs/demo/arcade.html
+++ b/docs/demo/arcade.html
@@ -27,6 +27,17 @@
        power-on screen shown when the page is embedded in an iframe. */
     html, body { height: 100%; }
     body { margin: 0; background: #e8ecf2; }
+    /* Chrome on Android's text autosizer (the system "Text scaling"
+       accessibility setting) inflates text-heavy blocks while the document's
+       authored column width stays fixed, re-breaking every line — the game
+       screen garbles into extra wrapped rows as frames fill in. A document
+       viewer never inflates document text (the fit-to-width zoom is the
+       legibility affordance), so opt the whole cabinet out. The property is
+       non-inherited and Blink consults the autosizing cluster roots it picks
+       itself (an ancestor-only rule demonstrably does not stick on Android),
+       hence the universal selector. Newer engines emit this inside the
+       document render too; page-level covers the pinned engine today. */
+    html, body * { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
     #app { height: 100%; }
     #home {
       position: fixed; top: 10px; right: 12px; z-index: 50;

--- a/docs/demo/ascii-arcade.js
+++ b/docs/demo/ascii-arcade.js
@@ -26,7 +26,7 @@
 // Playwright webroot gets a pretest copy. It is demo content, not library
 // machinery, and is deliberately NOT shipped in the npm package.
 
-import { COLS, ROWS, frameXml } from './ascii-scenes.js';
+import { COLS, ROWS, frameXml, createCanvasPin } from './ascii-scenes.js';
 import { FREEDOOM_LEVEL } from './freedoom-e1m1.js';
 
 // ─── Screen geometry ──────────────────────────────────────────────────
@@ -1311,6 +1311,8 @@ export function startArcade({ editor, session, ui, cart: startCart, intro = true
   const seeded = seedArcade(session);
   let canvasAnchor = seeded.canvasAnchor;
   let openTag = seeded.openTag;
+  const pinCanvas = createCanvasPin();
+  pinCanvas(canvasAnchor);
 
   const carts = [platformerCart(), dungeonCart(), freedoomCart()];
   let cart = carts.find((c) => c.name === startCart) ?? carts[0];
@@ -1355,6 +1357,7 @@ export function startArcade({ editor, session, ui, cart: startCart, intro = true
     const t1 = performance.now();
     if (!res.success) throw new Error(`replaceXml: ${res.error?.code} ${res.error?.message}`);
     canvasAnchor = res.modified[0]?.id ?? res.created[0]?.id ?? canvasAnchor;
+    pinCanvas(canvasAnchor);
     editor.refresh();
     const t2 = performance.now();
 

--- a/docs/demo/ascii-scenes.js
+++ b/docs/demo/ascii-scenes.js
@@ -302,6 +302,34 @@ export function frameXml(openTag, grid, bg) {
   return { xml: parts.join(''), runs };
 }
 
+/** The canvas rows must NEVER wrap. The grid is authored for Courier New at
+ *  8pt — 92 columns ≈ 6.1in, inside the 6.5in text column — but a platform
+ *  can render it wider than authored: Android has no Courier New (Chrome
+ *  substitutes a wider monospace face), and mobile Chrome's text autosizer
+ *  (the OS "Text scaling" accessibility setting) inflates text-heavy blocks
+ *  outright. Either way an over-wide row folds onto a second line and the
+ *  frame stacks into garbage — extra lines that multiply as the animation
+ *  fills the grid. Pinning `white-space: pre` keeps every row exactly one
+ *  line, so the worst case degrades to a clipped right edge instead.
+ *
+ *  Returns a `pin(canvasAnchor)` the driver calls once per frame: the rule is
+ *  keyed to the canvas paragraph's Unid (stable across frames, so this is a
+ *  no-op except on first paint and after the canvas is rebuilt). */
+export function createCanvasPin() {
+  const style = document.head.appendChild(document.createElement('style'));
+  let pinned = '';
+  return (canvasAnchor) => {
+    const unid = canvasAnchor.split(':')[2];
+    if (!unid || unid === pinned) return;
+    pinned = unid;
+    style.textContent =
+      `[data-anchor="${unid}"], [data-anchor="${unid}"] span {` +
+      ' white-space: pre !important;' +
+      ' -webkit-text-size-adjust: 100% !important; text-size-adjust: 100% !important; }\n' +
+      `[data-anchor="${unid}"] { overflow-x: hidden; }`;
+  };
+}
+
 // ─── The document itself ──────────────────────────────────────────────
 
 /** Seed a freshly opened blank session with the Observatory document — title,
@@ -367,6 +395,8 @@ export function startObservatory({ editor, session, ui }) {
   const seeded = seedObservatory(session);
   let canvasAnchor = seeded.canvasAnchor;
   const openTag = seeded.openTag;
+  const pinCanvas = createCanvasPin();
+  pinCanvas(canvasAnchor);
   editor.refresh();
 
   const unidOf = (anchor) => anchor.split(':')[2];
@@ -398,6 +428,7 @@ export function startObservatory({ editor, session, ui }) {
     const t1 = performance.now();
     if (!res.success) throw new Error(`replaceXml: ${res.error?.code} ${res.error?.message}`);
     canvasAnchor = res.modified[0]?.id ?? res.created[0]?.id ?? canvasAnchor;
+    pinCanvas(canvasAnchor);
 
     editor.refresh();
     const t2 = performance.now();

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -172,6 +172,15 @@
     /* The editor mount. Height is fixed so the surface scrolls the DOCUMENT rather than
        the page — the ribbon has to stay reachable while you scroll a long contract. */
     #workspace { height: clamp(560px, 78vh, 820px); }
+    /* Chrome on Android's text autosizer (the system "Text scaling" setting)
+       would inflate the embedded document's text while its authored column
+       width stays fixed, re-breaking every line the document says — so the
+       editor workspace opts out (the page's own prose keeps autosizing). The
+       property is non-inherited and Blink consults the autosizing cluster
+       roots it picks itself, hence the universal selector. Newer engines emit
+       this inside the document render too; page-level covers the pinned
+       engine today. */
+    #workspace, #workspace * { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
 
     .feature-strip { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; margin-top: 18px; overflow: hidden;
       border: 1px solid var(--line); border-radius: 16px; background: var(--line); box-shadow: var(--shadow-md); }

--- a/docs/demo/observatory.html
+++ b/docs/demo/observatory.html
@@ -14,6 +14,14 @@
        is the observatory dock pinned under the document. */
     html, body { height: 100%; }
     body { margin: 0; background: #e8ecf2; }
+    /* Chrome on Android's text autosizer (the system "Text scaling" setting)
+       inflates text-heavy blocks while the document's authored column width
+       stays fixed, re-breaking every line the document says. Opt the editor
+       surface out; the property is non-inherited and Blink consults the
+       autosizing cluster roots it picks itself, hence the universal selector.
+       Newer engines emit this inside the document render too; page-level
+       covers the pinned engine today. */
+    html, body * { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
     #app { height: 100%; }
     #home {
       position: fixed; top: 10px; right: 12px; z-index: 50;

--- a/docs/demo/player.html
+++ b/docs/demo/player.html
@@ -33,6 +33,14 @@
     :root { color-scheme: dark; --teal: #2DD4BF; --teal-soft: #5EEAD4; }
     * { box-sizing: border-box; }
     html, body { height: 100%; }
+    /* Chrome on Android's text autosizer (the system "Text scaling" setting)
+       inflates text-heavy blocks while the document's authored column width
+       stays fixed, re-breaking every line the document says. Opt the editor
+       surface out; the property is non-inherited and Blink consults the
+       autosizing cluster roots it picks itself, hence the universal selector.
+       Newer engines emit this inside the document render too; page-level
+       covers the pinned engine today. */
+    html, body * { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
     body { position: relative; margin: 0; overflow: hidden; font-family: Inter, ui-sans-serif, system-ui,
       -apple-system, "Segoe UI", sans-serif; background: #0F172A; color: #F8FAFC; display: flex; flex-direction: column; }
     body::before { position: absolute; inset: 0; content: ""; pointer-events: none; background:

--- a/npm/playwright.config.ts
+++ b/npm/playwright.config.ts
@@ -16,6 +16,14 @@ const visualParityLaunchEnv = process.env.DOCXODUS_VISUAL_PARITY === '1'
     }
   : {};
 
+// Sandboxed dev environments often pre-install one pinned Chromium build and
+// block downloads; DOCXODUS_CHROMIUM_PATH points the chromium-based projects
+// at it instead of the per-version browser Playwright would fetch. Unset (the
+// normal case, including CI), Playwright resolves its own browsers.
+const chromiumExecutable = process.env.DOCXODUS_CHROMIUM_PATH
+  ? { executablePath: process.env.DOCXODUS_CHROMIUM_PATH }
+  : {};
+
 export default defineConfig({
   testDir: './tests',
   fullyParallel: false, // WASM tests need sequential execution
@@ -40,7 +48,11 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'], launchOptions: visualParityLaunchEnv },
+      testIgnore: /demo-arcade-mobile\.spec\.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: { ...visualParityLaunchEnv, ...chromiumExecutable },
+      },
     },
     {
       // Firefox is the canary for cross-contenteditable drag feedback: its native selection
@@ -48,6 +60,19 @@ export default defineConfig({
       name: 'firefox-cross-block-selection',
       testMatch: /editor-multiblock-format\.spec\.ts/,
       use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      // Phone-shaped rig for the mobile arcade garble (device-inflated text
+      // re-breaking lines the document authored at a fixed column width):
+      // mobile viewport, touch, and the fit-to-width CSS zoom that a phone
+      // actually exercises. Its spec recreates the platform's text inflation
+      // itself, so it runs here only and the desktop chromium project skips it.
+      name: 'chromium-pixel5',
+      testMatch: /demo-arcade-mobile\.spec\.ts/,
+      use: {
+        ...devices['Pixel 5'],
+        launchOptions: { ...chromiumExecutable },
+      },
     },
   ],
   webServer: [

--- a/npm/src/ribbon-chrome.ts
+++ b/npm/src/ribbon-chrome.ts
@@ -74,6 +74,7 @@ export const RIBBON_CSS = `
   color: var(--dxr-ink);
   background: var(--dxr-desk);
   -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 .dxr *, .dxr *::before, .dxr *::after { box-sizing: border-box; }
 

--- a/npm/tests/demo-arcade-mobile.spec.ts
+++ b/npm/tests/demo-arcade-mobile.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect, Page } from '@playwright/test';
+
+// THE DOCX ARCADE on a phone — the mobile-Chrome regression that garbled the
+// GitHub Pages demo. On Android the canvas rows render WIDER than authored:
+// the system has no Courier New (Chrome substitutes a wider monospace face)
+// and mobile Chrome's text autosizer (the "Text scaling" accessibility
+// setting) inflates text-heavy blocks outright — the ribbon chrome's existing
+// ancestor-level `-webkit-text-size-adjust: 100%` demonstrably does not
+// protect the document inside it on a real phone. Once a 92-cell row outgrows
+// the 6.5in text column, `overflow-wrap: break-word` folds it onto a second
+// line and the frame stacks into garbage — extra lines multiplying as the
+// animation fills the grid (sparse early frames stay narrow, which is why the
+// screen "initially looks good").
+//
+// Neither platform trigger can be reproduced faithfully in a Linux Chromium
+// (its autosizer honors the ancestor rule that the phone ignores, and its
+// fontconfig substitutes a Courier-metric face), so this spec recreates the
+// CONDITION — text wider than the column was authored for — directly, by
+// inflating the canvas font, and asserts the driver's guarantee that makes
+// every trigger harmless: the canvas paragraph is pinned to
+// `white-space: pre`, so a frame row can never wrap; the worst case is a
+// clipped right edge, never stacked rows. Runs under the `chromium-pixel5`
+// project so the whole phone-shaped path (mobile viewport, fit-to-width CSS
+// zoom of the sheet) is the one exercised.
+
+const OVERRIDE = 'engine=./embed.bundle.js';
+
+async function waitForBoot(page: Page) {
+  await page.waitForFunction(
+    () =>
+      (window as any).__arcade !== undefined ||
+      (window as any).__arcadeError !== undefined,
+    { timeout: 90000 },
+  );
+  const err = await page.evaluate(() => (window as any).__arcadeError);
+  expect(err, `arcade boot failed: ${err}`).toBeUndefined();
+}
+
+/** Distinct line-box tops inside the canvas paragraph. The frame is 26 rows
+ * joined by `w:br`, so an intact render is exactly 26 line boxes; every
+ * over-wide row that wraps adds one more. Fragments on the same line share
+ * their top (same font size throughout the canvas), while the paragraph's
+ * exact 10pt line pitch is ≥ ~5px even under the phone's fit-to-width zoom,
+ * so a small fixed tolerance separates lines reliably — including when the
+ * inflated glyph boxes are TALLER than the line pitch. */
+async function canvasLineBoxes(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const el = (window as any).__arcade.canvasElement() as HTMLElement;
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    const rects = Array.from(range.getClientRects()).filter((r) => r.height >= 2);
+    const tops: number[] = [];
+    for (const r of rects) {
+      if (!tops.some((t) => Math.abs(t - r.top) < 2)) tops.push(r.top);
+    }
+    return tops.length;
+  });
+}
+
+/** What the phone does to the document: render its text substantially wider
+ * than the column was authored for. `!important` beats the converter's inline
+ * run styles, exactly as a UA text inflation does. */
+async function inflateDocumentText(page: Page) {
+  await page.addStyleTag({
+    content: '#app [data-anchor], #app [data-anchor] span { font-size: 175% !important; }',
+  });
+}
+
+test.describe('Arcade on a phone-shaped viewport', () => {
+  test('game frame keeps 26 rows with text inflated past the column', async ({ page }) => {
+    // Every game row runs bezel-to-bezel (column 92): un-pinned, 175% text
+    // folds each row onto a second line (52 line boxes) — the field garble.
+    await page.goto(`/demo-arcade.html?${OVERRIDE}&boot=tap&intro=0&cart=quest`);
+    await page.locator('#boot').click();
+    await waitForBoot(page);
+    await page.waitForFunction(() => (window as any).__arcade.frames() >= 3, { timeout: 60000 });
+    await inflateDocumentText(page);
+    await page.waitForFunction(() => (window as any).__arcade.frames() >= 6, { timeout: 60000 });
+    await page.evaluate(() => (window as any).__arcade.pause());
+
+    expect(await canvasLineBoxes(page)).toBe(26);
+  });
+
+  test('attract screen keeps 26 rows as the title card fills in', async ({ page }) => {
+    // The reported repro surface: the intro looked fine at first, then grew
+    // extra lines as the logo sweep filled the grid. Let it run well past the
+    // full title card (t ≈ 4.5s at 10fps) with the text inflated throughout.
+    await page.goto(`/demo-arcade.html?${OVERRIDE}&boot=tap`);
+    await page.locator('#boot').click();
+    await waitForBoot(page);
+    await inflateDocumentText(page);
+    await page.waitForFunction(() => (window as any).__arcade.frames() >= 50, { timeout: 60000 });
+    await page.evaluate(() => (window as any).__arcade.pause());
+
+    expect(await canvasLineBoxes(page)).toBe(26);
+  });
+});


### PR DESCRIPTION
## The bug

On mobile Chrome the GitHub Pages arcade (and observatory) starts clean, then grows **extra lines as the animation plays** — the pixel art stacks into garbage. Games garble immediately; the attract screen degrades as the logo sweep fills the grid.

## Diagnosis

Each frame is one Word paragraph of 92-cell monospace rows joined by `w:br`, authored for Courier New 8pt (~6.1in) inside the section's 6.5in text column. On Android the rows render **wider than authored**, from two compounding causes:

1. **Font substitution** — Android has no Courier New; Chrome substitutes a wider monospace face (~1.2× advance, measurable in the field screenshots).
2. **Mobile Chrome's text autosizer** — the system "Text scaling" accessibility setting inflates text-heavy blocks outright while the authored column width stays fixed.

Once a row outgrows the column, the converter's `overflow-wrap: break-word` folds it onto a second line, and every wrapped row shifts the grid downward — extra lines multiplying as the animation fills in. Sparse early frames stay narrow, which is exactly why it "initially looks good". Desktop-site mode (autosizer off) renders the intro intact, and the shipped bundle's ancestor-level `.dxr` `-webkit-text-size-adjust: 100%` demonstrably does **not** protect the document inside it on a real phone — the property is non-inherited and an intermediate-ancestor rule doesn't stick.

Reproduced headlessly: with Blink's autosizer forced on (`textAutosizingEnabled=true, accessibilityFontScaleFactor=1.3`, Pixel 5 emulation), a converter-shaped 92-char/8pt paragraph measures **52 line boxes instead of 26**; sparse rows stay 26 (the threshold behavior the user observed); `text-size-adjust: 100%` restores 26.

## The fix — three layers, in scope order

- **Converter** (`GenerateDocumentLayoutCss`, invariant 4): `-webkit-text-size-adjust: 100%; text-size-adjust: 100%` on **every document element**, not just `body`. A word processor never inflates document text; the viewport's fit-to-width zoom is the legibility affordance. `HC056` asserts the rule.
- **Demo pages** (`docs/demo/*.html`): the same opt-out page-level (scoped to `#workspace` on `index.html`, whose marketing prose keeps autosizing), so the **live site — pinned to the released 9.8.0 engine — is fixed on merge** without waiting for a release.
- **Demo drivers** (`ascii-scenes.js` `createCanvasPin()`, used by both the arcade and the observatory): pin the canvas paragraph to `white-space: pre`, keyed to its stable Unid. This is the mechanism-agnostic guarantee — a frame row can never wrap no matter what a platform does to glyph widths; the worst case degrades to a slightly clipped right edge instead of stacked rows.

Also: the ribbon chrome's `.dxr` rule gains the unprefixed property, and `playwright.config.ts` learns `DOCXODUS_CHROMIUM_PATH` for sandboxed environments with one pinned Chromium build.

## Regression test

`demo-arcade-mobile.spec.ts` under a new `chromium-pixel5` project (mobile viewport, touch, the fit-to-width CSS zoom a phone exercises). Neither platform trigger reproduces faithfully on Linux Chromium (its autosizer honors the ancestor rule the phone ignores; fontconfig substitutes a Courier-metric face), so the spec recreates the **condition** — text wider than the authored column — by inflating the document text 175% and asserts the frame stays 26 line boxes, on both the attract screen and a game cartridge. Red-checked: with the driver pin stubbed out, it measures 130+.

## Validation

- .NET: Release build (warnings-as-errors) + full suite, 3430 passed / 0 failed
- Playwright: new spec green (and red without the pin); `demo-arcade`, `demo-arcade-freedoom`, `demo-observatory`, `ascii-animation(-editor)`, `cdn-embed` (CSS-scoping round-trip of the new rule), `editor-page-geometry`, `editor-demo-grid` all green
- `npm run test:demo-logic`, `tsc` (src + tests) clean

One caveat worth stating: the Android autosizer path is pinned by field evidence (screenshots, desktop-site behavior, the ineffective `.dxr` rule) plus the flag-forced headless repro — I couldn't run a real Android device here. The `white-space: pre` pin makes the demos immune regardless of which platform mechanism fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EhU125kSMfuWouJWcghDMm

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhU125kSMfuWouJWcghDMm)_