### PR TITLE
ci: run the docx-scalpel Python suite on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,48 @@ jobs:
       - name: TypeScript type check
         run: cd npm && npx tsc --noEmit
 
+  # The docx-scalpel (python/) suite is a client of the .NET core: pyhost.csproj
+  # project-references Docxodus.csproj, so a core change that breaks a DocxSession
+  # op fails here. That is the point of running it on every PR rather than
+  # path-filtering on python/**. python-publish.yml covers the packaged wheel per
+  # RID at release time; this job covers the full suite against the working tree.
+  python-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      # Surface both interpreters' failures in one run.
+      fail-fast: false
+      matrix:
+        # Ends of the range declared by requires-python = ">=3.10" and the
+        # classifiers. 3.11/3.12 sit between them.
+        python-version: ['3.10', '3.13']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # A framework-dependent host is fine here: setup-dotnet makes .NET 10 the
+      # runner's primary runtime, so the apphost resolves it without DOTNET_ROOT.
+      # _host_locator.py's dev fallback then discovers this path by walking up to
+      # Docxodus.sln — no staging into _bin/ and no DOCXODUS_HOST needed.
+      - name: Build docxodus-pyhost
+        run: dotnet build tools/python-host/pyhost.csproj -c Release
+
+      - name: Install docx-scalpel (editable)
+        run: python -m pip install --upgrade pip && python -m pip install -e './python[test]'
+
+      - name: Run Python tests
+        run: python -m pytest python/tests -v
+
   build-matrix:
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
`python/tests` has never run in CI. The only automated check touching the Python client was `python-publish.yml`'s per-RID smoke test, which is a `ping` — it proves the host launches, not that any session op works.

That gap let ~1,500 lines of `python/` land across the `0.1.0a*` series — native comments and threads, footnotes/endnotes, header/footer and page-number authoring, revision listing and per-revision accept/reject, tracked-changes mode switching, list start overrides, block metadata, annotation CRUD — with no automated verification. Cutting `0.1.0` meant running the suite by hand to confirm it worked.

## What this adds

A `python-tests` job in `ci.yml`:

| | |
|---|---|
| Runner | `ubuntu-latest` |
| Python | `3.10` and `3.13` — the ends of the range declared by `requires-python` and the classifiers |
| `fail-fast` | `false`, so both interpreters report |
| Cost | 2 jobs, ~3 min each |

## Two choices worth reviewing

**Host build method.** `dotnet build tools/python-host/pyhost.csproj` rather than the `publish --self-contained` + stage-into-`_bin/` dance `python-publish.yml` does. A framework-dependent binary is fine here because `setup-dotnet` makes .NET 10 the runner's primary runtime, so the apphost resolves it without `DOTNET_ROOT`; `_host_locator.py`'s dev fallback then discovers it by walking up to `Docxodus.sln`. No staging, no `DOCXODUS_HOST`.

**No path filter, deliberately.** `pyhost.csproj` project-references `Docxodus.csproj`, so this job's real value is catching a **core** change that breaks a `DocxSession` op. Filtering on `python/**` would defeat the purpose. This also matches the existing jobs, none of which filter.

## Scope left alone

- `python-publish.yml` still owns per-RID wheel + lifecycle verification at release time; this job covers the full suite against the working tree.
- No lint or type-check on the Python source — none runs today, and that's a separate concern.
- No caching — no existing job caches, and adding it only here would be inconsistent.

## Verification

Replicated the job's steps locally against a clean venv with `DOCXODUS_HOST` unset, so the dev-fallback locator is the one exercised: **77/77 pass**.

The 3.10 leg is checked statically — every file in `python/src` and `python/tests` parses under 3.10 grammar — since only 3.12 is available on this machine. CI is the real test of that leg, and this PR is where it first runs.

## Note for after merge

This adds two required checks (`python-tests (3.10)`, `python-tests (3.13)`). If branch protection lists checks explicitly, they won't be enforced until added there.