### PR TITLE
Fix the red main: assert the thumb pad's cluster, not its wrapper

### DIFF
--- a/npm/tests/social-demo.spec.ts
+++ b/npm/tests/social-demo.spec.ts
@@ -386,10 +386,14 @@ test.describe('The landing page on a phone', () => {
     // The pad sits a fixed distance above the dock, so an opened sheet grows
     // the dock up underneath it: the D-pad covered the cartridge buttons and
     // the telemetry, and took the taps meant for them. It stands down instead.
-    await expect(page.locator('#pad')).toBeHidden();
+    //
+    // Assert on the CLUSTER, not on `#pad`: that wrapper spans the host with
+    // both clusters absolutely positioned inside it, so it is 390 × 0 and
+    // Playwright calls it hidden whether the pad is up or down.
+    await expect(page.locator('.dxa-dpad')).toBeHidden();
     await page.locator('#dockmore').click();
     await expect(page.locator('#dockcarts')).toBeHidden();
-    await expect(page.locator('#pad')).toBeVisible();
+    await expect(page.locator('.dxa-dpad')).toBeVisible();
 
     // Thumb reach, inside the card, and out of the middle of the game screen.
     const geometry = await page.evaluate(() => {


### PR DESCRIPTION
### What broke

#433's last commit made the arcade's thumb pad stand down while the `⋯` sheet is open (it was covering the sheet's own buttons and eating their taps) and asserted it:

```ts
await expect(page.locator('#pad')).toBeHidden();   // passed — for the wrong reason
await page.locator('#dockmore').click();
await expect(page.locator('#pad')).toBeVisible();  // can never pass
```

`#pad` is not the pad. It is the wrapper that spans the host so the two clusters can sit in its bottom corners, and **both clusters are absolutely positioned inside it** — so the wrapper measures 390 × 0 and Playwright calls it hidden whether the pad is up or down. The `toBeHidden()` half passed for a reason unrelated to the behaviour; the `toBeVisible()` half was unsatisfiable.

CI on `main` since the merge:

```
1 failed
  [chromium] › tests/social-demo.spec.ts:363:3 › The landing page on a phone ›
              the floating controls steer the game and keep the screen clear
    Expect "toBeVisible" … locator resolved to <div id="pad" class="dxa-pad">…</div>
      - unexpected value "hidden"
  9 skipped
  483 passed
```

Three `main` runs are red on it (`c391985`, `73e3a73`, `aa70a56`) — the same single test each time.

### The fix

Assert on the cluster, which has a real box. Measured directly in Chromium against the shipped `arcade-dock.js`:

| | `#pad` (wrapper) | `.dxa-dpad` (cluster) |
|---|---|---|
| sheet closed | `display: block`, **390 × 0** | `display: grid`, **146 × 134** |
| sheet open | `display: none`, 0 × 0 | 0 × 0 |

So `.dxa-dpad` distinguishes the two states and `#pad` does not.

**No product code changes.** The behaviour under test was correct before this PR and is unchanged by it — the D-pad really does hide with the sheet and return when it closes. The pad's other assertions already addressed real-size children (`#pad .dxa-dpad`, `#pad .dxa-fire`), which is why they passed and only this pair failed.

### Note on how it got in

#433's first commit was fully green (484 passed). The screenshot pass afterwards caught the real overlap bug, and its fix commit merged ~5 minutes after being pushed, before CI reported on it. The product fix was sound; only the new assertion was wrong.

### Verification

`tsc -p tsconfig.tests.json` passes, and the state table above was measured in a real browser. The Playwright suite itself needs a CI run here — the WASM stack can't be built in this environment (no dotnet).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRx9M5pGmCuwKCq8cSXyqK)_