### PR TITLE
Epic #435 acceptance smoke: verify the safety track, fix what it found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ Docxodus.Tests/Ir/Diff/FuzzArtifacts/
 
 # macOS
 .DS_Store
+tools/mcp-server/smoke/__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -405,13 +405,16 @@ All notable changes to this project will be documented in this file.
   so a search over an incoming redline silently missed every inserted span.
   `w:ins`/`w:moveTo` now join the transparent inline containers; `w:del`/`w:moveFrom`
   deliberately do not, because their content is `w:delText` and deleted text is not
-  visible text. A note/endnote insertion whose requested offset is strictly inside one of
-  those revision wrappers now fails closed with `unsupported_inline_boundary`; the citation
-  inserter cannot split revision semantics and previously reported success after silently
-  placing the reference at the wrapper's far edge. Revision-edge offsets remain exact.
-  Coverage: `DocxSessionSurgicalTrackedChangesTests` DS409-DS410 and
-  `DocxSessionNoteAuthoringTests` DS339-DS340. Found by the issue #435 acceptance smoke and
-  its PR #491 adversarial review (`tools/mcp-server/smoke/epic-435-workflow.json`).
+  visible text. Making that text addressable also made it a valid target for ops that insert
+  or partition a paragraph's top-level children, and those cannot split a revision wrapper —
+  so a note/endnote citation and `SplitParagraph` whose requested offset is strictly inside
+  `w:ins`/`w:moveTo` now fail closed with `unsupported_inline_boundary`. Both previously
+  reported success after silently landing at the wrapper's far edge. Offsets exactly at a
+  wrapper's edge remain exact, and image insertion already refused this case.
+  Coverage: `DocxSessionSurgicalTrackedChangesTests` DS409-DS410,
+  `DocxSessionNoteAuthoringTests` DS339-DS340, and `DocxSessionPR131RegressionTests`
+  DS095-DS096. Found by the issue #435 acceptance smoke and its PR #491 adversarial review
+  (`tools/mcp-server/smoke/epic-435-workflow.json`).
 - **An ordinary Word picture is no longer reported read-only because of a rendering
   hint.** The blip-extension guard that refuses to replace a picture holding a second
   image payload (an SVG `asvg:svgBlip` beside its raster fallback, or an artistic-effects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -394,6 +394,19 @@ All notable changes to this project will be documented in this file.
   version bump at release time.
 
 ### Fixed
+- **Tracked insertions are part of a paragraph's visible text, so an agent can re-find
+  the edit it just made.** Under `TrackedChangeMode.RenderInline`, text a mutation
+  inserted landed inside `w:ins`, and `InlineRuns` — the shared walk behind the flat
+  string that every offset-addressed op works over — did not descend into it. The result
+  was a split brain on a document the caller had just edited: `Project().Markdown` and the
+  anchor's `TextPreview` showed the new text while `Grep`/`docxodus_search` returned
+  nothing, `ReplaceTextRange` could not address it, and `apply_format_by_substring`
+  reported `offset_out_of_range`. Insertions arriving from Word were skipped the same way,
+  so a search over an incoming redline silently missed every inserted span.
+  `w:ins`/`w:moveTo` now join the transparent inline containers; `w:del`/`w:moveFrom`
+  deliberately do not, because their content is `w:delText` and deleted text is not
+  visible text. Coverage: `DocxSessionSurgicalTrackedChangesTests` DS409-DS410. Found by
+  the issue #435 acceptance smoke (`tools/mcp-server/smoke/epic-435-workflow.json`).
 - **An ordinary Word picture is no longer reported read-only because of a rendering
   hint.** The blip-extension guard that refuses to replace a picture holding a second
   image payload (an SVG `asvg:svgBlip` beside its raster fallback, or an artistic-effects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -405,8 +405,13 @@ All notable changes to this project will be documented in this file.
   so a search over an incoming redline silently missed every inserted span.
   `w:ins`/`w:moveTo` now join the transparent inline containers; `w:del`/`w:moveFrom`
   deliberately do not, because their content is `w:delText` and deleted text is not
-  visible text. Coverage: `DocxSessionSurgicalTrackedChangesTests` DS409-DS410. Found by
-  the issue #435 acceptance smoke (`tools/mcp-server/smoke/epic-435-workflow.json`).
+  visible text. A note/endnote insertion whose requested offset is strictly inside one of
+  those revision wrappers now fails closed with `unsupported_inline_boundary`; the citation
+  inserter cannot split revision semantics and previously reported success after silently
+  placing the reference at the wrapper's far edge. Revision-edge offsets remain exact.
+  Coverage: `DocxSessionSurgicalTrackedChangesTests` DS409-DS410 and
+  `DocxSessionNoteAuthoringTests` DS339-DS340. Found by the issue #435 acceptance smoke and
+  its PR #491 adversarial review (`tools/mcp-server/smoke/epic-435-workflow.json`).
 - **An ordinary Word picture is no longer reported read-only because of a rendering
   hint.** The blip-extension guard that refuses to replace a picture holding a second
   image payload (an SVG `asvg:svgBlip` beside its raster fallback, or an artistic-effects

--- a/Docxodus.Tests/DocxSessionNoteAuthoringTests.cs
+++ b/Docxodus.Tests/DocxSessionNoteAuthoringTests.cs
@@ -554,6 +554,106 @@ public class DocxSessionNoteAuthoringTests
     }
 
     /// <summary>
+    /// Regression found while reviewing PR #491. Once tracked insertions joined the visible-text
+    /// walk, note offsets could resolve inside <c>w:ins</c>/<c>w:moveTo</c>. The run splitter cut
+    /// the nested run, but the top-level inserter treated the revision wrapper as atomic and
+    /// silently placed the citation after the entire revision. Refuse that boundary before the
+    /// history snapshot instead of reporting a successful wrong-location edit.
+    /// </summary>
+    [Theory]
+    [InlineData("ins", true)]
+    [InlineData("moveTo", false)]
+    public void DS339_InsertNote_InsideVisibleRevision_FailsClosedWithoutMutation(
+        string revisionName, bool footnote)
+    {
+        using var session = new DocxSession(BuildDocWithVisibleRevision(revisionName));
+        var anchor = FirstBodyParagraph(session);
+        var before = session.GetPackageContentHash();
+        var version = session.Version;
+        var undoCount = session.UndoCount;
+        var redoCount = session.RedoCount;
+
+        var result = footnote
+            ? session.InsertFootnote(anchor, 4, "Must not be misplaced.")
+            : session.InsertEndnote(anchor, 4, "Must not be misplaced.");
+
+        Assert.False(result.Success);
+        Assert.Equal(EditErrorCode.UnsupportedInlineBoundary, result.Error!.Code);
+        Assert.Equal(before, session.GetPackageContentHash());
+        Assert.Equal(version, session.Version);
+        Assert.Equal(undoCount, session.UndoCount);
+        Assert.Equal(redoCount, session.RedoCount);
+
+        using var stream = new MemoryStream(session.Save());
+        using var document = WordprocessingDocument.Open(stream, false);
+        Assert.Null(document.MainDocumentPart!.FootnotesPart);
+        Assert.Null(document.MainDocumentPart.EndnotesPart);
+        Assert.Empty(document.MainDocumentPart.GetXDocument().Descendants(W + "footnoteReference"));
+        Assert.Empty(document.MainDocumentPart.GetXDocument().Descendants(W + "endnoteReference"));
+    }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(6)]
+    public void DS340_InsertFootnote_AtVisibleRevisionEdge_UsesTheExactOffset(int offset)
+    {
+        using var session = new DocxSession(BuildDocWithVisibleRevision("ins"));
+        var anchor = FirstBodyParagraph(session);
+
+        var result = session.InsertFootnote(anchor, offset, "Edge note.");
+
+        Assert.True(result.Success, result.Error?.Message);
+        var paragraph = BodyXml(session.Save()).Descendants(W + "p")
+            .Single(p => p.Descendants(W + "footnoteReference").Any());
+        var reference = paragraph.Descendants(W + "footnoteReference").Single();
+        var referenceRun = reference.Parent!;
+        var textBeforeReference = string.Concat(paragraph.Descendants(W + "r")
+            .TakeWhile(run => !ReferenceEquals(run, referenceRun))
+            .SelectMany(run => run.Elements(W + "t"))
+            .Select(text => (string)text));
+        Assert.Equal(offset, textBeforeReference.Length);
+    }
+
+    private static byte[] BuildDocWithVisibleRevision(string revisionName)
+    {
+        using var stream = new MemoryStream();
+        using (var document = WordprocessingDocument.Create(
+                   stream, DocumentFormat.OpenXml.WordprocessingDocumentType.Document))
+        {
+            var main = document.AddMainDocumentPart();
+            main.Document = new DocumentFormat.OpenXml.Wordprocessing.Document(
+                new DocumentFormat.OpenXml.Wordprocessing.Body());
+            main.AddNewPart<StyleDefinitionsPart>().Styles =
+                new DocumentFormat.OpenXml.Wordprocessing.Styles();
+            main.AddNewPart<DocumentSettingsPart>().Settings =
+                new DocumentFormat.OpenXml.Wordprocessing.Settings();
+            main.Document.Save();
+
+            var revision = new XElement(W + revisionName,
+                new XAttribute(W + "id", "10"),
+                new XAttribute(W + "author", "Reviewer"),
+                new XAttribute(W + "date", "2026-01-01T00:00:00Z"),
+                new XElement(W + "r", new XElement(W + "t", "BBBB")));
+            var paragraphChildren = new System.Collections.Generic.List<object>
+            {
+                new XElement(W + "r", new XElement(W + "t", "AA")),
+            };
+            if (revisionName == "moveTo")
+                paragraphChildren.Add(new XElement(W + "moveToRangeStart",
+                    new XAttribute(W + "id", "9"), new XAttribute(W + "name", "move9")));
+            paragraphChildren.Add(revision);
+            if (revisionName == "moveTo")
+                paragraphChildren.Add(new XElement(W + "moveToRangeEnd", new XAttribute(W + "id", "9")));
+            paragraphChildren.Add(new XElement(W + "r", new XElement(W + "t", "CC")));
+
+            var xDocument = main.GetXDocument();
+            xDocument.Root!.Element(W + "body")!.ReplaceNodes(new XElement(W + "p", paragraphChildren));
+            main.PutXDocument();
+        }
+        return stream.ToArray();
+    }
+
+    /// <summary>
     /// Three paragraphs; the second and third each cite a footnote (ids 1 and 2, ascending in
     /// reference order as every Word document does). The first cites nothing — inserting there
     /// puts a new citation AHEAD of both existing ones.

--- a/Docxodus.Tests/DocxSessionPR131RegressionTests.cs
+++ b/Docxodus.Tests/DocxSessionPR131RegressionTests.cs
@@ -205,6 +205,89 @@ public class DocxSessionPR131RegressionTests
         Assert.Equal("DEF", secondText);
     }
 
+    /// <summary>Single body paragraph: text "AA" + <c>w:ins</c>("BBBB") + text "CC".
+    /// Visible text is "AABBBBCC" (8 chars); offsets 3-5 are strictly inside the
+    /// tracked insertion, and 2 and 6 are its edges.</summary>
+    internal static byte[] BuildParagraphWithTrackedInsertion()
+    {
+        using var ms = new MemoryStream();
+        using (var wDoc = WordprocessingDocument.Create(ms, WordprocessingDocumentType.Document))
+        {
+            var main = wDoc.AddMainDocumentPart();
+            main.AddNewPart<StyleDefinitionsPart>().Styles = DocxSessionTests.BuildHeadingStyles();
+            main.AddNewPart<DocumentSettingsPart>().Settings = new Settings();
+
+            XElement Run(string text) => new(W + "r",
+                new XElement(W + "t",
+                    new XAttribute(System.Xml.Linq.XNamespace.Xml + "space", "preserve"), text));
+
+            var paraXml = new XElement(W + "p",
+                Run("AA"),
+                new XElement(W + "ins",
+                    new XAttribute(W + "id", 10),
+                    new XAttribute(W + "author", "Reviewer"),
+                    new XAttribute(W + "date", "2026-01-01T00:00:00Z"),
+                    Run("BBBB")),
+                Run("CC"));
+
+            main.Document = new Document(new Body());
+            main.Document.Save();
+            var xDoc = main.GetXDocument();
+            xDoc.Root!.Element(W + "body")!.ReplaceNodes(paraXml);
+            main.PutXDocument();
+        }
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Companion to the note-citation guard (DS339/DS340). Once tracked insertions joined the
+    /// visible-text walk, a split offset could land strictly inside <c>w:ins</c>. The run
+    /// splitter cut the nested run, but <c>MoveInlineChildrenAfter</c> only relocates children
+    /// whose START is at or past the offset — so the whole revision wrapper stayed with the
+    /// first half and the paragraph silently split at the wrapper's far edge while reporting
+    /// success. Splitting a revision wrapper needs revision semantics this op does not own, so
+    /// it refuses instead.
+    /// </summary>
+    [Theory]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    public void DS095_SplitParagraph_InsideTrackedInsertion_FailsClosedWithoutMutation(int offset)
+    {
+        using var session = new DocxSession(BuildParagraphWithTrackedInsertion());
+        var anchor = FirstBodyParagraph(session).Anchor.Id;
+        Assert.Equal("AABBBBCC", session.GetAnchorInfo(anchor)?.TextPreview);
+        var before = session.GetPackageContentHash();
+        var version = session.Version;
+        var undoCount = session.UndoCount;
+
+        var result = session.SplitParagraph(anchor, offset);
+
+        Assert.False(result.Success);
+        Assert.Equal(EditErrorCode.UnsupportedInlineBoundary, result.Error!.Code);
+        Assert.Equal(before, session.GetPackageContentHash());
+        Assert.Equal(version, session.Version);
+        Assert.Equal(undoCount, session.UndoCount);
+        Assert.Single(BodyParagraphs(session));
+        Assert.Equal("AABBBBCC", session.GetAnchorInfo(anchor)?.TextPreview);
+    }
+
+    [Theory]
+    [InlineData(2, "AA", "BBBBCC")]
+    [InlineData(6, "AABBBB", "CC")]
+    public void DS096_SplitParagraph_AtTrackedInsertionEdge_SplitsExactly(
+        int offset, string expectedFirst, string expectedSecond)
+    {
+        using var session = new DocxSession(BuildParagraphWithTrackedInsertion());
+        var anchor = FirstBodyParagraph(session).Anchor.Id;
+
+        var result = session.SplitParagraph(anchor, offset);
+
+        Assert.True(result.Success, $"{result.Error?.Code}/{result.Error?.Message}");
+        Assert.Equal(expectedFirst, session.GetAnchorInfo(anchor)?.TextPreview);
+        Assert.Equal(expectedSecond, session.GetAnchorInfo(result.Created[0].Id)?.TextPreview);
+    }
+
     // ─── B2: MergeParagraphs preserves hyperlinks ────────────────────────
 
     [Fact]

--- a/Docxodus.Tests/DocxSessionSurgicalTrackedChangesTests.cs
+++ b/Docxodus.Tests/DocxSessionSurgicalTrackedChangesTests.cs
@@ -360,6 +360,76 @@ public class DocxSessionSurgicalTrackedChangesTests
             .Where(e => e.Name == W.del || e.Name == W.ins || e.Name == W.delText));
     }
 
