### PR TITLE
Fix the three regressions that turned Playwright CI red

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -315,6 +315,17 @@ All notable changes to this project will be documented in this file.
   recompile.
 
 ### Changed
+- **A footnote too long for its page now keeps flowing instead of being clipped.**
+  Browser pagination reserves at most 60% of the body height for the note band; a
+  note whose tail did not fit there used to be handed to the next page whole and
+  drawn past the band's bottom edge, so the overflow was in the DOM but not on the
+  page — and therefore missing from the `PageMap` a citation resolves against. The
+  tail is now partitioned at whole-paragraph boundaries and drained across as many
+  note areas as it needs, opening note-only pages after the last body block when
+  the document runs out of pages first. A note is still never split below one
+  paragraph, so an indivisible oversized paragraph keeps the established clipped
+  fallback. Documents whose notes always fit paginate unchanged; a document with a
+  note longer than one page's band gains pages it previously dropped content on.
 - **The GitHub Pages landing page serves THE DOCX ARCADE on a phone, keeps its
   navigation, and gives the arcade thumb controls** — three fixes to the same
   problem, that the demo's mobile visit was its worst one:

--- a/npm/tests/docx-session.spec.ts
+++ b/npm/tests/docx-session.spec.ts
@@ -426,7 +426,9 @@ test.describe('DocxSession (WASM bridge)', () => {
           .map(([id]) => id)[0];
 
         const inserted = JSON.parse(bridge.InsertTable(handle, anchorId, 'after', 3, 3, ''));
-        const topLeft = inserted.created[0].id;   // row-major cell paragraphs
+        // Canonical table addressing: InsertTable reports row-major `tc` cell anchors, and
+        // every cell op takes that same anchor.
+        const topLeft = inserted.created[0].id;   // row 0, column 0
         const midRight = inserted.created[5].id;  // row 1, column 2 — outside the rectangle
 
         // A 2x2 header block: w:gridSpan across, w:vMerge down.
@@ -440,10 +442,19 @@ test.describe('DocxSession (WASM bridge)', () => {
         const unmerged = JSON.parse(bridge.UnmergeCells(handle, topLeft));
         const again = JSON.parse(bridge.UnmergeCells(handle, topLeft));
 
+        // The cell outside the rectangle must still be addressable down to its text. A `tc`
+        // anchor is not a text anchor, so go through the canonical resolution the API gives
+        // for exactly this: the cell reports its own paragraphs, and ReplaceText takes one.
+        const surviving = JSON.parse(bridge.ResolveTableCellAnchor(handle, midRight));
+        const survivingParagraph = surviving.cell?.paragraphAnchors?.[0]?.id;
+
         return {
           mergedOk: merged.success,
-          survivingAnchorAddressable:
-            JSON.parse(bridge.ReplaceText(handle, midRight, 'still editable')).success,
+          survivingCoordinate: surviving.cell
+            ? [surviving.cell.rowIndex, surviving.cell.columnIndex]
+            : null,
+          survivingAnchorAddressable: survivingParagraph !== undefined
+            && JSON.parse(bridge.ReplaceText(handle, survivingParagraph, 'still editable')).success,
           opaque: mergedMd.includes('```table'),
           clippedCode: clipped.error?.code,
           unmergedOk: unmerged.success,
@@ -455,6 +466,8 @@ test.describe('DocxSession (WASM bridge)', () => {
     }, Array.from(bytes));
 
     expect(result.mergedOk).toBe(true);
+    // The ordinal into `created` still names the cell the comment claims it does.
+    expect(result.survivingCoordinate).toEqual([1, 2]);
     expect(result.survivingAnchorAddressable).toBe(true);
     expect(result.opaque).toBe(true);
     expect(result.clippedCode).toBe('invalid_table_merge');

--- a/npm/tests/editor-move-latency-bench.spec.ts
+++ b/npm/tests/editor-move-latency-bench.spec.ts
@@ -174,15 +174,37 @@ test.describe('DocxEditor — block-move latency benchmark', () => {
       const trackedUnits: HTMLElement[] = tracked['bodyUnitNodes']().filter(
         (el: HTMLElement) => tracked['isMovableBlockUnit'](el),
       );
-      // Pick the pair from the engine's own answer: section breaks partition this charter, so a
-      // fixed index pair is not necessarily a legal move.
-      const tSrcId = trackedAnchor(trackedUnits[Math.floor(trackedUnits.length / 2)]);
+      // Pick the pair from the engine's own answer, SOURCE included. Section breaks partition
+      // this charter, and in review mode a block carrying bookmark markers cannot be moved at
+      // all — both revision sides would be live — which on this document is most of them:
+      // Word puts a _Toc bookmark on nearly every heading. A fixed index is therefore not
+      // necessarily a movable block, so scan outward from the middle for one that is.
+      const trackedTargetsFor = (id: string) =>
+        (JSON.parse(
+          D.DocxSessionBridge.ValidMoveTargets(tracked.sessionHandle, id),
+        ) as Array<{ anchorId: string; after: boolean }>).filter((t) => t.after);
+
+      let tSrcId = '';
+      let legal: Array<{ anchorId: string; after: boolean }> = [];
+      const mid = Math.floor(trackedUnits.length / 2);
+      for (let step = 0; step <= trackedUnits.length && legal.length === 0; step++) {
+        for (const index of step === 0 ? [mid] : [mid - step, mid + step]) {
+          if (index < 0 || index >= trackedUnits.length) continue;
+          const id = trackedAnchor(trackedUnits[index]);
+          if (!id) continue;
+          const targets = trackedTargetsFor(id);
+          if (targets.length > 0) { tSrcId = id; legal = targets; break; }
+        }
+      }
+      // Not a budget: if NOTHING on this charter admits a tracked move, the bench has no
+      // subject and the silent pass would be worse than the failure.
+      if (legal.length === 0) {
+        throw new Error('no block on this charter admits a tracked move');
+      }
+
       measure('ValidMoveTargets review (bridge)', 3, () => {
         D.DocxSessionBridge.ValidMoveTargets(tracked.sessionHandle, tSrcId);
       });
-      const legal = (JSON.parse(
-        D.DocxSessionBridge.ValidMoveTargets(tracked.sessionHandle, tSrcId),
-      ) as Array<{ anchorId: string; after: boolean }>).filter((t) => t.after);
       measure('moveBlock tracked', 1, () => {
         trackedOk = tracked.moveBlock(tSrcId, legal[legal.length - 1].anchorId, 'after');
       });

--- a/npm/tests/pagination-footnote-geometry.spec.ts
+++ b/npm/tests/pagination-footnote-geometry.spec.ts
@@ -158,9 +158,11 @@ test.describe('Paginated footnote geometry', () => {
     expect(twoNotes.items.length).toBe(2);
     const [first, second] = twoNotes.items;
     expect(second.top - first.bottom, 'inter-note gap').toBeLessThanOrEqual(TOL);
-    // Both notes' text must still be present and distinct.
-    expect(first.text).toContain('Footnote 1 text.');
-    expect(second.text).toContain('Footnote 2 text.');
+    // Both notes' text must still be present and distinct. The fixture numbers every note
+    // paragraph, single-paragraph notes included, so that a note split across pages can be
+    // told apart paragraph by paragraph; a one-paragraph note reads "paragraph 1".
+    expect(first.text).toContain('Footnote 1 paragraph 1 text.');
+    expect(second.text).toContain('Footnote 2 paragraph 1 text.');
     // The area still ends on the margin line with two notes stacked.
     expect(
       twoNotes.boxBottom - twoNotes.notesBottom,

--- a/npm/tests/pagination-keep-with-next.spec.ts
+++ b/npm/tests/pagination-keep-with-next.spec.ts
@@ -119,7 +119,11 @@ test.describe('Pagination keep-with-next chains', () => {
       [],
       ['heading', 'body'],
     ]);
-    expect(result.footnotePages).toEqual([true, true, false]);
+    // The note is 3 x 30pt against a 60pt band (60% of a 100pt body), and the band carries
+    // the separator: one paragraph measures 40.5pt and two measure 70.5pt, so exactly one
+    // paragraph fits per page and the tail needs a third note area. The chain placement is
+    // what this test pins; the note simply keeps flowing under it rather than being clipped.
+    expect(result.footnotePages).toEqual([true, true, true]);
   });
 
   test('does not force a chain onto a fresh page without room for its pending continuation', async ({ page }) => {
@@ -142,10 +146,15 @@ test.describe('Pagination keep-with-next chains', () => {
 
     const result = await paginateWithFootnoteInfo(page);
 
+    // The chain is placed greedily: `heading` stays with `lead`, `body` opens page 2. The
+    // trailing page carries no body text — it is the note-only substrate for the last
+    // paragraph of the continuation (see the band arithmetic above), which the engine
+    // drains rather than clipping off the bottom of page 2.
     expect(result.content).toEqual([
       ['lead1', 'heading'],
       ['body'],
+      [],
     ]);
-    expect(result.footnotePages).toEqual([true, true]);
+    expect(result.footnotePages).toEqual([true, true, true]);
   });
 });


### PR DESCRIPTION
`Playwright Tests` has been red on `main` since 2026-08-14, with 5 failures across 4 specs. They came from three unrelated merges, and only one of the three was a stale test in the way it first looked.

| Failing spec | Culprit | Verdict |
|---|---|---|
| `pagination-footnote-geometry:157` | #483 (issue #454, page citations) | Fixture prose drift |
| `pagination-keep-with-next:97`, `:125` | #483 (issue #454, page citations) | Real behaviour change, correct — tests were stale |
| `docx-session:415` (mergeCells) | #478 (issue #450, table addressing) | Test drift to canonical `tc` anchors |
| `editor-move-latency-bench:60` | #480 (issue #451, links/bookmarks) | Latent test bug exposed by an intended guard |

No product code changes: the diff is 4 test specs plus one CHANGELOG entry.

### The one that was not what it looked like

The keep-with-next pair read as stale assertions, but the change underneath is genuine and worth stating plainly. A footnote tail that did not fit its band used to be handed to the next page *whole* and drawn past the band's bottom edge — present in the DOM, invisible on the page, and therefore missing from the `PageMap` a citation resolves against. It is now partitioned at whole-paragraph boundaries and drained across as many note areas as it needs.

That the third page is forced rather than an under-filling bug was settled by measuring the real in-flight calls, not by reading the code: against a 60pt band (60% of a 100pt body), one note paragraph measures 40.5pt and two measure 70.5pt once the separator is counted, so exactly one paragraph fits per page and a 3×30pt note needs three note areas. Both tests keep their subject — the chain placement they pin is unchanged.

The behaviour was user-visible and undocumented (#483's entry covered only the PageMap), so it gets a `### Changed` entry of its own.

### The other two

**mergeCells.** `InsertTable` reports canonical `tc` cell anchors since #478; the spec still read `created` as cell *paragraphs* and handed one to `ReplaceText`, which answers `anchor_wrong_kind`. The merge was never damaging the surviving cell. The test now resolves the cell and edits the paragraph it reports, which keeps what the assertion proved — addressability down to the text, not merely cell-level — and additionally pins that `created[5]` still names row 1, column 2.

**Move bench.** It crashed on `legal[legal.length - 1].anchorId`, which read like a broken receipt shape but was an empty target list. Since #480 a tracked move of a block carrying bookmark markers is refused outright, and this bench deliberately runs on a bookmark-dense charter where Word has put a `_Toc` bookmark on nearly every heading: 33 of 234 blocks are movable in review mode against 231 in direct. The guard is intended and pinned by `DocxSessionMoveBlockTests`. The bench already took its *target* from the engine's answer for the same class of reason; it now takes the source that way too, and fails loudly rather than passing with nothing measured. The measurement it exists to take is restored — `moveBlock tracked`, 653ms against a 1500ms guard.

### Verification

Full local Playwright run: **518 passed, 9 skipped**, all four target families green.

Five failures remain locally in `tabs-visual.spec.ts`, all pre-existing and environment-dependent — pure height deltas at identical width (443→472, 575→617, 108→111 px), the signature of different font metrics against snapshots captured elsewhere. They cannot be caused by this branch: `npm/tsconfig.json` includes only `src/**/*`, so the bundle those snapshots render against is byte-identical with or without these commits, and CI passed them on this same commit. This PR run is the real check.