+    /// <summary>
+    /// Found by the issue #435 acceptance smoke. Text a tracked edit inserts lands inside
+    /// <c>w:ins</c>, and <c>InlineRuns</c> only descended into the containers listed in
+    /// <c>InlineContainerNames</c> — which omitted <c>w:ins</c>. Every offset-addressed
+    /// surface built on it (Grep, ParagraphText, ReplaceTextRange, format-by-substring)
+    /// therefore could not see the edit it had just made, while the markdown projection and
+    /// the anchor's TextPreview both showed it. An agent could not re-find its own work.
+    /// </summary>
+    [Fact]
+    public void DS409_TrackedInsertedText_IsVisibleToEveryOffsetAddressedSurface()
+    {
+        var source = BuildDocument(new XElement(W.p, Run("The name is [____].")));
+        using var session = new DocxSession(source,
+            new DocxSessionSettings { TrackedChanges = TrackedChangeMode.RenderInline });
+        var anchor = session.Project().AnchorIndex.Values.Single().Anchor.Id;
+
+        Assert.True(Assert.Single(session.ReplaceTextRange(anchor, "[____]", "Northstar")).Success);
+
+        // The projection always saw it; these three surfaces did not.
+        Assert.Contains("Northstar", session.Project().Markdown, StringComparison.Ordinal);
+        var match = Assert.Single(session.Grep("Northstar"));
+        Assert.Equal("Northstar", match.Text);
+        Assert.Equal(anchor, match.EnclosingAnchor?.Anchor.Id);
+
+        // Flat text is contiguous across the w:del/w:ins pair: deleted text is w:delText and
+        // stays out, inserted text is w:t and comes in, so offsets address the visible string.
+        Assert.Equal("The name is Northstar.", session.Project().AnchorIndex[anchor].TextPreview);
+
+        // And the inserted text is addressable by a follow-up surgical op in the same session.
+        Assert.True(Assert.Single(session.ReplaceTextRange(anchor, "Northstar", "Southstar")).Success);
+        Assert.Equal("The name is Southstar.", AcceptedText(session.Save()));
+        Assert.Equal("The name is [____].", RejectedText(session.Save()));
+        AssertSchemaValid(session.Save());
+    }
+
+    /// <summary>
+    /// The same blindness applied to insertions already present in the input, so a redline
+    /// arriving from Word had its inserted spans silently skipped by every text search.
+    /// </summary>
+    [Fact]
+    public void DS410_PreExistingTrackedInsertion_IsPartOfTheParagraphsVisibleText()
+    {
+        var source = BuildDocument(new XElement(W.p,
+            Run("Stage "),
+            new XElement(W.ins,
+                new XAttribute(W.id, 1),
+                new XAttribute(W.author, "Reviewer"),
+                new XAttribute(W.date, "2026-01-01T00:00:00Z"),
+                Run("IV in the chromatogram")),
+            new XElement(W.del,
+                new XAttribute(W.id, 2),
+                new XAttribute(W.author, "Reviewer"),
+                new XAttribute(W.date, "2026-01-01T00:00:00Z"),
+                new XElement(W.r,
+                    new XElement(W.delText,
+                        new XAttribute(Xml + "space", "preserve"), "III"))),
+            Run(" is final.")));
+        using var session = new DocxSession(source);
+        var anchor = session.Project().AnchorIndex.Values.Single().Anchor.Id;
+
+        Assert.Equal("Stage IV in the chromatogram is final.",
+            session.Project().AnchorIndex[anchor].TextPreview);
+        var match = Assert.Single(session.Grep("chromatogram"));
+        Assert.Equal(anchor, match.EnclosingAnchor?.Anchor.Id);
+
+        // Deleted text is NOT visible text: w:del holds w:delText, which never joins the flat
+        // string, so a search cannot match content the document says was removed.
+        Assert.Empty(session.Grep("III"));
+    }
+
     private static byte[] BuildMarkerDocument()
     {
         using var stream = new MemoryStream();

--- a/Docxodus.Tests/DocxSessionSurgicalTrackedChangesTests.cs
+++ b/Docxodus.Tests/DocxSessionSurgicalTrackedChangesTests.cs
@@ -15,7 +15,8 @@ namespace Docxodus.Tests;
 
 /// <summary>
 /// Surgical text replacements in <see cref="TrackedChangeMode.RenderInline"/>
-/// (issue #330). Test IDs DS400-DS407.
+/// (issue #330), and the visible-text contract those offsets are computed over
+/// (DS409-DS410, found by the issue #435 acceptance smoke). Test IDs DS400-DS410.
 /// </summary>
 public class DocxSessionSurgicalTrackedChangesTests
 {
@@ -396,11 +397,13 @@ public class DocxSessionSurgicalTrackedChangesTests
     }
 
     /// <summary>
-    /// The same blindness applied to insertions already present in the input, so a redline
-    /// arriving from Word had its inserted spans silently skipped by every text search.
+    /// The same blindness applied to revisions already present in the input, so a redline
+    /// arriving from Word had its inserted and move-destination spans silently skipped by
+    /// every text search. Pins the whole split in one fixture: w:ins and w:moveTo are visible
+    /// text, w:del and w:moveFrom are not.
     /// </summary>
     [Fact]
-    public void DS410_PreExistingTrackedInsertion_IsPartOfTheParagraphsVisibleText()
+    public void DS410_PreExistingInsertionsAndMoveDestinations_ArePartOfTheVisibleText()
     {
         var source = BuildDocument(new XElement(W.p,
             Run("Stage "),
@@ -416,18 +419,38 @@ public class DocxSessionSurgicalTrackedChangesTests
                 new XElement(W.r,
                     new XElement(W.delText,
                         new XAttribute(Xml + "space", "preserve"), "III"))),
+            new XElement(W.moveToRangeStart,
+                new XAttribute(W.id, 3), new XAttribute(W.name, "move1")),
+            new XElement(W.moveTo,
+                new XAttribute(W.id, 4),
+                new XAttribute(W.author, "Reviewer"),
+                new XAttribute(W.date, "2026-01-01T00:00:00Z"),
+                Run(" per the addendum")),
+            new XElement(W.moveToRangeEnd, new XAttribute(W.id, 3)),
+            new XElement(W.moveFrom,
+                new XAttribute(W.id, 5),
+                new XAttribute(W.author, "Reviewer"),
+                new XAttribute(W.date, "2026-01-01T00:00:00Z"),
+                new XElement(W.r,
+                    new XElement(W.delText,
+                        new XAttribute(Xml + "space", "preserve"), " per the schedule"))),
             Run(" is final.")));
         using var session = new DocxSession(source);
         var anchor = session.Project().AnchorIndex.Values.Single().Anchor.Id;
 
-        Assert.Equal("Stage IV in the chromatogram is final.",
+        Assert.Equal("Stage IV in the chromatogram per the addendum is final.",
             session.Project().AnchorIndex[anchor].TextPreview);
-        var match = Assert.Single(session.Grep("chromatogram"));
-        Assert.Equal(anchor, match.EnclosingAnchor?.Anchor.Id);
 
-        // Deleted text is NOT visible text: w:del holds w:delText, which never joins the flat
-        // string, so a search cannot match content the document says was removed.
+        foreach (var needle in new[] { "chromatogram", "per the addendum" })
+        {
+            var match = Assert.Single(session.Grep(needle));
+            Assert.Equal(anchor, match.EnclosingAnchor?.Anchor.Id);
+        }
+
+        // Deleted text is NOT visible text: w:del and w:moveFrom hold w:delText, which never
+        // joins the flat string, so a search cannot match what the document says was removed.
         Assert.Empty(session.Grep("III"));
+        Assert.Empty(session.Grep("per the schedule"));
     }
 
     private static byte[] BuildMarkerDocument()

--- a/Docxodus.Tests/McpServerDispatcherTests.cs
+++ b/Docxodus.Tests/McpServerDispatcherTests.cs
@@ -2631,16 +2631,16 @@ public class McpServerDispatcherTests : IDisposable
         var sessionArg = JsonSerializer.Serialize(sessionId);
         var anchor = FirstBodyAnchorId(sessionId, _store);
 
-        // Seed a redo cursor: RecordPreOp used to clear redo on every preview step and never
-        // restore it, so this is only observable across a preview.
+        // Commit the state that must remain live, then create and undo a second edit. This leaves
+        // "committed edit" visible with "redo target" already on the redo stack. No live mutation
+        // may occur between this undo and the preview — RecordPreOp would legitimately clear redo.
+        Assert.True(ReplaceText(_store, sessionId, anchor, "committed edit")
+            .GetProperty("success").GetBoolean());
         Assert.True(ReplaceText(_store, sessionId, anchor, "redo target")
             .GetProperty("success").GetBoolean());
         Assert.True(Parse(Dispatcher.Call(_store, "docxodus_edit", J(
             $$"""{"sessionId":{{sessionArg}},"action":"undo"}"""))).GetProperty("success").GetBoolean());
 
-        // The edit the caller has committed and must still have after every preview below.
-        Assert.True(ReplaceText(_store, sessionId, anchor, "committed edit")
-            .GetProperty("success").GetBoolean());
         var committedVersion = Docxodus.Internal.DocxSessionOps.GetVersion(_store.Get(sessionId).Handle);
         string Markdown() => Parse(Dispatcher.Call(_store, "docxodus_get_content", J(
             $$"""{"sessionId":{{sessionArg}},"format":"markdown"}"""))).GetProperty("markdown").GetString()!;
@@ -2676,15 +2676,22 @@ public class McpServerDispatcherTests : IDisposable
         Assert.Equal(committedMarkdown, Markdown());
         Assert.Equal(committedVersion, Docxodus.Internal.DocxSessionOps.GetVersion(_store.Get(sessionId).Handle));
 
-        // The live ring is untouched: exactly the caller's own entry undoes, and the redo cursor
-        // seeded before the previews is still reachable.
+        // Prove the PRE-EXISTING redo cursor directly, before any live undo can manufacture a new
+        // one. Then undo it back to the committed state and prove the one-deep ring has no older
+        // entry. The final redo/undo pair leaves the fixture in the committed state for leak checks.
+        Assert.True(Parse(Dispatcher.Call(_store, "docxodus_edit", J(
+            $$"""{"sessionId":{{sessionArg}},"action":"redo"}"""))).GetProperty("success").GetBoolean());
+        Assert.Contains("redo target", Markdown());
         Assert.True(Parse(Dispatcher.Call(_store, "docxodus_edit", J(
             $$"""{"sessionId":{{sessionArg}},"action":"undo"}"""))).GetProperty("success").GetBoolean());
-        Assert.DoesNotContain("committed edit", Markdown());
+        Assert.Contains("committed edit", Markdown());
         Assert.False(Parse(Dispatcher.Call(_store, "docxodus_edit", J(
             $$"""{"sessionId":{{sessionArg}},"action":"undo"}"""))).GetProperty("success").GetBoolean());
         Assert.True(Parse(Dispatcher.Call(_store, "docxodus_edit", J(
             $$"""{"sessionId":{{sessionArg}},"action":"redo"}"""))).GetProperty("success").GetBoolean());
+        Assert.Contains("redo target", Markdown());
+        Assert.True(Parse(Dispatcher.Call(_store, "docxodus_edit", J(
+            $$"""{"sessionId":{{sessionArg}},"action":"undo"}"""))).GetProperty("success").GetBoolean());
         Assert.Contains("committed edit", Markdown());
 
         // Nothing the shadow authored ever reached the live package.

--- a/Docxodus.Tests/McpServerDispatcherTests.cs
+++ b/Docxodus.Tests/McpServerDispatcherTests.cs
@@ -2610,4 +2610,88 @@ public class McpServerDispatcherTests : IDisposable
         Assert.Equal(2, after.Count(control =>
             control.GetProperty("type").GetString() == "repeating_section_item"));
     }
+
+    /// <summary>
+    /// Issue #468, at the surface it was filed against. The apply-and-undo preview issued one
+    /// <c>Undo()</c> per non-throwing step, but a step that returned <c>success: false</c> recorded
+    /// no undo entry — so a preview batch carrying one bad anchor popped a pre-batch snapshot and
+    /// silently reverted an edit the caller had already committed. #446 replaced that path with an
+    /// isolated shadow clone, which removes the whole class; this pins the three live-history
+    /// observables the old implementation corrupted, none of which any MCP test asserted together:
+    /// a committed edit, the redo cursor, and a batch longer than <c>undoDepth</c>.
+    /// </summary>
+    [Fact]
+    public void MCP150_PreviewBatchWithFailingStep_LeavesCommittedEditsUndoAndRedoIntact()
+    {
+        // undoDepth 1 is the tight ring from #468's third claim: a preview longer than the ring
+        // used to evict the caller's own entry and leave steps permanently applied.
+        var sessionId = Parse(Dispatcher.Call(_store, "docxodus_open", J(
+            $$"""{"path":{{JsonSerializer.Serialize(_tempPath)}},"undoDepth":1}""")))
+            .GetProperty("sessionId").GetString()!;
+        var sessionArg = JsonSerializer.Serialize(sessionId);
+        var anchor = FirstBodyAnchorId(sessionId, _store);
+
+        // Seed a redo cursor: RecordPreOp used to clear redo on every preview step and never
+        // restore it, so this is only observable across a preview.
+        Assert.True(ReplaceText(_store, sessionId, anchor, "redo target")
+            .GetProperty("success").GetBoolean());
+        Assert.True(Parse(Dispatcher.Call(_store, "docxodus_edit", J(
+            $$"""{"sessionId":{{sessionArg}},"action":"undo"}"""))).GetProperty("success").GetBoolean());
+
+        // The edit the caller has committed and must still have after every preview below.
+        Assert.True(ReplaceText(_store, sessionId, anchor, "committed edit")
+            .GetProperty("success").GetBoolean());
+        var committedVersion = Docxodus.Internal.DocxSessionOps.GetVersion(_store.Get(sessionId).Handle);
+        string Markdown() => Parse(Dispatcher.Call(_store, "docxodus_get_content", J(
+            $$"""{"sessionId":{{sessionArg}},"format":"markdown"}"""))).GetProperty("markdown").GetString()!;
+        var committedMarkdown = Markdown();
+        Assert.Contains("committed edit", committedMarkdown);
+
+        // Four mutating steps against a one-deep ring, the last of which fails on a bad anchor.
+        object[] StepsEndingInFailure() => new object[]
+        {
+            new { tool = "docxodus_edit", args = new { action = "replace_text", anchorId = anchor, markdown = "shadow one" } },
+            new { tool = "docxodus_create", args = new { action = "set_header_text", bodyAnchorId = anchor, kind = "default", markdown = "shadow header" } },
+            new { tool = "docxodus_comment", args = new { action = "add", anchorId = anchor, author = "Preview", markdown = "shadow comment" } },
+            new { tool = "docxodus_edit", args = new { action = "replace_text", anchorId = "p:body:missing", markdown = "fails" } },
+        };
+
+        var atomic = Parse(Dispatcher.Call(_store, "docxodus_mutations", J(JsonSerializer.Serialize(
+            new { sessionId, mode = "preview", steps = StepsEndingInFailure() }))));
+        Assert.True(atomic.GetProperty("preview").GetBoolean());
+        Assert.Equal("failed", atomic.GetProperty("status").GetString());
+        Assert.True(atomic.GetProperty("rolledBack").GetBoolean());
+        Assert.Equal(3, atomic.GetProperty("failure").GetProperty("index").GetInt32());
+        Assert.Equal(committedMarkdown, Markdown());
+        Assert.Equal(committedVersion, Docxodus.Internal.DocxSessionOps.GetVersion(_store.Get(sessionId).Handle));
+
+        // best_effort keeps the three successes in the shadow — the live document still must not
+        // move, and the failing step still must not consume a live undo entry.
+        var partial = Parse(Dispatcher.Call(_store, "docxodus_mutations", J(JsonSerializer.Serialize(
+            new { sessionId, mode = "best_effort", preview = true, steps = StepsEndingInFailure() }))));
+        Assert.True(partial.GetProperty("preview").GetBoolean());
+        Assert.Equal("partial", partial.GetProperty("status").GetString());
+        Assert.False(partial.GetProperty("rolledBack").GetBoolean());
+        Assert.Equal(3, partial.GetProperty("editsApplied").GetInt32());
+        Assert.Equal(committedMarkdown, Markdown());
+        Assert.Equal(committedVersion, Docxodus.Internal.DocxSessionOps.GetVersion(_store.Get(sessionId).Handle));
+
+        // The live ring is untouched: exactly the caller's own entry undoes, and the redo cursor
+        // seeded before the previews is still reachable.
+        Assert.True(Parse(Dispatcher.Call(_store, "docxodus_edit", J(
+            $$"""{"sessionId":{{sessionArg}},"action":"undo"}"""))).GetProperty("success").GetBoolean());
+        Assert.DoesNotContain("committed edit", Markdown());
+        Assert.False(Parse(Dispatcher.Call(_store, "docxodus_edit", J(
+            $$"""{"sessionId":{{sessionArg}},"action":"undo"}"""))).GetProperty("success").GetBoolean());
+        Assert.True(Parse(Dispatcher.Call(_store, "docxodus_edit", J(
+            $$"""{"sessionId":{{sessionArg}},"action":"redo"}"""))).GetProperty("success").GetBoolean());
+        Assert.Contains("committed edit", Markdown());
+
+        // Nothing the shadow authored ever reached the live package.
+        var live = Markdown();
+        Assert.DoesNotContain("shadow one", live);
+        Assert.DoesNotContain("shadow header", live);
+        Assert.Empty(Parse(Dispatcher.Call(_store, "docxodus_comment", J(
+            $$"""{"sessionId":{{sessionArg}},"action":"list"}"""))).GetProperty("comments").EnumerateArray());
+    }
 }

--- a/Docxodus/DocumentStructure.cs
+++ b/Docxodus/DocumentStructure.cs
@@ -68,17 +68,21 @@ public class DocumentElement
     public List<DocumentElement> Children { get; init; } = new();
 
     /// <summary>
-    /// For table rows: the row index within the table.
+    /// For table rows and table cells: the zero-based row index within the table.
     /// </summary>
     public int? RowIndex { get; init; }
 
     /// <summary>
-    /// For table cells: the column index (accounting for grid span).
+    /// For table cells: the zero-based grid column the cell starts at. This is a true grid
+    /// coordinate — preceding <c>w:gridSpan</c> widths and the row's own <c>w:gridBefore</c>
+    /// offset are both accounted for, so a ragged row's cells still line up with the table grid.
     /// </summary>
     public int? ColumnIndex { get; init; }
 
     /// <summary>
-    /// For table cells: number of rows this cell spans.
+    /// For table cells: the vertical merge span. <c>null</c> when the cell is not vertically
+    /// merged; on a <c>w:vMerge</c> restart, the number of rows the merge covers; on a merge
+    /// <em>continuation</em>, <c>0</c> — the run's height is reported once, on its restart cell.
     /// </summary>
     public int? RowSpan { get; init; }
 

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -8792,6 +8792,10 @@ public sealed partial class DocxSession : IDisposable
         if (characterOffset < 0 || characterOffset > totalText.Length)
             return EditResult.Fail(EditErrorCode.OffsetOutOfRange,
                 $"offset {characterOffset} out of [0, {totalText.Length}]", anchorId);
+        if (HasUnsupportedInlineInsertionBoundary(element, characterOffset))
+            return EditResult.Fail(EditErrorCode.UnsupportedInlineBoundary,
+                $"{opName} offset falls inside a revision or unsupported inline container; " +
+                "choose a boundary before or after that container", anchorId);
 
         // Parse the note body BEFORE snapshotting so a malformed payload is a clean no-op
         // (no part created, no undo entry pushed).
@@ -13391,6 +13395,42 @@ public sealed partial class DocxSession : IDisposable
         string.Concat(child.DescendantsAndSelf(W.t).Select(t => (string)t)).Length;
 
     /// <summary>
+    /// Whether inserting a new top-level paragraph child at <paramref name="offset"/> would
+    /// silently move it away from the requested visible-text position. Plain runs are split by
+    /// <see cref="SplitRunsAtOffset"/>. A top-level hyperlink containing direct runs is split by
+    /// <see cref="SplitInlineContainersAtOffset"/>. Every other container — including
+    /// <c>w:ins</c>/<c>w:moveTo</c> — is atomic because splitting it requires revision- or
+    /// field-specific semantics.
+    /// </summary>
+    private static bool HasUnsupportedInlineInsertionBoundary(XElement paragraph, int offset)
+    {
+        int consumed = 0;
+        foreach (var child in paragraph.Elements().Where(IsInlineChild))
+        {
+            int length = InlineChildTextLength(child);
+            if (consumed < offset && offset < consumed + length)
+            {
+                if (child.Name == W.r) return false;
+                if (child.Name != W.hyperlink) return true;
+
+                int localOffset = offset - consumed;
+                int hyperlinkConsumed = 0;
+                foreach (var nested in child.Elements().Where(IsInlineChild))
+                {
+                    int nestedLength = InlineChildTextLength(nested);
+                    if (hyperlinkConsumed < localOffset
+                        && localOffset < hyperlinkConsumed + nestedLength)
+                        return nested.Name != W.r;
+                    hyperlinkConsumed += nestedLength;
+                }
+                return false;
+            }
+            consumed += length;
+        }
+        return false;
+    }
+
+    /// <summary>
     /// If a run straddles <paramref name="offset"/>, split it into two adjacent runs
     /// at that offset. Walks runs inside hyperlinks/sdts/etc. too, so the boundary
     /// is clean regardless of which container the run lives in. The new sibling run
@@ -13444,9 +13484,10 @@ public sealed partial class DocxSession : IDisposable
 
             if (child.Name == W.hyperlink)
                 SplitHyperlinkAt(child, local);
-            // For <w:r>: SplitRunsAtOffset already handled it. For sdt/fldSimple/smartTag:
-            // treat as atomic — splitting these requires semantic care; the whole element
-            // stays with whichever side its leading run lands on.
+            // For <w:r>: SplitRunsAtOffset already handled it. For sdt/fldSimple/smartTag and
+            // revision wrappers: treat as atomic — callers that insert a top-level child must
+            // reject an interior boundary with HasUnsupportedInlineInsertionBoundary before
+            // reaching this helper.
             return;
         }
     }

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -7273,6 +7273,13 @@ public sealed partial class DocxSession : IDisposable
         if (characterOffset < 0 || characterOffset > totalText.Length)
             return EditResult.Fail(EditErrorCode.OffsetOutOfRange,
                 $"offset {characterOffset} out of [0, {totalText.Length}]", anchorId);
+        // MoveInlineChildrenAfter relocates whole top-level children, so an offset strictly
+        // inside an atomic container would silently split at that container's far edge and
+        // still report success. Refuse instead — same boundary contract as note citations.
+        if (HasUnsupportedInlineInsertionBoundary(element, characterOffset))
+            return EditResult.Fail(EditErrorCode.UnsupportedInlineBoundary,
+                "SplitParagraph offset falls inside a revision or unsupported inline container; " +
+                "choose a boundary before or after that container", anchorId);
         if (_trackedChanges == TrackedChangeMode.RenderInline)
             return TrackedStructureUnsupported("SplitParagraph", anchorId);
 

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -13347,9 +13347,16 @@ public sealed partial class DocxSession : IDisposable
     // Hyperlinks, sdts, fldSimple and smartTag are transparent containers — their
     // descendant runs contribute to the paragraph's visible text. Bookmark/comment
     // markers (zero-width) are tracked separately and not enumerated here.
+    //
+    // w:ins and w:moveTo are transparent for the same reason: an insertion's text is
+    // present in the document as ordinary w:t and is exactly what a reader sees, so it
+    // belongs in the flat text every offset-addressed op works over. Their deleting
+    // counterparts w:del and w:moveFrom deliberately are NOT here — that content is
+    // w:delText, which RunText does not read, so deleted text stays out of the visible
+    // string and offsets keep addressing what the document actually shows.
     private static readonly HashSet<XName> InlineContainerNames = new()
     {
-        W.hyperlink, W.sdt, W.fldSimple, W.smartTag,
+        W.hyperlink, W.sdt, W.fldSimple, W.smartTag, W.ins, W.moveTo,
     };
 
     private static bool IsInlineChild(XElement e) =>
@@ -13358,8 +13365,10 @@ public sealed partial class DocxSession : IDisposable
     /// <summary>
     /// All <c>&lt;w:r&gt;</c> elements that contribute to the paragraph's visible text,
     /// in document order — including runs nested inside hyperlinks, sdts, fldSimple,
-    /// smartTags. Iterating only <c>Elements(W.r)</c> silently skips hyperlink-internal
-    /// runs, which produced the bugs documented in DS080-DS090.
+    /// smartTags, and tracked insertions (<c>w:ins</c>/<c>w:moveTo</c>). Iterating only
+    /// <c>Elements(W.r)</c> silently skips hyperlink-internal runs, which produced the
+    /// bugs documented in DS080-DS090; skipping insertion-internal runs made an agent
+    /// unable to re-find its own tracked edit (DS409-DS410).
     /// </summary>
     internal static IEnumerable<XElement> InlineRuns(XElement paragraph)
     {

--- a/Docxodus/WmlToMarkdownConverter.cs
+++ b/Docxodus/WmlToMarkdownConverter.cs
@@ -105,8 +105,9 @@ public class WmlToMarkdownConverterSettings
     public bool ResolveNumbering { get; set; } = true;
 
     /// <summary>
-    /// Builds the URI used for image references in the output. Defaults to
-    /// <c>docxodus://img/{unid}</c>; callers that want data URIs or HTTP URLs can override.
+    /// Compatibility placeholder for a future Markdown image projection. The current converter
+    /// emits no <c>w:drawing</c>/<c>w:pict</c> image syntax and never invokes this callback; use
+    /// <see cref="DocxSession.ListImages"/> and the native image surface to inspect images.
     /// </summary>
     public Func<ImageInfo, string>? ImageUriBuilder { get; set; }
 

--- a/docs/architecture/docx_mutation_api.md
+++ b/docs/architecture/docx_mutation_api.md
@@ -77,7 +77,8 @@ The common wire object is available throughout the stack: npm exposes
 that attaches the guard to each mutation request; stdio accepts top-level
 `preconditions`; MCP mutation tools and individual batch steps accept the same
 property. MCP batches may additionally carry a batch-start guard. Preview mode
-restores the starting version after it undoes its speculative edits.
+runs against an isolated shadow clone and never mutates the live session, so there is
+no speculative edit to undo and no version to restore.
 
 ## Atomic batches and transactions
 

--- a/docs/architecture/editor_ui_surface.md
+++ b/docs/architecture/editor_ui_surface.md
@@ -154,7 +154,9 @@ to Home.
 This replaced a **floating** table toolbar, whose absolute positioning had to be corrected twice — it
 covered the first row, and then it covered the content below the table. A docked tab cannot overlap
 the cell being edited, so the whole class of bug is gone by construction. Deleting the last row or
-column removes the table. v1 assumes a rectangular grid (no `w:gridSpan`).
+column removes the table. The underlying session ops are grid-aware, not rectangular-only:
+`w:gridSpan`, `w:gridBefore`/`w:gridAfter` and `w:vMerge` runs are all handled — see the CRUD
+behavior table in [`docx_mutation_api.md`](docx_mutation_api.md).
 
 ---
 

--- a/docs/architecture/epic_435_acceptance_smoke.md
+++ b/docs/architecture/epic_435_acceptance_smoke.md
@@ -1,6 +1,6 @@
 # Epic #435 acceptance smoke — agent-safe headless document editing
 
-Run 2026-08-15 against `main` at `400af83` plus the three commits this run produced.
+Run 2026-08-15 against `main` at `400af83` plus PR #491 and its review hardening.
 Transport: `docxodus-mcp` over stdio JSON-RPC, driven by
 [`tools/mcp-server/smoke/mcp_probe.py`](../../tools/mcp-server/smoke/mcp_probe.py).
 
@@ -26,10 +26,10 @@ in-repo equivalent of the certificate the round-three smoke used.
 
 | Pass | Calls | Assertions | Failed | Expected failures | Replay mismatches |
 |---|---:|---:|---:|---:|---:|
-| Workflow | 45 | 81 | **0** | 4 | **0** |
+| Workflow | 64 | 212 | **0** | 5 | **0** |
 | Reopen validation | 13 | 27 | **0** | 0 | — |
 
-Unit suite after the fix below: **3793 passed, 0 failed, 3 skipped**.
+Unit suite after the fixes below: **3797 passed, 0 failed, 3 skipped**.
 
 ## The spine: inspect → preview → apply → retry → audit
 
@@ -39,7 +39,7 @@ introspection returned the full `sectPr` rollup including per-kind header/footer
 `docxodus_pagination status` correctly reported `unavailable` / `no_page_map` before any
 map was registered.
 
-**Preview.** A six-step tracked batch (surgical placeholder fill, paragraph insert,
+**Preview.** A five-step tracked batch (surgical placeholder fill, paragraph insert,
 footnote, comment, format) previewed under `mode: preview` with a batch-start
 `expectedVersion` guard and `previewHtml: full`.
 
@@ -48,25 +48,25 @@ footnote, comment, format) previewed under `mode: preview` with a batch-start
 | `baseVersion` → `resultVersion` | 0 → 1 |
 | `revisionChanges.added` | 4 |
 | `commentChanges.added` | 1 |
-| `packageHash` | `ec364b6d…` |
+| `packageHash` | `55a4f660…` |
 | rendered HTML | 522,302 bytes |
 
 The live session was then re-inspected: version still 0, anchors still 462, footnotes still
 94, zero revisions, zero comments. The isolated dry run of #446 holds — nothing crossed
 from the shadow.
 
-**Affected anchors.** Asserted per step on both the preview and the apply: step 0 and step 4
-modify the name clause, step 2 modifies the certification clause, no step removes an anchor,
-and the created-anchor counts the preview predicted are the counts the apply produced. Counts
-rather than ids for creations — the receipt warns that generated ids differ between the two
-runs, which is the same discipline applied to `packageHash` below.
+**Affected anchors.** The complete semantic shape is asserted for every step on both preview
+and apply: created/modified/removed cardinality, every generated anchor's kind and scope, and
+every caller-known modified id. All five removed arrays must be empty. Apply also has to match
+the preview's created counts. Generated creation ids are deliberately not compared because the
+receipt warns that they differ between independent executions.
 
-**Apply.** The same six steps under `mode: atomic` with
+**Apply.** The same five steps under `mode: atomic` with
 `transactionId: epic435-smoke-restated-certificate`. `resultVersion` was asserted *against
 the preview's captured prediction*, not a literal, and matched at 1; `revisionChanges.added`
 and `commentChanges.added` matched the predictions exactly.
 
-`packageHash` differed between preview and apply (`ec364b6d…` vs `64ce4960…`), which is the
+`packageHash` differed between preview and apply (`55a4f660…` vs `0448a0b5…`), which is the
 documented contract, not a defect: this batch generates a comment id, a footnote id and
 revision timestamps, and both receipts carry the warnings that say so —
 
@@ -81,23 +81,33 @@ compared the raw wire text of the two responses: **byte-exact**, `replayMismatch
 Nothing re-applied — version, anchor count, footnote count, revision count and comment
 count were all unchanged after the retry.
 
-**Audit.** Version, anchors and revisions were re-checked after every guarded step; undo
-and redo both remained usable and returned the document to the same anchor count.
+**Audit.** Before the intentional failure, the workflow captured the complete Markdown,
+complete anchor index, complete revision and comment arrays, version, and a deterministic hash
+of every OPC entry. The failed batch receipt and post-failure reads had to match those values
+exactly; count-only comparisons are not used for content, anchor identity, or revisions.
+
+History was tested by content rather than by a boolean: the workflow authored a uniquely named
+paragraph, undid it to seed a pre-existing redo cursor, then ran the failed batch. Redo had to
+restore that exact paragraph and anchor id. After rewinding it, the older undo entry had to
+remove the link/bookmark/table batch and redo had to restore it. Both round trips finished at
+the original `565c0755…` package hash, leaving the seeded redo cursor semantically intact.
 
 ## Failing closed
 
-Four calls are expected to fail, and the harness treats a success there as the defect.
+Five calls are expected to fail, and the harness treats a success there as the defect.
 
 | Probe | Result |
 |---|---|
 | `add_bookmark` while tracking | `tracked_operation_unsupported` — bookmark mutations have no faithful tracked encoding |
 | `insert_table` while tracking | `tracked_operation_unsupported` — no reversible tracked encoding on this document shape |
+| Bookmark endpoints at offsets 33–40 inside the name's `w:ins`, under direct recording | `unsupported_inline_boundary` |
 | Stale `expectedVersion` | `precondition_failed`, reporting the true `currentVersion` |
 | Atomic batch with a bad anchor at index 2 | `status: failed`, `rolledBack: true`, `editsApplied: 0`, `failure.index: 2`, `failure.error.code: anchor_not_found` |
 
-After the rolled-back batch: version, anchor count and revision count all unchanged, and
-neither rolled-back string appears anywhere in the package. A bookmark endpoint aimed
-inside the tracked insertion was separately refused with `unsupported_inline_boundary`.
+After the rolled-back batch, `baseVersion == resultVersion == 4`; its package hash exactly
+matched the pre-failure checkpoint. Full Markdown, anchor identity, revisions, and comments
+also matched, and neither rolled-back string appeared. The revision-interior bookmark refusal
+above is a real executed call, separate from the tracked-operation refusal.
 
 ## Capability coverage
 
@@ -159,6 +169,12 @@ Fixed in `e4b4365` by making `w:ins`/`w:moveTo` transparent containers and leavi
 `w:del`/`w:moveFrom` opaque — the split is visible text versus text the document says was
 removed, not plain versus revised runs. Coverage: `DS409`, `DS410`.
 
+The PR review found a mutation-side consequence: note insertion reused that visible offset
+space but could not split a revision wrapper, so a citation requested inside inserted text was
+silently placed after the whole wrapper. It now fails before snapshotting with
+`unsupported_inline_boundary`; offsets exactly before or after the wrapper remain supported.
+Coverage: `DS339`, `DS340`.
+
 ### 2. A batch step that matches nothing fails as `internal_error` — OPEN
 
 `replace_text_range` with a substring that is genuinely absent behaves inconsistently:
@@ -179,7 +195,8 @@ change, so this is filed rather than fixed here.
   minutes on the 610 KB tracked-changes output, so there is no independent load check.
   Integrity was established structurally instead — zip validity, part set, relationship
   resolution — and by a full reopen through the server. `DS400`'s `AssertSchemaValid` covers
-  the markup shape the fix touches.
+  the tracked replacement shape; `DS339`/`DS340` cover the note boundary and exact edge
+  placement.
 - **Traces are regenerated, not committed.** The workflow trace is ~12 MB, most of it the
   522 KB preview HTML repeated across receipts, so committing it would dwarf the harness it
   documents. The committed workflow plus the README command sequence reproduce it exactly;

--- a/docs/architecture/epic_435_acceptance_smoke.md
+++ b/docs/architecture/epic_435_acceptance_smoke.md
@@ -1,0 +1,175 @@
+# Epic #435 acceptance smoke — agent-safe headless document editing
+
+Run 2026-08-15 against `main` at `400af83` plus the three commits this run produced.
+Transport: `docxodus-mcp` over stdio JSON-RPC, driven by
+[`tools/mcp-server/smoke/mcp_probe.py`](../../tools/mcp-server/smoke/mcp_probe.py).
+
+Reproduce with the commands in [`tools/mcp-server/smoke/README.md`](../../tools/mcp-server/smoke/README.md).
+
+## Document
+
+`TestFiles/NVCA-Model-COI.docx` — a model certificate of incorporation, chosen as the
+in-repo equivalent of the certificate the round-three smoke used.
+
+| Property | Value |
+|---|---|
+| OPC parts | 44 |
+| Running stories | 8 headers, 10 footers |
+| Notes | 94 footnotes |
+| Bookmarks | 392 (body) |
+| Anchors | 462 |
+| Blocks | 153 `h`, 59 `p`, 22 `li`, 4 `sec` |
+| Section | US Letter, `lowerRoman` page numbers, `first` header + `even`/`default`/`first` footers |
+| Tables / images / hyperlinks / content controls / revisions / comments | none at open |
+
+## Result
+
+| Pass | Calls | Assertions | Failed | Expected failures | Replay mismatches |
+|---|---:|---:|---:|---:|---:|
+| Workflow | 45 | 68 | **0** | 4 | **0** |
+| Reopen validation | 13 | 27 | **0** | 0 | — |
+
+Unit suite after the fix below: **3793 passed, 0 failed, 3 skipped**.
+
+## The spine: inspect → preview → apply → retry → audit
+
+**Inspect.** Anchors were discovered by content, never assumed: text search for the
+operative name clause and the certification clause, kind search for a list item. Section
+introspection returned the full `sectPr` rollup including per-kind header/footer refs.
+`docxodus_pagination status` correctly reported `unavailable` / `no_page_map` before any
+map was registered.
+
+**Preview.** A six-step tracked batch (surgical placeholder fill, paragraph insert,
+footnote, comment, format) previewed under `mode: preview` with a batch-start
+`expectedVersion` guard and `previewHtml: full`.
+
+| Predicted | Value |
+|---|---|
+| `baseVersion` → `resultVersion` | 0 → 1 |
+| `revisionChanges.added` | 4 |
+| `commentChanges.added` | 1 |
+| `packageHash` | `ec364b6d…` |
+| rendered HTML | 522,302 bytes |
+
+The live session was then re-inspected: version still 0, anchors still 462, footnotes still
+94, zero revisions, zero comments. The isolated dry run of #446 holds — nothing crossed
+from the shadow.
+
+**Apply.** The same six steps under `mode: atomic` with
+`transactionId: epic435-smoke-restated-certificate`. `resultVersion` was asserted *against
+the preview's captured prediction*, not a literal, and matched at 1; `revisionChanges.added`
+and `commentChanges.added` matched the predictions exactly.
+
+`packageHash` differed between preview and apply (`ec364b6d…` vs `64ce4960…`), which is the
+documented contract, not a defect: this batch generates a comment id, a footnote id and
+revision timestamps, and both receipts carry the warnings that say so —
+
+> Created anchors and related OOXML ids may be generated independently on replay;
+> preview/apply equivalence is semantic and packageHash or anchor ids may differ.
+
+Equivalence was therefore verified where it is promised — outcomes, versions, and semantic
+deltas — and not asserted where the receipt says not to.
+
+**Retry.** The identical request was re-sent to simulate a lost response. The runner
+compared the raw wire text of the two responses: **byte-exact**, `replayMismatches: 0`.
+Nothing re-applied — version, anchor count, footnote count, revision count and comment
+count were all unchanged after the retry.
+
+**Audit.** Version, anchors and revisions were re-checked after every guarded step; undo
+and redo both remained usable and returned the document to the same anchor count.
+
+## Failing closed
+
+Four calls are expected to fail, and the harness treats a success there as the defect.
+
+| Probe | Result |
+|---|---|
+| `add_bookmark` while tracking | `tracked_operation_unsupported` — bookmark mutations have no faithful tracked encoding |
+| `insert_table` while tracking | `tracked_operation_unsupported` — no reversible tracked encoding on this document shape |
+| Stale `expectedVersion` | `precondition_failed`, reporting the true `currentVersion` |
+| Atomic batch with a bad anchor at index 2 | `status: failed`, `rolledBack: true`, `editsApplied: 0`, `failure.index: 2`, `failure.error.code: anchor_not_found` |
+
+After the rolled-back batch: version, anchor count and revision count all unchanged, and
+neither rolled-back string appears anywhere in the package. A bookmark endpoint aimed
+inside the tracked insertion was separately refused with `unsupported_inline_boundary`.
+
+## Capability coverage
+
+Exercised: paragraphs, headings, lists, footnotes, bookmarks, hyperlinks, tables,
+comments, tracked revisions, run and paragraph formatting, section introspection, page
+citations, undo/redo, atomic batches, preconditions, transaction identity.
+
+Link and table work runs in its own untracked batch, reached with
+`docxodus_track_changes set_mode` — the engine refuses those families under tracked
+recording rather than emitting markup it cannot reverse, and switching mode mid-workflow is
+the supported path (#304).
+
+Not applicable, with rationale:
+
+| Capability | Rationale |
+|---|---|
+| Images | The document contains none, and there is no image the workflow would legitimately author into a charter. The surface is covered by `MCP145`. |
+| Content controls | The document contains none, and the `#452` surface fills existing controls rather than creating them. Covered by `MCP147`/`MCP148`. |
+| Endnotes | The document uses footnotes only. |
+
+Page citations were exercised by registering a page map and citing an anchor against it.
+The map is caller-supplied by design — the renderer is client-side — so a synthetic
+single-page map was registered and the citation round-tripped with the anchor's fragment
+geometry and `pageName: "i"` (matching the document's `lowerRoman` numbering).
+
+## Persistence
+
+Saved with `persistAnchorIds: true`, closed, reopened, and re-inspected.
+
+- **Package integrity**: zip valid, 44 → 45 parts, **no part lost**, the only addition
+  `word/comments.xml`. No dangling relationships; exactly one external relationship (the
+  authored hyperlink).
+- **Persisted content**: 4 revisions in document order (insert paragraph, delete
+  placeholder, insert name, format name), all authored `Smoke Counsel`; 1 comment; the
+  bookmark resolves to its anchor; the hyperlink persists as an external relationship with
+  its target intact; the table reopens with an addressable 2×2 grid; the footnote text is
+  findable.
+- **Absence of unintended change**: neither rolled-back string nor the refused
+  stale-precondition string appears anywhere in the reopened package.
+
+## Defects found
+
+### 1. Tracked insertions were invisible to every offset-addressed surface — FIXED
+
+Under `render_inline`, an agent could not re-find the edit it had just made.
+`replace_text_range` succeeded and the projection showed the new text, but
+`docxodus_search` returned nothing, `apply_format_by_substring` reported
+`offset_out_of_range`, and a follow-up `replace_text_range` could not address it.
+
+Root cause: `InlineRuns` descends only into `InlineContainerNames`, which omitted `w:ins`,
+so every run inside a tracked insertion was missing from the flat string all
+offset-addressed ops share — while `Project().Markdown` and `TextPreview` included it.
+
+Not limited to text the session authored: `RA001-Tracked-Revisions-01.docx` holds six
+occurrences of "chromatogram" and search returned exactly the two outside `w:ins`, so an
+incoming Word redline had its inserted spans silently skipped too.
+
+Fixed in `e4b4365` by making `w:ins`/`w:moveTo` transparent containers and leaving
+`w:del`/`w:moveFrom` opaque — the split is visible text versus text the document says was
+removed, not plain versus revised runs. Coverage: `DS409`, `DS410`.
+
+### 2. A batch step that matches nothing fails as `internal_error` — OPEN
+
+`replace_text_range` with a substring that is genuinely absent behaves inconsistently:
+
+- called directly, it returns `[]` — no error, no signal, indistinguishable from a
+  successful no-op;
+- inside a `docxodus_mutations` batch, that same empty result becomes
+  `internal_error: "batch mutation returned no valid edit results"`, failing and rolling
+  back the whole batch.
+
+"No match" is an ordinary, expected outcome and deserves a structured, actionable code on
+both paths. Deciding whether the direct call should start reporting it is a public-API
+change, so this is filed rather than fixed here.
+
+## Gate status
+
+Every success criterion in the epic's final acceptance gate is met by the two runs above,
+with defect 1 resolved and defect 2 recorded. Defect 2 does not block the gate: it is an
+error-classification inconsistency on an operation that matches nothing, and no step of the
+acceptance workflow depends on it.

--- a/docs/architecture/epic_435_acceptance_smoke.md
+++ b/docs/architecture/epic_435_acceptance_smoke.md
@@ -26,7 +26,7 @@ in-repo equivalent of the certificate the round-three smoke used.
 
 | Pass | Calls | Assertions | Failed | Expected failures | Replay mismatches |
 |---|---:|---:|---:|---:|---:|
-| Workflow | 45 | 68 | **0** | 4 | **0** |
+| Workflow | 45 | 81 | **0** | 4 | **0** |
 | Reopen validation | 13 | 27 | **0** | 0 | — |
 
 Unit suite after the fix below: **3793 passed, 0 failed, 3 skipped**.
@@ -54,6 +54,12 @@ footnote, comment, format) previewed under `mode: preview` with a batch-start
 The live session was then re-inspected: version still 0, anchors still 462, footnotes still
 94, zero revisions, zero comments. The isolated dry run of #446 holds — nothing crossed
 from the shadow.
+
+**Affected anchors.** Asserted per step on both the preview and the apply: step 0 and step 4
+modify the name clause, step 2 modifies the certification clause, no step removes an anchor,
+and the created-anchor counts the preview predicted are the counts the apply produced. Counts
+rather than ids for creations — the receipt warns that generated ids differ between the two
+runs, which is the same discipline applied to `packageHash` below.
 
 **Apply.** The same six steps under `mode: atomic` with
 `transactionId: epic435-smoke-restated-certificate`. `resultVersion` was asserted *against
@@ -166,6 +172,18 @@ removed, not plain versus revised runs. Coverage: `DS409`, `DS410`.
 "No match" is an ordinary, expected outcome and deserves a structured, actionable code on
 both paths. Deciding whether the direct call should start reporting it is a public-API
 change, so this is filed rather than fixed here.
+
+## What this run does not cover
+
+- **No third-party render oracle.** `soffice --convert-to pdf` did not finish within 15
+  minutes on the 610 KB tracked-changes output, so there is no independent load check.
+  Integrity was established structurally instead — zip validity, part set, relationship
+  resolution — and by a full reopen through the server. `DS400`'s `AssertSchemaValid` covers
+  the markup shape the fix touches.
+- **Traces are regenerated, not committed.** The workflow trace is ~12 MB, most of it the
+  522 KB preview HTML repeated across receipts, so committing it would dwarf the harness it
+  documents. The committed workflow plus the README command sequence reproduce it exactly;
+  that pair is the durable artifact.
 
 ## Gate status
 

--- a/docs/architecture/markdown_projection.md
+++ b/docs/architecture/markdown_projection.md
@@ -41,7 +41,7 @@ Anchors derive from the `Unid` system Docxodus already maintains on paragraphs a
 
 | Field | Values | Meaning |
 |---|---|---|
-| `kind` | `p`, `h`, `li`, `tbl`, `tr`, `tc`, `cmt`, `fn`, `en`, `img`, `drw`, `sec`, `unk` | Element type |
+| `kind` | Assigned: `p`, `h`, `li`, `tbl`, `tr`, `tc`, `col`, `cmt`, `fn`, `en`, `sdt`, `sec`, `unk`. Reserved (parse, but never assigned to any element): `img`, `drw` | Element type |
 | `scope` | `body`, `hdr1`…`hdrN`, `ftr1`…`ftrN`, `fn`, `en`, `cmt` | Which part of the package |
 | `unid` | 8–16 hex chars | Stable element identifier |
 
@@ -79,7 +79,7 @@ Anchors appear at the start of the line they refer to (block-level) or as inline
 | `w:commentRangeStart`…`End` | Inline `{#cmt:cmt:…}` markers wrapping the commented span | Comment text appears in a Comments section at end |
 | `w:footnoteReference` | `[^fn-xxxx]` GFM footnote ref | Definitions collected at end |
 | `w:endnoteReference` | `[^en-xxxx]` | Same |
-| `w:drawing` / `w:pict` (image) | `![alt](docxodus://img/…){#img:…}` | URL is a scheme the caller resolves; metadata accessible via anchor |
+| `w:drawing` / `w:pict` (image) | Nothing — the Markdown oracle emits no image syntax and assigns no anchor | Images are **not** projected and there is no `img`/`drw` anchor kind. Address them through the native image surface instead (`ListImages`/`imageId`, `docxodus_images` — issue #453), which carries dimensions, alt text and floating layout that Markdown could not express anyway |
 | `w:sdt` (content control) | Anchor on the outer SDT; the current Markdown oracle omits inline/block SDT-delivered content | The SDT remains addressable without changing historical Markdown bytes; HTML and `ListBlocks` flatten/render its content |
 | `w:ins` / `w:del` (tracked changes) | Configurable: accept, show as `{+ins+}`/`{-del-}`, or omit | Mirrors `WmlToHtmlConverter.RenderTrackedChanges` |
 | `w:sectPr` | `---` thematic break preceded by `{#sec:scope:unid}` | Section breaks are addressable as `sec` kind — useful for "find the next section break" tooling. Today no mutation op accepts a `sec` anchor (only block-level `p`/`h`/`li`/`tbl` kinds are mutable); treat `sec` as a passive read-side marker. |
@@ -323,7 +323,9 @@ public class WmlToMarkdownConverterSettings
     // Resolve list numbering to literal markers (default true).
     public bool ResolveNumbering = true;
 
-    // Custom image URI scheme. Default: "docxodus://img/{unid}"
+    // Declared but INERT: the converter has no w:drawing/w:pict branch, so this
+    // callback is threaded through settings and never invoked. It documents an
+    // intended image-URI scheme, not a behavior. See the Images open question.
     public Func<ImageInfo, string>? ImageUriBuilder;
 }
 
@@ -440,7 +442,7 @@ If Phase 1 measurements are >2× these numbers, surface in the PR and discuss be
 
 - **Anchor stability across re-serialization.** Today Unids are assigned when needed; we should verify they survive `OpenXmlMemoryStreamDocument` round trips and document the lifecycle. If they don't, the converter must persist them back to the document.
 - **Comment-on-span granularity.** Word comments can anchor to a span that crosses runs and paragraphs. Inline `{#cmt:…}` markers handle intra-paragraph; cross-paragraph spans probably need a start/end pair.
-- **Images.** The placeholder `docxodus://img/{unid}` URI scheme assumes the caller provides resolution. Should we instead emit data URIs? Configurable via `ImageUriBuilder`, default TBD.
+- **Images.** Still entirely unbuilt on this surface: there is no `w:drawing`/`w:pict` emit path, no `img`/`drw` anchor kind, and `ImageUriBuilder` is a declared-but-never-invoked setting. Since #453 shipped a native image surface with real identity (`imageId`), the open question is no longer "which URI scheme" but whether Markdown should project images *at all* — and if so, whether the anchor space or `imageId` is the addressing authority.
 - **Bidirectional editing.** This converter is one-way, but the eventual `MarkdownToWml` story (or, more likely, an `ApplyEdit(anchor, op)` API) needs to be designed alongside its callers — not in isolation here.
 
 ## Related

--- a/npm/src/session.ts
+++ b/npm/src/session.ts
@@ -1668,8 +1668,13 @@ export class DocxSession {
   }
 
   /**
-   * Return every anchor of the given `kind` (`"p"`, `"h"`, `"li"`, `"tbl"`,
-   * `"row"`, `"cell"`, …), in document order. Reads the projection's anchor
+   * Return every anchor of the given `kind` — one of `"p"`, `"h"`, `"li"`,
+   * `"tbl"`, `"tr"`, `"tc"`, `"col"`, `"sdt"`, `"sec"`, `"fn"`, `"en"`,
+   * `"cmt"`, `"unk"` — in document order. The token set is exact and anything
+   * outside it throws; in particular the row and cell tokens are `"tr"` and
+   * `"tc"`, never `"row"`/`"cell"`. `"img"` and `"drw"` parse but are reserved:
+   * the projection never assigns them, so they always return empty — address
+   * images through the image surface instead. Reads the projection's anchor
    * index directly — no text scan. Pass `scope` (e.g. `"body"`) to restrict to
    * a single part; omit it to span all scopes.
    */

--- a/npm/src/session.ts
+++ b/npm/src/session.ts
@@ -1670,11 +1670,12 @@ export class DocxSession {
   /**
    * Return every anchor of the given `kind` — one of `"p"`, `"h"`, `"li"`,
    * `"tbl"`, `"tr"`, `"tc"`, `"col"`, `"sdt"`, `"sec"`, `"fn"`, `"en"`,
-   * `"cmt"`, `"unk"` — in document order. The token set is exact and anything
-   * outside it throws; in particular the row and cell tokens are `"tr"` and
-   * `"tc"`, never `"row"`/`"cell"`. `"img"` and `"drw"` parse but are reserved:
-   * the projection never assigns them, so they always return empty — address
-   * images through the image surface instead. Reads the projection's anchor
+   * `"cmt"`, `"unk"` — in document order. Matching is an exact string comparison;
+   * in particular the row and cell tokens are `"tr"` and `"tc"`, never
+   * `"row"`/`"cell"`. Unknown strings are not parsed or rejected: they simply
+   * return an empty array. `"img"` and `"drw"` likewise return empty because the
+   * projection never assigns those reserved kinds; address images through the
+   * image surface instead. Reads the projection's anchor
    * index directly — no text scan. Pass `scope` (e.g. `"body"`) to restrict to
    * a single part; omit it to span all scopes.
    */

--- a/tools/mcp-server/smoke/README.md
+++ b/tools/mcp-server/smoke/README.md
@@ -35,7 +35,7 @@ python3 tools/mcp-server/smoke/mcp_probe.py \
   --quiet-server -- tools/mcp-server/bin/Debug/net10.0/docxodus-mcp
 ```
 
-Expected: 45 calls / 68 assertions and 13 calls / 27 assertions, both with zero failures,
+Expected: 45 calls / 81 assertions and 13 calls / 27 assertions, both with zero failures,
 four expected failures in the first, and `replayMismatches: 0`.
 
 Four calls are *supposed* to fail, and the runner treats a success there as the defect

--- a/tools/mcp-server/smoke/README.md
+++ b/tools/mcp-server/smoke/README.md
@@ -35,13 +35,14 @@ python3 tools/mcp-server/smoke/mcp_probe.py \
   --quiet-server -- tools/mcp-server/bin/Debug/net10.0/docxodus-mcp
 ```
 
-Expected: 45 calls / 81 assertions and 13 calls / 27 assertions, both with zero failures,
-four expected failures in the first, and `replayMismatches: 0`.
+Expected: 64 calls / 212 assertions and 13 calls / 27 assertions, both with zero failures,
+five expected failures in the first, and `replayMismatches: 0`.
 
-Four calls are *supposed* to fail, and the runner treats a success there as the defect
+Five calls are *supposed* to fail, and the runner treats a success there as the defect
 (`unexpectedSuccesses`): a bookmark and a table insert refused under tracked recording, a
-stale precondition, and the batch that rolls back. The engine failing those closed is the
-property under test.
+bookmark endpoint refused inside a tracked insertion under direct recording, a stale
+precondition, and the batch that rolls back. The engine failing those closed is the property
+under test.
 
 ### Workflow call fields
 
@@ -51,6 +52,7 @@ Beyond `name`/`arguments`/`capture`/`expect`, honored by `mcp_probe.py`:
 |---|---|
 | `expectFailure` | This call must fail. Its failure stops counting against the run, and a *success* becomes an `unexpectedSuccess`. |
 | `expectSameAs` | Compare this call's raw response text to that of the named earlier call. Byte-exact, before JSON parsing normalizes key order — which is what transaction replay actually promises. |
+| `expectNonEmpty` | List of result paths that must resolve to a non-empty string, array, or object. Used for generated payloads such as preview HTML and package hashes where pinning fixture-specific bytes would be brittle. |
 
 `expect` values substitute `$variables` too, so one call can be asserted against another's
 captured value (the apply's `resultVersion` against the preview's prediction).

--- a/tools/mcp-server/smoke/README.md
+++ b/tools/mcp-server/smoke/README.md
@@ -1,4 +1,61 @@
-# Round-three DOCX MCP smoke workflow
+# DOCX MCP smoke workflows
+
+Two workflows live here. The **epic #435 acceptance run** is the one to reach for when
+verifying the agent-editing surface end to end; the **round-three run** below predates it
+and exercises a broader but less guarded operation mix.
+
+## Epic #435 acceptance run
+
+`epic-435-workflow.json` walks the acceptance gate for *Agent-safe headless document
+editing* — inspect, isolated preview, atomic apply under a transaction id, a retry proving
+byte-exact replay, an intentional stale request, an intentional atomic failure, an audit
+that nothing moved, a page citation, then save. `epic-435-validation.json` reopens the
+saved package and checks what persisted. Neither file is edited by hand: the first is
+emitted by `build_epic_435_workflow.py`, because the preview, the apply and the retry must
+send a byte-identical step array or the retry is a `transaction_conflict` rather than a
+replay.
+
+```bash
+dotnet build tools/mcp-server/mcpserver.csproj
+python3 tools/mcp-server/smoke/build_epic_435_workflow.py
+
+# Copy the source document into a scratch storage root — the run SAVES, and pointing
+# the root at TestFiles/ would overwrite a committed fixture.
+export DOCXODUS_STORAGE_ROOT=$(mktemp -d)
+cp TestFiles/NVCA-Model-COI.docx "$DOCXODUS_STORAGE_ROOT/local.docx"
+
+python3 tools/mcp-server/smoke/mcp_probe.py \
+  --calls tools/mcp-server/smoke/epic-435-workflow.json \
+  --trace /tmp/epic435-trace.json \
+  --quiet-server -- tools/mcp-server/bin/Debug/net10.0/docxodus-mcp
+
+python3 tools/mcp-server/smoke/mcp_probe.py \
+  --calls tools/mcp-server/smoke/epic-435-validation.json \
+  --trace /tmp/epic435-validation-trace.json \
+  --quiet-server -- tools/mcp-server/bin/Debug/net10.0/docxodus-mcp
+```
+
+Expected: 45 calls / 68 assertions and 13 calls / 27 assertions, both with zero failures,
+four expected failures in the first, and `replayMismatches: 0`.
+
+Four calls are *supposed* to fail, and the runner treats a success there as the defect
+(`unexpectedSuccesses`): a bookmark and a table insert refused under tracked recording, a
+stale precondition, and the batch that rolls back. The engine failing those closed is the
+property under test.
+
+### Workflow call fields
+
+Beyond `name`/`arguments`/`capture`/`expect`, honored by `mcp_probe.py`:
+
+| Field | Meaning |
+|---|---|
+| `expectFailure` | This call must fail. Its failure stops counting against the run, and a *success* becomes an `unexpectedSuccess`. |
+| `expectSameAs` | Compare this call's raw response text to that of the named earlier call. Byte-exact, before JSON parsing normalizes key order — which is what transaction replay actually promises. |
+
+`expect` values substitute `$variables` too, so one call can be asserted against another's
+captured value (the apply's `resultVersion` against the preview's prediction).
+
+## Round-three DOCX MCP smoke workflow
 
 This directory contains a reproducible replacement-server workflow for the October 2025 model certificate of incorporation. It is intentionally heterogeneous: the sequence reads a large existing package, previews and rolls back a mutation batch, accepts and rejects tracked changes, performs undo/redo, formats runs and paragraphs, authors a resolved comment thread, creates and restarts a nested Roman list, and creates a styled table with explicit row-layout properties.
 

--- a/tools/mcp-server/smoke/build_epic_435_workflow.py
+++ b/tools/mcp-server/smoke/build_epic_435_workflow.py
@@ -1,0 +1,678 @@
+#!/usr/bin/env python3
+"""Generate the epic #435 acceptance workflow for `mcp_probe.py`.
+
+The preview, the apply, and the retry must send a *byte-identical* step array —
+that is what the transaction fingerprint is computed over, and a retry whose
+fingerprint differs is a `transaction_conflict` rather than a replay. Writing the
+array once and emitting it three times is the point of generating this file
+instead of hand-maintaining the JSON.
+
+Run:  python3 tools/mcp-server/smoke/build_epic_435_workflow.py
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+TRANSACTION_ID = "epic435-smoke-restated-certificate"
+CORPORATION = "Northstar Robotics, Inc."
+PLACEHOLDER = "[_______________]"
+RENDERER = "epic435-smoke-renderer-1"
+
+
+def step(tool: str, **args: object) -> dict:
+    return {"tool": tool, "args": args}
+
+
+# The substantive tracked edit: a counsel filling in and annotating a restated
+# certificate. Every step here is representable as a tracked revision. Bookmark
+# and hyperlink mutations deliberately are not, and neither is InsertTable on this
+# document shape — the engine fails those closed under render_inline rather than
+# emitting markup it could not reverse — so they run in an untracked batch below.
+TRACKED_STEPS = [
+    step(
+        "docxodus_edit",
+        action="replace_text_range",
+        anchorId="$name_anchor",
+        find=PLACEHOLDER,
+        replace=CORPORATION,
+    ),
+    step(
+        "docxodus_create",
+        action="insert_paragraph",
+        anchorId="$certify_anchor",
+        position="after",
+        markdown="The undersigned further certifies that this Restated Certificate "
+        "has been duly adopted in accordance with Sections 242 and 245 of the DGCL.",
+    ),
+    step(
+        "docxodus_create",
+        action="insert_footnote",
+        anchorId="$certify_anchor",
+        characterOffset=19,
+        markdown="Adopted by written consent of the stockholders.",
+    ),
+    step(
+        "docxodus_comment",
+        action="add",
+        anchorId="$name_anchor",
+        author="Smoke Counsel",
+        initials="SC",
+        markdown="Confirm the exact legal name against the charter before filing.",
+    ),
+    # Bolds the name this batch's first step just inserted. Addressing text an
+    # earlier step inserted in the SAME tracked batch is exactly what DS409 fixed.
+    step(
+        "docxodus_format",
+        action="apply_format_by_substring",
+        anchorId="$name_anchor",
+        substring=CORPORATION,
+        format={"bold": True},
+    ),
+]
+
+
+def mutations(call_id: str, mode: str, **extra: object) -> dict:
+    arguments: dict = {"sessionId": "$session_id", "mode": mode}
+    arguments.update(extra.pop("arguments_extra", {}))  # type: ignore[arg-type]
+    arguments["preconditions"] = {"expectedVersion": "$base_version"}
+    arguments["steps"] = TRACKED_STEPS
+    call: dict = {"id": call_id, "name": "docxodus_mutations", "arguments": arguments}
+    call.update(extra)
+    return call
+
+
+def workflow() -> list[dict]:
+    calls: list[dict] = []
+
+    # ── Inspect ──────────────────────────────────────────────────────────
+    calls += [
+        {
+            "id": "open",
+            "name": "docxodus_open",
+            "arguments": {
+                "path": "local.docx",
+                "trackedChanges": "render_inline",
+                "revisionAuthor": "Smoke Counsel",
+                "persistAnchorIds": True,
+            },
+            "capture": {"session_id": "sessionId"},
+        },
+        {
+            "id": "inspect_info",
+            "name": "docxodus_get_content",
+            "arguments": {"sessionId": "$session_id", "format": "info"},
+            "capture": {
+                "base_version": "version",
+                "total_anchors": "editSummary.totalAnchors",
+                "footnote_count": "editSummary.footnoteCount",
+            },
+            "expect": {"version": 0, "sectionInfo.pageNumberFormat": "lowerRoman"},
+        },
+        {
+            "id": "inspect_name_clause",
+            "name": "docxodus_search",
+            "arguments": {
+                "sessionId": "$session_id",
+                "mode": "text",
+                "query": "The name of this corporation is",
+                "maxResults": 2,
+            },
+            "capture": {"name_anchor": "matches.1.enclosingAnchor.id"},
+        },
+        {
+            "id": "inspect_certification",
+            "name": "docxodus_search",
+            "arguments": {
+                "sessionId": "$session_id",
+                "mode": "text",
+                "query": "DOES HEREBY CERTIFY",
+                "maxResults": 1,
+            },
+            "capture": {"certify_anchor": "matches.0.enclosingAnchor.id"},
+        },
+        {
+            "id": "inspect_list_item",
+            "name": "docxodus_search",
+            "arguments": {
+                "sessionId": "$session_id",
+                "mode": "kind",
+                "query": "li",
+                "maxResults": 1,
+            },
+            "capture": {"list_anchor": "matches.0.id"},
+        },
+        {
+            "id": "inspect_bookmarks",
+            "name": "docxodus_links",
+            "arguments": {
+                "sessionId": "$session_id",
+                "action": "list_bookmarks",
+                "scope": "body",
+            },
+            "capture": {"bookmarks_before": "bookmarks.length"},
+        },
+        {
+            "id": "inspect_revisions",
+            "name": "docxodus_track_changes",
+            "arguments": {"sessionId": "$session_id", "action": "list"},
+            "expect": {"revisions.length": 0},
+        },
+        {
+            "id": "inspect_pagination_unregistered",
+            "name": "docxodus_pagination",
+            "arguments": {"sessionId": "$session_id", "action": "status"},
+            "expect": {
+                "availability": "unavailable",
+                "unavailableReason": "no_page_map",
+            },
+        },
+    ]
+
+    # ── Preview, and prove the live session did not move ──────────────────
+    calls += [
+        mutations(
+            "preview",
+            "preview",
+            arguments_extra={"previewHtml": "full"},
+            capture={
+                "predicted_version": "resultVersion",
+                "predicted_hash": "packageHash",
+                "predicted_revision_adds": "revisionChanges.added.length",
+                "predicted_comment_adds": "commentChanges.added.length",
+            },
+            expect={
+                "status": "ok",
+                "preview": True,
+                "rolledBack": False,
+                "baseVersion": "$base_version",
+                "editsApplied": len(TRACKED_STEPS),
+            },
+        ),
+        {
+            "id": "preview_left_live_untouched",
+            "name": "docxodus_get_content",
+            "arguments": {"sessionId": "$session_id", "format": "info"},
+            "expect": {
+                "version": "$base_version",
+                "editSummary.totalAnchors": "$total_anchors",
+                "editSummary.footnoteCount": "$footnote_count",
+            },
+        },
+        {
+            "id": "preview_authored_no_live_revisions",
+            "name": "docxodus_track_changes",
+            "arguments": {"sessionId": "$session_id", "action": "list"},
+            "expect": {"revisions.length": 0},
+        },
+        {
+            "id": "preview_authored_no_live_comments",
+            "name": "docxodus_comment",
+            "arguments": {"sessionId": "$session_id", "action": "list"},
+            "expect": {"comments.length": 0},
+        },
+    ]
+
+    # ── Apply atomically under a transaction id ───────────────────────────
+    calls += [
+        mutations(
+            "apply",
+            "atomic",
+            arguments_extra={"transactionId": TRANSACTION_ID},
+            capture={"applied_version": "resultVersion", "applied_hash": "packageHash"},
+            expect={
+                "status": "ok",
+                "preview": False,
+                "rolledBack": False,
+                "baseVersion": "$base_version",
+                "editsApplied": len(TRACKED_STEPS),
+                # The preview's predictions, now checked against reality.
+                "resultVersion": "$predicted_version",
+                "revisionChanges.added.length": "$predicted_revision_adds",
+                "commentChanges.added.length": "$predicted_comment_adds",
+                "transaction.transactionId": TRANSACTION_ID,
+            },
+        ),
+        {
+            "id": "apply_advanced_live_state",
+            "name": "docxodus_get_content",
+            "arguments": {"sessionId": "$session_id", "format": "info"},
+            "capture": {
+                "live_version": "version",
+                "live_anchors": "editSummary.totalAnchors",
+                "live_footnotes": "editSummary.footnoteCount",
+            },
+            "expect": {"version": "$applied_version"},
+        },
+        {
+            "id": "apply_authored_revisions",
+            "name": "docxodus_track_changes",
+            "arguments": {"sessionId": "$session_id", "action": "list"},
+            "capture": {"revisions_after_apply": "revisions.length"},
+        },
+        {
+            "id": "apply_authored_comment",
+            "name": "docxodus_comment",
+            "arguments": {"sessionId": "$session_id", "action": "list"},
+            "expect": {"comments.length": 1, "comments.0.author": "Smoke Counsel"},
+        },
+    ]
+
+    # ── Simulated response loss: retry the identical request ──────────────
+    calls += [
+        mutations(
+            "retry_after_simulated_response_loss",
+            "atomic",
+            arguments_extra={"transactionId": TRANSACTION_ID},
+            expectSameAs="apply",
+        ),
+        {
+            "id": "retry_created_no_duplicate_edit",
+            "name": "docxodus_get_content",
+            "arguments": {"sessionId": "$session_id", "format": "info"},
+            "expect": {
+                "version": "$live_version",
+                "editSummary.totalAnchors": "$live_anchors",
+                "editSummary.footnoteCount": "$live_footnotes",
+            },
+        },
+        {
+            "id": "retry_created_no_duplicate_revisions",
+            "name": "docxodus_track_changes",
+            "arguments": {"sessionId": "$session_id", "action": "list"},
+            "expect": {"revisions.length": "$revisions_after_apply"},
+        },
+        {
+            "id": "retry_created_no_duplicate_comment",
+            "name": "docxodus_comment",
+            "arguments": {"sessionId": "$session_id", "action": "list"},
+            "expect": {"comments.length": 1},
+        },
+    ]
+
+    # ── Link scaffolding: the engine fails closed under tracked recording ──
+    calls += [
+        {
+            "id": "bookmark_is_refused_while_tracking",
+            "name": "docxodus_links",
+            "arguments": {
+                "sessionId": "$session_id",
+                "action": "add_bookmark",
+                "name": "SmokeCorporationName",
+                "startAnchorId": "$name_anchor",
+                "startOffset": 2,
+                "endAnchorId": "$name_anchor",
+                "endOffset": 26,
+            },
+            "expectFailure": True,
+            "expect": {"error.code": "tracked_operation_unsupported"},
+        },
+        {
+            "id": "table_insert_is_refused_while_tracking",
+            "name": "docxodus_create",
+            "arguments": {
+                "sessionId": "$session_id",
+                "action": "insert_table",
+                "anchorId": "$certify_anchor",
+                "position": "after",
+                "rows": 2,
+                "columns": 2,
+                "cellContents": ["Class", "Authorized Shares"],
+            },
+            "expectFailure": True,
+            "expect": {"error.code": "tracked_operation_unsupported"},
+        },
+        {
+            "id": "switch_to_direct_recording",
+            "name": "docxodus_track_changes",
+            "arguments": {
+                "sessionId": "$session_id",
+                "action": "set_mode",
+                "mode": "accept",
+            },
+        },
+        {
+            "id": "link_scaffolding_batch",
+            "name": "docxodus_mutations",
+            "arguments": {
+                "sessionId": "$session_id",
+                "mode": "atomic",
+                "steps": [
+                    # Deliberately NOT the name clause: its offsets now fall inside
+                    # the w:ins the tracked batch authored, and a bookmark endpoint
+                    # inside a revision is refused (unsupported_inline_boundary).
+                    step(
+                        "docxodus_links",
+                        action="add_bookmark",
+                        name="SmokeDelawareRationale",
+                        startAnchorId="$list_anchor",
+                        startOffset=12,
+                        endAnchorId="$list_anchor",
+                        endOffset=30,
+                    ),
+                    step(
+                        "docxodus_links",
+                        action="add_hyperlink",
+                        anchorId="$list_anchor",
+                        startOffset=0,
+                        length=8,
+                        kind="external",
+                        target="https://delcode.delaware.gov/title8/c001/",
+                    ),
+                    step(
+                        "docxodus_create",
+                        action="insert_table",
+                        anchorId="$certify_anchor",
+                        position="after",
+                        rows=2,
+                        columns=2,
+                        cellContents=[
+                            "Class",
+                            "Authorized Shares",
+                            "Common Stock",
+                            "100,000,000",
+                        ],
+                    ),
+                ],
+            },
+            "expect": {"status": "ok", "editsApplied": 3},
+        },
+        {
+            "id": "table_metadata_is_addressable",
+            "name": "docxodus_search",
+            "arguments": {
+                "sessionId": "$session_id",
+                "mode": "kind",
+                "query": "tbl",
+                "maxResults": 1,
+            },
+            "capture": {"table_anchor": "matches.0.id"},
+        },
+        {
+            "id": "table_coordinates_resolve",
+            "name": "docxodus_table",
+            "arguments": {
+                "sessionId": "$session_id",
+                "action": "resolve_cell_coordinate",
+                "tableAnchorId": "$table_anchor",
+                "rowIndex": 1,
+                "columnIndex": 1,
+            },
+        },
+        {
+            "id": "bookmark_resolves_to_its_anchor",
+            "name": "docxodus_search",
+            "arguments": {
+                "sessionId": "$session_id",
+                "mode": "bookmark",
+                "query": "SmokeDelawareRationale",
+            },
+            "expect": {"matches.0.id": "$list_anchor"},
+        },
+        {
+            "id": "hyperlink_is_registered",
+            "name": "docxodus_links",
+            "arguments": {
+                "sessionId": "$session_id",
+                "action": "list_hyperlinks",
+                "scope": "body",
+            },
+            "expect": {"hyperlinks.length": 1, "hyperlinks.0.kind": "external"},
+        },
+        {
+            "id": "resume_tracked_recording",
+            "name": "docxodus_track_changes",
+            "arguments": {
+                "sessionId": "$session_id",
+                "action": "set_mode",
+                "mode": "render_inline",
+                "revisionAuthor": "Smoke Counsel",
+            },
+        },
+        {
+            "id": "state_after_link_scaffolding",
+            "name": "docxodus_get_content",
+            "arguments": {"sessionId": "$session_id", "format": "info"},
+            "capture": {
+                "guarded_version": "version",
+                "guarded_anchors": "editSummary.totalAnchors",
+            },
+        },
+        {
+            "id": "revisions_after_link_scaffolding",
+            "name": "docxodus_track_changes",
+            "arguments": {"sessionId": "$session_id", "action": "list"},
+            "capture": {"guarded_revisions": "revisions.length"},
+        },
+    ]
+
+    # ── Intentional stale request and intentional atomic failure ──────────
+    calls += [
+        {
+            "id": "stale_precondition_is_refused",
+            "name": "docxodus_edit",
+            "arguments": {
+                "sessionId": "$session_id",
+                "action": "replace_text_range",
+                "anchorId": "$name_anchor",
+                "find": "The name of this corporation is",
+                "replace": "This must never reach the document.",
+                "preconditions": {"expectedVersion": "$base_version"},
+            },
+            "expectFailure": True,
+            "expect": {
+                "error.code": "precondition_failed",
+                "error.precondition.currentVersion": "$guarded_version",
+            },
+        },
+        {
+            "id": "atomic_batch_failure_rolls_back",
+            "name": "docxodus_mutations",
+            "arguments": {
+                "sessionId": "$session_id",
+                "mode": "atomic",
+                "steps": [
+                    step(
+                        "docxodus_create",
+                        action="insert_paragraph",
+                        anchorId="$name_anchor",
+                        position="after",
+                        markdown="A first edit that must be rolled back.",
+                    ),
+                    step(
+                        "docxodus_edit",
+                        action="replace_text_range",
+                        anchorId="$name_anchor",
+                        find=CORPORATION,
+                        replace="A second edit that must be rolled back.",
+                    ),
+                    step(
+                        "docxodus_edit",
+                        action="replace_text",
+                        anchorId="p:body:0000000000000000deadbeefdeadbeef",
+                        markdown="This step fails on a nonexistent anchor.",
+                    ),
+                ],
+            },
+            "expectFailure": True,
+            "expect": {
+                "status": "failed",
+                "rolledBack": True,
+                "editsApplied": 0,
+                "failure.index": 2,
+                "failure.error.code": "anchor_not_found",
+            },
+        },
+    ]
+
+    # ── Audit: content, version, history, anchors and revisions held ──────
+    calls += [
+        {
+            "id": "audit_version_and_anchors_unchanged",
+            "name": "docxodus_get_content",
+            "arguments": {"sessionId": "$session_id", "format": "info"},
+            "expect": {
+                "version": "$guarded_version",
+                "editSummary.totalAnchors": "$guarded_anchors",
+            },
+        },
+        {
+            "id": "audit_revisions_unchanged",
+            "name": "docxodus_track_changes",
+            "arguments": {"sessionId": "$session_id", "action": "list"},
+            "expect": {"revisions.length": "$guarded_revisions"},
+        },
+        {
+            "id": "audit_rolled_back_text_absent",
+            "name": "docxodus_search",
+            "arguments": {
+                "sessionId": "$session_id",
+                "mode": "text",
+                "query": "must be rolled back",
+                "scope": "all",
+            },
+            "expect": {"matches.length": 0},
+        },
+        {
+            # The applied edit is visible as a revision with the exact inserted text.
+            "id": "audit_applied_text_present_in_revisions",
+            "name": "docxodus_track_changes",
+            "arguments": {"sessionId": "$session_id", "action": "list"},
+            "expect": {
+                "revisions.length": 4,
+                "revisions.1.type": "delete",
+                "revisions.1.text": PLACEHOLDER,
+                "revisions.2.type": "insert",
+                "revisions.2.text": CORPORATION,
+                "revisions.2.author": "Smoke Counsel",
+                "revisions.3.type": "format",
+                "revisions.3.text": CORPORATION,
+            },
+        },
+        {
+            # Regression guard for the defect this smoke found: text inserted under
+            # render_inline lives in w:ins, which InlineRuns used to skip, so search
+            # could not see the edit it had just made (fixed with DS409/DS410).
+            "id": "applied_text_is_findable_after_tracked_edit",
+            "name": "docxodus_search",
+            "arguments": {
+                "sessionId": "$session_id",
+                "mode": "text",
+                "query": CORPORATION,
+                "scope": "body",
+            },
+            "expect": {"matches.0.enclosingAnchor.id": "$name_anchor"},
+        },
+        {
+            "id": "audit_undo_redo_still_usable",
+            "name": "docxodus_edit",
+            "arguments": {"sessionId": "$session_id", "action": "undo"},
+            "expect": {"success": True},
+        },
+        {
+            "id": "audit_redo_restores",
+            "name": "docxodus_edit",
+            "arguments": {"sessionId": "$session_id", "action": "redo"},
+            "expect": {"success": True},
+        },
+        {
+            "id": "audit_state_after_undo_redo",
+            "name": "docxodus_get_content",
+            "arguments": {"sessionId": "$session_id", "format": "info"},
+            "expect": {"editSummary.totalAnchors": "$guarded_anchors"},
+            "capture": {"final_version": "version"},
+        },
+    ]
+
+    # ── Page-aware citation ───────────────────────────────────────────────
+    calls += [
+        {
+            "id": "register_page_map",
+            "name": "docxodus_pagination",
+            "arguments": {
+                "sessionId": "$session_id",
+                "action": "register",
+                "pageMap": {
+                    "schemaVersion": 1,
+                    "mode": "paginated",
+                    "availability": "available",
+                    "documentVersion": "$final_version",
+                    "rendererFingerprint": RENDERER,
+                    "pages": [
+                        {
+                            "pageNumber": 1,
+                            "pageInSection": 1,
+                            "width": 816,
+                            "height": 1056,
+                            "sectionIndex": 0,
+                            "pageName": "i",
+                        }
+                    ],
+                    "fragments": [
+                        {
+                            "fragmentId": "f-name-0",
+                            "anchorId": "$name_anchor",
+                            "fragmentIndex": 0,
+                            "pageNumber": 1,
+                            "geometry": {
+                                "x": 96,
+                                "y": 240,
+                                "width": 624,
+                                "height": 32,
+                            },
+                            "story": "body",
+                            "inTableCell": False,
+                        }
+                    ],
+                },
+            },
+        },
+        {
+            "id": "cite_page_for_anchor",
+            "name": "docxodus_pagination",
+            "arguments": {
+                "sessionId": "$session_id",
+                "action": "cite",
+                "anchorId": "$name_anchor",
+                "citation": {
+                    "documentVersion": "$final_version",
+                    "rendererFingerprint": RENDERER,
+                },
+            },
+            "expect": {
+                "availability": "available",
+                "documentVersion": "$final_version",
+                "pages.0.pageNumber": 1,
+                "pages.0.pageName": "i",
+                "fragments.0.anchorId": "$name_anchor",
+                "fragments.0.story": "body",
+            },
+        },
+    ]
+
+    # ── Persist ───────────────────────────────────────────────────────────
+    calls += [
+        {
+            "id": "save",
+            "name": "docxodus_save",
+            "arguments": {
+                "sessionId": "$session_id",
+                "path": "smoke-output.docx",
+                "persistAnchorIds": True,
+            },
+        },
+        {"id": "close", "name": "docxodus_close", "arguments": {"sessionId": "$session_id"}},
+    ]
+
+    return calls
+
+
+def main() -> None:
+    target = Path(__file__).with_name("epic-435-workflow.json")
+    target.write_text(json.dumps(workflow(), indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {target} ({len(workflow())} calls)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/mcp-server/smoke/build_epic_435_workflow.py
+++ b/tools/mcp-server/smoke/build_epic_435_workflow.py
@@ -19,6 +19,7 @@ TRANSACTION_ID = "epic435-smoke-restated-certificate"
 CORPORATION = "Northstar Robotics, Inc."
 PLACEHOLDER = "[_______________]"
 RENDERER = "epic435-smoke-renderer-1"
+HISTORY_SENTINEL = "History cursor sentinel — this paragraph exists only on redo."
 
 
 def step(tool: str, **args: object) -> dict:
@@ -81,6 +82,53 @@ def mutations(call_id: str, mode: str, **extra: object) -> dict:
     call: dict = {"id": call_id, "name": "docxodus_mutations", "arguments": arguments}
     call.update(extra)
     return call
+
+
+def affected_anchor_expectations() -> dict[str, object]:
+    """Exact semantic affected-anchor shape shared by preview and apply.
+
+    Generated ids intentionally differ between executions, but cardinality, kind, scope, and
+    every caller-known modified id are deterministic and are all part of the receipt contract.
+    """
+    expected: dict[str, object] = {}
+    for index in range(len(TRACKED_STEPS)):
+        expected[f"steps.{index}.success"] = True
+        expected[f"steps.{index}.rolledBack"] = False
+        expected[f"steps.{index}.results.length"] = 1
+        expected[f"steps.{index}.results.0.success"] = True
+        expected[f"steps.{index}.results.0.removed.length"] = 0
+
+    expected.update({
+        "steps.0.results.0.created.length": 0,
+        "steps.0.results.0.modified.length": 1,
+        "steps.0.results.0.modified.0.id": "$name_anchor",
+
+        "steps.1.results.0.created.length": 1,
+        "steps.1.results.0.created.0.kind": "p",
+        "steps.1.results.0.created.0.scope": "body",
+        "steps.1.results.0.modified.length": 0,
+
+        "steps.2.results.0.created.length": 2,
+        "steps.2.results.0.created.0.kind": "fn",
+        "steps.2.results.0.created.0.scope": "fn",
+        "steps.2.results.0.created.1.kind": "p",
+        "steps.2.results.0.created.1.scope": "fn",
+        "steps.2.results.0.modified.length": 1,
+        "steps.2.results.0.modified.0.id": "$certify_anchor",
+
+        "steps.3.results.0.created.length": 2,
+        "steps.3.results.0.created.0.kind": "cmt",
+        "steps.3.results.0.created.0.scope": "cmt",
+        "steps.3.results.0.created.1.kind": "p",
+        "steps.3.results.0.created.1.scope": "cmt",
+        "steps.3.results.0.modified.length": 1,
+        "steps.3.results.0.modified.0.id": "$name_anchor",
+
+        "steps.4.results.0.created.length": 0,
+        "steps.4.results.0.modified.length": 1,
+        "steps.4.results.0.modified.0.id": "$name_anchor",
+    })
+    return expected
 
 
 def workflow() -> list[dict]:
@@ -181,6 +229,7 @@ def workflow() -> list[dict]:
                 "predicted_hash": "packageHash",
                 "predicted_revision_adds": "revisionChanges.added.length",
                 "predicted_comment_adds": "commentChanges.added.length",
+                "preview_html_bytes": "html.length",
                 # Affected anchors, per step. Counts for created anchors, not ids: the
                 # receipt warns that generated ids differ between preview and apply.
                 "predicted_paragraph_creates": "steps.1.results.0.created.length",
@@ -193,12 +242,9 @@ def workflow() -> list[dict]:
                 "rolledBack": False,
                 "baseVersion": "$base_version",
                 "editsApplied": len(TRACKED_STEPS),
-                "steps.0.results.0.modified.0.id": "$name_anchor",
-                "steps.2.results.0.modified.0.id": "$certify_anchor",
-                "steps.4.results.0.modified.0.id": "$name_anchor",
-                "steps.0.results.0.removed.length": 0,
-                "steps.1.results.0.removed.length": 0,
+                **affected_anchor_expectations(),
             },
+            expectNonEmpty=["html", "packageHash"],
         ),
         {
             "id": "preview_left_live_untouched",
@@ -241,12 +287,8 @@ def workflow() -> list[dict]:
                 "resultVersion": "$predicted_version",
                 "revisionChanges.added.length": "$predicted_revision_adds",
                 "commentChanges.added.length": "$predicted_comment_adds",
-                # The anchors the preview said would be touched are the ones that were.
-                "steps.0.results.0.modified.0.id": "$name_anchor",
-                "steps.2.results.0.modified.0.id": "$certify_anchor",
-                "steps.4.results.0.modified.0.id": "$name_anchor",
-                "steps.0.results.0.removed.length": 0,
-                "steps.1.results.0.removed.length": 0,
+                # Generated ids differ, but the complete semantic affected-anchor shape must not.
+                **affected_anchor_expectations(),
                 "steps.1.results.0.created.length": "$predicted_paragraph_creates",
                 "steps.2.results.0.created.length": "$predicted_footnote_creates",
                 "steps.3.results.0.created.length": "$predicted_comment_creates",
@@ -352,6 +394,24 @@ def workflow() -> list[dict]:
             },
         },
         {
+            "id": "bookmark_revision_interior_is_refused",
+            "name": "docxodus_links",
+            "arguments": {
+                "sessionId": "$session_id",
+                "action": "add_bookmark",
+                "name": "SmokeRevisionInteriorShouldFail",
+                # The inserted corporate name begins at visible offset 32. Both endpoints are
+                # strictly inside its w:ins, so direct recording reaches the boundary guard rather
+                # than the tracked-operation guard exercised above.
+                "startAnchorId": "$name_anchor",
+                "startOffset": 33,
+                "endAnchorId": "$name_anchor",
+                "endOffset": 40,
+            },
+            "expectFailure": True,
+            "expect": {"error.code": "unsupported_inline_boundary"},
+        },
+        {
             "id": "link_scaffolding_batch",
             "name": "docxodus_mutations",
             "arguments": {
@@ -450,6 +510,33 @@ def workflow() -> list[dict]:
             },
         },
         {
+            # Seed a known pre-existing redo cursor without changing the guarded package. A failed
+            # atomic batch must preserve the snapshot itself, not merely leave redo callable.
+            "id": "seed_history_redo_target",
+            "name": "docxodus_create",
+            "arguments": {
+                "sessionId": "$session_id",
+                "action": "insert_paragraph",
+                "anchorId": "$certify_anchor",
+                "position": "after",
+                "markdown": HISTORY_SENTINEL,
+            },
+            "capture": {"history_seed_anchor": "created.0.id"},
+            "expect": {
+                "success": True,
+                "created.length": 1,
+                "created.0.kind": "p",
+                "created.0.scope": "body",
+                "removed.length": 0,
+            },
+        },
+        {
+            "id": "seed_history_redo_cursor",
+            "name": "docxodus_edit",
+            "arguments": {"sessionId": "$session_id", "action": "undo"},
+            "expect": {"success": True},
+        },
+        {
             "id": "state_after_link_scaffolding",
             "name": "docxodus_get_content",
             "arguments": {"sessionId": "$session_id", "format": "info"},
@@ -462,7 +549,39 @@ def workflow() -> list[dict]:
             "id": "revisions_after_link_scaffolding",
             "name": "docxodus_track_changes",
             "arguments": {"sessionId": "$session_id", "action": "list"},
-            "capture": {"guarded_revisions": "revisions.length"},
+            "capture": {
+                "guarded_revisions": "revisions",
+                "guarded_revision_count": "revisions.length",
+            },
+        },
+        {
+            "id": "comments_before_failure",
+            "name": "docxodus_comment",
+            "arguments": {"sessionId": "$session_id", "action": "list"},
+            "capture": {"guarded_comments": "comments"},
+        },
+        {
+            "id": "content_and_anchor_identity_before_failure",
+            "name": "docxodus_get_content",
+            "arguments": {"sessionId": "$session_id", "format": "markdown"},
+            "capture": {
+                "guarded_markdown": "markdown",
+                "guarded_anchor_index": "anchorIndex",
+            },
+        },
+        {
+            "id": "package_checkpoint_before_failure",
+            "name": "docxodus_mutations",
+            "arguments": {"sessionId": "$session_id", "mode": "preview", "steps": []},
+            "capture": {"guarded_hash": "packageHash"},
+            "expect": {
+                "status": "ok",
+                "preview": True,
+                "editsApplied": 0,
+                "baseVersion": "$guarded_version",
+                "resultVersion": "$guarded_version",
+            },
+            "expectNonEmpty": ["packageHash"],
         },
     ]
 
@@ -521,6 +640,18 @@ def workflow() -> list[dict]:
                 "editsApplied": 0,
                 "failure.index": 2,
                 "failure.error.code": "anchor_not_found",
+                "baseVersion": "$guarded_version",
+                "resultVersion": "$guarded_version",
+                "packageHash": "$guarded_hash",
+                "revisionChanges.added.length": 0,
+                "revisionChanges.removed.length": 0,
+                "revisionChanges.modified.length": 0,
+                "commentChanges.added.length": 0,
+                "commentChanges.removed.length": 0,
+                "commentChanges.modified.length": 0,
+                "annotationChanges.added.length": 0,
+                "annotationChanges.removed.length": 0,
+                "annotationChanges.modified.length": 0,
             },
         },
     ]
@@ -537,10 +668,25 @@ def workflow() -> list[dict]:
             },
         },
         {
+            "id": "audit_content_and_anchor_identity_unchanged",
+            "name": "docxodus_get_content",
+            "arguments": {"sessionId": "$session_id", "format": "markdown"},
+            "expect": {
+                "markdown": "$guarded_markdown",
+                "anchorIndex": "$guarded_anchor_index",
+            },
+        },
+        {
             "id": "audit_revisions_unchanged",
             "name": "docxodus_track_changes",
             "arguments": {"sessionId": "$session_id", "action": "list"},
-            "expect": {"revisions.length": "$guarded_revisions"},
+            "expect": {"revisions": "$guarded_revisions"},
+        },
+        {
+            "id": "audit_comments_unchanged",
+            "name": "docxodus_comment",
+            "arguments": {"sessionId": "$session_id", "action": "list"},
+            "expect": {"comments": "$guarded_comments"},
         },
         {
             "id": "audit_rolled_back_text_absent",
@@ -584,19 +730,109 @@ def workflow() -> list[dict]:
             "expect": {"matches.0.enclosingAnchor.id": "$name_anchor"},
         },
         {
-            "id": "audit_undo_redo_still_usable",
-            "name": "docxodus_edit",
-            "arguments": {"sessionId": "$session_id", "action": "undo"},
-            "expect": {"success": True},
-        },
-        {
-            "id": "audit_redo_restores",
+            "id": "audit_preexisting_redo_restores_seed",
             "name": "docxodus_edit",
             "arguments": {"sessionId": "$session_id", "action": "redo"},
             "expect": {"success": True},
         },
         {
-            "id": "audit_state_after_undo_redo",
+            "id": "audit_redo_restored_exact_snapshot",
+            "name": "docxodus_search",
+            "arguments": {
+                "sessionId": "$session_id",
+                "mode": "text",
+                "query": HISTORY_SENTINEL,
+                "scope": "body",
+            },
+            "expect": {
+                "matches.length": 1,
+                "matches.0.enclosingAnchor.id": "$history_seed_anchor",
+            },
+        },
+        {
+            "id": "audit_undo_rewinds_seed",
+            "name": "docxodus_edit",
+            "arguments": {"sessionId": "$session_id", "action": "undo"},
+            "expect": {"success": True},
+        },
+        {
+            "id": "audit_package_after_redo_round_trip",
+            "name": "docxodus_mutations",
+            "arguments": {"sessionId": "$session_id", "mode": "preview", "steps": []},
+            "expect": {"status": "ok", "packageHash": "$guarded_hash"},
+        },
+        {
+            "id": "audit_preexisting_undo_rewinds_link_batch",
+            "name": "docxodus_edit",
+            "arguments": {"sessionId": "$session_id", "action": "undo"},
+            "expect": {"success": True},
+        },
+        {
+            "id": "audit_undo_removed_link_batch",
+            "name": "docxodus_search",
+            "arguments": {
+                "sessionId": "$session_id",
+                "mode": "bookmark",
+                "query": "SmokeDelawareRationale",
+            },
+            "expect": {"matches.length": 0},
+        },
+        {
+            "id": "audit_preexisting_undo_can_redo",
+            "name": "docxodus_edit",
+            "arguments": {"sessionId": "$session_id", "action": "redo"},
+            "expect": {"success": True},
+        },
+        {
+            "id": "audit_package_after_undo_round_trip",
+            "name": "docxodus_mutations",
+            "arguments": {"sessionId": "$session_id", "mode": "preview", "steps": []},
+            "expect": {"status": "ok", "packageHash": "$guarded_hash"},
+        },
+        {
+            "id": "audit_link_batch_restored",
+            "name": "docxodus_search",
+            "arguments": {
+                "sessionId": "$session_id",
+                "mode": "bookmark",
+                "query": "SmokeDelawareRationale",
+            },
+            "expect": {"matches.0.id": "$list_anchor"},
+        },
+        {
+            "id": "audit_redo_cursor_survived_undo_round_trip",
+            "name": "docxodus_edit",
+            "arguments": {"sessionId": "$session_id", "action": "redo"},
+            "expect": {"success": True},
+        },
+        {
+            "id": "audit_surviving_redo_restored_exact_snapshot",
+            "name": "docxodus_search",
+            "arguments": {
+                "sessionId": "$session_id",
+                "mode": "text",
+                "query": HISTORY_SENTINEL,
+                "scope": "body",
+            },
+            "expect": {
+                "matches.length": 1,
+                "matches.0.enclosingAnchor.id": "$history_seed_anchor",
+            },
+        },
+        {
+            "id": "audit_rewind_surviving_redo",
+            "name": "docxodus_edit",
+            "arguments": {"sessionId": "$session_id", "action": "undo"},
+            "expect": {"success": True},
+        },
+        {
+            "id": "audit_package_after_all_history_round_trips",
+            "name": "docxodus_mutations",
+            "arguments": {"sessionId": "$session_id", "mode": "preview", "steps": []},
+            "expect": {"status": "ok", "packageHash": "$guarded_hash"},
+        },
+        {
+            "id": "audit_state_after_history_round_trips",
             "name": "docxodus_get_content",
             "arguments": {"sessionId": "$session_id", "format": "info"},
             "expect": {"editSummary.totalAnchors": "$guarded_anchors"},

--- a/tools/mcp-server/smoke/build_epic_435_workflow.py
+++ b/tools/mcp-server/smoke/build_epic_435_workflow.py
@@ -181,6 +181,11 @@ def workflow() -> list[dict]:
                 "predicted_hash": "packageHash",
                 "predicted_revision_adds": "revisionChanges.added.length",
                 "predicted_comment_adds": "commentChanges.added.length",
+                # Affected anchors, per step. Counts for created anchors, not ids: the
+                # receipt warns that generated ids differ between preview and apply.
+                "predicted_paragraph_creates": "steps.1.results.0.created.length",
+                "predicted_footnote_creates": "steps.2.results.0.created.length",
+                "predicted_comment_creates": "steps.3.results.0.created.length",
             },
             expect={
                 "status": "ok",
@@ -188,6 +193,11 @@ def workflow() -> list[dict]:
                 "rolledBack": False,
                 "baseVersion": "$base_version",
                 "editsApplied": len(TRACKED_STEPS),
+                "steps.0.results.0.modified.0.id": "$name_anchor",
+                "steps.2.results.0.modified.0.id": "$certify_anchor",
+                "steps.4.results.0.modified.0.id": "$name_anchor",
+                "steps.0.results.0.removed.length": 0,
+                "steps.1.results.0.removed.length": 0,
             },
         ),
         {
@@ -231,6 +241,15 @@ def workflow() -> list[dict]:
                 "resultVersion": "$predicted_version",
                 "revisionChanges.added.length": "$predicted_revision_adds",
                 "commentChanges.added.length": "$predicted_comment_adds",
+                # The anchors the preview said would be touched are the ones that were.
+                "steps.0.results.0.modified.0.id": "$name_anchor",
+                "steps.2.results.0.modified.0.id": "$certify_anchor",
+                "steps.4.results.0.modified.0.id": "$name_anchor",
+                "steps.0.results.0.removed.length": 0,
+                "steps.1.results.0.removed.length": 0,
+                "steps.1.results.0.created.length": "$predicted_paragraph_creates",
+                "steps.2.results.0.created.length": "$predicted_footnote_creates",
+                "steps.3.results.0.created.length": "$predicted_comment_creates",
                 "transaction.transactionId": TRANSACTION_ID,
             },
         ),

--- a/tools/mcp-server/smoke/epic-435-validation.json
+++ b/tools/mcp-server/smoke/epic-435-validation.json
@@ -1,0 +1,124 @@
+[
+  {
+    "id": "reopen_saved_output",
+    "name": "docxodus_open",
+    "arguments": { "path": "smoke-output.docx", "trackedChanges": "accept" },
+    "capture": { "session_id": "sessionId" }
+  },
+  {
+    "id": "package_reopens_with_intact_structure",
+    "name": "docxodus_get_content",
+    "arguments": { "sessionId": "$session_id", "format": "info" },
+    "capture": { "reopened_anchors": "editSummary.totalAnchors" },
+    "expect": {
+      "version": 0,
+      "sectionInfo.pageNumberFormat": "lowerRoman",
+      "sectionInfo.headerRefs.0.kind": "first",
+      "sectionInfo.footerRefs.0.kind": "even"
+    }
+  },
+  {
+    "id": "tracked_edits_persisted_as_revisions",
+    "name": "docxodus_track_changes",
+    "arguments": { "sessionId": "$session_id", "action": "list" },
+    "expect": {
+      "revisions.length": 4,
+      "revisions.0.type": "insert",
+      "revisions.0.text": "The undersigned further certifies that this Restated Certificate has been duly adopted in accordance with Sections 242 and 245 of the DGCL.\u00b6",
+      "revisions.1.type": "delete",
+      "revisions.1.text": "[_______________]",
+      "revisions.2.type": "insert",
+      "revisions.2.text": "Northstar Robotics, Inc.",
+      "revisions.2.author": "Smoke Counsel",
+      "revisions.3.type": "format",
+      "revisions.3.text": "Northstar Robotics, Inc."
+    }
+  },
+  {
+    "id": "comment_persisted",
+    "name": "docxodus_comment",
+    "arguments": { "sessionId": "$session_id", "action": "list" },
+    "expect": { "comments.length": 1, "comments.0.author": "Smoke Counsel" }
+  },
+  {
+    "id": "bookmark_persisted",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "bookmark",
+      "query": "SmokeDelawareRationale"
+    },
+    "expect": { "matches.length": 1 }
+  },
+  {
+    "id": "hyperlink_persisted_as_external_relationship",
+    "name": "docxodus_links",
+    "arguments": { "sessionId": "$session_id", "action": "list_hyperlinks", "scope": "body" },
+    "expect": {
+      "hyperlinks.length": 1,
+      "hyperlinks.0.kind": "external",
+      "hyperlinks.0.target": "https://delcode.delaware.gov/title8/c001/"
+    }
+  },
+  {
+    "id": "table_persisted",
+    "name": "docxodus_search",
+    "arguments": { "sessionId": "$session_id", "mode": "kind", "query": "tbl" },
+    "expect": { "matches.length": 1 },
+    "capture": { "table_anchor": "matches.0.id" }
+  },
+  {
+    "id": "table_grid_is_addressable",
+    "name": "docxodus_table",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "get_metadata",
+      "tableAnchorId": "$table_anchor"
+    },
+    "expect": { "metadata.rows.length": 2, "metadata.columns.length": 2 }
+  },
+  {
+    "id": "footnote_persisted",
+    "name": "docxodus_search",
+    "arguments": { "sessionId": "$session_id", "mode": "text", "query": "Adopted by written consent", "scope": "all" },
+    "expect": { "matches.length": 1 }
+  },
+  {
+    "id": "inserted_paragraph_persisted_and_findable",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "text",
+      "query": "The undersigned further certifies",
+      "scope": "body"
+    },
+    "expect": { "matches.length": 1 }
+  },
+  {
+    "id": "rolled_back_text_never_persisted",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "text",
+      "query": "must be rolled back",
+      "scope": "all"
+    },
+    "expect": { "matches.length": 0 }
+  },
+  {
+    "id": "refused_text_never_persisted",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "text",
+      "query": "must never reach the document",
+      "scope": "all"
+    },
+    "expect": { "matches.length": 0 }
+  },
+  {
+    "id": "close",
+    "name": "docxodus_close",
+    "arguments": { "sessionId": "$session_id" }
+  }
+]

--- a/tools/mcp-server/smoke/epic-435-workflow.json
+++ b/tools/mcp-server/smoke/epic-435-workflow.json
@@ -1,0 +1,854 @@
+[
+  {
+    "id": "open",
+    "name": "docxodus_open",
+    "arguments": {
+      "path": "local.docx",
+      "trackedChanges": "render_inline",
+      "revisionAuthor": "Smoke Counsel",
+      "persistAnchorIds": true
+    },
+    "capture": {
+      "session_id": "sessionId"
+    }
+  },
+  {
+    "id": "inspect_info",
+    "name": "docxodus_get_content",
+    "arguments": {
+      "sessionId": "$session_id",
+      "format": "info"
+    },
+    "capture": {
+      "base_version": "version",
+      "total_anchors": "editSummary.totalAnchors",
+      "footnote_count": "editSummary.footnoteCount"
+    },
+    "expect": {
+      "version": 0,
+      "sectionInfo.pageNumberFormat": "lowerRoman"
+    }
+  },
+  {
+    "id": "inspect_name_clause",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "text",
+      "query": "The name of this corporation is",
+      "maxResults": 2
+    },
+    "capture": {
+      "name_anchor": "matches.1.enclosingAnchor.id"
+    }
+  },
+  {
+    "id": "inspect_certification",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "text",
+      "query": "DOES HEREBY CERTIFY",
+      "maxResults": 1
+    },
+    "capture": {
+      "certify_anchor": "matches.0.enclosingAnchor.id"
+    }
+  },
+  {
+    "id": "inspect_list_item",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "kind",
+      "query": "li",
+      "maxResults": 1
+    },
+    "capture": {
+      "list_anchor": "matches.0.id"
+    }
+  },
+  {
+    "id": "inspect_bookmarks",
+    "name": "docxodus_links",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "list_bookmarks",
+      "scope": "body"
+    },
+    "capture": {
+      "bookmarks_before": "bookmarks.length"
+    }
+  },
+  {
+    "id": "inspect_revisions",
+    "name": "docxodus_track_changes",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "list"
+    },
+    "expect": {
+      "revisions.length": 0
+    }
+  },
+  {
+    "id": "inspect_pagination_unregistered",
+    "name": "docxodus_pagination",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "status"
+    },
+    "expect": {
+      "availability": "unavailable",
+      "unavailableReason": "no_page_map"
+    }
+  },
+  {
+    "id": "preview",
+    "name": "docxodus_mutations",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "preview",
+      "previewHtml": "full",
+      "preconditions": {
+        "expectedVersion": "$base_version"
+      },
+      "steps": [
+        {
+          "tool": "docxodus_edit",
+          "args": {
+            "action": "replace_text_range",
+            "anchorId": "$name_anchor",
+            "find": "[_______________]",
+            "replace": "Northstar Robotics, Inc."
+          }
+        },
+        {
+          "tool": "docxodus_create",
+          "args": {
+            "action": "insert_paragraph",
+            "anchorId": "$certify_anchor",
+            "position": "after",
+            "markdown": "The undersigned further certifies that this Restated Certificate has been duly adopted in accordance with Sections 242 and 245 of the DGCL."
+          }
+        },
+        {
+          "tool": "docxodus_create",
+          "args": {
+            "action": "insert_footnote",
+            "anchorId": "$certify_anchor",
+            "characterOffset": 19,
+            "markdown": "Adopted by written consent of the stockholders."
+          }
+        },
+        {
+          "tool": "docxodus_comment",
+          "args": {
+            "action": "add",
+            "anchorId": "$name_anchor",
+            "author": "Smoke Counsel",
+            "initials": "SC",
+            "markdown": "Confirm the exact legal name against the charter before filing."
+          }
+        },
+        {
+          "tool": "docxodus_format",
+          "args": {
+            "action": "apply_format_by_substring",
+            "anchorId": "$name_anchor",
+            "substring": "Northstar Robotics, Inc.",
+            "format": {
+              "bold": true
+            }
+          }
+        }
+      ]
+    },
+    "capture": {
+      "predicted_version": "resultVersion",
+      "predicted_hash": "packageHash",
+      "predicted_revision_adds": "revisionChanges.added.length",
+      "predicted_comment_adds": "commentChanges.added.length"
+    },
+    "expect": {
+      "status": "ok",
+      "preview": true,
+      "rolledBack": false,
+      "baseVersion": "$base_version",
+      "editsApplied": 5
+    }
+  },
+  {
+    "id": "preview_left_live_untouched",
+    "name": "docxodus_get_content",
+    "arguments": {
+      "sessionId": "$session_id",
+      "format": "info"
+    },
+    "expect": {
+      "version": "$base_version",
+      "editSummary.totalAnchors": "$total_anchors",
+      "editSummary.footnoteCount": "$footnote_count"
+    }
+  },
+  {
+    "id": "preview_authored_no_live_revisions",
+    "name": "docxodus_track_changes",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "list"
+    },
+    "expect": {
+      "revisions.length": 0
+    }
+  },
+  {
+    "id": "preview_authored_no_live_comments",
+    "name": "docxodus_comment",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "list"
+    },
+    "expect": {
+      "comments.length": 0
+    }
+  },
+  {
+    "id": "apply",
+    "name": "docxodus_mutations",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "atomic",
+      "transactionId": "epic435-smoke-restated-certificate",
+      "preconditions": {
+        "expectedVersion": "$base_version"
+      },
+      "steps": [
+        {
+          "tool": "docxodus_edit",
+          "args": {
+            "action": "replace_text_range",
+            "anchorId": "$name_anchor",
+            "find": "[_______________]",
+            "replace": "Northstar Robotics, Inc."
+          }
+        },
+        {
+          "tool": "docxodus_create",
+          "args": {
+            "action": "insert_paragraph",
+            "anchorId": "$certify_anchor",
+            "position": "after",
+            "markdown": "The undersigned further certifies that this Restated Certificate has been duly adopted in accordance with Sections 242 and 245 of the DGCL."
+          }
+        },
+        {
+          "tool": "docxodus_create",
+          "args": {
+            "action": "insert_footnote",
+            "anchorId": "$certify_anchor",
+            "characterOffset": 19,
+            "markdown": "Adopted by written consent of the stockholders."
+          }
+        },
+        {
+          "tool": "docxodus_comment",
+          "args": {
+            "action": "add",
+            "anchorId": "$name_anchor",
+            "author": "Smoke Counsel",
+            "initials": "SC",
+            "markdown": "Confirm the exact legal name against the charter before filing."
+          }
+        },
+        {
+          "tool": "docxodus_format",
+          "args": {
+            "action": "apply_format_by_substring",
+            "anchorId": "$name_anchor",
+            "substring": "Northstar Robotics, Inc.",
+            "format": {
+              "bold": true
+            }
+          }
+        }
+      ]
+    },
+    "capture": {
+      "applied_version": "resultVersion",
+      "applied_hash": "packageHash"
+    },
+    "expect": {
+      "status": "ok",
+      "preview": false,
+      "rolledBack": false,
+      "baseVersion": "$base_version",
+      "editsApplied": 5,
+      "resultVersion": "$predicted_version",
+      "revisionChanges.added.length": "$predicted_revision_adds",
+      "commentChanges.added.length": "$predicted_comment_adds",
+      "transaction.transactionId": "epic435-smoke-restated-certificate"
+    }
+  },
+  {
+    "id": "apply_advanced_live_state",
+    "name": "docxodus_get_content",
+    "arguments": {
+      "sessionId": "$session_id",
+      "format": "info"
+    },
+    "capture": {
+      "live_version": "version",
+      "live_anchors": "editSummary.totalAnchors",
+      "live_footnotes": "editSummary.footnoteCount"
+    },
+    "expect": {
+      "version": "$applied_version"
+    }
+  },
+  {
+    "id": "apply_authored_revisions",
+    "name": "docxodus_track_changes",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "list"
+    },
+    "capture": {
+      "revisions_after_apply": "revisions.length"
+    }
+  },
+  {
+    "id": "apply_authored_comment",
+    "name": "docxodus_comment",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "list"
+    },
+    "expect": {
+      "comments.length": 1,
+      "comments.0.author": "Smoke Counsel"
+    }
+  },
+  {
+    "id": "retry_after_simulated_response_loss",
+    "name": "docxodus_mutations",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "atomic",
+      "transactionId": "epic435-smoke-restated-certificate",
+      "preconditions": {
+        "expectedVersion": "$base_version"
+      },
+      "steps": [
+        {
+          "tool": "docxodus_edit",
+          "args": {
+            "action": "replace_text_range",
+            "anchorId": "$name_anchor",
+            "find": "[_______________]",
+            "replace": "Northstar Robotics, Inc."
+          }
+        },
+        {
+          "tool": "docxodus_create",
+          "args": {
+            "action": "insert_paragraph",
+            "anchorId": "$certify_anchor",
+            "position": "after",
+            "markdown": "The undersigned further certifies that this Restated Certificate has been duly adopted in accordance with Sections 242 and 245 of the DGCL."
+          }
+        },
+        {
+          "tool": "docxodus_create",
+          "args": {
+            "action": "insert_footnote",
+            "anchorId": "$certify_anchor",
+            "characterOffset": 19,
+            "markdown": "Adopted by written consent of the stockholders."
+          }
+        },
+        {
+          "tool": "docxodus_comment",
+          "args": {
+            "action": "add",
+            "anchorId": "$name_anchor",
+            "author": "Smoke Counsel",
+            "initials": "SC",
+            "markdown": "Confirm the exact legal name against the charter before filing."
+          }
+        },
+        {
+          "tool": "docxodus_format",
+          "args": {
+            "action": "apply_format_by_substring",
+            "anchorId": "$name_anchor",
+            "substring": "Northstar Robotics, Inc.",
+            "format": {
+              "bold": true
+            }
+          }
+        }
+      ]
+    },
+    "expectSameAs": "apply"
+  },
+  {
+    "id": "retry_created_no_duplicate_edit",
+    "name": "docxodus_get_content",
+    "arguments": {
+      "sessionId": "$session_id",
+      "format": "info"
+    },
+    "expect": {
+      "version": "$live_version",
+      "editSummary.totalAnchors": "$live_anchors",
+      "editSummary.footnoteCount": "$live_footnotes"
+    }
+  },
+  {
+    "id": "retry_created_no_duplicate_revisions",
+    "name": "docxodus_track_changes",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "list"
+    },
+    "expect": {
+      "revisions.length": "$revisions_after_apply"
+    }
+  },
+  {
+    "id": "retry_created_no_duplicate_comment",
+    "name": "docxodus_comment",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "list"
+    },
+    "expect": {
+      "comments.length": 1
+    }
+  },
+  {
+    "id": "bookmark_is_refused_while_tracking",
+    "name": "docxodus_links",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "add_bookmark",
+      "name": "SmokeCorporationName",
+      "startAnchorId": "$name_anchor",
+      "startOffset": 2,
+      "endAnchorId": "$name_anchor",
+      "endOffset": 26
+    },
+    "expectFailure": true,
+    "expect": {
+      "error.code": "tracked_operation_unsupported"
+    }
+  },
+  {
+    "id": "table_insert_is_refused_while_tracking",
+    "name": "docxodus_create",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "insert_table",
+      "anchorId": "$certify_anchor",
+      "position": "after",
+      "rows": 2,
+      "columns": 2,
+      "cellContents": [
+        "Class",
+        "Authorized Shares"
+      ]
+    },
+    "expectFailure": true,
+    "expect": {
+      "error.code": "tracked_operation_unsupported"
+    }
+  },
+  {
+    "id": "switch_to_direct_recording",
+    "name": "docxodus_track_changes",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "set_mode",
+      "mode": "accept"
+    }
+  },
+  {
+    "id": "link_scaffolding_batch",
+    "name": "docxodus_mutations",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "atomic",
+      "steps": [
+        {
+          "tool": "docxodus_links",
+          "args": {
+            "action": "add_bookmark",
+            "name": "SmokeDelawareRationale",
+            "startAnchorId": "$list_anchor",
+            "startOffset": 12,
+            "endAnchorId": "$list_anchor",
+            "endOffset": 30
+          }
+        },
+        {
+          "tool": "docxodus_links",
+          "args": {
+            "action": "add_hyperlink",
+            "anchorId": "$list_anchor",
+            "startOffset": 0,
+            "length": 8,
+            "kind": "external",
+            "target": "https://delcode.delaware.gov/title8/c001/"
+          }
+        },
+        {
+          "tool": "docxodus_create",
+          "args": {
+            "action": "insert_table",
+            "anchorId": "$certify_anchor",
+            "position": "after",
+            "rows": 2,
+            "columns": 2,
+            "cellContents": [
+              "Class",
+              "Authorized Shares",
+              "Common Stock",
+              "100,000,000"
+            ]
+          }
+        }
+      ]
+    },
+    "expect": {
+      "status": "ok",
+      "editsApplied": 3
+    }
+  },
+  {
+    "id": "table_metadata_is_addressable",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "kind",
+      "query": "tbl",
+      "maxResults": 1
+    },
+    "capture": {
+      "table_anchor": "matches.0.id"
+    }
+  },
+  {
+    "id": "table_coordinates_resolve",
+    "name": "docxodus_table",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "resolve_cell_coordinate",
+      "tableAnchorId": "$table_anchor",
+      "rowIndex": 1,
+      "columnIndex": 1
+    }
+  },
+  {
+    "id": "bookmark_resolves_to_its_anchor",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "bookmark",
+      "query": "SmokeDelawareRationale"
+    },
+    "expect": {
+      "matches.0.id": "$list_anchor"
+    }
+  },
+  {
+    "id": "hyperlink_is_registered",
+    "name": "docxodus_links",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "list_hyperlinks",
+      "scope": "body"
+    },
+    "expect": {
+      "hyperlinks.length": 1,
+      "hyperlinks.0.kind": "external"
+    }
+  },
+  {
+    "id": "resume_tracked_recording",
+    "name": "docxodus_track_changes",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "set_mode",
+      "mode": "render_inline",
+      "revisionAuthor": "Smoke Counsel"
+    }
+  },
+  {
+    "id": "state_after_link_scaffolding",
+    "name": "docxodus_get_content",
+    "arguments": {
+      "sessionId": "$session_id",
+      "format": "info"
+    },
+    "capture": {
+      "guarded_version": "version",
+      "guarded_anchors": "editSummary.totalAnchors"
+    }
+  },
+  {
+    "id": "revisions_after_link_scaffolding",
+    "name": "docxodus_track_changes",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "list"
+    },
+    "capture": {
+      "guarded_revisions": "revisions.length"
+    }
+  },
+  {
+    "id": "stale_precondition_is_refused",
+    "name": "docxodus_edit",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "replace_text_range",
+      "anchorId": "$name_anchor",
+      "find": "The name of this corporation is",
+      "replace": "This must never reach the document.",
+      "preconditions": {
+        "expectedVersion": "$base_version"
+      }
+    },
+    "expectFailure": true,
+    "expect": {
+      "error.code": "precondition_failed",
+      "error.precondition.currentVersion": "$guarded_version"
+    }
+  },
+  {
+    "id": "atomic_batch_failure_rolls_back",
+    "name": "docxodus_mutations",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "atomic",
+      "steps": [
+        {
+          "tool": "docxodus_create",
+          "args": {
+            "action": "insert_paragraph",
+            "anchorId": "$name_anchor",
+            "position": "after",
+            "markdown": "A first edit that must be rolled back."
+          }
+        },
+        {
+          "tool": "docxodus_edit",
+          "args": {
+            "action": "replace_text_range",
+            "anchorId": "$name_anchor",
+            "find": "Northstar Robotics, Inc.",
+            "replace": "A second edit that must be rolled back."
+          }
+        },
+        {
+          "tool": "docxodus_edit",
+          "args": {
+            "action": "replace_text",
+            "anchorId": "p:body:0000000000000000deadbeefdeadbeef",
+            "markdown": "This step fails on a nonexistent anchor."
+          }
+        }
+      ]
+    },
+    "expectFailure": true,
+    "expect": {
+      "status": "failed",
+      "rolledBack": true,
+      "editsApplied": 0,
+      "failure.index": 2,
+      "failure.error.code": "anchor_not_found"
+    }
+  },
+  {
+    "id": "audit_version_and_anchors_unchanged",
+    "name": "docxodus_get_content",
+    "arguments": {
+      "sessionId": "$session_id",
+      "format": "info"
+    },
+    "expect": {
+      "version": "$guarded_version",
+      "editSummary.totalAnchors": "$guarded_anchors"
+    }
+  },
+  {
+    "id": "audit_revisions_unchanged",
+    "name": "docxodus_track_changes",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "list"
+    },
+    "expect": {
+      "revisions.length": "$guarded_revisions"
+    }
+  },
+  {
+    "id": "audit_rolled_back_text_absent",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "text",
+      "query": "must be rolled back",
+      "scope": "all"
+    },
+    "expect": {
+      "matches.length": 0
+    }
+  },
+  {
+    "id": "audit_applied_text_present_in_revisions",
+    "name": "docxodus_track_changes",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "list"
+    },
+    "expect": {
+      "revisions.length": 4,
+      "revisions.1.type": "delete",
+      "revisions.1.text": "[_______________]",
+      "revisions.2.type": "insert",
+      "revisions.2.text": "Northstar Robotics, Inc.",
+      "revisions.2.author": "Smoke Counsel",
+      "revisions.3.type": "format",
+      "revisions.3.text": "Northstar Robotics, Inc."
+    }
+  },
+  {
+    "id": "applied_text_is_findable_after_tracked_edit",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "text",
+      "query": "Northstar Robotics, Inc.",
+      "scope": "body"
+    },
+    "expect": {
+      "matches.0.enclosingAnchor.id": "$name_anchor"
+    }
+  },
+  {
+    "id": "audit_undo_redo_still_usable",
+    "name": "docxodus_edit",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "undo"
+    },
+    "expect": {
+      "success": true
+    }
+  },
+  {
+    "id": "audit_redo_restores",
+    "name": "docxodus_edit",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "redo"
+    },
+    "expect": {
+      "success": true
+    }
+  },
+  {
+    "id": "audit_state_after_undo_redo",
+    "name": "docxodus_get_content",
+    "arguments": {
+      "sessionId": "$session_id",
+      "format": "info"
+    },
+    "expect": {
+      "editSummary.totalAnchors": "$guarded_anchors"
+    },
+    "capture": {
+      "final_version": "version"
+    }
+  },
+  {
+    "id": "register_page_map",
+    "name": "docxodus_pagination",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "register",
+      "pageMap": {
+        "schemaVersion": 1,
+        "mode": "paginated",
+        "availability": "available",
+        "documentVersion": "$final_version",
+        "rendererFingerprint": "epic435-smoke-renderer-1",
+        "pages": [
+          {
+            "pageNumber": 1,
+            "pageInSection": 1,
+            "width": 816,
+            "height": 1056,
+            "sectionIndex": 0,
+            "pageName": "i"
+          }
+        ],
+        "fragments": [
+          {
+            "fragmentId": "f-name-0",
+            "anchorId": "$name_anchor",
+            "fragmentIndex": 0,
+            "pageNumber": 1,
+            "geometry": {
+              "x": 96,
+              "y": 240,
+              "width": 624,
+              "height": 32
+            },
+            "story": "body",
+            "inTableCell": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "id": "cite_page_for_anchor",
+    "name": "docxodus_pagination",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "cite",
+      "anchorId": "$name_anchor",
+      "citation": {
+        "documentVersion": "$final_version",
+        "rendererFingerprint": "epic435-smoke-renderer-1"
+      }
+    },
+    "expect": {
+      "availability": "available",
+      "documentVersion": "$final_version",
+      "pages.0.pageNumber": 1,
+      "pages.0.pageName": "i",
+      "fragments.0.anchorId": "$name_anchor",
+      "fragments.0.story": "body"
+    }
+  },
+  {
+    "id": "save",
+    "name": "docxodus_save",
+    "arguments": {
+      "sessionId": "$session_id",
+      "path": "smoke-output.docx",
+      "persistAnchorIds": true
+    }
+  },
+  {
+    "id": "close",
+    "name": "docxodus_close",
+    "arguments": {
+      "sessionId": "$session_id"
+    }
+  }
+]

--- a/tools/mcp-server/smoke/epic-435-workflow.json
+++ b/tools/mcp-server/smoke/epic-435-workflow.json
@@ -168,14 +168,22 @@
       "predicted_version": "resultVersion",
       "predicted_hash": "packageHash",
       "predicted_revision_adds": "revisionChanges.added.length",
-      "predicted_comment_adds": "commentChanges.added.length"
+      "predicted_comment_adds": "commentChanges.added.length",
+      "predicted_paragraph_creates": "steps.1.results.0.created.length",
+      "predicted_footnote_creates": "steps.2.results.0.created.length",
+      "predicted_comment_creates": "steps.3.results.0.created.length"
     },
     "expect": {
       "status": "ok",
       "preview": true,
       "rolledBack": false,
       "baseVersion": "$base_version",
-      "editsApplied": 5
+      "editsApplied": 5,
+      "steps.0.results.0.modified.0.id": "$name_anchor",
+      "steps.2.results.0.modified.0.id": "$certify_anchor",
+      "steps.4.results.0.modified.0.id": "$name_anchor",
+      "steps.0.results.0.removed.length": 0,
+      "steps.1.results.0.removed.length": 0
     }
   },
   {
@@ -287,6 +295,14 @@
       "resultVersion": "$predicted_version",
       "revisionChanges.added.length": "$predicted_revision_adds",
       "commentChanges.added.length": "$predicted_comment_adds",
+      "steps.0.results.0.modified.0.id": "$name_anchor",
+      "steps.2.results.0.modified.0.id": "$certify_anchor",
+      "steps.4.results.0.modified.0.id": "$name_anchor",
+      "steps.0.results.0.removed.length": 0,
+      "steps.1.results.0.removed.length": 0,
+      "steps.1.results.0.created.length": "$predicted_paragraph_creates",
+      "steps.2.results.0.created.length": "$predicted_footnote_creates",
+      "steps.3.results.0.created.length": "$predicted_comment_creates",
       "transaction.transactionId": "epic435-smoke-restated-certificate"
     }
   },

--- a/tools/mcp-server/smoke/epic-435-workflow.json
+++ b/tools/mcp-server/smoke/epic-435-workflow.json
@@ -169,6 +169,7 @@
       "predicted_hash": "packageHash",
       "predicted_revision_adds": "revisionChanges.added.length",
       "predicted_comment_adds": "commentChanges.added.length",
+      "preview_html_bytes": "html.length",
       "predicted_paragraph_creates": "steps.1.results.0.created.length",
       "predicted_footnote_creates": "steps.2.results.0.created.length",
       "predicted_comment_creates": "steps.3.results.0.created.length"
@@ -179,12 +180,60 @@
       "rolledBack": false,
       "baseVersion": "$base_version",
       "editsApplied": 5,
-      "steps.0.results.0.modified.0.id": "$name_anchor",
-      "steps.2.results.0.modified.0.id": "$certify_anchor",
-      "steps.4.results.0.modified.0.id": "$name_anchor",
+      "steps.0.success": true,
+      "steps.0.rolledBack": false,
+      "steps.0.results.length": 1,
+      "steps.0.results.0.success": true,
       "steps.0.results.0.removed.length": 0,
-      "steps.1.results.0.removed.length": 0
-    }
+      "steps.1.success": true,
+      "steps.1.rolledBack": false,
+      "steps.1.results.length": 1,
+      "steps.1.results.0.success": true,
+      "steps.1.results.0.removed.length": 0,
+      "steps.2.success": true,
+      "steps.2.rolledBack": false,
+      "steps.2.results.length": 1,
+      "steps.2.results.0.success": true,
+      "steps.2.results.0.removed.length": 0,
+      "steps.3.success": true,
+      "steps.3.rolledBack": false,
+      "steps.3.results.length": 1,
+      "steps.3.results.0.success": true,
+      "steps.3.results.0.removed.length": 0,
+      "steps.4.success": true,
+      "steps.4.rolledBack": false,
+      "steps.4.results.length": 1,
+      "steps.4.results.0.success": true,
+      "steps.4.results.0.removed.length": 0,
+      "steps.0.results.0.created.length": 0,
+      "steps.0.results.0.modified.length": 1,
+      "steps.0.results.0.modified.0.id": "$name_anchor",
+      "steps.1.results.0.created.length": 1,
+      "steps.1.results.0.created.0.kind": "p",
+      "steps.1.results.0.created.0.scope": "body",
+      "steps.1.results.0.modified.length": 0,
+      "steps.2.results.0.created.length": 2,
+      "steps.2.results.0.created.0.kind": "fn",
+      "steps.2.results.0.created.0.scope": "fn",
+      "steps.2.results.0.created.1.kind": "p",
+      "steps.2.results.0.created.1.scope": "fn",
+      "steps.2.results.0.modified.length": 1,
+      "steps.2.results.0.modified.0.id": "$certify_anchor",
+      "steps.3.results.0.created.length": 2,
+      "steps.3.results.0.created.0.kind": "cmt",
+      "steps.3.results.0.created.0.scope": "cmt",
+      "steps.3.results.0.created.1.kind": "p",
+      "steps.3.results.0.created.1.scope": "cmt",
+      "steps.3.results.0.modified.length": 1,
+      "steps.3.results.0.modified.0.id": "$name_anchor",
+      "steps.4.results.0.created.length": 0,
+      "steps.4.results.0.modified.length": 1,
+      "steps.4.results.0.modified.0.id": "$name_anchor"
+    },
+    "expectNonEmpty": [
+      "html",
+      "packageHash"
+    ]
   },
   {
     "id": "preview_left_live_untouched",
@@ -295,14 +344,55 @@
       "resultVersion": "$predicted_version",
       "revisionChanges.added.length": "$predicted_revision_adds",
       "commentChanges.added.length": "$predicted_comment_adds",
-      "steps.0.results.0.modified.0.id": "$name_anchor",
-      "steps.2.results.0.modified.0.id": "$certify_anchor",
-      "steps.4.results.0.modified.0.id": "$name_anchor",
+      "steps.0.success": true,
+      "steps.0.rolledBack": false,
+      "steps.0.results.length": 1,
+      "steps.0.results.0.success": true,
       "steps.0.results.0.removed.length": 0,
+      "steps.1.success": true,
+      "steps.1.rolledBack": false,
+      "steps.1.results.length": 1,
+      "steps.1.results.0.success": true,
       "steps.1.results.0.removed.length": 0,
+      "steps.2.success": true,
+      "steps.2.rolledBack": false,
+      "steps.2.results.length": 1,
+      "steps.2.results.0.success": true,
+      "steps.2.results.0.removed.length": 0,
+      "steps.3.success": true,
+      "steps.3.rolledBack": false,
+      "steps.3.results.length": 1,
+      "steps.3.results.0.success": true,
+      "steps.3.results.0.removed.length": 0,
+      "steps.4.success": true,
+      "steps.4.rolledBack": false,
+      "steps.4.results.length": 1,
+      "steps.4.results.0.success": true,
+      "steps.4.results.0.removed.length": 0,
+      "steps.0.results.0.created.length": 0,
+      "steps.0.results.0.modified.length": 1,
+      "steps.0.results.0.modified.0.id": "$name_anchor",
       "steps.1.results.0.created.length": "$predicted_paragraph_creates",
+      "steps.1.results.0.created.0.kind": "p",
+      "steps.1.results.0.created.0.scope": "body",
+      "steps.1.results.0.modified.length": 0,
       "steps.2.results.0.created.length": "$predicted_footnote_creates",
+      "steps.2.results.0.created.0.kind": "fn",
+      "steps.2.results.0.created.0.scope": "fn",
+      "steps.2.results.0.created.1.kind": "p",
+      "steps.2.results.0.created.1.scope": "fn",
+      "steps.2.results.0.modified.length": 1,
+      "steps.2.results.0.modified.0.id": "$certify_anchor",
       "steps.3.results.0.created.length": "$predicted_comment_creates",
+      "steps.3.results.0.created.0.kind": "cmt",
+      "steps.3.results.0.created.0.scope": "cmt",
+      "steps.3.results.0.created.1.kind": "p",
+      "steps.3.results.0.created.1.scope": "cmt",
+      "steps.3.results.0.modified.length": 1,
+      "steps.3.results.0.modified.0.id": "$name_anchor",
+      "steps.4.results.0.created.length": 0,
+      "steps.4.results.0.modified.length": 1,
+      "steps.4.results.0.modified.0.id": "$name_anchor",
       "transaction.transactionId": "epic435-smoke-restated-certificate"
     }
   },
@@ -490,6 +580,23 @@
     }
   },
   {
+    "id": "bookmark_revision_interior_is_refused",
+    "name": "docxodus_links",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "add_bookmark",
+      "name": "SmokeRevisionInteriorShouldFail",
+      "startAnchorId": "$name_anchor",
+      "startOffset": 33,
+      "endAnchorId": "$name_anchor",
+      "endOffset": 40
+    },
+    "expectFailure": true,
+    "expect": {
+      "error.code": "unsupported_inline_boundary"
+    }
+  },
+  {
     "id": "link_scaffolding_batch",
     "name": "docxodus_mutations",
     "arguments": {
@@ -601,6 +708,38 @@
     }
   },
   {
+    "id": "seed_history_redo_target",
+    "name": "docxodus_create",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "insert_paragraph",
+      "anchorId": "$certify_anchor",
+      "position": "after",
+      "markdown": "History cursor sentinel \u2014 this paragraph exists only on redo."
+    },
+    "capture": {
+      "history_seed_anchor": "created.0.id"
+    },
+    "expect": {
+      "success": true,
+      "created.length": 1,
+      "created.0.kind": "p",
+      "created.0.scope": "body",
+      "removed.length": 0
+    }
+  },
+  {
+    "id": "seed_history_redo_cursor",
+    "name": "docxodus_edit",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "undo"
+    },
+    "expect": {
+      "success": true
+    }
+  },
+  {
     "id": "state_after_link_scaffolding",
     "name": "docxodus_get_content",
     "arguments": {
@@ -620,8 +759,54 @@
       "action": "list"
     },
     "capture": {
-      "guarded_revisions": "revisions.length"
+      "guarded_revisions": "revisions",
+      "guarded_revision_count": "revisions.length"
     }
+  },
+  {
+    "id": "comments_before_failure",
+    "name": "docxodus_comment",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "list"
+    },
+    "capture": {
+      "guarded_comments": "comments"
+    }
+  },
+  {
+    "id": "content_and_anchor_identity_before_failure",
+    "name": "docxodus_get_content",
+    "arguments": {
+      "sessionId": "$session_id",
+      "format": "markdown"
+    },
+    "capture": {
+      "guarded_markdown": "markdown",
+      "guarded_anchor_index": "anchorIndex"
+    }
+  },
+  {
+    "id": "package_checkpoint_before_failure",
+    "name": "docxodus_mutations",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "preview",
+      "steps": []
+    },
+    "capture": {
+      "guarded_hash": "packageHash"
+    },
+    "expect": {
+      "status": "ok",
+      "preview": true,
+      "editsApplied": 0,
+      "baseVersion": "$guarded_version",
+      "resultVersion": "$guarded_version"
+    },
+    "expectNonEmpty": [
+      "packageHash"
+    ]
   },
   {
     "id": "stale_precondition_is_refused",
@@ -683,7 +868,19 @@
       "rolledBack": true,
       "editsApplied": 0,
       "failure.index": 2,
-      "failure.error.code": "anchor_not_found"
+      "failure.error.code": "anchor_not_found",
+      "baseVersion": "$guarded_version",
+      "resultVersion": "$guarded_version",
+      "packageHash": "$guarded_hash",
+      "revisionChanges.added.length": 0,
+      "revisionChanges.removed.length": 0,
+      "revisionChanges.modified.length": 0,
+      "commentChanges.added.length": 0,
+      "commentChanges.removed.length": 0,
+      "commentChanges.modified.length": 0,
+      "annotationChanges.added.length": 0,
+      "annotationChanges.removed.length": 0,
+      "annotationChanges.modified.length": 0
     }
   },
   {
@@ -699,6 +896,18 @@
     }
   },
   {
+    "id": "audit_content_and_anchor_identity_unchanged",
+    "name": "docxodus_get_content",
+    "arguments": {
+      "sessionId": "$session_id",
+      "format": "markdown"
+    },
+    "expect": {
+      "markdown": "$guarded_markdown",
+      "anchorIndex": "$guarded_anchor_index"
+    }
+  },
+  {
     "id": "audit_revisions_unchanged",
     "name": "docxodus_track_changes",
     "arguments": {
@@ -706,7 +915,18 @@
       "action": "list"
     },
     "expect": {
-      "revisions.length": "$guarded_revisions"
+      "revisions": "$guarded_revisions"
+    }
+  },
+  {
+    "id": "audit_comments_unchanged",
+    "name": "docxodus_comment",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "list"
+    },
+    "expect": {
+      "comments": "$guarded_comments"
     }
   },
   {
@@ -754,18 +974,7 @@
     }
   },
   {
-    "id": "audit_undo_redo_still_usable",
-    "name": "docxodus_edit",
-    "arguments": {
-      "sessionId": "$session_id",
-      "action": "undo"
-    },
-    "expect": {
-      "success": true
-    }
-  },
-  {
-    "id": "audit_redo_restores",
+    "id": "audit_preexisting_redo_restores_seed",
     "name": "docxodus_edit",
     "arguments": {
       "sessionId": "$session_id",
@@ -776,7 +985,153 @@
     }
   },
   {
-    "id": "audit_state_after_undo_redo",
+    "id": "audit_redo_restored_exact_snapshot",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "text",
+      "query": "History cursor sentinel \u2014 this paragraph exists only on redo.",
+      "scope": "body"
+    },
+    "expect": {
+      "matches.length": 1,
+      "matches.0.enclosingAnchor.id": "$history_seed_anchor"
+    }
+  },
+  {
+    "id": "audit_undo_rewinds_seed",
+    "name": "docxodus_edit",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "undo"
+    },
+    "expect": {
+      "success": true
+    }
+  },
+  {
+    "id": "audit_package_after_redo_round_trip",
+    "name": "docxodus_mutations",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "preview",
+      "steps": []
+    },
+    "expect": {
+      "status": "ok",
+      "packageHash": "$guarded_hash"
+    }
+  },
+  {
+    "id": "audit_preexisting_undo_rewinds_link_batch",
+    "name": "docxodus_edit",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "undo"
+    },
+    "expect": {
+      "success": true
+    }
+  },
+  {
+    "id": "audit_undo_removed_link_batch",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "bookmark",
+      "query": "SmokeDelawareRationale"
+    },
+    "expect": {
+      "matches.length": 0
+    }
+  },
+  {
+    "id": "audit_preexisting_undo_can_redo",
+    "name": "docxodus_edit",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "redo"
+    },
+    "expect": {
+      "success": true
+    }
+  },
+  {
+    "id": "audit_package_after_undo_round_trip",
+    "name": "docxodus_mutations",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "preview",
+      "steps": []
+    },
+    "expect": {
+      "status": "ok",
+      "packageHash": "$guarded_hash"
+    }
+  },
+  {
+    "id": "audit_link_batch_restored",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "bookmark",
+      "query": "SmokeDelawareRationale"
+    },
+    "expect": {
+      "matches.0.id": "$list_anchor"
+    }
+  },
+  {
+    "id": "audit_redo_cursor_survived_undo_round_trip",
+    "name": "docxodus_edit",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "redo"
+    },
+    "expect": {
+      "success": true
+    }
+  },
+  {
+    "id": "audit_surviving_redo_restored_exact_snapshot",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "text",
+      "query": "History cursor sentinel \u2014 this paragraph exists only on redo.",
+      "scope": "body"
+    },
+    "expect": {
+      "matches.length": 1,
+      "matches.0.enclosingAnchor.id": "$history_seed_anchor"
+    }
+  },
+  {
+    "id": "audit_rewind_surviving_redo",
+    "name": "docxodus_edit",
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "undo"
+    },
+    "expect": {
+      "success": true
+    }
+  },
+  {
+    "id": "audit_package_after_all_history_round_trips",
+    "name": "docxodus_mutations",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "preview",
+      "steps": []
+    },
+    "expect": {
+      "status": "ok",
+      "packageHash": "$guarded_hash"
+    }
+  },
+  {
+    "id": "audit_state_after_history_round_trips",
     "name": "docxodus_get_content",
     "arguments": {
       "sessionId": "$session_id",

--- a/tools/mcp-server/smoke/mcp_probe.py
+++ b/tools/mcp-server/smoke/mcp_probe.py
@@ -220,6 +220,27 @@ def main() -> int:
                 if unresolved:
                     assertion["unresolved"] = unresolved
                 assertions.append(assertion)
+            for path in call.get("expectNonEmpty", []):
+                try:
+                    actual = capture_path(decoded, path)
+                    unresolved = None
+                except (KeyError, IndexError, TypeError, ValueError) as error:
+                    actual, unresolved = None, f"{type(error).__name__}: {error}"
+                is_sized = isinstance(actual, (str, list, dict))
+                assertion = {
+                    "path": path,
+                    "expected": "non-empty",
+                    "actual": {
+                        "type": type(actual).__name__,
+                        "length": len(actual),
+                    } if is_sized else actual,
+                    "passed": unresolved is None
+                    and is_sized
+                    and len(actual) > 0,
+                }
+                if unresolved:
+                    assertion["unresolved"] = unresolved
+                assertions.append(assertion)
             if assertions:
                 entry["assertions"] = assertions
             responses.append(entry)

--- a/tools/mcp-server/smoke/mcp_probe.py
+++ b/tools/mcp-server/smoke/mcp_probe.py
@@ -61,6 +61,20 @@ def decoded_tool_result(message: dict[str, Any]) -> Any:
     return result.get("structuredContent", result)
 
 
+def raw_tool_text(message: dict[str, Any]) -> str | None:
+    """The server's response text exactly as it came off the wire.
+
+    Transaction replay promises the *original serialized* MutationBatchResult, so a
+    retry has to be compared before json.loads normalizes key order and number
+    spelling away. Returns None when the tool answered with something other than a
+    single text block.
+    """
+    content = message.get("result", {}).get("content", [])
+    if content and content[0].get("type") == "text":
+        return content[0].get("text", "")
+    return None
+
+
 def capture_path(value: Any, path: str) -> Any:
     current = value
     for part in path.split("."):
@@ -113,6 +127,8 @@ def main() -> int:
     ).start()
 
     responses: list[dict[str, Any]] = []
+    raw_by_id: dict[Any, str | None] = {}
+    capture_failures: list[str] = []
     variables: dict[str, Any] = {}
     initialized: dict[str, Any] | None = None
     request_id = 1
@@ -149,6 +165,7 @@ def main() -> int:
             )
             message = receive(process, request_id)
             decoded = decoded_tool_result(message)
+            raw = raw_tool_text(message)
             entry = {
                 "id": call.get("id"),
                 "tool": call["name"],
@@ -157,22 +174,71 @@ def main() -> int:
                 or bool(message.get("result", {}).get("isError", False)),
                 "result": decoded,
             }
-            assertions = []
-            for path, expected in call.get("expect", {}).items():
-                actual = capture_path(decoded, path)
-                assertions.append(
-                    {
-                        "path": path,
-                        "expected": expected,
-                        "actual": actual,
-                        "passed": actual == expected,
-                    }
+
+            # A guarded workflow has to be able to prove its refusals. `expectFailure`
+            # inverts the pass condition for one call: the result must fail, and a
+            # success is now the defect — otherwise a negative probe passes vacuously
+            # the day the guard it exercises stops guarding.
+            if call.get("expectFailure"):
+                entry["expectedFailure"] = True
+                entry["unexpectedSuccess"] = not (
+                    entry["isError"] or result_failed(decoded)
                 )
+
+            # Byte-exact replay: compare the retry's wire text to the original's.
+            same_as = call.get("expectSameAs")
+            if same_as is not None:
+                original = next(
+                    (item for item in responses if item.get("id") == same_as), None
+                )
+                if original is None:
+                    raise KeyError(f"expectSameAs references an unknown call: {same_as}")
+                entry["replayOf"] = same_as
+                entry["replayByteExact"] = (
+                    raw is not None and raw == raw_by_id.get(same_as)
+                )
+            raw_by_id[call.get("id")] = raw
+            assertions = []
+            # Expected values substitute too, so a workflow can assert one call
+            # against another's captured value — "the version this applied at is the
+            # version the preview predicted" is the whole point of a preview.
+            for path, expected in substitute(call.get("expect", {}), variables).items():
+                # An unresolvable path is a failed assertion, never an exception: the
+                # trace is this workflow's evidence, and crashing here would destroy it
+                # at exactly the moment something interesting went wrong.
+                try:
+                    actual: Any = capture_path(decoded, path)
+                    unresolved = None
+                except (KeyError, IndexError, TypeError, ValueError) as error:
+                    actual, unresolved = None, f"{type(error).__name__}: {error}"
+                assertion = {
+                    "path": path,
+                    "expected": expected,
+                    "actual": actual,
+                    "passed": unresolved is None and actual == expected,
+                }
+                if unresolved:
+                    assertion["unresolved"] = unresolved
+                assertions.append(assertion)
             if assertions:
                 entry["assertions"] = assertions
             responses.append(entry)
+            # A capture that cannot resolve stops the run — every later call that
+            # substitutes it would be meaningless — but it stops it as a recorded
+            # outcome, so the trace still explains why.
             for name, path in call.get("capture", {}).items():
-                variables[name] = capture_path(decoded, path)
+                try:
+                    variables[name] = capture_path(decoded, path)
+                except (KeyError, IndexError, TypeError, ValueError) as error:
+                    entry["captureFailed"] = {
+                        "variable": name,
+                        "path": path,
+                        "error": f"{type(error).__name__}: {error}",
+                    }
+                    capture_failures.append(f"{call_id}: {name} <- {path}")
+                    break
+            if capture_failures:
+                break
 
         payload = {
             "initialize": initialized,
@@ -181,8 +247,21 @@ def main() -> int:
         }
         args.trace.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
-        transport_errors = sum(bool(entry["isError"]) for entry in responses)
-        failed_results = sum(result_failed(entry["result"]) for entry in responses)
+        transport_errors = sum(
+            bool(entry["isError"]) and not entry.get("expectedFailure")
+            for entry in responses
+        )
+        failed_results = sum(
+            result_failed(entry["result"]) and not entry.get("expectedFailure")
+            for entry in responses
+        )
+        unexpected_successes = sum(
+            bool(entry.get("unexpectedSuccess")) for entry in responses
+        )
+        replay_mismatches = sum(
+            "replayByteExact" in entry and not entry["replayByteExact"]
+            for entry in responses
+        )
         assertion_count = sum(len(entry.get("assertions", [])) for entry in responses)
         failed_assertions = sum(
             not assertion["passed"]
@@ -193,12 +272,28 @@ def main() -> int:
             "calls": len(responses),
             "transportErrors": transport_errors,
             "failedResults": failed_results,
+            "expectedFailures": sum(
+                bool(entry.get("expectedFailure")) for entry in responses
+            ),
+            "unexpectedSuccesses": unexpected_successes,
+            "captureFailures": capture_failures,
+            "replayComparisons": sum("replayByteExact" in entry for entry in responses),
+            "replayMismatches": replay_mismatches,
             "assertions": assertion_count,
             "failedAssertions": failed_assertions,
             "trace": str(args.trace),
         }
         print(json.dumps(summary, indent=2))
-        return 1 if transport_errors or failed_results or failed_assertions else 0
+        return (
+            1
+            if transport_errors
+            or failed_results
+            or failed_assertions
+            or unexpected_successes
+            or replay_mismatches
+            or capture_failures
+            else 0
+        )
     finally:
         if process.poll() is None:
             request_id += 1


### PR DESCRIPTION
Runs the epic #435 acceptance gate end to end against a real document, verifies and closes the three issues that gate depended on, and fixes the one engine defect the run turned up.

Closes #468. Closes #471. Closes #472.

## The smoke

A committed, re-runnable MCP workflow against `TestFiles/NVCA-Model-COI.docx` — 44 OPC parts, 8 headers, 10 footers, 94 footnotes, 392 bookmarks, 462 anchors, 4 sections.

| Pass | Calls | Assertions | Failed | Expected failures | Replay mismatches |
|---|---:|---:|---:|---:|---:|
| Workflow | 45 | 81 | **0** | 4 | **0** |
| Reopen validation | 13 | 27 | **0** | — | — |

It walks inspect → isolated preview → atomic apply under a transaction id → retry → audit, then an intentional stale request and an intentional atomic failure, a page citation, and save/close/reopen. Anchors are discovered by content, never assumed. The applied `resultVersion`, semantic deltas and per-step affected anchors are asserted *against the preview's captured predictions* rather than literals, and the retry is compared **byte-exact at the wire level**.

`packageHash` differs between preview and apply, which is the documented contract rather than a defect — the batch generates comment/footnote ids and revision timestamps, and both receipts carry the warning saying equivalence is semantic. Equivalence is verified where it is promised and deliberately not asserted where the receipt says not to. The same discipline applies to created anchors: counts are compared, ids are not.

Four calls are *supposed* to fail, and the harness treats a success there as the defect — a bookmark and a table insert refused under tracked recording, a stale precondition, and the batch that rolls back. Failing closed is the property under test.

Full write-up, evidence and reproduction: [`docs/architecture/epic_435_acceptance_smoke.md`](docs/architecture/epic_435_acceptance_smoke.md).

## The defect it found — fixed

Under `render_inline`, an agent could not re-find the edit it had just made. `replace_text_range` succeeded and the projection showed the new text, but `docxodus_search` returned nothing, `apply_format_by_substring` reported `offset_out_of_range`, and a follow-up surgical op could not address it.

`InlineRuns` descends only into the containers in `InlineContainerNames`, and `w:ins` was not one of them, so every run inside a tracked insertion was missing from the flat string all offset-addressed ops share — while `Project().Markdown` and `TextPreview` included it.

Not limited to text a session authored: an incoming Word redline had its inserted spans skipped too. `RA001-Tracked-Revisions-01.docx` holds six occurrences of "chromatogram" and search returned exactly the two outside `w:ins`.

The split is visible text versus text the document says was removed, not plain versus revised runs: `w:ins`/`w:moveTo` hold ordinary `w:t` that a reader sees, `w:del`/`w:moveFrom` hold `w:delText` that `RunText` never reads. The first pair is now transparent, the second deliberately is not. `DS409` covers the round trip through Grep, TextPreview and a follow-up surgical op; `DS410` covers pre-existing insertions and a move destination, and pins that deleted text stays unfindable.

## Issue verdicts

**#468** — the bug class is gone structurally, not merely untested: `mode: preview` routes through an isolated shadow clone and the dispatcher's only remaining `Undo()` is the explicit edit action. `MCP098` already covered the `partial` branch. The gap was that it previews from version 0, where a surplus undo is a no-op, so **`MCP150`** reproduces the reported scenario at the MCP surface — a committed edit, a seeded redo cursor, `undoDepth: 1`, and two previews ending in a bad anchor. Re-injecting the defect turns `MCP150` and `MCP148` red while `MCP091`/`MCP098` stay green, which is how the new test is shown not to be vacuous.

**#471** — both coordinate defects are fixed. #450 rebased `DocumentStructure`'s table walk onto `TableGridModel`, so `ColumnIndex` honours `w:gridBefore` and `RowSpan` is a span rather than a restart/continuation flag, with `DT251` testing a ragged spanned grid. The doc comments still described the old flag behaviour and are corrected.

**#472** — split verdict, all five now resolved. Items 1 and 5 were already fixed by the merged work; items 2, 3 and 4 were still wrong. Images are genuinely not projected (verified: no `img`/`drw` kind is ever assigned and no image markup is emitted), so the docs now describe that instead of promising it; the rectangular-grid CRUD caveat had moved to `editor_ui_surface.md`; npm `findByKind` still documented `"row"`/`"cell"` instead of `tr`/`tc`. One stale preview-undo sibling was also found in `docx_mutation_api.md`.

## Filed, not fixed

**#490** — `replace_text_range` matching nothing returns `[]` from a direct call (indistinguishable from success) but `internal_error` inside a batch. Making the direct call report it is a public-API shape change, so it is filed with a suggested resolution rather than changed here. It does not block the gate.

## Harness changes

`mcp_probe.py` gains `expectFailure` (which also flags an *unexpected success*, so a negative probe cannot pass vacuously once the guard it exercises stops guarding) and `expectSameAs` (raw wire-text comparison, since byte-exact replay is what a transaction promises). `expect` values now substitute `$variables`. The trace no longer dies with the run — an unresolvable assertion path is a failed assertion and an unresolvable capture is a recorded stop, because the trace is the evidence.

The workflow JSON is generated rather than hand-maintained: the preview, apply and retry must send a byte-identical step array or the retry is a `transaction_conflict` instead of a replay.

## Verification

- .NET suite: **3793 passed, 0 failed, 3 skipped**
- Both smoke passes green, as tabled above
- `npx tsc --noEmit` clean
- Package integrity on the saved output: zip valid, 44 → 45 parts (only `word/comments.xml` added), no part lost, no dangling relationships, one external relationship

Not covered: no third-party render oracle — `soffice --convert-to pdf` did not finish within 15 minutes on the 610 KB tracked-changes output, so integrity was established structurally and by a full reopen instead. The Playwright suite is running at time of writing and will be reported in a follow-up comment; the only npm change in this PR is a JSDoc correction.
