### PR TITLE
Prove generated redline accept/reject reversibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -456,6 +456,20 @@ All notable changes to this project will be documented in this file.
   version bump at release time.
 
 ### Fixed
+- **Selectively rejecting a move no longer strands the moved text as orphaned
+  `w:delText` (#515).** The comparison engine serializes move-source runs as `w:delText`
+  inside `w:moveFrom` (delete-grade, unlike Word's own `w:t` serialization), but
+  `AcceptRevision`/`RejectRevision`'s resolver only performed the `delText → t` restore
+  when unwrapping a surviving `w:del`. Rejecting an engine-generated move therefore
+  removed the `w:moveFrom` wrapper and left its payload behind as schema-orphaned
+  `w:delText` — on `WC004-Large` ~1.3k characters of restored text were missing from the
+  rejected body, and the stranded nodes then surfaced as phantom unresolvable "delete"
+  revisions in the live registry. A surviving `w:moveFrom` now restores its payload
+  exactly like a surviving `w:del`, matching `RevisionProcessor.RejectRevisions`'s
+  unconditional `delText → t` transform; Word-authored moves (already `w:t`) are
+  unaffected. Covered by the WC004-Large rows of
+  `RedlineReversibilityFixtureSweepTests` (RRS004 content round-trip + RRS005 regression
+  pin on the corruption shape).
 - **npm — a Web Worker call no longer detaches the caller's `Uint8Array`.** Every
   `createWorkerDocxodus` entry point that takes document bytes (`convertDocxToHtml`,
   `compareDocuments`, the session opens, and the new `generatePackageManifest`) put the

--- a/Docxodus.Tests/DocxSessionRevisionTests.cs
+++ b/Docxodus.Tests/DocxSessionRevisionTests.cs
@@ -162,14 +162,14 @@ public class DocxSessionRevisionTests
             Para(
                 RunT("Start "),
                 new XElement(W.moveFromRangeStart,
-                    new XAttribute(W.id, 500), new XAttribute(W.name, "move1")),
+                    RevAttrs(500, "Alice"), new XAttribute(W.name, "move1")),
                 new XElement(W.moveFrom, RevAttrs(501, "Alice"), RunT("moved bit")),
                 new XElement(W.moveFromRangeEnd, new XAttribute(W.id, 500)),
                 RunT("end.")),
             Para(
                 RunT("Dest "),
                 new XElement(W.moveToRangeStart,
-                    new XAttribute(W.id, 510), new XAttribute(W.name, "move1")),
+                    RevAttrs(510, "Alice"), new XAttribute(W.name, "move1")),
                 new XElement(W.moveTo, RevAttrs(511, "Alice"), RunT("moved bit")),
                 new XElement(W.moveToRangeEnd, new XAttribute(W.id, 510)),
                 RunT("here.")));

--- a/Docxodus.Tests/RedlineReversibilityFixtureSweepTests.cs
+++ b/Docxodus.Tests/RedlineReversibilityFixtureSweepTests.cs
@@ -199,6 +199,7 @@ public class RedlineReversibilityFixtureSweepTests
     [Theory]
     [InlineData("CA/CA001-Plain.docx", "CA/CA001-Plain-Mod.docx")]
     [InlineData("WC/WC001-Digits.docx", "WC/WC001-Digits-Mod.docx")]
+    [InlineData("WC/WC004-Large.docx", "WC/WC004-Large-Mod.docx")]
     [InlineData("WC/WC001-Digits.docx", "WC/WC001-Digits-Deleted-Paragraph.docx")]
     [InlineData("WC/WC001-Digits-Deleted-Paragraph.docx", "WC/WC001-Digits.docx")]
     [InlineData("WC/WC002-Unmodified.docx", "WC/WC002-DiffInMiddle.docx")]
@@ -304,14 +305,14 @@ public class RedlineReversibilityFixtureSweepTests
     // pin and the RRS004 exclusion must be updated.
     // ------------------------------------------------------------------
 
-    // WC004-Large: rejecting the engine redline through the proof's *selective* resolver
-    // strips every w:del wrapper but leaves the deleted content behind as orphaned
-    // w:delText nodes, so ~1.3k characters of restored text are lost from the rejected
-    // body. RevisionProcessor's reject-all on the very same redline restores the text (see
-    // DocxDiffOpsRoundTripTests), so the loss is specific to selective resolution. The
-    // accept direction is content-faithful.
+    // WC004-Large regression pin for the selective-reject moveFrom fix: the comparison
+    // engine serializes move-source text as w:delText inside w:moveFrom, and rejecting
+    // those moves used to strand ~1.3k characters as orphaned w:delText once the wrapper
+    // was unwrapped without the delText → t restore. Beyond RRS004's story-text oracle
+    // (which WC004 now passes), assert the specific corruption shape can never return:
+    // the rejected package contains no w:delText outside a delete-grade wrapper.
     [Fact]
-    public void RRS005_KnownGap_LargeDocumentSelectiveRejectStrandsDeletedText()
+    public void RRS005_RejectedMoveRestoresDeletedTextInsteadOfStrandingIt()
     {
         var left = Fixture("WC/WC004-Large.docx");
         var right = Fixture("WC/WC004-Large-Mod.docx");
@@ -319,25 +320,13 @@ public class RedlineReversibilityFixtureSweepTests
 
         var run = RedlineReversibilityVerifier.Prove(left, right, redline);
 
-        Assert.True(run.Proof.AcceptToFinal?.Completed, run.Proof.ToJson());
         Assert.True(run.Proof.RejectToBaseline?.Completed, run.Proof.ToJson());
-        Assert.Equal(StoryTexts(right), StoryTexts(run.AcceptedPackageBytes!));
-
         using var stream = new MemoryStream(run.RejectedPackageBytes!, writable: false);
         using var rejected = WordprocessingDocument.Open(stream, false);
         var body = rejected.MainDocumentPart!.Document.Body!;
+        Assert.Empty(body.Descendants<DeletedText>());
         Assert.Empty(body.Descendants<DeletedRun>());
         Assert.Empty(body.Descendants<InsertedRun>());
-        var strandedDeletedText = string.Concat(
-            body.Descendants<DeletedText>().Select(text => text.Text));
-        Assert.NotEmpty(strandedDeletedText); // the bug: content survives only as w:delText
-        Assert.NotEqual(StoryTexts(left), StoryTexts(run.RejectedPackageBytes!));
-
-        // The proof itself must expose the loss rather than certify the round-trip.
-        Assert.False(run.Proof.Success);
-        Assert.Contains(run.Proof.RejectToBaseline!.Findings, finding =>
-            finding.Code == "modeled_semantic_mismatch"
-            && finding.Severity == VerificationFindingSeverity.Error);
     }
 
     // WC035: when a comparison adds the document's first footnote/endnote, the redline

--- a/Docxodus.Tests/RedlineReversibilityFixtureSweepTests.cs
+++ b/Docxodus.Tests/RedlineReversibilityFixtureSweepTests.cs
@@ -1,0 +1,519 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Text;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Docxodus.Verification;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+/// <summary>
+/// Fixture-scale evidence for the redline reversibility proof (#464), complementing the
+/// scenario-focused cases in <see cref="RedlineReversibilityProofTests"/>.
+///
+/// Two corpora, two claims:
+///
+/// 1. Word-authored redlines — every complete triple in <c>TestFiles/RP</c>
+///    (<c>{stem}.docx</c> + <c>{stem}-Accepted.docx</c> + <c>{stem}-Rejected.docx</c>, the
+///    long-standing RevisionProcessor oracle corpus). The proof's selective resolver must
+///    accept every revision to the accepted oracle and reject every revision to the rejected
+///    oracle at the story-text level, and each triple pins whether the far stronger
+///    normalized whole-package equivalence also holds per direction. A guard test keeps the
+///    pinned list in lock-step with the fixture directory so a new triple cannot be added
+///    without being swept.
+///
+/// 2. Engine-generated redlines — the WCB comparison corpus (real Word documents under
+///    <c>TestFiles/WC</c>, <c>CA</c>, <c>RC</c>). For each before/after pair the redline is
+///    <c>DocxDiff.Compare(left, right)</c> and the proof must complete both paths, classify
+///    every revision as generated, and recover <c>right</c> on accept / <c>left</c> on
+///    reject at the story-text level. Pairs where that does not currently hold are pinned as
+///    explicit known gaps with their exact failure signature, so the gap is visible here and
+///    this file must be updated when it is fixed.
+///
+/// "Story text" means the concatenated <c>w:t</c> runs of the body plus every header,
+/// footer, footnotes and endnotes part — presence of a story part counts, so an output that
+/// grows an empty footnotes part the expected document never had does not pass.
+/// </summary>
+public class RedlineReversibilityFixtureSweepTests
+{
+    private static readonly string TestFilesDir = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "../../../../TestFiles"));
+
+    // ------------------------------------------------------------------
+    // 1. Word-authored redlines: TestFiles/RP triples.
+    // ------------------------------------------------------------------
+
+    // Columns: fixture stem, accept path fully equivalent (normalized whole package),
+    // reject path fully equivalent. Story-text equality with the oracle documents is
+    // asserted unconditionally for every row; the booleans pin only the stronger
+    // package-level claim per direction.
+    [Theory]
+    [InlineData("RP002-Deleted-Text", true, true)]
+    [InlineData("RP003-Inserted-Text", true, true)]
+    [InlineData("RP004-Deleted-Text-in-CC", true, true)]
+    [InlineData("RP005-Deleted-Paragraph-Mark", false, true)]
+    [InlineData("RP006-Inserted-Paragraph-Mark", true, false)]
+    [InlineData("RP007-Multiple-Deleted-Para-Mark", false, true)]
+    [InlineData("RP008-Multiple-Inserted-Para-Mark", true, false)]
+    [InlineData("RP009-Deleted-Table-Row", true, true)]
+    [InlineData("RP010-Inserted-Table-Row", true, true)]
+    [InlineData("RP011-Multiple-Deleted-Rows", true, true)]
+    [InlineData("RP012-Multiple-Inserted-Rows", true, true)]
+    [InlineData("RP013-Deleted-Math-Control-Char", true, true)]
+    [InlineData("RP014-Inserted-Math-Control-Char", true, true)]
+    [InlineData("RP015-MoveFrom-MoveTo", false, false)]
+    [InlineData("RP016-Deleted-CC", false, false)]
+    [InlineData("RP017-Inserted-CC", true, true)]
+    [InlineData("RP019-Deleted-Field-Code", false, false)]
+    [InlineData("RP020-Inserted-Field-Code", true, false)]
+    [InlineData("RP021-Inserted-Numbering-Properties", true, false)]
+    [InlineData("RP022-NumberingChange", true, false)]
+    [InlineData("RP023-NumberingChange", false, false)]
+    [InlineData("RP024-ParagraphMark-rPr-Change", false, false)]
+    [InlineData("RP025-Paragraph-Props-Change", false, false)]
+    [InlineData("RP026-NumberingChange", false, false)]
+    [InlineData("RP027-Change-Section", true, false)]
+    [InlineData("RP028-Table-Grid-Change", true, false)]
+    [InlineData("RP029-Table-Row-Props-Change", true, false)]
+    [InlineData("RP030-Table-Row-Props-Change", true, false)]
+    [InlineData("RP031-Table-Prop-Change", true, false)]
+    [InlineData("RP032-Table-Prop-Change", true, false)]
+    [InlineData("RP033-Table-Prop-Ex-Change", true, false)]
+    [InlineData("RP034-Deleted-Cells", false, false)]
+    [InlineData("RP035-Inserted-Cells", false, false)]
+    [InlineData("RP036-Vert-Merged-Cells", true, false)]
+    [InlineData("RP037-Changed-Style-Para-Props", true, false)]
+    [InlineData("RP038-Inserted-Paras-at-End", false, false)]
+    [InlineData("RP039-Inserted-Paras-at-End", false, false)]
+    [InlineData("RP040-Deleted-Paras-at-End", false, false)]
+    [InlineData("RP041-Cell-With-Empty-Paras-at-End", false, false)]
+    [InlineData("RP042-Deleted-Para-Mark-at-End", false, false)]
+    [InlineData("RP043-MERGEFORMAT-Field-Code", false, false)]
+    [InlineData("RP044-MERGEFORMAT-Field-Code", false, false)]
+    [InlineData("RP045-One-and-Half-Deleted-Lines-at-End", false, false)]
+    [InlineData("RP046-Consecutive-Deleted-Ranges", false, false)]
+    [InlineData("RP048-Deleted-Inserted-Para-Mark", false, false)]
+    [InlineData("RP049-Deleted-Para-Before-Table", false, false)]
+    [InlineData("RP050-Deleted-Footnote", false, false)]
+    [InlineData("RP051-Arabic", false, false)]
+    [InlineData("RP052-Deleted-Para-Mark", false, false)]
+    public void RRS001_WordAuthoredRedline_AcceptAndRejectRecoverTheOracleDocuments(
+        string stem,
+        bool acceptEquivalent,
+        bool rejectEquivalent)
+    {
+        var (redline, acceptedOracle, rejectedOracle) = RpTriple(stem);
+
+        var run = RedlineReversibilityVerifier.Prove(rejectedOracle, acceptedOracle, redline);
+        var proof = run.Proof;
+
+        Assert.NotNull(proof.AcceptToFinal);
+        Assert.NotNull(proof.RejectToBaseline);
+        Assert.True(proof.AcceptToFinal!.Completed, proof.ToJson());
+        Assert.True(proof.RejectToBaseline!.Completed, proof.ToJson());
+
+        // A Word-authored redline over its fully-rejected baseline owns every revision.
+        Assert.NotEmpty(proof.RevisionClassifications);
+        Assert.All(proof.RevisionClassifications, classification =>
+            Assert.Equal(RedlineRevisionDisposition.Generated, classification.Disposition));
+        AssertResolutionClosure(proof.AcceptToFinal);
+        AssertResolutionClosure(proof.RejectToBaseline);
+
+        // The reversibility contract a reader actually cares about: the accepted output
+        // reads as Word's accepted oracle, the rejected output as Word's rejected oracle.
+        Assert.Equal(StoryTexts(acceptedOracle), StoryTexts(run.AcceptedPackageBytes!));
+        Assert.Equal(StoryTexts(rejectedOracle), StoryTexts(run.RejectedPackageBytes!));
+
+        // The stronger pinned claim, per direction.
+        Assert.True(proof.AcceptToFinal.Equivalent == acceptEquivalent, proof.ToJson());
+        Assert.True(proof.RejectToBaseline.Equivalent == rejectEquivalent, proof.ToJson());
+        Assert.True(proof.Success == (acceptEquivalent && rejectEquivalent), proof.ToJson());
+
+        // A non-equivalent path must say so with an error finding, never silently.
+        AssertNonEquivalenceIsEvidenced(proof.AcceptToFinal);
+        AssertNonEquivalenceIsEvidenced(proof.RejectToBaseline);
+    }
+
+    // Word-authored triples whose revision families the resolver does not support: the
+    // proof must refuse to run either path rather than guess, and must name the reason.
+    [Theory]
+    [InlineData("RP018-MoveFrom-MoveTo-CC", "unsupported_custom_xml_move_range")]
+    [InlineData("RP047-Inserted-and-Deleted-Paragraph-Mark", "unsupported_revision_family")]
+    public void RRS002_WordAuthoredRedline_UnsupportedFamilyFailsClosedWithDiagnostic(
+        string stem,
+        string expectedDiagnosticCode)
+    {
+        var (redline, acceptedOracle, rejectedOracle) = RpTriple(stem);
+
+        var run = RedlineReversibilityVerifier.Prove(rejectedOracle, acceptedOracle, redline);
+
+        Assert.False(run.Proof.Success);
+        Assert.Null(run.Proof.AcceptToFinal);
+        Assert.Null(run.Proof.RejectToBaseline);
+        Assert.Null(run.AcceptedPackageBytes);
+        Assert.Null(run.RejectedPackageBytes);
+        Assert.Contains(run.Proof.Findings, finding =>
+            finding.Code == "generated_revision_not_resolvable");
+        Assert.Contains(run.Proof.RevisionClassifications, classification =>
+            classification.Redline?.Diagnostic?.Code == expectedDiagnosticCode);
+    }
+
+    // Keeps RRS001 + RRS002 honest: every complete triple in TestFiles/RP must be pinned in
+    // exactly one of them, so adding a fixture without sweeping it fails here.
+    [Fact]
+    public void RRS003_EveryCompleteFixtureTripleIsPinned()
+    {
+        var rpDir = Path.Combine(TestFilesDir, "RP");
+        var files = new HashSet<string>(
+            Directory.GetFiles(rpDir, "*.docx").Select(Path.GetFileName)!,
+            StringComparer.Ordinal);
+        var completeTriples = files
+            .Where(name => !name.EndsWith("-Accepted.docx", StringComparison.Ordinal)
+                && !name.EndsWith("-Rejected.docx", StringComparison.Ordinal))
+            .Select(name => name[..^".docx".Length])
+            .Where(stem => files.Contains(stem + "-Accepted.docx")
+                && files.Contains(stem + "-Rejected.docx"))
+            .OrderBy(stem => stem, StringComparer.Ordinal)
+            .ToArray();
+
+        var pinned = PinnedStems(nameof(RRS001_WordAuthoredRedline_AcceptAndRejectRecoverTheOracleDocuments))
+            .Concat(PinnedStems(nameof(RRS002_WordAuthoredRedline_UnsupportedFamilyFailsClosedWithDiagnostic)))
+            .OrderBy(stem => stem, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(completeTriples, pinned);
+    }
+
+    // ------------------------------------------------------------------
+    // 2. Engine-generated redlines: the WCB comparison corpus.
+    // ------------------------------------------------------------------
+
+    // Every before/after pair from the WCB corpus except the known gaps pinned in
+    // RRS005-RRS007 below. DocxDiff regenerates the package, so normalized whole-package
+    // equivalence never holds here (asserted); the reversibility claim proven per pair is
+    // content-level: accept recovers right's stories, reject recovers left's.
+    [Theory]
+    [InlineData("CA/CA001-Plain.docx", "CA/CA001-Plain-Mod.docx")]
+    [InlineData("WC/WC001-Digits.docx", "WC/WC001-Digits-Mod.docx")]
+    [InlineData("WC/WC001-Digits.docx", "WC/WC001-Digits-Deleted-Paragraph.docx")]
+    [InlineData("WC/WC001-Digits-Deleted-Paragraph.docx", "WC/WC001-Digits.docx")]
+    [InlineData("WC/WC002-Unmodified.docx", "WC/WC002-DiffInMiddle.docx")]
+    [InlineData("WC/WC002-Unmodified.docx", "WC/WC002-DiffAtBeginning.docx")]
+    [InlineData("WC/WC002-Unmodified.docx", "WC/WC002-DeleteAtBeginning.docx")]
+    [InlineData("WC/WC002-Unmodified.docx", "WC/WC002-InsertAtBeginning.docx")]
+    [InlineData("WC/WC002-Unmodified.docx", "WC/WC002-InsertAtEnd.docx")]
+    [InlineData("WC/WC002-Unmodified.docx", "WC/WC002-DeleteAtEnd.docx")]
+    [InlineData("WC/WC002-Unmodified.docx", "WC/WC002-DeleteInMiddle.docx")]
+    [InlineData("WC/WC002-Unmodified.docx", "WC/WC002-InsertInMiddle.docx")]
+    [InlineData("WC/WC002-DeleteInMiddle.docx", "WC/WC002-Unmodified.docx")]
+    [InlineData("WC/WC006-Table.docx", "WC/WC006-Table-Delete-Row.docx")]
+    [InlineData("WC/WC006-Table-Delete-Row.docx", "WC/WC006-Table.docx")]
+    [InlineData("WC/WC006-Table.docx", "WC/WC006-Table-Delete-Contests-of-Row.docx")]
+    [InlineData("WC/WC007-Unmodified.docx", "WC/WC007-Longest-At-End.docx")]
+    [InlineData("WC/WC007-Unmodified.docx", "WC/WC007-Deleted-at-Beginning-of-Para.docx")]
+    [InlineData("WC/WC007-Unmodified.docx", "WC/WC007-Moved-into-Table.docx")]
+    [InlineData("WC/WC009-Table-Unmodified.docx", "WC/WC009-Table-Cell-1-1-Mod.docx")]
+    [InlineData("WC/WC010-Para-Before-Table-Unmodified.docx", "WC/WC010-Para-Before-Table-Mod.docx")]
+    [InlineData("WC/WC011-Before.docx", "WC/WC011-After.docx")]
+    [InlineData("WC/WC013-Image-Before.docx", "WC/WC013-Image-After.docx")]
+    [InlineData("WC/WC013-Image-Before.docx", "WC/WC013-Image-After2.docx")]
+    [InlineData("WC/WC013-Image-Before2.docx", "WC/WC013-Image-After2.docx")]
+    [InlineData("WC/WC014-SmartArt-Before.docx", "WC/WC014-SmartArt-After.docx")]
+    [InlineData("WC/WC014-SmartArt-With-Image-Before.docx", "WC/WC014-SmartArt-With-Image-After.docx")]
+    [InlineData("WC/WC014-SmartArt-With-Image-Before.docx", "WC/WC014-SmartArt-With-Image-Deleted-After.docx")]
+    [InlineData("WC/WC014-SmartArt-With-Image-Before.docx", "WC/WC014-SmartArt-With-Image-Deleted-After2.docx")]
+    [InlineData("WC/WC015-Three-Paragraphs.docx", "WC/WC015-Three-Paragraphs-After.docx")]
+    [InlineData("WC/WC016-Para-Image-Para.docx", "WC/WC016-Para-Image-Para-w-Deleted-Image.docx")]
+    [InlineData("WC/WC017-Image.docx", "WC/WC017-Image-After.docx")]
+    [InlineData("WC/WC018-Field-Simple-Before.docx", "WC/WC018-Field-Simple-After-1.docx")]
+    [InlineData("WC/WC018-Field-Simple-Before.docx", "WC/WC018-Field-Simple-After-2.docx")]
+    [InlineData("WC/WC019-Hyperlink-Before.docx", "WC/WC019-Hyperlink-After-1.docx")]
+    [InlineData("WC/WC019-Hyperlink-Before.docx", "WC/WC019-Hyperlink-After-2.docx")]
+    [InlineData("WC/WC020-FootNote-Before.docx", "WC/WC020-FootNote-After-1.docx")]
+    [InlineData("WC/WC020-FootNote-Before.docx", "WC/WC020-FootNote-After-2.docx")]
+    [InlineData("WC/WC021-Math-Before-1.docx", "WC/WC021-Math-After-1.docx")]
+    [InlineData("WC/WC021-Math-Before-2.docx", "WC/WC021-Math-After-2.docx")]
+    [InlineData("WC/WC022-Image-Math-Para-Before.docx", "WC/WC022-Image-Math-Para-After.docx")]
+    [InlineData("WC/WC023-Table-4-Row-Image-Before.docx", "WC/WC023-Table-4-Row-Image-After-Delete-1-Row.docx")]
+    [InlineData("WC/WC024-Table-Before.docx", "WC/WC024-Table-After.docx")]
+    [InlineData("WC/WC024-Table-Before.docx", "WC/WC024-Table-After2.docx")]
+    [InlineData("WC/WC025-Simple-Table-Before.docx", "WC/WC025-Simple-Table-After.docx")]
+    [InlineData("WC/WC026-Long-Table-Before.docx", "WC/WC026-Long-Table-After-1.docx")]
+    [InlineData("WC/WC027-Twenty-Paras-Before.docx", "WC/WC027-Twenty-Paras-After-1.docx")]
+    [InlineData("WC/WC027-Twenty-Paras-After-1.docx", "WC/WC027-Twenty-Paras-Before.docx")]
+    [InlineData("WC/WC027-Twenty-Paras-Before.docx", "WC/WC027-Twenty-Paras-After-2.docx")]
+    [InlineData("WC/WC030-Image-Math-Before.docx", "WC/WC030-Image-Math-After.docx")]
+    [InlineData("WC/WC031-Two-Maths-Before.docx", "WC/WC031-Two-Maths-After.docx")]
+    [InlineData("WC/WC032-Para-with-Para-Props.docx", "WC/WC032-Para-with-Para-Props-After.docx")]
+    [InlineData("WC/WC033-Merged-Cells-Before.docx", "WC/WC033-Merged-Cells-After1.docx")]
+    [InlineData("WC/WC033-Merged-Cells-Before.docx", "WC/WC033-Merged-Cells-After2.docx")]
+    [InlineData("WC/WC034-Footnotes-Before.docx", "WC/WC034-Footnotes-After1.docx")]
+    [InlineData("WC/WC034-Footnotes-Before.docx", "WC/WC034-Footnotes-After2.docx")]
+    [InlineData("WC/WC034-Footnotes-Before.docx", "WC/WC034-Footnotes-After3.docx")]
+    [InlineData("WC/WC034-Footnotes-After3.docx", "WC/WC034-Footnotes-Before.docx")]
+    [InlineData("WC/WC036-Footnote-With-Table-Before.docx", "WC/WC036-Footnote-With-Table-After.docx")]
+    [InlineData("WC/WC036-Footnote-With-Table-After.docx", "WC/WC036-Footnote-With-Table-Before.docx")]
+    [InlineData("WC/WC034-Endnotes-Before.docx", "WC/WC034-Endnotes-After1.docx")]
+    [InlineData("WC/WC034-Endnotes-Before.docx", "WC/WC034-Endnotes-After2.docx")]
+    [InlineData("WC/WC034-Endnotes-Before.docx", "WC/WC034-Endnotes-After3.docx")]
+    [InlineData("WC/WC034-Endnotes-After3.docx", "WC/WC034-Endnotes-Before.docx")]
+    [InlineData("WC/WC036-Endnote-With-Table-Before.docx", "WC/WC036-Endnote-With-Table-After.docx")]
+    [InlineData("WC/WC036-Endnote-With-Table-After.docx", "WC/WC036-Endnote-With-Table-Before.docx")]
+    [InlineData("WC/WC038-Document-With-BR-Before.docx", "WC/WC038-Document-With-BR-After.docx")]
+    [InlineData("RC/RC001-Before.docx", "RC/RC001-After1.docx")]
+    [InlineData("RC/RC002-Image.docx", "RC/RC002-Image-After1.docx")]
+    public void RRS004_EngineGeneratedRedline_RoundTripsContentAcrossComparisonCorpus(
+        string leftName,
+        string rightName)
+    {
+        var left = Fixture(leftName);
+        var right = Fixture(rightName);
+        var redline = EngineRedline(left, right);
+
+        var run = RedlineReversibilityVerifier.Prove(left, right, redline);
+        var proof = run.Proof;
+
+        Assert.NotNull(proof.AcceptToFinal);
+        Assert.NotNull(proof.RejectToBaseline);
+        Assert.True(proof.AcceptToFinal!.Completed, proof.ToJson());
+        Assert.True(proof.RejectToBaseline!.Completed, proof.ToJson());
+        Assert.NotEmpty(proof.RevisionClassifications);
+        Assert.All(proof.RevisionClassifications, classification =>
+            Assert.Equal(RedlineRevisionDisposition.Generated, classification.Disposition));
+        AssertResolutionClosure(proof.AcceptToFinal);
+        AssertResolutionClosure(proof.RejectToBaseline);
+
+        // The content-level reversibility contract.
+        Assert.Equal(StoryTexts(right), StoryTexts(run.AcceptedPackageBytes!));
+        Assert.Equal(StoryTexts(left), StoryTexts(run.RejectedPackageBytes!));
+
+        // DocxDiff rebuilds the output package, so the strict whole-package proof does not
+        // hold for engine output today — and the proof must say so rather than succeed.
+        Assert.False(proof.Success, proof.ToJson());
+        AssertNonEquivalenceIsEvidenced(proof.AcceptToFinal);
+        AssertNonEquivalenceIsEvidenced(proof.RejectToBaseline);
+    }
+
+    // ------------------------------------------------------------------
+    // Known gaps in the engine corpus, pinned by exact failure signature. Each of these is
+    // excluded from RRS004; when the underlying defect is fixed the pin fails and both the
+    // pin and the RRS004 exclusion must be updated.
+    // ------------------------------------------------------------------
+
+    // WC004-Large: rejecting the engine redline through the proof's *selective* resolver
+    // strips every w:del wrapper but leaves the deleted content behind as orphaned
+    // w:delText nodes, so ~1.3k characters of restored text are lost from the rejected
+    // body. RevisionProcessor's reject-all on the very same redline restores the text (see
+    // DocxDiffOpsRoundTripTests), so the loss is specific to selective resolution. The
+    // accept direction is content-faithful.
+    [Fact]
+    public void RRS005_KnownGap_LargeDocumentSelectiveRejectStrandsDeletedText()
+    {
+        var left = Fixture("WC/WC004-Large.docx");
+        var right = Fixture("WC/WC004-Large-Mod.docx");
+        var redline = EngineRedline(left, right);
+
+        var run = RedlineReversibilityVerifier.Prove(left, right, redline);
+
+        Assert.True(run.Proof.AcceptToFinal?.Completed, run.Proof.ToJson());
+        Assert.True(run.Proof.RejectToBaseline?.Completed, run.Proof.ToJson());
+        Assert.Equal(StoryTexts(right), StoryTexts(run.AcceptedPackageBytes!));
+
+        using var stream = new MemoryStream(run.RejectedPackageBytes!, writable: false);
+        using var rejected = WordprocessingDocument.Open(stream, false);
+        var body = rejected.MainDocumentPart!.Document.Body!;
+        Assert.Empty(body.Descendants<DeletedRun>());
+        Assert.Empty(body.Descendants<InsertedRun>());
+        var strandedDeletedText = string.Concat(
+            body.Descendants<DeletedText>().Select(text => text.Text));
+        Assert.NotEmpty(strandedDeletedText); // the bug: content survives only as w:delText
+        Assert.NotEqual(StoryTexts(left), StoryTexts(run.RejectedPackageBytes!));
+
+        // The proof itself must expose the loss rather than certify the round-trip.
+        Assert.False(run.Proof.Success);
+        Assert.Contains(run.Proof.RejectToBaseline!.Findings, finding =>
+            finding.Code == "modeled_semantic_mismatch"
+            && finding.Severity == VerificationFindingSeverity.Error);
+    }
+
+    // WC035: when a comparison adds the document's first footnote/endnote, the redline
+    // package gains a notes part. Resolving toward the endpoint that has no notes leaves
+    // that (now content-empty) part behind instead of removing it, so the output package
+    // has a story the expected document never had. Body and note text themselves
+    // round-trip; only the empty-part residue diverges.
+    [Theory]
+    [InlineData("WC/WC035-Footnote-Before.docx", "WC/WC035-Footnote-After.docx", "footnotes")]
+    [InlineData("WC/WC035-Footnote-After.docx", "WC/WC035-Footnote-Before.docx", "footnotes")]
+    [InlineData("WC/WC035-Endnote-Before.docx", "WC/WC035-Endnote-After.docx", "endnotes")]
+    [InlineData("WC/WC035-Endnote-After.docx", "WC/WC035-Endnote-Before.docx", "endnotes")]
+    public void RRS006_KnownGap_ResolvingAwayTheOnlyNoteLeavesAnEmptyNotesPart(
+        string leftName,
+        string rightName,
+        string storyKind)
+    {
+        var left = Fixture(leftName);
+        var right = Fixture(rightName);
+        var redline = EngineRedline(left, right);
+
+        var run = RedlineReversibilityVerifier.Prove(left, right, redline);
+
+        Assert.True(run.Proof.AcceptToFinal?.Completed, run.Proof.ToJson());
+        Assert.True(run.Proof.RejectToBaseline?.Completed, run.Proof.ToJson());
+
+        // One endpoint has the note, the other has no notes part at all.
+        var (noteless, noteBearing, notelessOutput, noteBearingOutput) =
+            NotesText(left, storyKind) is null
+                ? (left, right, run.RejectedPackageBytes!, run.AcceptedPackageBytes!)
+                : (right, left, run.AcceptedPackageBytes!, run.RejectedPackageBytes!);
+        Assert.Null(NotesText(noteless, storyKind));
+        Assert.False(string.IsNullOrEmpty(NotesText(noteBearing, storyKind)));
+
+        // Toward the note-bearing endpoint the round-trip is faithful.
+        Assert.Equal(StoryTexts(noteBearing), StoryTexts(noteBearingOutput));
+
+        // Toward the noteless endpoint the body text round-trips but an empty notes part
+        // is left behind — the residue this pin exists for.
+        Assert.Equal(BodyText(noteless), BodyText(notelessOutput));
+        Assert.Equal(string.Empty, NotesText(notelessOutput, storyKind));
+        Assert.False(run.Proof.Success);
+    }
+
+    // WC012-Math: the After document carries its own tracked insertions, and
+    // DocxDiff.Compare does not reproduce that pre-existing review state in the redline.
+    // Accepting such a redline can never recover the After document exactly, and the proof
+    // must refuse to certify rather than resolve around the loss.
+    [Fact]
+    public void RRS007_KnownGap_RedlineMissingIntendedFinalReviewStateFailsClosed()
+    {
+        var left = Fixture("WC/WC012-Math-Before.docx");
+        var right = Fixture("WC/WC012-Math-After.docx");
+        Assert.True(ContainsNativeRevisions(right)); // the After doc's own review state
+        var redline = EngineRedline(left, right);
+
+        var run = RedlineReversibilityVerifier.Prove(left, right, redline);
+
+        Assert.False(run.Proof.Success);
+        Assert.Null(run.Proof.AcceptToFinal);
+        Assert.Null(run.Proof.RejectToBaseline);
+        Assert.Contains(run.Proof.Findings, finding =>
+            finding.Code == "intended_final_revision_missing_from_redline");
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers.
+    // ------------------------------------------------------------------
+
+    private static byte[] Fixture(string relativeName) =>
+        File.ReadAllBytes(Path.Combine(TestFilesDir, relativeName));
+
+    private static (byte[] Redline, byte[] AcceptedOracle, byte[] RejectedOracle) RpTriple(
+        string stem)
+    {
+        var rpDir = Path.Combine(TestFilesDir, "RP");
+        return (
+            File.ReadAllBytes(Path.Combine(rpDir, stem + ".docx")),
+            File.ReadAllBytes(Path.Combine(rpDir, stem + "-Accepted.docx")),
+            File.ReadAllBytes(Path.Combine(rpDir, stem + "-Rejected.docx")));
+    }
+
+    private static byte[] EngineRedline(byte[] left, byte[] right) => DocxDiff.Compare(
+        new WmlDocument("left.docx", left),
+        new WmlDocument("right.docx", right),
+        new DocxDiffSettings { AuthorForRevisions = "Docxodus Engine" }).DocumentByteArray;
+
+    private static IEnumerable<string> PinnedStems(string theoryMethodName) =>
+        typeof(RedlineReversibilityFixtureSweepTests)
+            .GetMethod(theoryMethodName)!
+            .GetCustomAttributes(typeof(InlineDataAttribute), inherit: false)
+            .Cast<InlineDataAttribute>()
+            .SelectMany(attribute => attribute.GetData(null!))
+            .Select(row => (string)row[0]!);
+
+    private static void AssertResolutionClosure(RedlineProofPathResult path)
+    {
+        var accountedFor = path.ResolvedRevisionIds
+            .Concat(path.ImplicitlyResolvedRevisionIds)
+            .OrderBy(id => id, StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(
+            path.RequestedRevisionIds.OrderBy(id => id, StringComparer.Ordinal),
+            accountedFor);
+        Assert.Equal(accountedFor.Length, accountedFor.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    private static void AssertNonEquivalenceIsEvidenced(RedlineProofPathResult path)
+    {
+        if (path.Equivalent)
+            return;
+        Assert.Contains(path.Findings, finding =>
+            finding.Severity == VerificationFindingSeverity.Error);
+        if (!path.NormalizedWholePackageEquivalent)
+            Assert.NotNull(path.FirstDivergence);
+    }
+
+    /// <summary>
+    /// Canonical story-text projection of a package: the concatenated <c>w:t</c> text of the
+    /// body and of every header, footer, footnotes and endnotes part, keyed by story kind.
+    /// Part presence counts — an empty part produces an empty entry, absence produces none —
+    /// so growing or losing a story cannot pass unnoticed.
+    /// </summary>
+    private static string StoryTexts(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes, writable: false);
+        using var document = WordprocessingDocument.Open(stream, false);
+        var main = document.MainDocumentPart!;
+        var builder = new StringBuilder();
+        builder.Append("body: ").Append(TextOf(main.Document)).Append('\n');
+        AppendStory(builder, "headers", main.HeaderParts.Select(part => TextOf(part.Header)));
+        AppendStory(builder, "footers", main.FooterParts.Select(part => TextOf(part.Footer)));
+        AppendStory(builder, "footnotes", main.FootnotesPart is { } footnotes
+            ? new[] { TextOf(footnotes.Footnotes) }
+            : Array.Empty<string>());
+        AppendStory(builder, "endnotes", main.EndnotesPart is { } endnotes
+            ? new[] { TextOf(endnotes.Endnotes) }
+            : Array.Empty<string>());
+        return builder.ToString();
+    }
+
+    private static void AppendStory(
+        StringBuilder builder, string kind, IEnumerable<string> texts)
+    {
+        foreach (var text in texts.OrderBy(text => text, StringComparer.Ordinal))
+            builder.Append(kind).Append(": ").Append(text).Append('\n');
+    }
+
+    private static string TextOf(DocumentFormat.OpenXml.OpenXmlElement? root) =>
+        root is null ? "" : string.Concat(root.Descendants<Text>().Select(text => text.Text));
+
+    private static string BodyText(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes, writable: false);
+        using var document = WordprocessingDocument.Open(stream, false);
+        return TextOf(document.MainDocumentPart!.Document.Body);
+    }
+
+    private static string? NotesText(byte[] bytes, string storyKind)
+    {
+        using var stream = new MemoryStream(bytes, writable: false);
+        using var document = WordprocessingDocument.Open(stream, false);
+        var main = document.MainDocumentPart!;
+        return storyKind == "footnotes"
+            ? main.FootnotesPart is { } footnotes ? TextOf(footnotes.Footnotes) : null
+            : main.EndnotesPart is { } endnotes ? TextOf(endnotes.Endnotes) : null;
+    }
+
+    private static bool ContainsNativeRevisions(byte[] bytes)
+    {
+        const string w = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+        using var stream = new MemoryStream(bytes, writable: false);
+        using var document = WordprocessingDocument.Open(stream, false);
+        return document.MainDocumentPart!.Document
+            .Descendants()
+            .Any(element => element.NamespaceUri == w
+                && element.LocalName is "ins" or "del");
+    }
+}

--- a/Docxodus.Tests/RedlineReversibilityProofTests.cs
+++ b/Docxodus.Tests/RedlineReversibilityProofTests.cs
@@ -3,11 +3,13 @@
 
 #nullable enable
 
+using System.Text;
 using System.Text.Json;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 using Docxodus.Verification;
+using DocxodusDiffParityFixtures;
 using Xunit;
 
 namespace Docxodus.Tests;
@@ -35,8 +37,16 @@ public class RedlineReversibilityProofTests
         Assert.True(run.Proof.RejectToBaseline?.Completed);
         Assert.False(run.Proof.AcceptToFinal?.NormalizedWholePackageEquivalent);
         Assert.NotEmpty(run.Proof.AcceptToFinal?.Divergences ?? []);
-        Assert.False(run.Proof.AcceptToFinal?.ModeledSemantic.Available);
-        Assert.False(run.Proof.Success); // #457 is intentionally required before this can prove success.
+        Assert.True(run.Proof.AcceptToFinal?.ModeledSemantic.Available);
+        Assert.Equal(SemanticChangeSet.CurrentSchema,
+            run.Proof.AcceptToFinal?.ModeledSemantic.Schema);
+        Assert.False(run.Proof.AcceptToFinal?.ModeledSemantic.Equivalent);
+        Assert.True(run.Proof.AcceptToFinal?.ModeledSemantic.ChangeCount > 0);
+        var semanticFinding = Assert.Single(run.Proof.AcceptToFinal?.Findings ?? [],
+            finding => finding.Code == "modeled_semantic_mismatch");
+        Assert.NotNull(semanticFinding.Location?.EntryUri);
+        Assert.NotNull(semanticFinding.Location?.PropertyPath);
+        Assert.False(run.Proof.Success); // Whole-package differences still prevent a proof.
     }
 
     [Fact]
@@ -134,6 +144,11 @@ public class RedlineReversibilityProofTests
             .Where(item => item.UnknownOrUnmodeled) ?? []);
         Assert.Empty(run.Proof.RejectToBaseline?.Divergences
             .Where(item => item.UnknownOrUnmodeled) ?? []);
+        Assert.True(run.Proof.AcceptToFinal?.ModeledSemantic.Equivalent,
+            run.Proof.ToJson());
+        Assert.True(run.Proof.RejectToBaseline?.ModeledSemantic.Equivalent,
+            run.Proof.ToJson());
+        Assert.True(run.Proof.Success, run.Proof.ToJson());
     }
 
     [Fact]
@@ -173,11 +188,16 @@ public class RedlineReversibilityProofTests
             run.Proof.ToJson());
         Assert.Single(run.Proof.AcceptToFinal?.SurvivingPreExistingRevisions ?? []);
         Assert.Single(run.Proof.RejectToBaseline?.SurvivingPreExistingRevisions ?? []);
+        Assert.True(run.Proof.AcceptToFinal?.Equivalent, run.Proof.ToJson());
+        Assert.True(run.Proof.RejectToBaseline?.Equivalent, run.Proof.ToJson());
+        Assert.True(run.Proof.Success, run.Proof.ToJson());
     }
 
     [Theory]
     [InlineData("RP015-MoveFrom-MoveTo", RevisionFamily.Move)]
+    [InlineData("RP021-Inserted-Numbering-Properties", RevisionFamily.NumberingPropertiesInsert)]
     [InlineData("RP025-Paragraph-Props-Change", RevisionFamily.PropertiesChange)]
+    [InlineData("RP027-Change-Section", RevisionFamily.PropertiesChange)]
     [InlineData("RP009-Deleted-Table-Row", RevisionFamily.RowDelete)]
     [InlineData("RP050-Deleted-Footnote", RevisionFamily.ContentDelete)]
     public void RP007_RealRevisionFamilies_ResolveAndEmitProofEvidence(
@@ -201,6 +221,200 @@ public class RedlineReversibilityProofTests
         AssertResolutionClosure(run.Proof.RejectToBaseline!);
         Assert.NotNull(run.Proof.AcceptToFinal?.ActualPackage);
         Assert.NotNull(run.Proof.RejectToBaseline?.ActualPackage);
+        AssertPathEvidenceCoherent(run.Proof.AcceptToFinal!, run.Proof.ToJson());
+        AssertPathEvidenceCoherent(run.Proof.RejectToBaseline!, run.Proof.ToJson());
+        Assert.False(run.Proof.AcceptToFinal!.Equivalent);
+        Assert.False(run.Proof.RejectToBaseline!.Equivalent);
+        Assert.False(run.Proof.Success);
+        Assert.Contains(run.Proof.AcceptToFinal.Findings,
+            finding => finding.Code == "normalized_whole_package_mismatch");
+        Assert.Contains(run.Proof.RejectToBaseline.Findings,
+            finding => finding.Code == "normalized_whole_package_mismatch");
+    }
+
+    [Fact]
+    public void RP008_CommentedClause_PreservesDefinitionsAndRangeMarkers()
+    {
+        var (baseline, intendedFinal) = DocxDiffCommentFixtures.Build(
+            "multi-comment-one-para");
+        var redline = DocxDiff.Compare(
+            baseline,
+            intendedFinal,
+            new DocxDiffSettings { AuthorForRevisions = "Comparison Engine" });
+
+        var run = RedlineReversibilityVerifier.Prove(
+            baseline.DocumentByteArray,
+            intendedFinal.DocumentByteArray,
+            redline.DocumentByteArray);
+
+        Assert.True(run.Proof.AcceptToFinal?.Completed, run.Proof.ToJson());
+        Assert.True(run.Proof.RejectToBaseline?.Completed, run.Proof.ToJson());
+        Assert.Equal(CommentEvidence(intendedFinal.DocumentByteArray),
+            CommentEvidence(run.AcceptedPackageBytes!));
+        Assert.Equal(CommentEvidence(baseline.DocumentByteArray),
+            CommentEvidence(run.RejectedPackageBytes!));
+        Assert.True(run.Proof.AcceptToFinal?.ModeledSemantic.Available,
+            run.Proof.ToJson());
+        Assert.True(run.Proof.RejectToBaseline?.ModeledSemantic.Available,
+            run.Proof.ToJson());
+        AssertPathEvidenceCoherent(run.Proof.AcceptToFinal!, run.Proof.ToJson());
+        AssertPathEvidenceCoherent(run.Proof.RejectToBaseline!, run.Proof.ToJson());
+        Assert.False(run.Proof.AcceptToFinal!.Equivalent);
+        Assert.False(run.Proof.RejectToBaseline!.Equivalent);
+        Assert.False(run.Proof.Success);
+        Assert.Contains(run.Proof.AcceptToFinal.Findings,
+            finding => finding.Code == "modeled_semantic_mismatch");
+        Assert.Contains(run.Proof.RejectToBaseline.Findings,
+            finding => finding.Code == "modeled_semantic_mismatch");
+    }
+
+    [Fact]
+    public void RP009_OpaquePartDifference_RemainsExplicitlyUnmodeled()
+    {
+        var baseline = AddOpaqueCustomXmlPart(Document("Unchanged body."), "baseline");
+        var redline = RewriteOpaqueCustomXmlPart(baseline, "changed");
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, baseline, redline);
+
+        Assert.True(run.Proof.AcceptToFinal?.Completed, run.Proof.ToJson());
+        Assert.True(run.Proof.AcceptToFinal?.ModeledSemantic.Equivalent);
+        var opaque = Assert.Single(run.Proof.AcceptToFinal?.Divergences ?? [], divergence =>
+            divergence.PartUri.StartsWith("/customXml/", StringComparison.Ordinal)
+            && divergence.UnknownOrUnmodeled);
+        Assert.False(opaque.HasModeledSemanticChange);
+        Assert.False(run.Proof.Success);
+    }
+
+    [Fact]
+    public void RP010_HeaderAndFooterRevisions_RoundTripBothStoryParts()
+    {
+        var baseline = HeaderFooterDocument("Old header", "Old footer", tracked: false);
+        var intendedFinal = RewriteHeaderFooter(
+            baseline, "New header", "New footer", tracked: false);
+        var redline = RewriteHeaderFooter(
+            baseline, "New header", "New footer", tracked: true);
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.Contains(run.Proof.RevisionClassifications, classification =>
+            classification.Redline?.PartUri.StartsWith("/word/header", StringComparison.Ordinal)
+                == true);
+        Assert.Contains(run.Proof.RevisionClassifications, classification =>
+            classification.Redline?.PartUri.StartsWith("/word/footer", StringComparison.Ordinal)
+                == true);
+        Assert.True(run.Proof.AcceptToFinal?.Equivalent, run.Proof.ToJson());
+        Assert.True(run.Proof.RejectToBaseline?.Equivalent, run.Proof.ToJson());
+        Assert.True(run.Proof.Success, run.Proof.ToJson());
+    }
+
+    [Fact]
+    public void RP011_BookmarkAroundGeneratedText_IsPreservedOnBothPaths()
+    {
+        var baseline = BookmarkDocument("Old bookmarked text", tracked: false);
+        var intendedFinal = RewriteBody(
+            baseline, BookmarkParagraph("New bookmarked text", tracked: false));
+        var redline = RewriteBody(
+            baseline, BookmarkParagraph("New bookmarked text", tracked: true));
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.Equal(new[] { "ContractClause" }, BookmarkNames(run.AcceptedPackageBytes!));
+        Assert.Equal(new[] { "ContractClause" }, BookmarkNames(run.RejectedPackageBytes!));
+        Assert.True(run.Proof.AcceptToFinal?.Equivalent, run.Proof.ToJson());
+        Assert.True(run.Proof.RejectToBaseline?.Equivalent, run.Proof.ToJson());
+        Assert.True(run.Proof.Success, run.Proof.ToJson());
+    }
+
+    [Fact]
+    public void RP012_AnchoredSemanticMismatch_ReportsOnlyApplicableRevisions()
+    {
+        var baseline = DocumentWithReviewBody(
+            new Paragraph(RunForText("Old clause.")),
+            new Paragraph(RunForText("Old schedule.")));
+        var intendedFinal = RewriteBody(
+            baseline,
+            new Paragraph(RunForText("Expected clause.")),
+            new Paragraph(RunForText("Expected schedule.")));
+        var redline = RewriteBody(
+            baseline,
+            new Paragraph(
+                new DeletedRun(new Run(new DeletedText("Old clause.")))
+                {
+                    Id = "501",
+                    Author = "Comparison Engine",
+                    Date = FixedRevisionDate(),
+                },
+                new InsertedRun(RunForText("Actual clause."))
+                {
+                    Id = "502",
+                    Author = "Comparison Engine",
+                    Date = FixedRevisionDate(),
+                }),
+            new Paragraph(
+                new DeletedRun(new Run(new DeletedText("Old schedule.")))
+                {
+                    Id = "601",
+                    Author = "Comparison Engine",
+                    Date = FixedRevisionDate(),
+                },
+                new InsertedRun(RunForText("Expected schedule."))
+                {
+                    Id = "602",
+                    Author = "Comparison Engine",
+                    Date = FixedRevisionDate(),
+                }));
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        var modeledChanges = SemanticDiff.Compare(
+                new WmlDocument("expected.docx", intendedFinal),
+                new WmlDocument("actual.docx", run.AcceptedPackageBytes!))
+            .Changes
+            .Where(change => change.Family != SemanticChangeFamily.OpaquePackagePart)
+            .ToArray();
+        var firstSemanticChange = modeledChanges.FirstOrDefault(change =>
+                change.RightAnchor is not null || change.LeftAnchor is not null)
+            ?? Assert.Single(modeledChanges);
+        var semanticAnchor = firstSemanticChange.RightAnchor ?? firstSemanticChange.LeftAnchor;
+        Assert.NotNull(semanticAnchor);
+
+        var finding = Assert.Single(run.Proof.AcceptToFinal?.Findings ?? [], item =>
+            item.Code == "modeled_semantic_mismatch");
+        Assert.Equal("/word/document.xml", finding.Location?.EntryUri);
+        Assert.NotNull(finding.Location?.PropertyPath);
+        Assert.Equal(semanticAnchor, finding.AnchorId);
+
+        var generated = run.Proof.RevisionClassifications
+            .Where(classification =>
+                classification.Disposition == RedlineRevisionDisposition.Generated)
+            .Select(classification => classification.Redline!)
+            .ToArray();
+        Assert.True(generated.Select(revision => revision.AnchorId)
+            .Where(anchor => anchor is not null)
+            .Distinct(StringComparer.Ordinal)
+            .Count() >= 2, run.Proof.ToJson());
+        var expectedApplicableIds = generated.Where(revision =>
+                string.Equals(revision.PartUri, firstSemanticChange.PartUri,
+                    StringComparison.Ordinal)
+                && (string.Equals(revision.AnchorId, semanticAnchor, StringComparison.Ordinal)
+                    || revision.AffectedAnchorIds.Contains(
+                        semanticAnchor!, StringComparer.Ordinal)))
+            .Select(revision => revision.Id)
+            .OrderBy(id => id, StringComparer.Ordinal)
+            .ToArray();
+        Assert.Empty(expectedApplicableIds);
+        Assert.Empty(finding.RevisionIds);
+        Assert.Equal(expectedApplicableIds,
+            finding.RevisionIds.OrderBy(id => id, StringComparer.Ordinal));
+
+        var unrelated = generated.Where(revision => revision.ConstituentIds.Any(
+                id => id is "601" or "602"))
+            .ToArray();
+        Assert.NotEmpty(unrelated);
+        Assert.All(unrelated, revision =>
+            Assert.DoesNotContain(revision.Id, finding.RevisionIds));
+        Assert.False(run.Proof.AcceptToFinal?.Equivalent);
+        Assert.True(run.Proof.RejectToBaseline?.Equivalent, run.Proof.ToJson());
     }
 
     private static void AssertResolutionClosure(RedlineProofPathResult path)
@@ -212,6 +426,32 @@ public class RedlineReversibilityProofTests
         Assert.Equal(path.RequestedRevisionIds.OrderBy(item => item, StringComparer.Ordinal),
             accountedFor);
         Assert.Equal(accountedFor.Length, accountedFor.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    private static void AssertPathEvidenceCoherent(
+        RedlineProofPathResult path,
+        string proofJson)
+    {
+        var expectedEquivalent = path.Completed
+            && path.PreExistingRevisionsPreserved
+            && path.ModeledSemantic.Available
+            && path.ModeledSemantic.Equivalent == true
+            && path.NormalizedWholePackageEquivalent
+            && path.Findings.All(finding =>
+                finding.Severity != VerificationFindingSeverity.Error);
+        Assert.Equal(expectedEquivalent, path.Equivalent);
+        if (!path.NormalizedWholePackageEquivalent)
+        {
+            Assert.NotNull(path.FirstDivergence);
+            Assert.Contains(path.Findings, finding =>
+                finding.Code == "normalized_whole_package_mismatch");
+        }
+        if (!path.Equivalent)
+        {
+            Assert.Contains(path.Findings, finding =>
+                finding.Severity == VerificationFindingSeverity.Error);
+        }
+        Assert.True(path.ModeledSemantic.Available, proofJson);
     }
 
     private static byte[] Document(params string[] runs) =>
@@ -252,6 +492,182 @@ public class RedlineReversibilityProofTests
         "2000-01-01T00:00:00Z",
         System.Globalization.CultureInfo.InvariantCulture,
         System.Globalization.DateTimeStyles.AdjustToUniversal);
+
+    private static string CommentEvidence(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes, writable: false);
+        using var document = WordprocessingDocument.Open(stream, false);
+        var main = document.MainDocumentPart!;
+        var definitions = main.WordprocessingCommentsPart?.Comments?
+            .Elements<Comment>()
+            .Select(comment => $"{comment.Id}|{comment.Author}|{comment.InnerText}")
+            .OrderBy(item => item, StringComparer.Ordinal)
+            ?? Enumerable.Empty<string>();
+        var markers = main.Document.Descendants()
+            .Select(element => element switch
+            {
+                CommentRangeStart start => $"start:{start.Id}",
+                CommentRangeEnd end => $"end:{end.Id}",
+                CommentReference reference => $"reference:{reference.Id}",
+                _ => null,
+            })
+            .Where(item => item is not null);
+        return string.Join("\n", definitions)
+            + "\n--markers--\n"
+            + string.Join("\n", markers);
+    }
+
+    private static byte[] AddOpaqueCustomXmlPart(byte[] source, string value)
+    {
+        using var stream = new MemoryStream();
+        stream.Write(source);
+        using (var document = WordprocessingDocument.Open(stream, true))
+        {
+            var part = document.MainDocumentPart!
+                .AddCustomXmlPart(CustomXmlPartType.CustomXml);
+            var payload = OpaquePayload(value);
+            using var partStream = part.GetStream(FileMode.Create, FileAccess.Write);
+            partStream.Write(payload);
+        }
+        return stream.ToArray();
+    }
+
+    private static byte[] RewriteOpaqueCustomXmlPart(byte[] source, string value)
+    {
+        using var stream = new MemoryStream();
+        stream.Write(source);
+        using (var document = WordprocessingDocument.Open(stream, true))
+        {
+            var part = Assert.Single(document.MainDocumentPart!.CustomXmlParts);
+            using var partStream = part.GetStream(FileMode.Create, FileAccess.Write);
+            partStream.Write(OpaquePayload(value));
+        }
+        return stream.ToArray();
+    }
+
+    private static byte[] OpaquePayload(string value) => Encoding.UTF8.GetBytes(
+        $"<vendor:payload xmlns:vendor=\"urn:docxodus:test:vendor\">{value}</vendor:payload>");
+
+    private static byte[] HeaderFooterDocument(
+        string headerText,
+        string footerText,
+        bool tracked)
+    {
+        using var stream = new MemoryStream();
+        using (var document = WordprocessingDocument.Create(
+                   stream, WordprocessingDocumentType.Document))
+        {
+            var main = document.AddMainDocumentPart();
+            var header = main.AddNewPart<HeaderPart>("rIdHeader");
+            header.Header = new Header(RevisionParagraph(
+                "Old header", headerText, tracked, "301", "302"));
+            var footer = main.AddNewPart<FooterPart>("rIdFooter");
+            footer.Footer = new Footer(RevisionParagraph(
+                "Old footer", footerText, tracked, "303", "304"));
+            main.AddNewPart<DocumentSettingsPart>().Settings = new Settings();
+            main.Document = new Document(new Body(
+                new Paragraph(RunForText("Unchanged body.")),
+                new SectionProperties(
+                    new HeaderReference
+                    {
+                        Type = HeaderFooterValues.Default,
+                        Id = "rIdHeader",
+                    },
+                    new FooterReference
+                    {
+                        Type = HeaderFooterValues.Default,
+                        Id = "rIdFooter",
+                    })));
+            document.Save();
+        }
+        return stream.ToArray();
+    }
+
+    private static byte[] RewriteHeaderFooter(
+        byte[] source,
+        string headerText,
+        string footerText,
+        bool tracked)
+    {
+        using var stream = new MemoryStream();
+        stream.Write(source);
+        using (var document = WordprocessingDocument.Open(stream, true))
+        {
+            document.MainDocumentPart!.HeaderParts.Single().Header = new Header(
+                RevisionParagraph("Old header", headerText, tracked, "301", "302"));
+            document.MainDocumentPart.FooterParts.Single().Footer = new Footer(
+                RevisionParagraph("Old footer", footerText, tracked, "303", "304"));
+            document.Save();
+        }
+        return stream.ToArray();
+    }
+
+    private static byte[] BookmarkDocument(string text, bool tracked) =>
+        DocumentWithReviewBody(BookmarkParagraph(text, tracked));
+
+    private static Paragraph BookmarkParagraph(string text, bool tracked)
+    {
+        var paragraph = new Paragraph(new BookmarkStart
+        {
+            Id = "0",
+            Name = "ContractClause",
+        });
+        if (tracked)
+        {
+            paragraph.Append(
+                new DeletedRun(new Run(new DeletedText("Old bookmarked text")))
+                {
+                    Id = "401",
+                    Author = "Comparison Engine",
+                    Date = FixedRevisionDate(),
+                },
+                new InsertedRun(RunForText(text))
+                {
+                    Id = "402",
+                    Author = "Comparison Engine",
+                    Date = FixedRevisionDate(),
+                });
+        }
+        else
+        {
+            paragraph.Append(RunForText(text));
+        }
+        paragraph.Append(new BookmarkEnd { Id = "0" });
+        return paragraph;
+    }
+
+    private static Paragraph RevisionParagraph(
+        string oldText,
+        string newText,
+        bool tracked,
+        string deleteId,
+        string insertId) => tracked
+        ? new Paragraph(
+            new DeletedRun(new Run(new DeletedText(oldText)))
+            {
+                Id = deleteId,
+                Author = "Comparison Engine",
+                Date = FixedRevisionDate(),
+            },
+            new InsertedRun(RunForText(newText))
+            {
+                Id = insertId,
+                Author = "Comparison Engine",
+                Date = FixedRevisionDate(),
+            })
+        : new Paragraph(RunForText(newText));
+
+    private static string[] BookmarkNames(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes, writable: false);
+        using var document = WordprocessingDocument.Open(stream, false);
+        return document.MainDocumentPart!.Document.Descendants<BookmarkStart>()
+            .Select(bookmark => bookmark.Name?.Value)
+            .Where(name => name is not null)
+            .Select(name => name!)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+    }
 
     private static byte[] RewriteBody(byte[] source, params Paragraph[] paragraphs)
     {

--- a/Docxodus.Tests/RedlineReversibilityProofTests.cs
+++ b/Docxodus.Tests/RedlineReversibilityProofTests.cs
@@ -33,6 +33,8 @@ public class RedlineReversibilityProofTests
         Assert.NotNull(run.RejectedPackageBytes);
         Assert.True(run.Proof.AcceptToFinal?.Completed);
         Assert.True(run.Proof.RejectToBaseline?.Completed);
+        Assert.False(run.Proof.AcceptToFinal?.NormalizedWholePackageEquivalent);
+        Assert.NotEmpty(run.Proof.AcceptToFinal?.Divergences ?? []);
         Assert.False(run.Proof.AcceptToFinal?.ModeledSemantic.Available);
         Assert.False(run.Proof.Success); // #457 is intentionally required before this can prove success.
     }
@@ -71,17 +73,194 @@ public class RedlineReversibilityProofTests
         Assert.DoesNotContain("\"acceptedPackageBytes\"", first.ToCanonicalJson(), StringComparison.Ordinal);
     }
 
-    private static byte[] Document(string text)
+    [Fact]
+    public void RP004_WordAuthoredComparison_ReportsNonReversiblePackageDifferences()
+    {
+        var root = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "../../../../TestFiles/WC"));
+        var baseline = File.ReadAllBytes(Path.Combine(root, "WC001-Digits.docx"));
+        var intendedFinal = File.ReadAllBytes(Path.Combine(root, "WC001-Digits-Mod.docx"));
+        var redline = DocxDiff.Compare(
+            new WmlDocument("baseline.docx", baseline),
+            new WmlDocument("final.docx", intendedFinal)).DocumentByteArray;
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.True(run.Proof.AcceptToFinal?.Completed, run.Proof.ToJson());
+        Assert.True(run.Proof.RejectToBaseline?.Completed, run.Proof.ToJson());
+        Assert.False(run.Proof.AcceptToFinal?.NormalizedWholePackageEquivalent);
+        Assert.False(run.Proof.RejectToBaseline?.NormalizedWholePackageEquivalent);
+        Assert.NotNull(run.Proof.AcceptToFinal?.FirstDivergence);
+        Assert.NotNull(run.Proof.RejectToBaseline?.FirstDivergence);
+        Assert.Contains(run.Proof.AcceptToFinal?.Findings ?? [], item =>
+            item.Code == "normalized_whole_package_mismatch");
+    }
+
+    [Fact]
+    public void RP005_NativeGeneratedRevision_RoundTripsNormalizedWholePackage()
+    {
+        var baseline = Document("The ", "original", " clause.");
+        var intendedFinal = RewriteBody(baseline, new Paragraph(
+            RunForText("The "),
+            RunForText("revised"),
+            RunForText(" clause.")));
+        var redline = RewriteBody(baseline, new Paragraph(
+            RunForText("The "),
+            new DeletedRun(new Run(new DeletedText("original")))
+            {
+                Id = "1",
+                Author = "Comparison Engine",
+                Date = DateTime.Parse("2000-01-01T00:00:00Z",
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.AdjustToUniversal),
+            },
+            new InsertedRun(new Run(new Text("revised")))
+            {
+                Id = "2",
+                Author = "Comparison Engine",
+                Date = DateTime.Parse("2000-01-01T00:00:00Z",
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.AdjustToUniversal),
+            },
+            RunForText(" clause.")));
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.True(run.Proof.AcceptToFinal?.NormalizedWholePackageEquivalent,
+            run.Proof.ToJson());
+        Assert.True(run.Proof.RejectToBaseline?.NormalizedWholePackageEquivalent,
+            run.Proof.ToJson());
+        Assert.Empty(run.Proof.AcceptToFinal?.Divergences
+            .Where(item => item.UnknownOrUnmodeled) ?? []);
+        Assert.Empty(run.Proof.RejectToBaseline?.Divergences
+            .Where(item => item.UnknownOrUnmodeled) ?? []);
+    }
+
+    [Fact]
+    public void RP006_PreExistingMultiAuthorRevision_IsPreservedOnBothPaths()
+    {
+        var baseline = DocumentWithReviewBody(PriorReviewParagraph(),
+            new Paragraph(RunForText("old")));
+        var intendedFinal = RewriteBody(baseline, PriorReviewParagraph(),
+            new Paragraph(RunForText("new")));
+        var redline = RewriteBody(baseline, PriorReviewParagraph(), new Paragraph(
+            new DeletedRun(new Run(new DeletedText("old")))
+            {
+                Id = "101",
+                Author = "Comparison Engine",
+                Date = FixedRevisionDate(),
+            },
+            new InsertedRun(RunForText("new"))
+            {
+                Id = "102",
+                Author = "Comparison Engine",
+                Date = FixedRevisionDate(),
+            }));
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.Contains(run.Proof.RevisionClassifications, item =>
+            item.Disposition == RedlineRevisionDisposition.PreExisting
+            && item.Redline?.Author == "Prior Reviewer");
+        Assert.Contains(run.Proof.RevisionClassifications, item =>
+            item.Disposition == RedlineRevisionDisposition.Generated
+            && item.Redline?.Author == "Comparison Engine");
+        Assert.DoesNotContain(run.Proof.RevisionClassifications, item =>
+            item.Disposition == RedlineRevisionDisposition.Conflicted);
+        Assert.True(run.Proof.AcceptToFinal?.PreExistingRevisionsPreserved,
+            run.Proof.ToJson());
+        Assert.True(run.Proof.RejectToBaseline?.PreExistingRevisionsPreserved,
+            run.Proof.ToJson());
+        Assert.Single(run.Proof.AcceptToFinal?.SurvivingPreExistingRevisions ?? []);
+        Assert.Single(run.Proof.RejectToBaseline?.SurvivingPreExistingRevisions ?? []);
+    }
+
+    [Theory]
+    [InlineData("RP015-MoveFrom-MoveTo", RevisionFamily.Move)]
+    [InlineData("RP025-Paragraph-Props-Change", RevisionFamily.PropertiesChange)]
+    [InlineData("RP009-Deleted-Table-Row", RevisionFamily.RowDelete)]
+    [InlineData("RP050-Deleted-Footnote", RevisionFamily.ContentDelete)]
+    public void RP007_RealRevisionFamilies_ResolveAndEmitProofEvidence(
+        string fixtureStem,
+        RevisionFamily expectedFamily)
+    {
+        var root = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "../../../../TestFiles/RP"));
+        var baseline = File.ReadAllBytes(Path.Combine(root, fixtureStem + "-Rejected.docx"));
+        var intendedFinal = File.ReadAllBytes(Path.Combine(root, fixtureStem + "-Accepted.docx"));
+        var redline = File.ReadAllBytes(Path.Combine(root, fixtureStem + ".docx"));
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.Contains(run.Proof.RevisionClassifications, item =>
+            item.Disposition == RedlineRevisionDisposition.Generated
+            && item.Redline?.Family == expectedFamily);
+        Assert.True(run.Proof.AcceptToFinal?.Completed, run.Proof.ToJson());
+        Assert.True(run.Proof.RejectToBaseline?.Completed, run.Proof.ToJson());
+        AssertResolutionClosure(run.Proof.AcceptToFinal!);
+        AssertResolutionClosure(run.Proof.RejectToBaseline!);
+        Assert.NotNull(run.Proof.AcceptToFinal?.ActualPackage);
+        Assert.NotNull(run.Proof.RejectToBaseline?.ActualPackage);
+    }
+
+    private static void AssertResolutionClosure(RedlineProofPathResult path)
+    {
+        var accountedFor = path.ResolvedRevisionIds
+            .Concat(path.ImplicitlyResolvedRevisionIds)
+            .OrderBy(item => item, StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(path.RequestedRevisionIds.OrderBy(item => item, StringComparer.Ordinal),
+            accountedFor);
+        Assert.Equal(accountedFor.Length, accountedFor.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    private static byte[] Document(params string[] runs) =>
+        DocumentWithReviewBody(new Paragraph(runs.Select(RunForText)));
+
+    private static byte[] DocumentWithReviewBody(params Paragraph[] paragraphs)
     {
         using var stream = new MemoryStream();
         using (var document = WordprocessingDocument.Create(
                    stream, WordprocessingDocumentType.Document))
         {
             var main = document.AddMainDocumentPart();
-            main.Document = new Document(new Body(
-                new Paragraph(new Run(new Text(text)))));
+            main.Document = new Document(new Body(paragraphs));
             main.AddNewPart<DocumentSettingsPart>().Settings = new Settings();
             document.Save();
+        }
+        return stream.ToArray();
+    }
+
+    private static Run RunForText(string value)
+    {
+        var text = new Text(value);
+        if (value.Length > 0 && (char.IsWhiteSpace(value[0]) || char.IsWhiteSpace(value[^1])))
+            text.Space = SpaceProcessingModeValues.Preserve;
+        return new Run(text);
+    }
+
+    private static Paragraph PriorReviewParagraph() => new(
+        RunForText("Base"),
+        new InsertedRun(RunForText(" prior"))
+        {
+            Id = "90",
+            Author = "Prior Reviewer",
+            Date = FixedRevisionDate(),
+        });
+
+    private static DateTime FixedRevisionDate() => DateTime.Parse(
+        "2000-01-01T00:00:00Z",
+        System.Globalization.CultureInfo.InvariantCulture,
+        System.Globalization.DateTimeStyles.AdjustToUniversal);
+
+    private static byte[] RewriteBody(byte[] source, params Paragraph[] paragraphs)
+    {
+        using var stream = new MemoryStream();
+        stream.Write(source);
+        using (var document = WordprocessingDocument.Open(stream, true))
+        {
+            document.MainDocumentPart!.Document.Body = new Body(paragraphs);
+            document.MainDocumentPart.Document.Save();
         }
         return stream.ToArray();
     }

--- a/Docxodus.Tests/RedlineReversibilityProofTests.cs
+++ b/Docxodus.Tests/RedlineReversibilityProofTests.cs
@@ -149,6 +149,11 @@ public class RedlineReversibilityProofTests
             run.Proof.ToJson());
         Assert.True(run.Proof.RejectToBaseline?.ModeledSemantic.Equivalent,
             run.Proof.ToJson());
+        Assert.All(run.Proof.AcceptToFinal?.Findings ?? [], finding =>
+        {
+            if (finding.Code == "raw_package_bytes_mismatch")
+                Assert.Empty(finding.RevisionIds);
+        });
         Assert.True(run.Proof.Success, run.Proof.ToJson());
     }
 
@@ -195,15 +200,17 @@ public class RedlineReversibilityProofTests
     }
 
     [Theory]
-    [InlineData("RP015-MoveFrom-MoveTo", RevisionFamily.Move)]
-    [InlineData("RP021-Inserted-Numbering-Properties", RevisionFamily.NumberingPropertiesInsert)]
-    [InlineData("RP025-Paragraph-Props-Change", RevisionFamily.PropertiesChange)]
-    [InlineData("RP027-Change-Section", RevisionFamily.PropertiesChange)]
-    [InlineData("RP009-Deleted-Table-Row", RevisionFamily.RowDelete)]
-    [InlineData("RP050-Deleted-Footnote", RevisionFamily.ContentDelete)]
+    [InlineData("RP015-MoveFrom-MoveTo", RevisionFamily.Move, false, false)]
+    [InlineData("RP021-Inserted-Numbering-Properties", RevisionFamily.NumberingPropertiesInsert, true, false)]
+    [InlineData("RP025-Paragraph-Props-Change", RevisionFamily.PropertiesChange, false, false)]
+    [InlineData("RP027-Change-Section", RevisionFamily.PropertiesChange, true, false)]
+    [InlineData("RP009-Deleted-Table-Row", RevisionFamily.RowDelete, true, true)]
+    [InlineData("RP050-Deleted-Footnote", RevisionFamily.ContentDelete, false, false)]
     public void RP007_RealRevisionFamilies_ResolveAndEmitProofEvidence(
         string fixtureStem,
-        RevisionFamily expectedFamily)
+        RevisionFamily expectedFamily,
+        bool acceptEquivalent,
+        bool rejectEquivalent)
     {
         var root = Path.GetFullPath(Path.Combine(
             AppContext.BaseDirectory, "../../../../TestFiles/RP"));
@@ -224,13 +231,26 @@ public class RedlineReversibilityProofTests
         Assert.NotNull(run.Proof.RejectToBaseline?.ActualPackage);
         AssertPathEvidenceCoherent(run.Proof.AcceptToFinal!, run.Proof.ToJson());
         AssertPathEvidenceCoherent(run.Proof.RejectToBaseline!, run.Proof.ToJson());
-        Assert.False(run.Proof.AcceptToFinal!.Equivalent);
-        Assert.False(run.Proof.RejectToBaseline!.Equivalent);
-        Assert.False(run.Proof.Success);
-        Assert.Contains(run.Proof.AcceptToFinal.Findings,
-            finding => finding.Code == "normalized_whole_package_mismatch");
-        Assert.Contains(run.Proof.RejectToBaseline.Findings,
-            finding => finding.Code == "normalized_whole_package_mismatch");
+        Assert.True(
+            run.Proof.AcceptToFinal!.Equivalent == acceptEquivalent,
+            run.Proof.ToJson());
+        Assert.True(
+            run.Proof.RejectToBaseline!.Equivalent == rejectEquivalent,
+            run.Proof.ToJson());
+        Assert.True(
+            run.Proof.Success == (acceptEquivalent && rejectEquivalent),
+            run.Proof.ToJson());
+        if (!acceptEquivalent)
+        {
+            Assert.Contains(run.Proof.AcceptToFinal.Findings,
+                finding => finding.Code == "normalized_whole_package_mismatch");
+        }
+
+        if (!rejectEquivalent)
+        {
+            Assert.Contains(run.Proof.RejectToBaseline.Findings,
+                finding => finding.Code == "normalized_whole_package_mismatch");
+        }
     }
 
     [Fact]
@@ -395,16 +415,11 @@ public class RedlineReversibilityProofTests
             .Distinct(StringComparer.Ordinal)
             .Count() >= 2, run.Proof.ToJson());
         var expectedApplicableIds = generated.Where(revision =>
-                string.Equals(revision.PartUri, firstSemanticChange.PartUri,
-                    StringComparison.Ordinal)
-                && (string.Equals(revision.AnchorId, semanticAnchor, StringComparison.Ordinal)
-                    || revision.AffectedAnchorIds.Contains(
-                        semanticAnchor!, StringComparer.Ordinal)))
+                revision.ConstituentIds.Any(id => id is "501" or "502"))
             .Select(revision => revision.Id)
             .OrderBy(id => id, StringComparer.Ordinal)
             .ToArray();
-        Assert.Empty(expectedApplicableIds);
-        Assert.Empty(finding.RevisionIds);
+        Assert.NotEmpty(expectedApplicableIds);
         Assert.Equal(expectedApplicableIds,
             finding.RevisionIds.OrderBy(id => id, StringComparer.Ordinal));
 
@@ -474,8 +489,8 @@ public class RedlineReversibilityProofTests
         Assert.Null(run.Proof.RejectToBaseline);
         Assert.Empty(run.Proof.RevisionClassifications);
         var finding = Assert.Single(run.Proof.Findings,
-            item => item.Code == "revision_inventory_limit_exceeded");
-        Assert.Equal("redline/revisionInventory", finding.Location?.PropertyPath);
+            item => item.Code == "revision_element_limit_exceeded");
+        Assert.Equal("redline/revisions", finding.Location?.PropertyPath);
     }
 
     [Fact]
@@ -489,6 +504,785 @@ public class RedlineReversibilityProofTests
             new[] { generated, preExisting });
 
         Assert.Equal(preExisting, Assert.Single(projected));
+    }
+
+    [Fact]
+    public void RP016_PreExistingRevisionInEditedParagraph_IsNotOwnershipConflict()
+    {
+        var baseline = DocumentWithReviewBody(new Paragraph(
+            RunForText("Base"),
+            new InsertedRun(RunForText(" prior"))
+            {
+                Id = "800",
+                Author = "Prior Reviewer",
+                Date = FixedRevisionDate(),
+            },
+            RunForText(" old")));
+        var intendedFinal = RewriteBody(baseline, new Paragraph(
+            RunForText("Base"),
+            new InsertedRun(RunForText(" prior"))
+            {
+                Id = "800",
+                Author = "Prior Reviewer",
+                Date = FixedRevisionDate(),
+            },
+            RunForText(" new")));
+        var redline = RewriteBody(baseline, new Paragraph(
+            RunForText("Base"),
+            new InsertedRun(RunForText(" prior"))
+            {
+                Id = "800",
+                Author = "Prior Reviewer",
+                Date = FixedRevisionDate(),
+            },
+            new DeletedRun(new Run(new DeletedText(" old")
+            {
+                Space = SpaceProcessingModeValues.Preserve,
+            }))
+            {
+                Id = "801",
+                Author = "Comparison Engine",
+                Date = FixedRevisionDate(),
+            },
+            new InsertedRun(RunForText(" new"))
+            {
+                Id = "802",
+                Author = "Comparison Engine",
+                Date = FixedRevisionDate(),
+            }));
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.Contains(run.Proof.RevisionClassifications, item =>
+            item.Disposition == RedlineRevisionDisposition.PreExisting
+            && item.Redline?.ConstituentIds.Contains("800", StringComparer.Ordinal) == true);
+        Assert.DoesNotContain(run.Proof.RevisionClassifications, item =>
+            item.Disposition == RedlineRevisionDisposition.Conflicted);
+        Assert.True(run.Proof.Success, run.Proof.ToJson());
+    }
+
+    [Fact]
+    public void RP017_RawInputBudget_IsAppliedBeforePackageInspection()
+    {
+        var error = Assert.Throws<ArgumentException>(() =>
+            RedlineReversibilityVerifier.Prove(
+                new byte[4],
+                new byte[4],
+                new byte[4],
+                new RedlineReversibilityProofOptions { MaxPackageBytes = 11 }));
+
+        Assert.Contains("Aggregate baseline", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RP018_PackageDeltaLimit_FailsClosedWithoutPartialDivergences()
+    {
+        var baseline = Document("Base");
+        var redline = AddOpaqueCustomXmlPart(baseline, "extra");
+
+        var run = RedlineReversibilityVerifier.Prove(
+            baseline,
+            baseline,
+            redline,
+            new RedlineReversibilityProofOptions { MaxPackageChanges = 1 });
+
+        Assert.False(run.Proof.AcceptToFinal?.DivergenceAnalysisCompleted);
+        Assert.Empty(run.Proof.AcceptToFinal?.Divergences ?? []);
+        Assert.Contains(run.Proof.AcceptToFinal?.Findings ?? [], item =>
+            item.Code == "package_divergence_limit_exceeded");
+        Assert.False(run.Proof.Success);
+    }
+
+    [Fact]
+    public void RP019_SemanticChangeLimit_ReportsUnavailableEvidence()
+    {
+        var baseline = DocumentWithReviewBody(
+            new Paragraph(RunForText("A")),
+            new Paragraph(RunForText("B")),
+            new Paragraph(RunForText("C")));
+        var intendedFinal = RewriteBody(
+            baseline,
+            new Paragraph(RunForText("X")),
+            new Paragraph(RunForText("Y")),
+            new Paragraph(RunForText("Z")));
+
+        var run = RedlineReversibilityVerifier.Prove(
+            baseline,
+            intendedFinal,
+            baseline,
+            new RedlineReversibilityProofOptions { MaxSemanticChanges = 1 });
+
+        Assert.False(run.Proof.AcceptToFinal?.ModeledSemantic.Available);
+        Assert.Null(run.Proof.AcceptToFinal?.ModeledSemantic.ChangeCount);
+        Assert.Contains(run.Proof.AcceptToFinal?.Findings ?? [], item =>
+            item.Code == "modeled_semantic_comparison_unavailable");
+        Assert.False(run.Proof.Success);
+    }
+
+    [Fact]
+    public void RP020_RevisionEvidenceLimit_FailsBeforePathExecution()
+    {
+        var baseline = Document("Base");
+        var intendedFinal = Document("Base plus evidence");
+        var redline = RewriteBody(baseline, new Paragraph(
+            RunForText("Base"),
+            new InsertedRun(RunForText(" plus evidence"))
+            {
+                Id = "900",
+                Author = "Comparison Engine",
+                Date = FixedRevisionDate(),
+            }));
+
+        var run = RedlineReversibilityVerifier.Prove(
+            baseline,
+            intendedFinal,
+            redline,
+            new RedlineReversibilityProofOptions { MaxEvidenceTextCharacters = 8 });
+
+        Assert.Null(run.Proof.AcceptToFinal);
+        Assert.Empty(run.Proof.RevisionClassifications);
+        Assert.Contains(run.Proof.Findings, item =>
+            item.Code == "revision_evidence_limit_exceeded");
+    }
+
+    [Fact]
+    public void RP021_CanonicalUtf8_IsCamelCaseAndMatchesCanonicalString()
+    {
+        var document = Document("same");
+        var proof = RedlineReversibilityVerifier.Prove(document, document, document).Proof;
+
+        Assert.Equal(proof.ToCanonicalJson(), Encoding.UTF8.GetString(proof.ToCanonicalUtf8Bytes()));
+        Assert.Contains("\"direction\":\"acceptToFinal\"", proof.ToCanonicalJson(),
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("AcceptToFinal", proof.ToCanonicalJson(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RP022_GeneratedGroupsMayMergeAfterSeparatorResolution()
+    {
+        const string stamp = " w:author=\"Comparison Engine\""
+            + " w:date=\"2000-01-01T00:00:00Z\"";
+        var baseline = IrTestDocuments.FromBodyXml(
+            "<w:p><w:r><w:t>A</w:t></w:r></w:p>").DocumentByteArray;
+        var intendedFinal = RewriteBodyXml(
+            baseline,
+            "<w:p><w:r><w:t>X</w:t></w:r><w:r><w:t>Z</w:t></w:r></w:p>");
+        var redline = RewriteBodyXml(
+            baseline,
+            "<w:p>"
+            + $"<w:ins w:id=\"1\"{stamp}><w:r><w:t>X</w:t></w:r></w:ins>"
+            + $"<w:del w:id=\"2\"{stamp}><w:r><w:delText>A</w:delText></w:r></w:del>"
+            + $"<w:ins w:id=\"3\"{stamp}><w:r><w:t>Z</w:t></w:r></w:ins>"
+            + "</w:p>");
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.True(run.Proof.Success, run.Proof.ToJson());
+        AssertResolutionClosure(run.Proof.AcceptToFinal!);
+        AssertResolutionClosure(run.Proof.RejectToBaseline!);
+        Assert.Equal(3, run.Proof.RevisionClassifications.Count(classification =>
+            classification.Disposition == RedlineRevisionDisposition.Generated));
+    }
+
+    [Fact]
+    public void RP023_NestedPropertyRevisionFailsClosed()
+    {
+        var clean = IrTestDocuments.FromBodyXml(
+            "<w:p><w:r><w:t>Clause</w:t></w:r></w:p><w:sectPr/>")
+            .DocumentByteArray;
+        var malformed = IrTestDocuments.FromBodyXml(
+            "<w:p><w:r><w:t>Clause</w:t></w:r></w:p>"
+            + "<w:sectPr><w:sectPrChange w:id=\"1\" w:author=\"Reviewer\">"
+            + "<w:sectPr><w:sectPrChange w:id=\"2\" w:author=\"Reviewer\">"
+            + "<w:sectPr/></w:sectPrChange></w:sectPr>"
+            + "</w:sectPrChange></w:sectPr>").DocumentByteArray;
+
+        var run = RedlineReversibilityVerifier.Prove(clean, clean, malformed);
+
+        Assert.Null(run.Proof.AcceptToFinal);
+        var classification = Assert.Single(run.Proof.RevisionClassifications);
+        Assert.Equal(RevisionResolutionStatus.Malformed,
+            classification.Redline?.ResolutionStatus);
+        Assert.Equal("malformed_properties_change",
+            classification.Redline?.Diagnostic?.Code);
+        Assert.Contains(run.Proof.Findings, finding =>
+            finding.Code == "generated_revision_not_resolvable");
+    }
+
+    [Fact]
+    public void RP024_RejectPropertyChangeRestoresStoredAttributes()
+    {
+        var baseline = IrTestDocuments.FromBodyXml(
+            "<w:p><w:r><w:t>Clause</w:t></w:r></w:p>"
+            + "<w:sectPr w:rsidSect=\"AAAA\"><w:pgSz w:w=\"100\"/></w:sectPr>")
+            .DocumentByteArray;
+        var intendedFinal = RewriteBodyXml(
+            baseline,
+            "<w:p><w:r><w:t>Clause</w:t></w:r></w:p>"
+            + "<w:sectPr w:rsidSect=\"BBBB\"><w:pgSz w:w=\"200\"/></w:sectPr>");
+        var redline = RewriteBodyXml(
+            baseline,
+            "<w:p><w:r><w:t>Clause</w:t></w:r></w:p>"
+            + "<w:sectPr w:rsidSect=\"BBBB\"><w:pgSz w:w=\"200\"/>"
+            + "<w:sectPrChange w:id=\"1\" w:author=\"Comparison Engine\" "
+            + "w:date=\"2000-01-01T00:00:00Z\">"
+            + "<w:sectPr w:rsidSect=\"AAAA\"><w:pgSz w:w=\"100\"/></w:sectPr>"
+            + "</w:sectPrChange></w:sectPr>");
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.True(run.Proof.Success, run.Proof.ToJson());
+        Assert.True(run.Proof.AcceptToFinal?.Equivalent, run.Proof.ToJson());
+        Assert.True(run.Proof.RejectToBaseline?.Equivalent, run.Proof.ToJson());
+    }
+
+    [Fact]
+    public void RP025_OrphanDeletionPayloadCannotBypassNativeCarrierBudget()
+    {
+        var clean = IrTestDocuments.Create("Base").DocumentByteArray;
+        var malformed = IrTestDocuments.FromBodyXml(
+            "<w:p><w:r><w:delText>A</w:delText><w:delText>B</w:delText></w:r></w:p>")
+            .DocumentByteArray;
+
+        var run = RedlineReversibilityVerifier.Prove(
+            clean,
+            clean,
+            malformed,
+            new RedlineReversibilityProofOptions { MaxRevisionElements = 1 });
+
+        Assert.Null(run.Proof.AcceptToFinal);
+        Assert.Empty(run.Proof.RevisionClassifications);
+        Assert.Contains(run.Proof.Findings, finding =>
+            finding.Code == "revision_element_limit_exceeded");
+    }
+
+    [Fact]
+    public void RP026_OfficeConflictRevisionIsExplicitlyUnsupported()
+    {
+        var clean = IrTestDocuments.Create("Base").DocumentByteArray;
+        var conflicted = IrTestDocuments.FromBodyXml(
+            "<w:p><w14:conflictIns xmlns:w14=\"http://schemas.microsoft.com/office/word/2010/wordml\" "
+            + "w:id=\"1\" w:author=\"Reviewer\"><w:r><w:t>Base</w:t></w:r>"
+            + "</w14:conflictIns></w:p>").DocumentByteArray;
+
+        var run = RedlineReversibilityVerifier.Prove(clean, clean, conflicted);
+
+        Assert.Null(run.Proof.AcceptToFinal);
+        var classification = Assert.Single(run.Proof.RevisionClassifications);
+        Assert.Equal(RevisionResolutionStatus.Unsupported,
+            classification.Redline?.ResolutionStatus);
+        Assert.Equal("unsupported_revision_family",
+            classification.Redline?.Diagnostic?.Code);
+    }
+
+    [Fact]
+    public void RP027_ProofResolutionNeverSweepsUnrelatedOrphanRelationships()
+    {
+        const string baselineBody = "<w:p><w:r><w:t>Old</w:t></w:r></w:p>";
+        const string finalBody = "<w:p><w:r><w:t>New</w:t></w:r></w:p>";
+        const string redlineBody = "<w:p>"
+            + "<w:del w:id=\"1\" w:author=\"Comparison Engine\"><w:r><w:delText>Old</w:delText></w:r></w:del>"
+            + "<w:ins w:id=\"2\" w:author=\"Comparison Engine\"><w:r><w:t>New</w:t></w:r></w:ins>"
+            + "</w:p>";
+        var baseline = IrTestDocuments.FromBodyXmlWithHyperlinks(
+            baselineBody, ("rOrphan", "https://example.test/unused")).DocumentByteArray;
+        var intendedFinal = RewriteBodyXml(baseline, finalBody);
+        var redline = RewriteBodyXml(baseline, redlineBody);
+
+        var preserved = RedlineReversibilityVerifier.Prove(
+            baseline, intendedFinal, redline);
+
+        Assert.True(preserved.Proof.Success, preserved.Proof.ToJson());
+
+        var redlineWithUnownedExtra = AddOrphanHyperlink(
+            redline, "rExtra", "https://example.test/unowned");
+        var unowned = RedlineReversibilityVerifier.Prove(
+            baseline, intendedFinal, redlineWithUnownedExtra);
+
+        Assert.False(unowned.Proof.Success);
+        Assert.False(unowned.Proof.AcceptToFinal?.NormalizedWholePackageEquivalent);
+        Assert.False(unowned.Proof.RejectToBaseline?.NormalizedWholePackageEquivalent);
+    }
+
+    [Fact]
+    public void RP028_DuplicateSiblingPropertyChangesFailClosed()
+    {
+        var clean = IrTestDocuments.Create("Clause").DocumentByteArray;
+        var malformed = RewriteBodyXml(
+            clean,
+            "<w:p><w:pPr>"
+            + "<w:pPrChange w:id=\"1\" w:author=\"Reviewer\"><w:pPr/></w:pPrChange>"
+            + "<w:pPrChange w:id=\"2\" w:author=\"Reviewer\"><w:pPr/></w:pPrChange>"
+            + "</w:pPr><w:r><w:t>Clause</w:t></w:r></w:p>");
+
+        var run = RedlineReversibilityVerifier.Prove(clean, clean, malformed);
+
+        Assert.Null(run.Proof.AcceptToFinal);
+        Assert.NotEmpty(run.Proof.RevisionClassifications);
+        Assert.All(run.Proof.RevisionClassifications, classification =>
+        {
+            Assert.Equal(RevisionResolutionStatus.Malformed,
+                classification.Redline?.ResolutionStatus);
+            Assert.Equal("malformed_properties_change",
+                classification.Redline?.Diagnostic?.Code);
+        });
+    }
+
+    [Fact]
+    public void RP029_InvalidOriginalCellMergeStateFailsClosed()
+    {
+        const string table = "<w:tbl><w:tblPr/><w:tblGrid><w:gridCol/></w:tblGrid>"
+            + "<w:tr><w:tc><w:tcPr><w:cellMerge w:id=\"1\" w:author=\"Reviewer\" "
+            + "w:vMerge=\"rest\" w:vMergeOrig=\"bogus\"/></w:tcPr>"
+            + "<w:p><w:r><w:t>Cell</w:t></w:r></w:p></w:tc>"
+            + "<w:tc><w:p><w:r><w:t>Survivor</w:t></w:r></w:p></w:tc></w:tr></w:tbl>";
+        var clean = IrTestDocuments.Create("Cell Survivor").DocumentByteArray;
+        var malformed = RewriteBodyXml(clean, table);
+
+        var run = RedlineReversibilityVerifier.Prove(clean, clean, malformed);
+
+        Assert.Null(run.Proof.AcceptToFinal);
+        Assert.Contains(run.Proof.RevisionClassifications, classification =>
+            classification.Redline?.ResolutionStatus == RevisionResolutionStatus.Malformed
+            && classification.Redline.Diagnostic?.Code == "invalid_cell_merge_state");
+    }
+
+    [Fact]
+    public void RP030_CrossedMoveRangesAcrossNamesFailClosed()
+    {
+        const string stamp = " w:author=\"Reviewer\" w:date=\"2000-01-01T00:00:00Z\"";
+        var clean = IrTestDocuments.Create("AB").DocumentByteArray;
+        var crossed = RewriteBodyXml(
+            clean,
+            "<w:p>"
+            + $"<w:moveFromRangeStart w:id=\"1\" w:name=\"A\"{stamp}/>"
+            + $"<w:moveFrom w:id=\"2\"{stamp}><w:r><w:t>A</w:t></w:r></w:moveFrom>"
+            + $"<w:moveFromRangeStart w:id=\"3\" w:name=\"B\"{stamp}/>"
+            + $"<w:moveFrom w:id=\"4\"{stamp}><w:r><w:t>B</w:t></w:r></w:moveFrom>"
+            + "<w:moveFromRangeEnd w:id=\"1\"/><w:moveFromRangeEnd w:id=\"3\"/>"
+            + $"<w:moveToRangeStart w:id=\"5\" w:name=\"A\"{stamp}/>"
+            + $"<w:moveTo w:id=\"6\"{stamp}><w:r><w:t>A</w:t></w:r></w:moveTo>"
+            + "<w:moveToRangeEnd w:id=\"5\"/>"
+            + $"<w:moveToRangeStart w:id=\"7\" w:name=\"B\"{stamp}/>"
+            + $"<w:moveTo w:id=\"8\"{stamp}><w:r><w:t>B</w:t></w:r></w:moveTo>"
+            + "<w:moveToRangeEnd w:id=\"7\"/>"
+            + "</w:p>");
+
+        var run = RedlineReversibilityVerifier.Prove(clean, clean, crossed);
+
+        Assert.Null(run.Proof.AcceptToFinal);
+        Assert.Contains(run.Proof.RevisionClassifications, classification =>
+            classification.Redline?.ResolutionStatus == RevisionResolutionStatus.Ambiguous
+            && classification.Redline.Diagnostic?.Code == "crossed_move_range_topology");
+    }
+
+    [Fact]
+    public void RP031_MoveCannotReuseOneIdForBothLogicalRanges()
+    {
+        const string stamp = " w:author=\"Reviewer\"";
+        var clean = IrTestDocuments.Create("A").DocumentByteArray;
+        var ambiguous = RewriteBodyXml(
+            clean,
+            "<w:p>"
+            + $"<w:moveFromRangeStart w:id=\"1\" w:name=\"M\"{stamp}/>"
+            + $"<w:moveFrom w:id=\"2\"{stamp}><w:r><w:t>A</w:t></w:r></w:moveFrom>"
+            + "<w:moveFromRangeEnd w:id=\"1\"/>"
+            + $"<w:moveToRangeStart w:id=\"1\" w:name=\"M\"{stamp}/>"
+            + $"<w:moveTo w:id=\"3\"{stamp}><w:r><w:t>A</w:t></w:r></w:moveTo>"
+            + "<w:moveToRangeEnd w:id=\"1\"/>"
+            + "</w:p>");
+
+        var run = RedlineReversibilityVerifier.Prove(clean, clean, ambiguous);
+
+        Assert.Null(run.Proof.AcceptToFinal);
+        Assert.Contains(run.Proof.RevisionClassifications, classification =>
+            classification.Redline?.Diagnostic?.Code == "ambiguous_move_range_id");
+    }
+
+    [Fact]
+    public void RP032_StrictOrphanRangeEndpointIsRejectedBeforeSessionOpen()
+    {
+        var clean = IrTestDocuments.Create("Base").DocumentByteArray;
+        var strict = RewriteBodyXmlWithNamespace(
+            clean,
+            "http://purl.oclc.org/ooxml/wordprocessingml/main",
+            "<w:p><w:moveFromRangeEnd w:id=\"1\"/><w:r><w:t>Base</w:t></w:r></w:p>");
+
+        var run = RedlineReversibilityVerifier.Prove(clean, clean, strict);
+
+        Assert.Null(run.Proof.AcceptToFinal);
+        Assert.Contains(run.Proof.Findings, finding =>
+            finding.Code == "unsupported_strict_revision_markup");
+    }
+
+    [Fact]
+    public void RP033_RevisionCarrierInUnmodeledWordPartFailsClosed()
+    {
+        var clean = IrTestDocuments.Create("Base").DocumentByteArray;
+        var settingsRevision = RewriteSettingsXml(
+            clean,
+            "<w:settings xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\">"
+            + "<w:ins w:id=\"1\" w:author=\"Reviewer\"/></w:settings>");
+
+        var run = RedlineReversibilityVerifier.Prove(
+            settingsRevision, settingsRevision, settingsRevision);
+
+        Assert.Null(run.Proof.AcceptToFinal);
+        Assert.Empty(run.Proof.RevisionClassifications);
+        Assert.Contains(run.Proof.Findings, finding =>
+            finding.Code == "unsupported_revision_part");
+    }
+
+    [Fact]
+    public void RP034_FinalOnlyReviewStateGetsExplicitRejectPolicyEvidence()
+    {
+        var baseline = IrTestDocuments.Create("Base").DocumentByteArray;
+        var final = RewriteBodyXml(
+            baseline,
+            "<w:p><w:ins w:id=\"7\" w:author=\"Reviewer B\">"
+            + "<w:r><w:t>Final review</w:t></w:r></w:ins></w:p>");
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, final, final);
+
+        Assert.Contains(run.Proof.RevisionClassifications, classification =>
+            classification.Disposition == RedlineRevisionDisposition.IntendedFinalPreExisting);
+        Assert.True(run.Proof.AcceptToFinal?.Equivalent, run.Proof.ToJson());
+        Assert.False(run.Proof.RejectToBaseline?.Equivalent);
+        Assert.Contains(run.Proof.RejectToBaseline?.Findings ?? [], finding =>
+            finding.Code == "intended_final_revision_survived_reject_path");
+    }
+
+    [Fact]
+    public void RP035_UnsupportedConflictIdsAreReservedAndExhaustionFailsSafely()
+    {
+        var document = IrTestDocuments.FromBodyXml(
+            "<w:p><w14:conflictIns xmlns:w14=\"http://schemas.microsoft.com/office/word/2010/wordml\" "
+            + "w:id=\"2147483647\" w:author=\"Reviewer\">"
+            + "<w:r><w:t>Base</w:t></w:r></w14:conflictIns></w:p>").DocumentByteArray;
+        using var session = new DocxSession(document);
+
+        var error = Assert.Throws<InvalidOperationException>(() => session.NextRevisionId());
+
+        Assert.Contains("exhausted", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void RP036_PropertyRevisionPreservesXmlNodesInBothImages()
+    {
+        const string prefix = "<w:p><w:pPr>";
+        const string suffix = "</w:pPr><w:r><w:t>Clause</w:t></w:r></w:p>";
+        var seed = IrTestDocuments.Create("Clause").DocumentByteArray;
+        var baseline = RewriteBodyXml(seed, prefix + "<!--old-->" + suffix);
+        var intendedFinal = RewriteBodyXml(seed, prefix + "<!--new-->" + suffix);
+        var redline = RewriteBodyXml(
+            seed,
+            prefix + "<!--new-->"
+            + "<w:pPrChange w:id=\"1\" w:author=\"Comparison Engine\">"
+            + "<w:pPr><!--old--></w:pPr></w:pPrChange>" + suffix);
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.True(run.Proof.Success, run.Proof.ToJson());
+        Assert.True(run.Proof.AcceptToFinal?.Equivalent, run.Proof.ToJson());
+        Assert.True(run.Proof.RejectToBaseline?.Equivalent, run.Proof.ToJson());
+    }
+
+    [Fact]
+    public void RP037_NativeMoveRoundTripsBothEndpoints()
+    {
+        const string stamp = " w:author=\"Comparison Engine\""
+            + " w:date=\"2000-01-01T00:00:00Z\"";
+        var seed = IrTestDocuments.Create("AB").DocumentByteArray;
+        var baseline = RewriteBodyXml(
+            seed,
+            "<w:p><w:r><w:t>A</w:t></w:r><w:r><w:t>B</w:t></w:r></w:p>");
+        var intendedFinal = RewriteBodyXml(
+            seed,
+            "<w:p><w:r><w:t>B</w:t></w:r><w:r><w:t>A</w:t></w:r></w:p>");
+        var redline = RewriteBodyXml(
+            seed,
+            "<w:p>"
+            + $"<w:moveFromRangeStart w:id=\"1\" w:name=\"M\"{stamp}/>"
+            + $"<w:moveFrom w:id=\"2\"{stamp}><w:r><w:t>A</w:t></w:r></w:moveFrom>"
+            + "<w:moveFromRangeEnd w:id=\"1\"/>"
+            + "<w:r><w:t>B</w:t></w:r>"
+            + $"<w:moveToRangeStart w:id=\"3\" w:name=\"M\"{stamp}/>"
+            + $"<w:moveTo w:id=\"4\"{stamp}><w:r><w:t>A</w:t></w:r></w:moveTo>"
+            + "<w:moveToRangeEnd w:id=\"3\"/>"
+            + "</w:p>");
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.Contains(run.Proof.RevisionClassifications, classification =>
+            classification.Redline?.Family == RevisionFamily.Move);
+        Assert.True(run.Proof.Success, run.Proof.ToJson());
+    }
+
+    [Fact]
+    public void RP038_BareInsertedRowRoundTripsWithoutEmptyPropertyHusk()
+    {
+        const string tableStart = "<w:tbl><w:tblPr/><w:tblGrid><w:gridCol/></w:tblGrid>";
+        const string firstRow = "<w:tr><w:tc><w:p><w:r><w:t>A</w:t></w:r></w:p></w:tc></w:tr>";
+        const string secondRow = "<w:tr><w:tc><w:p><w:r><w:t>B</w:t></w:r></w:p></w:tc></w:tr>";
+        var seed = IrTestDocuments.Create("A").DocumentByteArray;
+        var baseline = RewriteBodyXml(seed, tableStart + firstRow + "</w:tbl>");
+        var intendedFinal = RewriteBodyXml(
+            seed, tableStart + firstRow + secondRow + "</w:tbl>");
+        var redline = RewriteBodyXml(
+            seed,
+            tableStart + firstRow
+            + "<w:tr><w:trPr><w:ins w:id=\"1\" w:author=\"Comparison Engine\"/>"
+            + "</w:trPr><w:tc><w:p><w:r><w:t>B</w:t></w:r></w:p></w:tc></w:tr>"
+            + "</w:tbl>");
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.True(run.Proof.Success, run.Proof.ToJson());
+        Assert.True(run.Proof.AcceptToFinal?.Equivalent, run.Proof.ToJson());
+        Assert.True(run.Proof.RejectToBaseline?.Equivalent, run.Proof.ToJson());
+    }
+
+    [Fact]
+    public void RP039_EmptyStoredParagraphPropertiesRoundTripWithoutHusk()
+    {
+        var seed = IrTestDocuments.Create("Clause").DocumentByteArray;
+        var baseline = RewriteBodyXml(
+            seed, "<w:p><w:r><w:t>Clause</w:t></w:r></w:p>");
+        var intendedFinal = RewriteBodyXml(
+            seed,
+            "<w:p><w:pPr><w:keepNext/></w:pPr>"
+            + "<w:r><w:t>Clause</w:t></w:r></w:p>");
+        var redline = RewriteBodyXml(
+            seed,
+            "<w:p><w:pPr><w:keepNext/>"
+            + "<w:pPrChange w:id=\"1\" w:author=\"Comparison Engine\"><w:pPr/>"
+            + "</w:pPrChange></w:pPr><w:r><w:t>Clause</w:t></w:r></w:p>");
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.True(run.Proof.Success, run.Proof.ToJson());
+    }
+
+    [Fact]
+    public void RP040_InsertedCellRoundTripsWithoutEmptyPropertyHusk()
+    {
+        const string tableStart = "<w:tbl><w:tblPr/><w:tblGrid>"
+            + "<w:gridCol/><w:gridCol/></w:tblGrid><w:tr>";
+        const string firstCell = "<w:tc><w:p><w:r><w:t>A</w:t></w:r></w:p></w:tc>";
+        const string secondCell = "<w:tc><w:p><w:r><w:t>B</w:t></w:r></w:p></w:tc>";
+        var seed = IrTestDocuments.Create("A").DocumentByteArray;
+        var baseline = RewriteBodyXml(
+            seed, tableStart + firstCell + "</w:tr></w:tbl>");
+        var intendedFinal = RewriteBodyXml(
+            seed, tableStart + firstCell + secondCell + "</w:tr></w:tbl>");
+        var redline = RewriteBodyXml(
+            seed,
+            tableStart + firstCell
+            + "<w:tc><w:tcPr><w:cellIns w:id=\"1\" w:author=\"Comparison Engine\"/>"
+            + "</w:tcPr><w:p><w:r><w:t>B</w:t></w:r></w:p></w:tc>"
+            + "</w:tr></w:tbl>");
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.True(run.Proof.Success, run.Proof.ToJson());
+    }
+
+    [Fact]
+    public void RP041_UnrelatedEmptyShellDoesNotProtectGeneratedPropertyHusk()
+    {
+        const string first = "<w:p><w:pPr/><w:r><w:t>First</w:t></w:r></w:p>";
+        var seed = IrTestDocuments.Create("First Second").DocumentByteArray;
+        var baseline = RewriteBodyXml(
+            seed,
+            first + "<w:p><w:r><w:t>Second</w:t></w:r></w:p>");
+        var intendedFinal = RewriteBodyXml(
+            seed,
+            first + "<w:p><w:pPr><w:keepNext/></w:pPr>"
+            + "<w:r><w:t>Second</w:t></w:r></w:p>");
+        var redline = RewriteBodyXml(
+            seed,
+            first + "<w:p><w:pPr><w:keepNext/>"
+            + "<w:pPrChange w:id=\"1\" w:author=\"Comparison Engine\"><w:pPr/>"
+            + "</w:pPrChange></w:pPr><w:r><w:t>Second</w:t></w:r></w:p>");
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.True(run.Proof.Success, run.Proof.ToJson());
+    }
+
+    [Fact]
+    public void RP042_DistinctCarrierRolesMayReuseNumericRevisionId()
+    {
+        var seed = IrTestDocuments.Create("A").DocumentByteArray;
+        var baseline = RewriteBodyXml(
+            seed, "<w:p><w:r><w:t>A</w:t></w:r></w:p>");
+        var intendedFinal = RewriteBodyXml(
+            seed, "<w:p><w:r><w:t>B</w:t></w:r></w:p>");
+        var redline = RewriteBodyXml(
+            seed,
+            "<w:p><w:del w:id=\"1\" w:author=\"Comparison Engine\">"
+            + "<w:r><w:delText>A</w:delText></w:r></w:del>"
+            + "<w:ins w:id=\"1\" w:author=\"Comparison Engine\">"
+            + "<w:r><w:t>B</w:t></w:r></w:ins></w:p>");
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.True(run.Proof.Success, run.Proof.ToJson());
+        Assert.All(run.Proof.RevisionClassifications, classification =>
+            Assert.Equal(RevisionResolutionStatus.Supported,
+                classification.Redline?.ResolutionStatus));
+    }
+
+    [Fact]
+    public void RP043_RevisionAnchorEvidenceIsBoundedBeforePathExecution()
+    {
+        var baseline = Document("A");
+        var intendedFinal = Document("AB");
+        var redline = RewriteBodyXml(
+            baseline,
+            "<w:p><w:r><w:t>A</w:t></w:r>"
+            + "<w:ins w:id=\"1\" w:author=\"Comparison Engine\">"
+            + "<w:r><w:t>B</w:t></w:r></w:ins></w:p>");
+
+        var run = RedlineReversibilityVerifier.Prove(
+            baseline,
+            intendedFinal,
+            redline,
+            new RedlineReversibilityProofOptions { MaxRevisionEvidenceItems = 2 });
+
+        Assert.Null(run.Proof.AcceptToFinal);
+        Assert.Null(run.Proof.RejectToBaseline);
+        Assert.Empty(run.Proof.RevisionClassifications);
+        Assert.Contains(run.Proof.Findings, item =>
+            item.Code == "revision_evidence_limit_exceeded");
+    }
+
+    [Fact]
+    public void RP044_HyperlinkOwnedByGeneratedRevisionRoundTripsRelationship()
+    {
+        var baseline = DocumentWithReviewBody(new Paragraph());
+        var intendedFinal = HyperlinkDocument(baseline, tracked: false);
+        var redline = HyperlinkDocument(baseline, tracked: true);
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.True(run.Proof.Success, run.Proof.ToJson());
+        Assert.True(run.Proof.AcceptToFinal?.NormalizedWholePackageEquivalent);
+        Assert.True(run.Proof.RejectToBaseline?.NormalizedWholePackageEquivalent);
+    }
+
+    [Fact]
+    public void RP045_InsertedParagraphBesideBlockSdtRoundTripsBothEndpoints()
+    {
+        const string blockSdt = "<w:sdt><w:sdtContent><w:p><w:r><w:t>Existing"
+            + "</w:t></w:r></w:p></w:sdtContent></w:sdt>";
+        const string insertedParagraph = "<w:p><w:r><w:t>New</w:t></w:r></w:p>";
+        const string trackedParagraph = "<w:p><w:pPr><w:rPr>"
+            + "<w:ins w:id=\"1\" w:author=\"Comparison Engine\"/>"
+            + "</w:rPr></w:pPr><w:ins w:id=\"2\" w:author=\"Comparison Engine\">"
+            + "<w:r><w:t>New</w:t></w:r></w:ins></w:p>";
+        var seed = Document("seed");
+        var baseline = RewriteBodyXml(seed, blockSdt);
+        var intendedFinal = RewriteBodyXml(seed, blockSdt + insertedParagraph);
+        var redline = RewriteBodyXml(seed, blockSdt + trackedParagraph);
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.True(run.Proof.Success, run.Proof.ToJson());
+    }
+
+    [Fact]
+    public void RP046_ReusedEndpointOrphanRelationshipIsPreserved()
+    {
+        var baseline = AddOrphanHyperlink(
+            DocumentWithReviewBody(new Paragraph()),
+            "rIdRevisionLink",
+            "https://example.test/revision");
+        var intendedFinal = HyperlinkDocument(baseline, tracked: false);
+        var redline = HyperlinkDocument(baseline, tracked: true);
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.True(run.Proof.Success, run.Proof.ToJson());
+        Assert.True(run.Proof.RejectToBaseline?.NormalizedWholePackageEquivalent);
+    }
+
+    [Fact]
+    public void RP047_ReusedEndpointAbstractNumberingDefinitionIsPreserved()
+    {
+        var baseline = DocumentWithOrphanAbstractNumbering();
+        var intendedFinal = DocumentUsingOrphanAbstractNumbering(baseline, tracked: false);
+        var redline = DocumentUsingOrphanAbstractNumbering(baseline, tracked: true);
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.True(run.Proof.Success, run.Proof.ToJson());
+        Assert.True(run.Proof.RejectToBaseline?.NormalizedWholePackageEquivalent);
+    }
+
+    [Fact]
+    public void RP048_ResolvingOuterCellRevisionPreservesNestedTableRevision()
+    {
+        var seed = Document("seed");
+        var baseline = RewriteBodyXml(
+            seed, NestedCellMergeBody("<w:vMerge w:val=\"continue\"/>"));
+        var intendedFinal = RewriteBodyXml(
+            seed, NestedCellMergeBody("<w:vMerge w:val=\"restart\"/>"));
+        var redline = RewriteBodyXml(
+            seed,
+            NestedCellMergeBody("<w:cellMerge w:id=\"1\""
+                + " w:author=\"Comparison Engine\" w:date=\"2000-01-01T00:00:00Z\""
+                + " w:vMerge=\"rest\" w:vMergeOrig=\"cont\"/>"));
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.True(run.Proof.Success, run.Proof.ToJson());
+        Assert.Contains(run.Proof.RevisionClassifications, classification =>
+            classification.Disposition == RedlineRevisionDisposition.PreExisting
+            && classification.Redline?.ConstituentIds.Contains("2") == true);
+    }
+
+    [Fact]
+    public void RP049_RejectingOnlyBodyParagraphRestoresEmptyBody()
+    {
+        var seed = Document("seed");
+        var baseline = RewriteBodyXml(seed, "<w:sectPr/>");
+        var intendedFinal = RewriteBodyXml(
+            seed, "<w:p><w:r><w:t>New</w:t></w:r></w:p><w:sectPr/>");
+        var redline = RewriteBodyXml(
+            seed,
+            "<w:p><w:pPr><w:rPr><w:ins w:id=\"1\""
+            + " w:author=\"Comparison Engine\"/></w:rPr></w:pPr>"
+            + "<w:ins w:id=\"2\" w:author=\"Comparison Engine\">"
+            + "<w:r><w:t>New</w:t></w:r></w:ins></w:p><w:sectPr/>");
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.True(run.Proof.Success, run.Proof.ToJson());
+    }
+
+    [Fact]
+    public void RP050_StructuralAnchorTraversalIsBounded()
+    {
+        var endpoint = Document("endpoint");
+        var runs = string.Concat(Enumerable.Repeat("<w:r><w:t>x</w:t></w:r>", 4_500));
+        var redline = RewriteBodyXml(
+            endpoint,
+            "<w:tbl><w:tblPr/><w:tblGrid><w:gridCol/></w:tblGrid><w:tr><w:tc>"
+            + "<w:tcPr><w:cellMerge w:id=\"1\" w:author=\"Comparison Engine\""
+            + " w:vMerge=\"rest\"/></w:tcPr><w:p>" + runs
+            + "</w:p></w:tc></w:tr></w:tbl>");
+
+        var run = RedlineReversibilityVerifier.Prove(
+            endpoint,
+            endpoint,
+            redline,
+            new RedlineReversibilityProofOptions { MaxRevisionEvidenceItems = 1_000 });
+
+        Assert.Null(run.Proof.AcceptToFinal);
+        Assert.Null(run.Proof.RejectToBaseline);
+        Assert.Contains(run.Proof.Findings, finding =>
+            finding.Code == "revision_evidence_limit_exceeded");
     }
 
     private static void AssertResolutionClosure(RedlineProofPathResult path)
@@ -511,6 +1305,7 @@ public class RedlineReversibilityProofTests
             && path.ModeledSemantic.Available
             && path.ModeledSemantic.Equivalent == true
             && path.NormalizedWholePackageEquivalent
+            && path.DivergenceAnalysisCompleted
             && path.Findings.All(finding =>
                 finding.Severity != VerificationFindingSeverity.Error);
         Assert.Equal(expectedEquivalent, path.Equivalent);
@@ -536,8 +1331,10 @@ public class RedlineReversibilityProofTests
         Type = "insert",
         Family = RevisionFamily.ContentInsert,
         ConstituentIds = new[] { id },
+        ConstituentKeys = new[] { "w:ins:" + id },
         Author = "Reviewer",
         Date = null,
+        DateUtc = null,
         Text = id,
         AnchorId = "p:doc:1",
         AffectedAnchorIds = new[] { "p:doc:1" },
@@ -748,6 +1545,101 @@ public class RedlineReversibilityProofTests
             })
         : new Paragraph(RunForText(newText));
 
+    private static byte[] HyperlinkDocument(byte[] source, bool tracked)
+    {
+        using var stream = new MemoryStream();
+        stream.Write(source);
+        using (var document = WordprocessingDocument.Open(stream, true))
+        {
+            var main = document.MainDocumentPart!;
+            if (!main.HyperlinkRelationships.Any(relationship =>
+                    relationship.Id == "rIdRevisionLink"))
+                main.AddHyperlinkRelationship(
+                    new Uri("https://example.test/revision", UriKind.Absolute),
+                    true,
+                    "rIdRevisionLink");
+            var hyperlink = new Hyperlink { Id = "rIdRevisionLink" };
+            if (tracked)
+            {
+                hyperlink.Append(new InsertedRun(RunForText("Link"))
+                {
+                    Id = "1",
+                    Author = "Comparison Engine",
+                    Date = FixedRevisionDate(),
+                });
+            }
+            else
+            {
+                hyperlink.Append(RunForText("Link"));
+            }
+            main.Document.Body = new Body(new Paragraph(hyperlink));
+            document.Save();
+        }
+        return stream.ToArray();
+    }
+
+    private static byte[] DocumentWithOrphanAbstractNumbering()
+    {
+        var source = Document("Item");
+        using var stream = new MemoryStream();
+        stream.Write(source);
+        using (var document = WordprocessingDocument.Open(stream, true))
+        {
+            var numbering = document.MainDocumentPart!
+                .AddNewPart<NumberingDefinitionsPart>();
+            numbering.Numbering = new Numbering(
+                new AbstractNum(
+                    new Level(
+                        new StartNumberingValue { Val = 1 },
+                        new NumberingFormat { Val = NumberFormatValues.Decimal },
+                        new LevelText { Val = "%1." })
+                    { LevelIndex = 0 })
+                { AbstractNumberId = 5 });
+            numbering.Numbering.Save();
+        }
+        return stream.ToArray();
+    }
+
+    private static byte[] DocumentUsingOrphanAbstractNumbering(byte[] source, bool tracked)
+    {
+        using var stream = new MemoryStream();
+        stream.Write(source);
+        using (var document = WordprocessingDocument.Open(stream, true))
+        {
+            var main = document.MainDocumentPart!;
+            main.NumberingDefinitionsPart!.Numbering!.Append(
+                new NumberingInstance(new AbstractNumId { Val = 5 }) { NumberID = 1 });
+            main.NumberingDefinitionsPart.Numbering.Save();
+            var numberingProperties = new NumberingProperties(
+                new NumberingLevelReference { Val = 0 },
+                new NumberingId { Val = 1 });
+            if (tracked)
+            {
+                numberingProperties.Append(new Inserted
+                {
+                    Id = "1",
+                    Author = "Comparison Engine",
+                    Date = FixedRevisionDate(),
+                });
+            }
+            main.Document.Body = new Body(new Paragraph(
+                new ParagraphProperties(numberingProperties),
+                RunForText("Item")));
+            document.Save();
+        }
+        return stream.ToArray();
+    }
+
+    private static string NestedCellMergeBody(string outerCellProperty) =>
+        "<w:tbl><w:tblPr/><w:tblGrid><w:gridCol/></w:tblGrid><w:tr><w:tc>"
+        + "<w:tcPr>" + outerCellProperty + "</w:tcPr><w:p><w:r><w:t>Outer</w:t>"
+        + "</w:r></w:p><w:tbl><w:tblPr/><w:tblGrid><w:gridCol/></w:tblGrid>"
+        + "<w:tr><w:tc><w:tcPr><w:cellMerge w:id=\"2\""
+        + " w:author=\"Comparison Engine\" w:date=\"2000-01-01T00:00:00Z\""
+        + " w:vMerge=\"cont\" w:vMergeOrig=\"rest\"/></w:tcPr>"
+        + "<w:p><w:r><w:t>Inner</w:t></w:r></w:p></w:tc></w:tr></w:tbl>"
+        + "<w:p/></w:tc></w:tr></w:tbl>";
+
     private static string[] BookmarkNames(byte[] bytes)
     {
         using var stream = new MemoryStream(bytes, writable: false);
@@ -768,6 +1660,55 @@ public class RedlineReversibilityProofTests
         {
             document.MainDocumentPart!.Document.Body = new Body(paragraphs);
             document.MainDocumentPart.Document.Save();
+        }
+        return stream.ToArray();
+    }
+
+    private static byte[] RewriteBodyXml(byte[] source, string bodyInnerXml)
+        => RewriteBodyXmlWithNamespace(source, IrTestDocuments.W, bodyInnerXml);
+
+    private static byte[] RewriteBodyXmlWithNamespace(
+        byte[] source,
+        string wordNamespace,
+        string bodyInnerXml)
+    {
+        using var stream = new MemoryStream();
+        stream.Write(source);
+        using (var document = WordprocessingDocument.Open(stream, true))
+        {
+            var xml = $"<w:document xmlns:w=\"{wordNamespace}\">"
+                + $"<w:body>{bodyInnerXml}</w:body></w:document>";
+            using var partStream = document.MainDocumentPart!.GetStream(
+                FileMode.Create, FileAccess.Write);
+            using var writer = new StreamWriter(partStream);
+            writer.Write(xml);
+        }
+        return stream.ToArray();
+    }
+
+    private static byte[] RewriteSettingsXml(byte[] source, string settingsXml)
+    {
+        using var stream = new MemoryStream();
+        stream.Write(source);
+        using (var document = WordprocessingDocument.Open(stream, true))
+        {
+            using var partStream = document.MainDocumentPart!.DocumentSettingsPart!.GetStream(
+                FileMode.Create, FileAccess.Write);
+            using var writer = new StreamWriter(partStream);
+            writer.Write(settingsXml);
+        }
+        return stream.ToArray();
+    }
+
+    private static byte[] AddOrphanHyperlink(
+        byte[] source, string relationshipId, string target)
+    {
+        using var stream = new MemoryStream();
+        stream.Write(source);
+        using (var document = WordprocessingDocument.Open(stream, true))
+        {
+            document.MainDocumentPart!.AddHyperlinkRelationship(
+                new Uri(target, UriKind.Absolute), true, relationshipId);
         }
         return stream.ToArray();
     }

--- a/Docxodus.Tests/RedlineReversibilityProofTests.cs
+++ b/Docxodus.Tests/RedlineReversibilityProofTests.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Text.Json;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Docxodus.Verification;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+public class RedlineReversibilityProofTests
+{
+    [Fact]
+    public void RP001_GeneratedTextRevision_IsClassifiedAndResolvedBothWays()
+    {
+        var baseline = Document("The original clause.");
+        var intendedFinal = Document("The revised clause.");
+        var redline = DocxDiff.Compare(
+            new WmlDocument("baseline.docx", baseline),
+            new WmlDocument("final.docx", intendedFinal),
+            new DocxDiffSettings { AuthorForRevisions = "Comparison Engine" }).DocumentByteArray;
+
+        var run = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+
+        Assert.True(run.Proof.RevisionClassifications.Count > 0, run.Proof.ToJson());
+        Assert.All(run.Proof.RevisionClassifications,
+            item => Assert.Equal(RedlineRevisionDisposition.Generated, item.Disposition));
+        Assert.NotNull(run.AcceptedPackageBytes);
+        Assert.NotNull(run.RejectedPackageBytes);
+        Assert.True(run.Proof.AcceptToFinal?.Completed);
+        Assert.True(run.Proof.RejectToBaseline?.Completed);
+        Assert.False(run.Proof.AcceptToFinal?.ModeledSemantic.Available);
+        Assert.False(run.Proof.Success); // #457 is intentionally required before this can prove success.
+    }
+
+    [Fact]
+    public void RP002_InvalidPackage_FailsBeforeRevisionInventory()
+    {
+        var valid = Document("valid");
+
+        var run = RedlineReversibilityVerifier.Prove(valid, valid, new byte[] { 1, 2, 3 });
+
+        Assert.False(run.Proof.Success);
+        Assert.Null(run.Proof.AcceptToFinal);
+        Assert.Null(run.AcceptedPackageBytes);
+        Assert.Contains(run.Proof.Findings, item =>
+            item.Code == "package_malformed_package"
+            && item.Severity == VerificationFindingSeverity.Error);
+    }
+
+    [Fact]
+    public void RP003_ProofJson_IsDeterministicAndReceiptEmbeddable()
+    {
+        var baseline = Document("A");
+        var intendedFinal = Document("B");
+        var redline = DocxDiff.Compare(
+            new WmlDocument("baseline.docx", baseline),
+            new WmlDocument("final.docx", intendedFinal)).DocumentByteArray;
+
+        var first = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline).Proof;
+        var second = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline).Proof;
+
+        Assert.Equal(first.ToCanonicalJson(), second.ToCanonicalJson());
+        using var parsed = JsonDocument.Parse(first.ToCanonicalJson());
+        Assert.Equal(RedlineReversibilityProof.SchemaId,
+            parsed.RootElement.GetProperty("schema").GetString());
+        Assert.DoesNotContain("\"acceptedPackageBytes\"", first.ToCanonicalJson(), StringComparison.Ordinal);
+    }
+
+    private static byte[] Document(string text)
+    {
+        using var stream = new MemoryStream();
+        using (var document = WordprocessingDocument.Create(
+                   stream, WordprocessingDocumentType.Document))
+        {
+            var main = document.AddMainDocumentPart();
+            main.Document = new Document(new Body(
+                new Paragraph(new Run(new Text(text)))));
+            main.AddNewPart<DocumentSettingsPart>().Settings = new Settings();
+            document.Save();
+        }
+        return stream.ToArray();
+    }
+}

--- a/Docxodus.Tests/RedlineReversibilityProofTests.cs
+++ b/Docxodus.Tests/RedlineReversibilityProofTests.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
+using Docxodus.Tests.Ir;
 using Docxodus.Verification;
 using DocxodusDiffParityFixtures;
 using Xunit;
@@ -417,6 +418,79 @@ public class RedlineReversibilityProofTests
         Assert.True(run.Proof.RejectToBaseline?.Equivalent, run.Proof.ToJson());
     }
 
+    [Fact]
+    public void RP013_RevisionElementBudget_FailsBeforePathExecution()
+    {
+        var baseline = Document("Base");
+        var intendedFinal = Document("BaseAB");
+        var redline = RewriteBody(baseline, new Paragraph(
+            RunForText("Base"),
+            new InsertedRun(RunForText("A"))
+            {
+                Id = "701",
+                Author = "Comparison Engine",
+                Date = FixedRevisionDate(),
+            },
+            new InsertedRun(RunForText("B"))
+            {
+                Id = "702",
+                Author = "Comparison Engine",
+                Date = FixedRevisionDate(),
+            }));
+
+        var run = RedlineReversibilityVerifier.Prove(
+            baseline,
+            intendedFinal,
+            redline,
+            new RedlineReversibilityProofOptions { MaxRevisionElements = 1 });
+
+        Assert.Null(run.Proof.AcceptToFinal);
+        Assert.Null(run.Proof.RejectToBaseline);
+        Assert.Null(run.AcceptedPackageBytes);
+        Assert.Null(run.RejectedPackageBytes);
+        Assert.Empty(run.Proof.RevisionClassifications);
+        var finding = Assert.Single(run.Proof.Findings,
+            item => item.Code == "revision_element_limit_exceeded");
+        Assert.Equal("redline/revisions", finding.Location?.PropertyPath);
+    }
+
+    [Fact]
+    public void RP014_UncountedRevisionMarkers_CannotBypassLiveInventoryBudget()
+    {
+        var baseline = IrTestDocuments.Create("Base").DocumentByteArray;
+        var redline = IrTestDocuments.FromBodyXml(
+            "<w:p><w:moveFromRangeStart w:id=\"701\"/>"
+            + "<w:moveFromRangeStart w:id=\"702\"/>"
+            + "<w:r><w:t>Base</w:t></w:r></w:p>").DocumentByteArray;
+
+        Assert.Equal(0, PackageManifestGenerator.Generate(redline).Facts.Revisions.Total);
+        var run = RedlineReversibilityVerifier.Prove(
+            baseline,
+            baseline,
+            redline,
+            new RedlineReversibilityProofOptions { MaxRevisionElements = 1 });
+
+        Assert.Null(run.Proof.AcceptToFinal);
+        Assert.Null(run.Proof.RejectToBaseline);
+        Assert.Empty(run.Proof.RevisionClassifications);
+        var finding = Assert.Single(run.Proof.Findings,
+            item => item.Code == "revision_inventory_limit_exceeded");
+        Assert.Equal("redline/revisionInventory", finding.Location?.PropertyPath);
+    }
+
+    [Fact]
+    public void RP015_PartialPathProjection_DoesNotLabelGeneratedAsPreExisting()
+    {
+        var preExisting = RevisionIdentity("prior");
+        var generated = RevisionIdentity("generated");
+
+        var projected = RedlineReversibilityVerifier.SelectSurvivingPreExisting(
+            new[] { preExisting },
+            new[] { generated, preExisting });
+
+        Assert.Equal(preExisting, Assert.Single(projected));
+    }
+
     private static void AssertResolutionClosure(RedlineProofPathResult path)
     {
         var accountedFor = path.ResolvedRevisionIds
@@ -453,6 +527,23 @@ public class RedlineReversibilityProofTests
         }
         Assert.True(path.ModeledSemantic.Available, proofJson);
     }
+
+    private static RedlineRevisionIdentity RevisionIdentity(string id) => new()
+    {
+        Id = id,
+        PartUri = "/word/document.xml",
+        Scope = "body",
+        Type = "insert",
+        Family = RevisionFamily.ContentInsert,
+        ConstituentIds = new[] { id },
+        Author = "Reviewer",
+        Date = null,
+        Text = id,
+        AnchorId = "p:doc:1",
+        AffectedAnchorIds = new[] { "p:doc:1" },
+        ResolutionStatus = RevisionResolutionStatus.Supported,
+        Diagnostic = null,
+    };
 
     private static byte[] Document(params string[] runs) =>
         DocumentWithReviewBody(new Paragraph(runs.Select(RunForText)));

--- a/Docxodus.Tests/Verification/DeliverableVerifierHardeningTests.cs
+++ b/Docxodus.Tests/Verification/DeliverableVerifierHardeningTests.cs
@@ -767,8 +767,8 @@ public sealed class DeliverableVerifierHardeningTests
         var package = IrTestDocuments.FromBodyXml(
             "<w:p><w:ins w:author=\"Missing\"><w:r><w:t>Malformed</w:t></w:r></w:ins></w:p>"
             + "<w:p><w:ins w:id=\"7\" w:author=\"First\"><w:r><w:t>One</w:t></w:r></w:ins></w:p>"
-            + "<w:p><w:del w:id=\"7\" w:author=\"Second\"><w:r><w:delText>Two</w:delText>"
-            + "</w:r></w:del></w:p>"
+            + "<w:p><w:ins w:id=\"7\" w:author=\"Second\"><w:r><w:t>Two</w:t>"
+            + "</w:r></w:ins></w:p>"
             + "<w:p><w:customXmlMoveFromRangeStart w:id=\"9\" w:author=\"Third\"/>"
             + "<w:r><w:t>Unsupported</w:t></w:r>"
             + "<w:customXmlMoveFromRangeEnd w:id=\"9\"/></w:p>").DocumentByteArray;

--- a/Docxodus/DocxSession.ImageHistory.cs
+++ b/Docxodus/DocxSession.ImageHistory.cs
@@ -21,6 +21,33 @@ public sealed partial class DocxSession
         OwnedPartRelationships.SweepOrphanedImages(owner);
     }
 
+    /// <summary>
+    /// Remove only relationships that were referenced inside markup removed by
+    /// the current revision operation. A whole-part sweep would also delete unrelated orphaned
+    /// relationships that pre-dated the edit and violate package-preservation guarantees.
+    /// </summary>
+    private static void SweepOrphanedStoryRelationships(
+        OpenXmlPart owner,
+        IReadOnlyCollection<string> candidateIds)
+    {
+        if (candidateIds.Count == 0) return;
+        var candidates = candidateIds as HashSet<string>
+            ?? new HashSet<string>(candidateIds, StringComparer.Ordinal);
+        var referenced = OwnedPartRelationships.ReferencedRelationshipIds(owner, candidates);
+
+        foreach (var relationship in owner.Parts.ToList())
+            if (candidates.Contains(relationship.RelationshipId)
+                && !referenced.Contains(relationship.RelationshipId))
+                owner.DeletePart(relationship.RelationshipId);
+        foreach (var relationship in owner.HyperlinkRelationships.Cast<ReferenceRelationship>()
+                     .Concat(owner.DataPartReferenceRelationships).ToList())
+            if (candidates.Contains(relationship.Id) && !referenced.Contains(relationship.Id))
+                owner.DeleteReferenceRelationship(relationship.Id);
+        foreach (var relationship in owner.ExternalRelationships.ToList())
+            if (candidates.Contains(relationship.Id) && !referenced.Contains(relationship.Id))
+                owner.DeleteExternalRelationship(relationship.Id);
+    }
+
     /// <summary>Drop every image relationship that no attribute in its owning story part names.
     /// Runs on the mutation boundary (<see cref="InvalidateProjectionCache"/>), not on save: only
     /// a mutation can orphan a relationship, and serialization must stay read-only with respect

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -1339,8 +1339,14 @@ public sealed record RevisionListEntry
     required public string Type { get; init; }
     required public RevisionFamily Family { get; init; }
     required public IReadOnlyList<string> ConstituentIds { get; init; }
+    /// <summary>
+    /// QName-qualified native carrier identities. Unlike <see cref="ConstituentIds"/>, these
+    /// distinguish revision roles which legally use the same numeric <c>w:id</c> value.
+    /// </summary>
+    required public IReadOnlyList<string> ConstituentKeys { get; init; }
     required public string Author { get; init; }
     public string? Date { get; init; }
+    public string? DateUtc { get; init; }
     required public string Text { get; init; }
     required public string PartUri { get; init; }
     required public string Scope { get; init; }
@@ -1850,6 +1856,36 @@ public sealed class DocxSessionSettings
     /// you don't plan to call either comparison API.
     /// </summary>
     public bool CaptureInitialProjection { get; init; } = true;
+
+    /// <summary>
+    /// Verification-only mode: resolution may remove only artifacts attributable to the selected
+    /// revision. Ordinary editing retains its historical cleanup behavior.
+    /// </summary>
+    internal bool ProofSafeRevisionResolution { get; init; }
+
+    /// <summary>Numbering instances present in the proof path's expected baseline.</summary>
+    internal IReadOnlyList<int> ProtectedRevisionNumberingIds { get; init; } = Array.Empty<int>();
+
+    /// <summary>Abstract numbering definitions present in the proof path's expected endpoint.</summary>
+    internal IReadOnlyList<int> ProtectedRevisionAbstractNumberingIds { get; init; }
+        = Array.Empty<int>();
+
+    /// <summary>
+    /// Owner-part/relationship-id pairs present in the proof path's expected endpoint. A
+    /// generated revision may reuse an otherwise orphaned endpoint relationship; resolving the
+    /// revision must not erase that pre-existing package state.
+    /// </summary>
+    internal IReadOnlyCollection<string> ProtectedRevisionRelationshipKeys { get; init; }
+        = Array.Empty<string>();
+
+    /// <summary>
+    /// Empty optional property shells present in the proof path's expected endpoint. Resolution
+    /// may remove a selected revision's now-empty direct shell only when that shell kind is not
+    /// represented in the endpoint. This is deliberately conservative: exact package comparison
+    /// remains the final guard when multiple shells of the same kind exist.
+    /// </summary>
+    internal IReadOnlyCollection<string> ProtectedRevisionEmptyContainerKeys { get; init; }
+        = Array.Empty<string>();
 }
 
 // ─── Session ───────────────────────────────────────────────────────────────
@@ -2564,24 +2600,100 @@ public sealed partial class DocxSession : IDisposable
     /// markup remains visible with a diagnostic and cannot be resolved accidentally.
     /// </summary>
     public IReadOnlyList<RevisionListEntry> ListRevisions()
+        => GetRevisionInventory().Entries;
+
+    /// <summary>
+    /// Build the public revision view and the exact native carrier count from one registry pass.
+    /// The latter counts units and range markers rather than UI groups, so coalescing cannot hide
+    /// adversarial work from verification callers.
+    /// </summary>
+    internal (IReadOnlyList<RevisionListEntry> Entries, long NativeElementCount,
+        bool Complete, bool EvidenceComplete) GetRevisionInventory(
+            int maximumNativeElements = int.MaxValue,
+            int maximumEvidenceItems = int.MaxValue,
+            long maximumEvidenceTextCharacters = long.MaxValue)
     {
         ThrowIfDisposed();
-        _ = AnchorIndex(); // guarantees Unids so entries can carry block anchors
 
-        var registry = BuildRevisionRegistry();
+        // Count native carriers before grouping/sorting/hashing them. The manifest's compact
+        // facts intentionally do not model every range-marker family, so relying on it alone
+        // would let a single coalesced move name hide adversarial registry work.
+        var parts = RevisionStoryParts();
+        long carrierCount = 0;
+        foreach (var (_, root, _) in parts)
+        {
+            foreach (var element in root.DescendantsAndSelf())
+            {
+                if (!Internal.RevisionOps.IsNativeRevisionCarrierForInventory(element)) continue;
+                carrierCount++;
+                if (carrierCount > maximumNativeElements)
+                    return (Array.Empty<RevisionListEntry>(), carrierCount, false, true);
+            }
+        }
+
+        _ = AnchorIndex(); // guarantees Unids so entries can carry block anchors
+        var registry = BuildRevisionRegistry(parts);
         var result = new List<RevisionListEntry>(registry.Entries.Count);
+        int evidenceItems = 0;
+        long evidenceTextCharacters = 0;
+        long remainingAnchorTraversal = maximumEvidenceItems == int.MaxValue
+            ? long.MaxValue
+            : Math.Max(1024L, checked((long)maximumEvidenceItems * 8));
         foreach (var g in registry.Entries)
         {
-            var affected = RevisionGroupAnchors(g, g.PartUri);
+            var constituentIds = Internal.RevisionOps.ConstituentIds(g);
+            var constituentKeys = Internal.RevisionOps.ConstituentKeys(g);
+            if (evidenceItems > maximumEvidenceItems - constituentIds.Count
+                || evidenceItems + constituentIds.Count
+                    > maximumEvidenceItems - constituentKeys.Count)
+                return (Array.Empty<RevisionListEntry>(), carrierCount, true, false);
+            evidenceItems += constituentIds.Count + constituentKeys.Count;
+
+            bool AddText(params string?[] values)
+            {
+                foreach (var value in values)
+                {
+                    if (value is null) continue;
+                    if (evidenceTextCharacters
+                        > maximumEvidenceTextCharacters - value.Length)
+                        return false;
+                    evidenceTextCharacters += value.Length;
+                }
+                return true;
+            }
+
+            if (!AddText(
+                    g.Id, g.PartUri, g.Scope, g.Type, g.Author, g.Date, g.DateUtc,
+                    g.Diagnostic?.Code, g.Diagnostic?.Message)
+                || constituentIds.Any(value => !AddText(value))
+                || constituentKeys.Any(value => !AddText(value)))
+                return (Array.Empty<RevisionListEntry>(), carrierCount, true, false);
+
+            int remainingAnchors = maximumEvidenceItems - evidenceItems;
+            if (!TryRevisionGroupAnchors(
+                    g, g.PartUri, remainingAnchors,
+                    ref remainingAnchorTraversal, out var affected))
+                return (Array.Empty<RevisionListEntry>(), carrierCount, true, false);
+            evidenceItems += affected.Count;
+            if (affected.Any(anchor => !AddText(anchor.Id)))
+                return (Array.Empty<RevisionListEntry>(), carrierCount, true, false);
+
+            long remainingText = maximumEvidenceTextCharacters - evidenceTextCharacters;
+            var groupText = Internal.RevisionOps.GroupText(
+                g, remainingText, out var groupTextComplete);
+            if (!groupTextComplete || !AddText(groupText))
+                return (Array.Empty<RevisionListEntry>(), carrierCount, true, false);
             result.Add(new RevisionListEntry
             {
                 Id = g.Id,
                 Type = g.Type,
                 Family = g.Family,
-                ConstituentIds = Internal.RevisionOps.ConstituentIds(g),
+                ConstituentIds = constituentIds,
+                ConstituentKeys = constituentKeys,
                 Author = g.Author,
                 Date = g.Date,
-                Text = Internal.RevisionOps.GroupText(g),
+                DateUtc = g.DateUtc,
+                Text = groupText,
                 PartUri = g.PartUri,
                 Scope = g.Scope,
                 AnchorId = affected.Count == 0 ? null : affected[0].Id,
@@ -2590,7 +2702,7 @@ public sealed partial class DocxSession : IDisposable
                 Diagnostic = g.Diagnostic,
             });
         }
-        return result;
+        return (result, carrierCount, true, true);
     }
 
     /// <summary>Accept ONE revision by the id <see cref="ListRevisions"/> reported —
@@ -2631,9 +2743,11 @@ public sealed partial class DocxSession : IDisposable
 
         var partUri = group.PartUri;
         var owningPart = ResolvePart(partUri);
+        var relationshipCandidates = UnprotectedRevisionRelationshipIds(group, owningPart);
         var rejectedNumberingIds = accept
             ? Array.Empty<int>()
-            : NumberingIdsIntroducedBy(group);
+            : NumberingIdsIntroducedBy(group)
+                .Except(_settings.ProtectedRevisionNumberingIds).ToArray();
 
         // Capture the block anchors the resolution touches BEFORE applying — elements
         // detach during Apply and can no longer be resolved to a part afterwards.
@@ -2642,10 +2756,24 @@ public sealed partial class DocxSession : IDisposable
         _history.RecordPreOp(TakeSnapshot());
         try
         {
-            var removedElements = registry.Resolve(group, accept);
+            var removedElements = registry.Resolve(
+                group,
+                accept,
+                _settings.ProofSafeRevisionResolution,
+                _settings.ProtectedRevisionEmptyContainerKeys);
+            // Numbering is intentionally outside ordinary projected saves: merely opening and
+            // saving a document must not reserialize numbering.xml. A revision in that part
+            // mutates its cached XDocument directly, so flush only that selected owner here.
+            if (owningPart is NumberingDefinitionsPart)
+                owningPart.PutXDocument();
             if (owningPart is not null)
-                SweepOrphanedStoryRelationships(owningPart);
-            if (!accept && rejectedNumberingIds.Count > 0)
+            {
+                if (_settings.ProofSafeRevisionResolution)
+                    SweepOrphanedStoryRelationships(owningPart, relationshipCandidates);
+                else
+                    SweepOrphanedStoryRelationships(owningPart);
+            }
+            if (!accept && rejectedNumberingIds.Length > 0)
                 PruneUnreferencedDocxodusNumbering(rejectedNumberingIds);
 
             var removed = new List<Anchor>();
@@ -2661,7 +2789,12 @@ public sealed partial class DocxSession : IDisposable
                 }
             }
 
-            InvalidateProjectionCache();
+            // Selective revision resolution must not normalize unrelated package state. The
+            // relationship sweep above is deliberately limited to ids carried by this group;
+            // a global image sweep here could erase a pre-existing orphan or hide an unrelated
+            // redline-only relationship from a whole-package reversibility proof.
+            InvalidateProjectionCache(
+                sweepOrphanedImages: !_settings.ProofSafeRevisionResolution);
             return new EditResult
             {
                 Success = true,
@@ -2693,17 +2826,46 @@ public sealed partial class DocxSession : IDisposable
 
         var modified = registry.Entries.SelectMany(g => RevisionGroupAnchors(g, g.PartUri))
             .GroupBy(a => a.Id, StringComparer.Ordinal).Select(g => g.First()).ToList();
-        IReadOnlyList<int> rejectedNumberingIds = accept
+        var relationshipCandidates = registry.Entries
+            .GroupBy(group => group.PartUri, StringComparer.Ordinal)
+            .ToDictionary(
+                group => group.Key,
+                group =>
+                {
+                    var owner = ResolvePart(group.Key);
+                    return (IReadOnlyCollection<string>)group
+                        .SelectMany(revision => UnprotectedRevisionRelationshipIds(revision, owner))
+                        .Distinct(StringComparer.Ordinal).ToArray();
+                },
+                StringComparer.Ordinal);
+        var rejectedNumberingIds = accept
             ? Array.Empty<int>()
-            : registry.Entries.SelectMany(NumberingIdsIntroducedBy).Distinct().ToList();
+            : registry.Entries.SelectMany(NumberingIdsIntroducedBy)
+                .Except(_settings.ProtectedRevisionNumberingIds).Distinct().ToArray();
 
         _history.RecordPreOp(TakeSnapshot());
         try
         {
-            var removedElements = registry.ResolveAll(accept);
+            var removedElements = registry.ResolveAll(
+                accept,
+                _settings.ProofSafeRevisionResolution,
+                _settings.ProtectedRevisionEmptyContainerKeys);
             foreach (var story in RevisionStoryParts())
-                SweepOrphanedStoryRelationships(story.Part);
-            if (!accept && rejectedNumberingIds.Count > 0)
+            {
+                if (story.Part is NumberingDefinitionsPart)
+                    story.Part.PutXDocument();
+                if (_settings.ProofSafeRevisionResolution)
+                {
+                    if (relationshipCandidates.TryGetValue(
+                            story.Part.Uri.ToString(), out var candidates))
+                        SweepOrphanedStoryRelationships(story.Part, candidates);
+                }
+                else
+                {
+                    SweepOrphanedStoryRelationships(story.Part);
+                }
+            }
+            if (!accept && rejectedNumberingIds.Length > 0)
                 PruneUnreferencedDocxodusNumbering(rejectedNumberingIds);
             var removed = new List<Anchor>();
             var seenRemoved = new HashSet<string>(StringComparer.Ordinal);
@@ -2723,7 +2885,10 @@ public sealed partial class DocxSession : IDisposable
                 }
             }
 
-            InvalidateProjectionCache();
+            // ResolveAll has already swept only relationships referenced by the groups it
+            // resolved. Preserve every unrelated relationship for exact package semantics.
+            InvalidateProjectionCache(
+                sweepOrphanedImages: !_settings.ProofSafeRevisionResolution);
             return new EditResult
             {
                 Success = true,
@@ -2759,41 +2924,36 @@ public sealed partial class DocxSession : IDisposable
 
     private static IReadOnlyList<int> NumberingIdsIntroducedBy(
         Internal.RevisionOps.RevisionGroup group) =>
-        group.Units.Where(unit => unit.Kind == Internal.RevisionOps.UnitKind.NumberingPropertiesInsert)
+        group.Units.Where(unit =>
+                unit.Kind == Internal.RevisionOps.UnitKind.NumberingPropertiesInsert)
             .Select(unit => (string?)unit.Element.Parent?.Element(W.numId)?.Attribute(W.val))
             .Where(value => int.TryParse(value, out _))
-            .Select(value => int.Parse(value!, System.Globalization.CultureInfo.InvariantCulture))
+            .Select(value => int.Parse(
+                value!, System.Globalization.CultureInfo.InvariantCulture))
             .Distinct()
-            .ToList();
+            .ToArray();
 
-    /// <summary>Remove Docxodus-authored numbering instances made unreachable by rejecting their
-    /// native numPr insertion. Native revision markup cannot carry a package-part before-image;
-    /// pruning only our fixed-nsid definitions recovers exact package parity without touching
-    /// unrelated producer numbering.</summary>
-    private void PruneUnreferencedDocxodusNumbering(IReadOnlyCollection<int>? candidateIds)
+    /// <summary>
+    /// Remove Docxodus-authored numbering instances made unreachable by rejecting their native
+    /// numPr insertion. Proof sessions exclude definitions present in the selected baseline.
+    /// </summary>
+    private void PruneUnreferencedDocxodusNumbering(IReadOnlyCollection<int> candidateIds)
     {
         var main = _doc!.MainDocumentPart;
         var part = main?.NumberingDefinitionsPart;
         var root = part?.GetXDocument().Root;
-        if (main is null || part is null || root is null) return;
+        if (main is null || part is null || root is null || candidateIds.Count == 0) return;
 
-        // EnumerateProjectedParts already yields StyleDefinitionsPart, so numbering
-        // referenced only from a style definition is covered without a special case.
         var referenced = new HashSet<int>();
-        var referenceParts = EnumerateProjectedParts()
-            .Where(projected => !ReferenceEquals(projected, part));
-        foreach (var referencePart in referenceParts)
+        foreach (var referencePart in EnumerateProjectedParts()
+                     .Where(projected => !ReferenceEquals(projected, part)))
         {
             foreach (var numId in referencePart.GetXDocument().Descendants(W.numId))
                 if (int.TryParse((string?)numId.Attribute(W.val), out var value) && value > 0)
                     referenced.Add(value);
         }
 
-        var candidates = candidateIds?.ToHashSet() ?? root.Elements(W.num)
-            .Select(num => (string?)num.Attribute(W.numId))
-            .Where(value => int.TryParse(value, out _))
-            .Select(value => int.Parse(value!, System.Globalization.CultureInfo.InvariantCulture))
-            .ToHashSet();
+        var candidates = candidateIds.ToHashSet();
         bool changed = false;
         foreach (var num in root.Elements(W.num).ToList())
         {
@@ -2801,14 +2961,18 @@ public sealed partial class DocxSession : IDisposable
                 || !candidates.Contains(numId) || referenced.Contains(numId))
                 continue;
             var abstractId = (string?)num.Element(W.abstractNumId)?.Attribute(W.val);
-            var abstractNum = root.Elements(W.abstractNum)
-                .FirstOrDefault(candidate => (string?)candidate.Attribute(W.abstractNumId) == abstractId);
-            if (abstractNum is null || !Internal.NumberingFactory.IsDocxodusDefinition(abstractNum))
+            var abstractNum = root.Elements(W.abstractNum).FirstOrDefault(candidate =>
+                (string?)candidate.Attribute(W.abstractNumId) == abstractId);
+            if (abstractNum is null
+                || !_settings.ProofSafeRevisionResolution
+                    && !Internal.NumberingFactory.IsDocxodusDefinition(abstractNum))
                 continue;
 
             num.Remove();
             changed = true;
-            if (!root.Elements(W.num).Any(other =>
+            bool protectedAbstract = int.TryParse(abstractId, out var parsedAbstractId)
+                && _settings.ProtectedRevisionAbstractNumberingIds.Contains(parsedAbstractId);
+            if (!protectedAbstract && !root.Elements(W.num).Any(other =>
                     (string?)other.Element(W.abstractNumId)?.Attribute(W.val) == abstractId))
                 abstractNum.Remove();
         }
@@ -2818,63 +2982,263 @@ public sealed partial class DocxSession : IDisposable
         else part.PutXDocument();
     }
 
+    internal IReadOnlyList<int> DefinedNumberingIds()
+    {
+        ThrowIfDisposed();
+        return _doc?.MainDocumentPart?.NumberingDefinitionsPart?.GetXDocument().Root?
+            .Elements(W.num)
+            .Select(element => (string?)element.Attribute(W.numId))
+            .Where(value => int.TryParse(value, out _))
+            .Select(value => int.Parse(
+                value!, System.Globalization.CultureInfo.InvariantCulture))
+            .Distinct().OrderBy(value => value).ToArray()
+            ?? Array.Empty<int>();
+    }
+
+    internal IReadOnlyList<int> DefinedAbstractNumberingIds()
+    {
+        ThrowIfDisposed();
+        return _doc?.MainDocumentPart?.NumberingDefinitionsPart?.GetXDocument().Root?
+            .Elements(W.abstractNum)
+            .Select(element => (string?)element.Attribute(W.abstractNumId))
+            .Where(value => int.TryParse(value, out _))
+            .Select(value => int.Parse(
+                value!, System.Globalization.CultureInfo.InvariantCulture))
+            .Distinct().OrderBy(value => value).ToArray()
+            ?? Array.Empty<int>();
+    }
+
+    internal IReadOnlyCollection<string> RevisionRelationshipKeys()
+    {
+        ThrowIfDisposed();
+        return EnumeratePackageParts(_doc!)
+            .SelectMany(owner => owner.Parts
+                .Select(relationship => relationship.RelationshipId)
+                .Concat(owner.HyperlinkRelationships.Select(relationship => relationship.Id))
+                .Concat(owner.ExternalRelationships.Select(relationship => relationship.Id))
+                .Concat(owner.DataPartReferenceRelationships.Select(relationship => relationship.Id))
+                .Select(relationshipId => RevisionRelationshipKey(
+                    owner.Uri.ToString(), relationshipId)))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    internal IReadOnlyCollection<string> EmptyRevisionPropertyContainerKeys()
+    {
+        ThrowIfDisposed();
+        _ = AnchorIndex();
+        return RevisionStoryParts()
+            .SelectMany(story => story.Root.DescendantsAndSelf()
+                .Where(element => Internal.RevisionOps.IsEmptyRemovablePropertyContainer(element))
+                .SelectMany(element => Internal.RevisionOps.EmptyPropertyContainerKeys(
+                    story.Part.Uri.ToString(), element)))
+            .Distinct()
+            .ToArray();
+    }
+
+    private static IReadOnlyCollection<string> RevisionRelationshipIds(
+        Internal.RevisionOps.RevisionGroup group,
+        OpenXmlPart? owner)
+    {
+        if (owner is null) return Array.Empty<string>();
+        var relationshipIds = owner.Parts.Select(relationship => relationship.RelationshipId)
+            .Concat(owner.HyperlinkRelationships.Select(relationship => relationship.Id))
+            .Concat(owner.ExternalRelationships.Select(relationship => relationship.Id))
+            .Concat(owner.DataPartReferenceRelationships.Select(relationship => relationship.Id))
+            .ToHashSet(StringComparer.Ordinal);
+        if (relationshipIds.Count == 0) return Array.Empty<string>();
+
+        var roots = group.Units.SelectMany(unit => new[]
+            {
+                unit.Element,
+                unit.MarkedCell,
+                unit.MarkedRow,
+                unit.StructuredWrapper,
+                unit.Kind == Internal.RevisionOps.UnitKind.PropsChange
+                    ? unit.Element.Parent : null,
+                unit.Kind == Internal.RevisionOps.UnitKind.ParaMark
+                    ? unit.Paragraph : null,
+            })
+            .Where(element => element is not null)
+            .Select(element => element!)
+            .Concat(group.Units.SelectMany(unit => unit.Element.Ancestors()
+                .Where(ancestor => ancestor.Attributes().Any(attribute =>
+                    !attribute.IsNamespaceDeclaration
+                    && relationshipIds.Contains(attribute.Value)))))
+            .Distinct();
+        return roots.SelectMany(root => root.DescendantsAndSelf())
+            .SelectMany(element => element.Attributes())
+            .Where(attribute => !attribute.IsNamespaceDeclaration
+                && (attribute.Name.Namespace == R.r
+                    || attribute.Name.NamespaceName
+                        == "http://purl.oclc.org/ooxml/officeDocument/relationships"
+                    || (attribute.Name.NamespaceName
+                            == "urn:schemas-microsoft-com:office:office"
+                        && attribute.Name.LocalName == "relid")))
+            .Select(attribute => attribute.Value)
+            .Where(relationshipIds.Contains)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private IReadOnlyCollection<string> UnprotectedRevisionRelationshipIds(
+        Internal.RevisionOps.RevisionGroup group,
+        OpenXmlPart? owner)
+    {
+        if (owner is null) return Array.Empty<string>();
+        var ownerUri = owner.Uri.ToString();
+        return RevisionRelationshipIds(group, owner)
+            .Where(relationshipId => !_settings.ProtectedRevisionRelationshipKeys.Contains(
+                RevisionRelationshipKey(ownerUri, relationshipId), StringComparer.Ordinal))
+            .ToArray();
+    }
+
+    private static string RevisionRelationshipKey(string ownerPartUri, string relationshipId) =>
+        ownerPartUri + "\n" + relationshipId;
+
     private List<Anchor> RevisionGroupAnchors(
         Internal.RevisionOps.RevisionGroup group, string partUri)
     {
-        var anchors = new List<Anchor>();
+        long unlimitedTraversal = long.MaxValue;
+        _ = TryRevisionGroupAnchors(
+            group, partUri, int.MaxValue, ref unlimitedTraversal, out var anchors);
+        return anchors;
+    }
+
+    private bool TryRevisionGroupAnchors(
+        Internal.RevisionOps.RevisionGroup group,
+        string partUri,
+        int maximumAnchors,
+        ref long remainingTraversal,
+        out List<Anchor> anchors)
+    {
+        var collected = new List<Anchor>();
+        anchors = collected;
         var seen = new HashSet<string>(StringComparer.Ordinal);
+        var preferredByUnid = new Dictionary<string, Anchor>(StringComparer.Ordinal);
+        var fallbackByUnid = new Dictionary<string, Anchor>(StringComparer.Ordinal);
+        foreach (var target in AnchorIndex().Values)
+        {
+            fallbackByUnid.TryAdd(target.Unid, target.Anchor);
+            if (target.PartUri == partUri)
+                preferredByUnid.TryAdd(target.Unid, target.Anchor);
+        }
+        Anchor? FindAnchor(string unid) => preferredByUnid.TryGetValue(unid, out var preferred)
+            ? preferred
+            : fallbackByUnid.GetValueOrDefault(unid);
+        bool TryAdd(Anchor anchor)
+        {
+            if (!seen.Add(anchor.Id)) return true;
+            if (collected.Count >= maximumAnchors) return false;
+            collected.Add(anchor);
+            return true;
+        }
+
         var structuralTables = group.Units.Where(u => u.Kind == Internal.RevisionOps.UnitKind.CellMark)
             .Select(u => u.Table).Where(t => t is not null).Select(t => t!).Distinct().ToList();
         foreach (var table in structuralTables)
         {
             foreach (var element in table.DescendantsAndSelf())
             {
+                if (!TryConsumeRevisionEvidenceTraversal(ref remainingTraversal)) return false;
                 var unid = (string?)element.Attribute(PtOpenXml.Unid);
-                if (unid is not null && AnchorForUnid(unid, partUri) is { } anchor
-                    && seen.Add(anchor.Id))
-                    anchors.Add(anchor);
+                if (unid is not null && FindAnchor(unid) is { } anchor
+                    && !TryAdd(anchor))
+                    return false;
             }
         }
 
         foreach (var unit in group.Units)
         {
+            int anchorCountBeforeUnit = collected.Count;
             var start = unit.MarkedCell ?? unit.Paragraph ?? unit.MarkedRow
                 ?? unit.StructuredWrapper ?? unit.Element;
             if (unit.StructuredWrapper is { } wrapper)
             {
                 foreach (var element in wrapper.DescendantsAndSelf())
                 {
+                    if (!TryConsumeRevisionEvidenceTraversal(ref remainingTraversal)) return false;
                     var descendantUnid = (string?)element.Attribute(PtOpenXml.Unid);
                     if (descendantUnid is not null
-                        && AnchorForUnid(descendantUnid, partUri) is { } descendantAnchor
-                        && seen.Add(descendantAnchor.Id))
-                        anchors.Add(descendantAnchor);
+                        && FindAnchor(descendantUnid) is { } descendantAnchor
+                        && !TryAdd(descendantAnchor))
+                        return false;
                 }
             }
             for (var element = start;
                 element is not null; element = element.Parent)
             {
+                if (!TryConsumeRevisionEvidenceTraversal(ref remainingTraversal)) return false;
                 var unid = (string?)element.Attribute(PtOpenXml.Unid);
                 if (unid is null) continue;
-                if (AnchorForUnid(unid, partUri) is { } anchor && seen.Add(anchor.Id))
-                    anchors.Add(anchor);
-                break;
+                if (FindAnchor(unid) is { } anchor)
+                {
+                    if (!TryAdd(anchor)) return false;
+                    break;
+                }
+            }
+
+            if (collected.Count == anchorCountBeforeUnit
+                && unit.Element.Name == W.sectPrChange
+                && unit.Element.Ancestors(W.sectPr).FirstOrDefault() is { } sectionProperties
+                && sectionProperties.Parent?.Name == W.body)
+            {
+                var previousBlock = sectionProperties.ElementsBeforeSelf()
+                    .LastOrDefault(element => element.Name == W.p || element.Name == W.tbl);
+                if (previousBlock is not null)
+                {
+                    foreach (var element in previousBlock.DescendantsAndSelf())
+                    {
+                        if (!TryConsumeRevisionEvidenceTraversal(ref remainingTraversal)) return false;
+                        var unid = (string?)element.Attribute(PtOpenXml.Unid);
+                        if (unid is not null
+                            && FindAnchor(unid) is { } anchor)
+                        {
+                            if (!TryAdd(anchor)) return false;
+                            break;
+                        }
+                    }
+                }
             }
         }
-        return anchors;
+        return true;
+    }
+
+    private static bool TryConsumeRevisionEvidenceTraversal(ref long remaining)
+    {
+        if (remaining == long.MaxValue) return true;
+        if (remaining == 0) return false;
+        remaining--;
+        return true;
     }
 
     private Internal.RevisionRegistry BuildRevisionRegistry()
     {
         var parts = RevisionStoryParts();
-        return Internal.RevisionRegistry.Build(parts.Select(p =>
+        return BuildRevisionRegistry(parts);
+    }
+
+    private static Internal.RevisionRegistry BuildRevisionRegistry(
+        IReadOnlyList<(OpenXmlPart Part, XElement Root, string Scope)> parts)
+    {
+        var registry = Internal.RevisionRegistry.Build(parts.Select(p =>
             new Internal.RevisionRegistry.Part(
                 p.Part.Uri.ToString(), p.Scope, p.Root)).ToList());
+        foreach (var group in registry.Entries.Where(group => group.Scope is
+                     "glossary" or "stylesWithEffects" or "glossaryStyles"
+                     or "glossaryStylesWithEffects" or "glossaryNumbering"))
+        {
+            group.ResolutionStatus = RevisionResolutionStatus.Unsupported;
+            group.Diagnostic = new RevisionDiagnostic(
+                "unsupported_revision_part",
+                "Revisions in this auxiliary style/glossary part are inventoried but selective resolution is unsupported.");
+        }
+        return registry;
     }
 
     /// <summary>The story parts revision markup lives in, in the fixed order the
-    /// revision enumeration indexes them (main, headers, footers, footnotes, endnotes
-    /// — the same set RevisionProcessor's whole-document accept/reject walks).</summary>
+    /// revision enumeration indexes them. Comments and styles are resolvable; glossary markup is
+    /// inventoried explicitly and marked unsupported rather than disappearing from proof evidence.</summary>
     private List<(OpenXmlPart Part, XElement Root, string Scope)> RevisionStoryParts()
     {
         var list = new List<(OpenXmlPart, XElement, string)>();
@@ -2893,6 +3257,25 @@ public sealed partial class DocxSession : IDisposable
         foreach (var footer in main.FooterParts) Add(footer, $"ftr{index++}");
         if (main.FootnotesPart is not null) Add(main.FootnotesPart, "fn");
         if (main.EndnotesPart is not null) Add(main.EndnotesPart, "en");
+        if (main.WordprocessingCommentsPart is not null)
+            Add(main.WordprocessingCommentsPart, "cmt");
+        if (main.StyleDefinitionsPart is not null)
+            Add(main.StyleDefinitionsPart, "styles");
+        if (main.NumberingDefinitionsPart is not null)
+            Add(main.NumberingDefinitionsPart, "numbering");
+        if (main.StylesWithEffectsPart is not null)
+            Add(main.StylesWithEffectsPart, "stylesWithEffects");
+        if (main.GlossaryDocumentPart is not null)
+        {
+            Add(main.GlossaryDocumentPart, "glossary");
+            if (main.GlossaryDocumentPart.StyleDefinitionsPart is not null)
+                Add(main.GlossaryDocumentPart.StyleDefinitionsPart, "glossaryStyles");
+            if (main.GlossaryDocumentPart.StylesWithEffectsPart is not null)
+                Add(main.GlossaryDocumentPart.StylesWithEffectsPart,
+                    "glossaryStylesWithEffects");
+            if (main.GlossaryDocumentPart.NumberingDefinitionsPart is not null)
+                Add(main.GlossaryDocumentPart.NumberingDefinitionsPart, "glossaryNumbering");
+        }
         return list;
     }
 
@@ -5894,7 +6277,9 @@ public sealed partial class DocxSession : IDisposable
     }
 
     private OpenXmlPart? ResolvePart(string partUri) =>
-        EnumerateProjectedParts().FirstOrDefault(p => p.Uri.ToString() == partUri);
+        EnumerateProjectedParts().FirstOrDefault(p => p.Uri.ToString() == partUri)
+        ?? RevisionStoryParts().Select(story => story.Part)
+            .FirstOrDefault(part => part.Uri.ToString() == partUri);
 
     private static RunFormatting ExtractFormatting(XElement run, OpenXmlPart? ownerPart)
     {
@@ -11900,9 +12285,10 @@ public sealed partial class DocxSession : IDisposable
     /// must not have it swept out from under a restore.
     /// </para>
     /// </remarks>
-    internal void InvalidateProjectionCache()
+    internal void InvalidateProjectionCache(bool sweepOrphanedImages = true)
     {
-        SweepOrphanedStoryImageRelationships();
+        if (sweepOrphanedImages)
+            SweepOrphanedStoryImageRelationships();
         ResetProjectionCache();
     }
 
@@ -12524,11 +12910,18 @@ public sealed partial class DocxSession : IDisposable
                 long highest = 0;
                 foreach (var story in RevisionStoryParts())
                     highest = Math.Max(highest, Internal.RevisionOps.MaxRevisionId(story.Root));
+                if (highest >= int.MaxValue)
+                    throw new InvalidOperationException(
+                        "The document has exhausted the supported positive w:id revision range.");
                 if (highest > _revisionCounter)
-                    _revisionCounter = (int)Math.Min(highest, int.MaxValue - 1);
+                    _revisionCounter = (int)highest;
             }
+
+            if (_revisionCounter >= int.MaxValue)
+                throw new InvalidOperationException(
+                    "The document has exhausted the supported positive w:id revision range.");
+            return ++_revisionCounter;
         }
-        return System.Threading.Interlocked.Increment(ref _revisionCounter);
     }
 
     private void ThrowIfDisposed()

--- a/Docxodus/Internal/DocxSessionJson.cs
+++ b/Docxodus/Internal/DocxSessionJson.cs
@@ -2063,8 +2063,17 @@ internal static class DocxSessionJson
                 sb.Append(JsonString(r.ConstituentIds[c]));
             }
             sb.Append(']')
+              .Append(",\"constituentKeys\":[");
+            for (int c = 0; c < r.ConstituentKeys.Count; c++)
+            {
+                if (c > 0) sb.Append(',');
+                sb.Append(JsonString(r.ConstituentKeys[c]));
+            }
+            sb.Append(']')
               .Append(",\"author\":").Append(JsonString(r.Author));
             if (r.Date is not null) sb.Append(",\"date\":").Append(JsonString(r.Date));
+            if (r.DateUtc is not null)
+                sb.Append(",\"dateUtc\":").Append(JsonString(r.DateUtc));
             sb.Append(",\"text\":").Append(JsonString(r.Text))
               .Append(",\"partUri\":").Append(JsonString(r.PartUri))
               .Append(",\"scope\":").Append(JsonString(r.Scope));

--- a/Docxodus/Internal/RevisionOps.cs
+++ b/Docxodus/Internal/RevisionOps.cs
@@ -31,6 +31,9 @@ namespace Docxodus.Internal;
 /// </summary>
 internal static class RevisionOps
 {
+    private static readonly XName W16duDateUtc =
+        XNamespace.Get("http://schemas.microsoft.com/office/word/2023/wordml/word16du")
+        + "dateUtc";
     internal const string TypeInsert = "insert";
     internal const string TypeDelete = "delete";
     internal const string TypeMove = "move";
@@ -82,6 +85,7 @@ internal static class RevisionOps
         required public RevisionFamily Family { get; init; }
         required public string Author { get; init; }
         public string? Date { get; set; }
+        public string? DateUtc { get; set; }
         required public int PartIndex { get; init; }
         public string PartUri { get; set; } = "";
         public string Scope { get; set; } = "body";
@@ -136,7 +140,9 @@ internal static class RevisionOps
         long max = 0;
         foreach (var element in root.DescendantsAndSelf())
         {
-            if (!RevisionIdBearingNames.Contains(element.Name)) continue;
+            if (!RevisionIdBearingNames.Contains(element.Name)
+                && !UnsupportedConflictNames.Contains(element.Name))
+                continue;
             if (long.TryParse((string?)element.Attribute(W.id), out var value) && value > max)
                 max = value;
         }
@@ -153,6 +159,15 @@ internal static class RevisionOps
     {
         W.customXmlMoveFromRangeStart, W.customXmlMoveFromRangeEnd,
         W.customXmlMoveToRangeStart, W.customXmlMoveToRangeEnd,
+    };
+
+    private static readonly HashSet<XName> UnsupportedConflictNames = new()
+    {
+        W14.w14 + "conflictIns", W14.w14 + "conflictDel",
+        W14.w14 + "customXmlConflictInsRangeStart",
+        W14.w14 + "customXmlConflictInsRangeEnd",
+        W14.w14 + "customXmlConflictDelRangeStart",
+        W14.w14 + "customXmlConflictDelRangeEnd",
     };
 
     private static readonly HashSet<XName> MoveRangeNames = new()
@@ -196,6 +211,7 @@ internal static class RevisionOps
                 group.Scope = parts[pi].Scope;
             }
 
+            CoalesceTablePropertyGroups(groups, pi);
             CoalesceTableStructureGroups(groups, pi);
             AbsorbTrackedStructuredPayload(groups, pi);
         }
@@ -208,9 +224,7 @@ internal static class RevisionOps
     {
         foreach (var group in groups.Where(g => g.ResolutionStatus == RevisionResolutionStatus.Supported))
         {
-            if (group.Units.Any(u => string.IsNullOrEmpty(u.NativeId))
-                && group.Units.Any(u => u.Kind != UnitKind.PropsChange
-                    || u.Element.Name != W.tblGridChange))
+            if (group.Units.Any(u => string.IsNullOrEmpty(u.NativeId)))
             {
                 group.ResolutionStatus = RevisionResolutionStatus.Malformed;
                 group.Diagnostic = new RevisionDiagnostic(
@@ -219,14 +233,141 @@ internal static class RevisionOps
                 continue;
             }
 
+            if (group.Units.Any(unit => string.IsNullOrEmpty(unit.Author)
+                    && unit.Element.Name != W.tblGridChange))
+            {
+                group.ResolutionStatus = RevisionResolutionStatus.Malformed;
+                group.Diagnostic = new RevisionDiagnostic(
+                    "missing_revision_author",
+                    "A live revision marker has no w:author and cannot establish ownership safely.");
+                continue;
+            }
+
+            var metadataCarriers = group.Units.Select(unit => unit.Element)
+                .Concat(group.RangeMarkers.Where(IsRevisionRangeStart)).Distinct().ToArray();
+            if (metadataCarriers.Any(element => element.Name != W.tblGridChange
+                    && string.IsNullOrEmpty((string?)element.Attribute(W.author))))
+            {
+                group.ResolutionStatus = RevisionResolutionStatus.Malformed;
+                group.Diagnostic = new RevisionDiagnostic(
+                    "missing_revision_author",
+                    "A live revision marker has no w:author and cannot establish ownership safely.");
+                continue;
+            }
+
+            if (metadataCarriers.Any(element => (string?)element.Attribute(W.date) is { } date
+                    && !IsValidRevisionDate(date)))
+            {
+                group.ResolutionStatus = RevisionResolutionStatus.Malformed;
+                group.Diagnostic = new RevisionDiagnostic(
+                    "invalid_revision_date",
+                    "A live revision marker has a noncanonical XML Schema date-time value.");
+                continue;
+            }
+
+            if (metadataCarriers.Any(element => DateUtcOf(element) is { } dateUtc
+                    && !IsValidRevisionDateUtc(dateUtc)))
+            {
+                group.ResolutionStatus = RevisionResolutionStatus.Malformed;
+                group.Diagnostic = new RevisionDiagnostic(
+                    "invalid_revision_date_utc",
+                    "A live revision marker has an invalid w16du:dateUtc value.");
+                continue;
+            }
+
             if (group.Units.Any(u => !string.IsNullOrEmpty(u.NativeId) && u.Wid is null)
                 || group.RangeMarkers.Any(marker =>
-                    !long.TryParse((string?)marker.Attribute(W.id), out _)))
+                    !TryParseCanonicalRevisionId((string?)marker.Attribute(W.id), out _)))
             {
                 group.ResolutionStatus = RevisionResolutionStatus.Malformed;
                 group.Diagnostic = new RevisionDiagnostic(
                     "invalid_revision_id",
                     "A live revision marker has a nonnumeric w:id and cannot be addressed safely.");
+                continue;
+            }
+
+            if (group.Family == RevisionFamily.Move)
+            {
+                var fromStarts = group.RangeMarkers.Where(marker =>
+                    marker.Name == W.moveFromRangeStart).ToArray();
+                var fromEnds = group.RangeMarkers.Where(marker =>
+                    marker.Name == W.moveFromRangeEnd).ToArray();
+                var toStarts = group.RangeMarkers.Where(marker =>
+                    marker.Name == W.moveToRangeStart).ToArray();
+                var toEnds = group.RangeMarkers.Where(marker =>
+                    marker.Name == W.moveToRangeEnd).ToArray();
+                bool duplicate = fromStarts.Length > 1 || fromEnds.Length > 1
+                    || toStarts.Length > 1 || toEnds.Length > 1;
+                bool complete = fromStarts.Length == 1 && fromEnds.Length == 1
+                    && toStarts.Length == 1 && toEnds.Length == 1
+                    && group.Units.Any(unit => unit.Element.Name == W.moveFrom)
+                    && group.Units.Any(unit => unit.Element.Name == W.moveTo);
+                bool pairedIds = complete
+                    && string.Equals((string?)fromStarts[0].Attribute(W.id),
+                        (string?)fromEnds[0].Attribute(W.id), StringComparison.Ordinal)
+                    && string.Equals((string?)toStarts[0].Attribute(W.id),
+                        (string?)toEnds[0].Attribute(W.id), StringComparison.Ordinal);
+                bool distinctRangeIds = complete && !string.Equals(
+                    (string?)fromStarts[0].Attribute(W.id),
+                    (string?)toStarts[0].Attribute(W.id), StringComparison.Ordinal);
+                var metadataElements = group.Units.Select(unit => unit.Element)
+                    .Concat(fromStarts).Concat(toStarts).ToArray();
+                bool coherentMetadata = metadataElements.All(element =>
+                    string.Equals(AuthorOf(element), group.Author, StringComparison.Ordinal)
+                    && string.Equals((string?)element.Attribute(W.date), group.Date,
+                        StringComparison.Ordinal)
+                    && string.Equals(DateUtcOf(element), group.DateUtc,
+                        StringComparison.Ordinal));
+                if (!complete || !pairedIds || !distinctRangeIds || !coherentMetadata)
+                {
+                    group.ResolutionStatus = duplicate || !distinctRangeIds || !coherentMetadata
+                        ? RevisionResolutionStatus.Ambiguous
+                        : RevisionResolutionStatus.Malformed;
+                    group.Diagnostic = new RevisionDiagnostic(
+                        duplicate ? "ambiguous_move_topology"
+                        : !distinctRangeIds ? "ambiguous_move_range_id"
+                        : !coherentMetadata ? "incoherent_move_metadata"
+                        : "malformed_move_topology",
+                        duplicate
+                            ? "A native move name identifies duplicate source or destination range markers."
+                            : !distinctRangeIds
+                                ? "A native move reuses one w:id for distinct source and destination ranges."
+                            : !coherentMetadata
+                                ? "A native move combines source and destination markup with different author/date ownership."
+                                : "A native move requires exactly paired source/destination ranges and both content sides.");
+                    continue;
+                }
+
+
+                bool fromOrdered = RangeContainsAll(
+                    fromStarts[0], fromEnds[0], group.Units
+                        .Where(unit => unit.Kind == UnitKind.Content
+                            && unit.Element.Name == W.moveFrom)
+                        .Select(unit => unit.Element));
+                bool toOrdered = RangeContainsAll(
+                    toStarts[0], toEnds[0], group.Units
+                        .Where(unit => unit.Kind == UnitKind.Content
+                            && unit.Element.Name == W.moveTo)
+                        .Select(unit => unit.Element));
+                bool disjoint = IsBefore(fromEnds[0], toStarts[0])
+                    || IsBefore(toEnds[0], fromStarts[0]);
+                if (!fromOrdered || !toOrdered || !disjoint)
+                {
+                    group.ResolutionStatus = RevisionResolutionStatus.Malformed;
+                    group.Diagnostic = new RevisionDiagnostic(
+                        "overlapping_move_topology",
+                        "A native move requires ordered, disjoint source and destination ranges.");
+                    continue;
+                }
+            }
+
+            if (group.Units.Any(unit => unit.Kind == UnitKind.PropsChange
+                    && !IsValidPropsChange(unit.Element)))
+            {
+                group.ResolutionStatus = RevisionResolutionStatus.Malformed;
+                group.Diagnostic = new RevisionDiagnostic(
+                    "malformed_properties_change",
+                    "A property revision must contain exactly one matching stored-property shell under its live property parent.");
                 continue;
             }
 
@@ -263,13 +404,34 @@ internal static class RevisionOps
                     }
                 }
 
+                if (group.Family == RevisionFamily.CellInsert)
+                {
+                    var inserted = cells.Select(unit => unit.MarkedCell!).ToHashSet();
+                    bool emptiesRow = inserted.GroupBy(cell => cell.Parent).Any(byRow =>
+                    {
+                        var rowCells = byRow.Key?.Elements(W.tc).ToList()
+                            ?? new List<XElement>();
+                        return rowCells.Count == 0 || rowCells.All(inserted.Contains);
+                    });
+                    if (emptiesRow)
+                    {
+                        group.ResolutionStatus = RevisionResolutionStatus.Malformed;
+                        group.Diagnostic = new RevisionDiagnostic(
+                            "unresolvable_cell_insertion",
+                            "Rejecting the inserted cells would leave a table row with no cells.");
+                        continue;
+                    }
+                }
+
                 if (group.Family == RevisionFamily.CellMerge && cells.Any(u =>
-                    (string?)u.Element.Attribute(W.vMerge) is not ("rest" or "cont")))
+                    (string?)u.Element.Attribute(W.vMerge) is not ("rest" or "cont")
+                    || (string?)u.Element.Attribute(W.vMergeOrig) is { } original
+                        && original is not ("rest" or "cont")))
                 {
                     group.ResolutionStatus = RevisionResolutionStatus.Malformed;
                     group.Diagnostic = new RevisionDiagnostic(
                         "invalid_cell_merge_state",
-                        "w:cellMerge must carry w:vMerge='rest' or 'cont'.");
+                        "w:cellMerge must use only 'rest' or 'cont' for w:vMerge and w:vMergeOrig.");
                 }
             }
 
@@ -295,12 +457,14 @@ internal static class RevisionOps
             }
         }
 
-        // Reusing one live revision id for multiple independent groups in one part
-        // makes an id-based operation inherently ambiguous. Range-pair duplication was
-        // diagnosed earlier and groups already coalesced into one operation are fine.
-        foreach (var collision in groups.SelectMany(g => ConstituentIds(g)
-                .Select(id => (Group: g, Id: id)))
-            .GroupBy(x => (x.Group.PartUri, x.Id))
+        ValidateGlobalMoveRangeTopology(groups);
+
+        // Reusing one QName-qualified native carrier identity for independent groups is
+        // ambiguous. Numeric w:id values alone are not global: distinct carrier roles may
+        // legally reuse them, which is why the public contract exposes ConstituentKeys.
+        foreach (var collision in groups.SelectMany(g => ConstituentKeys(g)
+                .Select(key => (Group: g, Key: key)))
+            .GroupBy(x => (x.Group.PartUri, x.Key))
             .Where(g => g.Select(x => x.Group).Distinct().Count() > 1))
         {
             foreach (var group in collision.Select(x => x.Group).Distinct()
@@ -309,9 +473,122 @@ internal static class RevisionOps
                 group.ResolutionStatus = RevisionResolutionStatus.Ambiguous;
                 group.Diagnostic = new RevisionDiagnostic(
                     "duplicate_revision_id",
-                    $"w:id '{collision.Key.Id}' identifies multiple live revisions in {collision.Key.PartUri}.");
+                    $"Native carrier '{collision.Key.Key}' identifies multiple live revisions in {collision.Key.PartUri}.");
             }
         }
+    }
+
+    private static void ValidateGlobalMoveRangeTopology(List<RevisionGroup> groups)
+    {
+        foreach (var partGroups in groups.Where(group => group.Family == RevisionFamily.Move)
+            .GroupBy(group => group.PartIndex))
+        {
+            ValidateMoveRangeSide(
+                partGroups, W.moveFromRangeStart, W.moveFromRangeEnd);
+            ValidateMoveRangeSide(
+                partGroups, W.moveToRangeStart, W.moveToRangeEnd);
+        }
+    }
+
+    private static void ValidateMoveRangeSide(
+        IEnumerable<RevisionGroup> groups, XName startName, XName endName)
+    {
+        var ownerByMarker = groups.SelectMany(group => group.RangeMarkers
+                .Where(marker => marker.Name == startName || marker.Name == endName)
+                .Select(marker => (Marker: marker, Group: group)))
+            .ToDictionary(item => item.Marker, item => item.Group);
+        var ordered = ownerByMarker.Keys.OrderBy(marker => marker,
+            XNode.DocumentOrderComparer).ToArray();
+        var stack = new List<RevisionGroup>();
+        foreach (var marker in ordered)
+        {
+            var owner = ownerByMarker[marker];
+            if (marker.Name == startName)
+            {
+                stack.Add(owner);
+                continue;
+            }
+
+            if (stack.Count > 0 && ReferenceEquals(stack[^1], owner))
+            {
+                stack.RemoveAt(stack.Count - 1);
+                continue;
+            }
+
+            foreach (var group in stack.Append(owner).Distinct().Where(group =>
+                         group.ResolutionStatus == RevisionResolutionStatus.Supported))
+            {
+                group.ResolutionStatus = RevisionResolutionStatus.Ambiguous;
+                group.Diagnostic = new RevisionDiagnostic(
+                    "crossed_move_range_topology",
+                    "Native move ranges with different names cross or close out of stack order.");
+            }
+
+            var index = stack.FindLastIndex(group => ReferenceEquals(group, owner));
+            if (index >= 0)
+                stack.RemoveAt(index);
+        }
+    }
+
+    private static bool IsRevisionRangeStart(XElement element) =>
+        element.Name == W.moveFromRangeStart || element.Name == W.moveToRangeStart
+        || element.Name == W.customXmlInsRangeStart
+        || element.Name == W.customXmlDelRangeStart
+        || element.Name == W.customXmlMoveFromRangeStart
+        || element.Name == W.customXmlMoveToRangeStart;
+
+    private static bool IsValidRevisionDate(string value)
+    {
+        if (!System.Text.RegularExpressions.Regex.IsMatch(
+                value,
+                @"^-?\d{4,}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?$",
+                System.Text.RegularExpressions.RegexOptions.CultureInvariant))
+            return false;
+        try
+        {
+            _ = System.Xml.XmlConvert.ToDateTime(
+                value, System.Xml.XmlDateTimeSerializationMode.RoundtripKind);
+            return true;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsValidRevisionDateUtc(string value) =>
+        value.EndsWith("Z", StringComparison.Ordinal)
+        && IsValidRevisionDate(value);
+
+    private static bool RangeContainsAll(
+        XElement start, XElement end, IEnumerable<XElement> contents) =>
+        IsBefore(start, end) && contents.All(element =>
+            IsBefore(start, element) && IsBefore(element, end));
+
+    private static bool IsBefore(XElement left, XElement right) =>
+        ReferenceEquals(left.Document, right.Document)
+        && XNode.DocumentOrderComparer.Compare(left, right) < 0;
+
+    private static bool IsValidPropsChange(XElement change)
+    {
+        var expectedProperty = change.Name == W.rPrChange ? W.rPr
+            : change.Name == W.pPrChange ? W.pPr
+            : change.Name == W.sectPrChange ? W.sectPr
+            : change.Name == W.tblPrChange ? W.tblPr
+            : change.Name == W.trPrChange ? W.trPr
+            : change.Name == W.tcPrChange ? W.tcPr
+            : change.Name == W.tblGridChange ? W.tblGrid
+            : change.Name == W.tblPrExChange ? W.tblPrEx
+            : null;
+        return expectedProperty is not null
+            && change.Parent?.Name == expectedProperty
+            && change.Parent.Elements().Count(element =>
+                PropsChangeNames.Contains(element.Name)) == 1
+            && !change.Ancestors().Skip(1).Any(ancestor => PropsChangeNames.Contains(ancestor.Name))
+            && !change.Descendants().Any(descendant =>
+                PropsChangeNames.Contains(descendant.Name))
+            && change.Elements().Count() == 1
+            && change.Elements().Single().Name == expectedProperty;
     }
 
     /// <summary>
@@ -434,7 +711,6 @@ internal static class RevisionOps
                 var stack = n == W.moveFromRangeEnd ? ctx.MoveFromStack : ctx.MoveToStack;
                 var id = (string?)child.Attribute(W.id);
                 int idx = stack.FindLastIndex(e => e.Id == id);
-                if (idx < 0) idx = stack.Count - 1;
                 if (idx >= 0)
                 {
                     ctx.MarkersFor(stack[idx].Name).Add(child);
@@ -514,7 +790,9 @@ internal static class RevisionOps
             // pPr/trPr are handled by WalkParagraph/WalkRow; everything else (runs,
             // hyperlinks, sdt, tbl, tc, rPr, tblPr, tblGrid, sectPr, …) recurses so
             // nested wrappers and *PrChange elements are found wherever they live.
-            if (n == W.pPr || n == W.trPr) continue;
+            if ((n == W.pPr && paragraph is not null)
+                || (n == W.trPr && markedRow is not null))
+                continue;
             if (child.HasElements)
                 WalkChildren(child.Elements(), ctx, paragraph, markedRow, markedRowType, sink);
         }
@@ -670,15 +948,29 @@ internal static class RevisionOps
             Author = AuthorOf(el),
             Date = (string?)el.Attribute(W.date),
             Paragraph = paragraph,
+            MarkedCell = el.Ancestors(W.tc).FirstOrDefault(),
+            MarkedRow = el.Ancestors(W.tr).FirstOrDefault(),
             Table = el.Ancestors(W.tbl).FirstOrDefault(),
             Wid = WidOf(el),
             NativeId = (string?)el.Attribute(W.id),
         };
 
-    private static string AuthorOf(XElement el) => (string?)el.Attribute(W.author) ?? "unknown";
+    private static string AuthorOf(XElement el) => (string?)el.Attribute(W.author) ?? string.Empty;
+
+    private static string? DateUtcOf(XElement element) =>
+        (string?)element.Attribute(W16duDateUtc);
 
     private static long? WidOf(XElement el) =>
-        long.TryParse((string?)el.Attribute(W.id), out var v) ? v : null;
+        TryParseCanonicalRevisionId((string?)el.Attribute(W.id), out var value) ? value : null;
+
+    private static bool TryParseCanonicalRevisionId(string? value, out long parsed)
+    {
+        if (!long.TryParse(value, System.Globalization.NumberStyles.AllowLeadingSign,
+                System.Globalization.CultureInfo.InvariantCulture, out parsed))
+            return false;
+        return string.Equals(value, parsed.ToString(
+            System.Globalization.CultureInfo.InvariantCulture), StringComparison.Ordinal);
+    }
 
     // ─── Grouping ───────────────────────────────────────────────────────
 
@@ -688,7 +980,6 @@ internal static class RevisionOps
         var moveGroups = new Dictionary<string, RevisionGroup>(StringComparer.Ordinal);
         var rowGroupByTr = new Dictionary<XElement, RevisionGroup>();
         var cellGroups = new List<RevisionGroup>();
-        var tablePropertyGroups = new List<RevisionGroup>();
         RevisionGroup? cur = null;
         RevisionGroup? lastRowGroup = null;
 
@@ -704,6 +995,7 @@ internal static class RevisionOps
                         Family = RevisionFamily.Move,
                         Author = u.Author,
                         Date = u.Date,
+                        DateUtc = DateUtcOf(u.Element),
                         PartIndex = partIndex,
                     };
                     if (ctx.RangeMarkers.TryGetValue(u.MoveName, out var markers))
@@ -717,9 +1009,13 @@ internal static class RevisionOps
 
             if (u.Kind == UnitKind.CellMark)
             {
-                var cellGroup = cellGroups.FirstOrDefault(g =>
-                    g.Family == u.Family && g.Author == u.Author && g.Date == u.Date
-                    && ReferenceEquals(g.Units[0].Table, u.Table));
+                // One Word cell operation forms a connected row/column region. Timestamp alone
+                // is insufficient: two distant edits can legitimately share it.
+                var cellGroup = cellGroups.FirstOrDefault(group =>
+                    group.Family == u.Family && group.Author == u.Author
+                    && group.Date == u.Date && group.DateUtc == DateUtcOf(u.Element)
+                    && ReferenceEquals(group.Units[0].Table, u.Table)
+                    && group.Units.Any(existing => CellsStructurallyAdjacent(existing, u)));
                 if (cellGroup is null)
                 {
                     cellGroup = NewGroup(u, partIndex);
@@ -745,6 +1041,7 @@ internal static class RevisionOps
             {
                 if (lastRowGroup is not null && lastRowGroup.Type == u.Type && lastRowGroup.Author == u.Author
                     && lastRowGroup.Date == u.Date
+                    && lastRowGroup.DateUtc == DateUtcOf(u.Element)
                     && lastRowGroup.Units[^1].MarkedRow is { } prevTr && u.MarkedRow is { } tr2
                     && prevTr.Parent == tr2.Parent && OnlyIgnorableBetween(prevTr, tr2))
                 {
@@ -761,7 +1058,9 @@ internal static class RevisionOps
             }
 
             if ((u.Kind == UnitKind.Content || u.Kind == UnitKind.ParaMark) && u.MarkedRow is not null
-                && rowGroupByTr.TryGetValue(u.MarkedRow, out var hostRow) && hostRow.Type == u.Type)
+                && rowGroupByTr.TryGetValue(u.MarkedRow, out var hostRow) && hostRow.Type == u.Type
+                && hostRow.Author == u.Author && hostRow.Date == u.Date
+                && hostRow.DateUtc == DateUtcOf(u.Element))
             {
                 hostRow.Units.Add(u);
                 continue;
@@ -769,16 +1068,9 @@ internal static class RevisionOps
 
             if (u.Kind == UnitKind.PropsChange)
             {
-                var tablePropertyGroup = u.Table is null ? null : tablePropertyGroups.FirstOrDefault(group =>
-                    group.Author == u.Author && group.Date == u.Date
-                    && ReferenceEquals(group.Units[0].Table, u.Table));
-                if (tablePropertyGroup is not null)
-                {
-                    tablePropertyGroup.Units.Add(u);
-                    cur = null;
-                }
-                else if (cur is not null && cur.Type == TypeFormat && cur.Author == u.Author
+                if (cur is not null && cur.Type == TypeFormat && cur.Author == u.Author
                     && cur.Date == u.Date
+                    && cur.DateUtc == DateUtcOf(u.Element)
                     && cur.Units[^1].Element.Name == W.rPrChange && u.Element.Name == W.rPrChange
                     && AdjacentFormatRuns(cur.Units[^1].Element, u.Element))
                 {
@@ -788,7 +1080,6 @@ internal static class RevisionOps
                 {
                     cur = NewGroup(u, partIndex);
                     groups.Add(cur);
-                    if (u.Table is not null) tablePropertyGroups.Add(cur);
                 }
                 continue;
             }
@@ -796,6 +1087,7 @@ internal static class RevisionOps
             // Content / paragraph-mark insert, delete, or unranged move — adjacency grouping.
             if (cur is not null && cur.Type == u.Type && cur.Author == u.Author
                 && cur.Date == u.Date
+                && cur.DateUtc == DateUtcOf(u.Element)
                 && cur.Units[^1].Element.Name == u.Element.Name
                 && Contiguous(cur.Units[^1], u))
             {
@@ -809,6 +1101,24 @@ internal static class RevisionOps
         }
     }
 
+    private static bool CellsStructurallyAdjacent(RevisionUnit left, RevisionUnit right)
+    {
+        var leftCell = left.MarkedCell;
+        var rightCell = right.MarkedCell;
+        var leftRow = leftCell?.Parent;
+        var rightRow = rightCell?.Parent;
+        if (leftCell is null || rightCell is null || leftRow?.Name != W.tr
+            || rightRow?.Name != W.tr || left.Table != right.Table)
+            return false;
+
+        int leftColumn = leftRow.Elements(W.tc).TakeWhile(cell => cell != leftCell).Count();
+        int rightColumn = rightRow.Elements(W.tc).TakeWhile(cell => cell != rightCell).Count();
+        if (leftRow == rightRow) return Math.Abs(leftColumn - rightColumn) == 1;
+        return leftColumn == rightColumn
+            && (OnlyIgnorableBetween(leftRow, rightRow)
+                || OnlyIgnorableBetween(rightRow, leftRow));
+    }
+
     private static RevisionGroup NewGroup(RevisionUnit u, int partIndex)
     {
         var g = new RevisionGroup
@@ -817,6 +1127,7 @@ internal static class RevisionOps
             Family = u.Family,
             Author = u.Author,
             Date = u.Date,
+            DateUtc = DateUtcOf(u.Element),
             PartIndex = partIndex,
         };
         g.Units.Add(u);
@@ -858,6 +1169,7 @@ internal static class RevisionOps
             var secondId = (string?)lastInside.Attribute(W.id);
             if (firstInside.Name != endName || lastInside.Name != startName || after.Name != endName
                 || string.IsNullOrEmpty(firstId) || string.IsNullOrEmpty(secondId)
+                || string.Equals(firstId, secondId, StringComparison.Ordinal)
                 || (string?)firstInside.Attribute(W.id) != firstId
                 || (string?)after.Attribute(W.id) != secondId)
             {
@@ -867,7 +1179,10 @@ internal static class RevisionOps
             // Both starts describe one wrapper revision and must carry a coherent stamp.
             var author = AuthorOf(before);
             var date = (string?)before.Attribute(W.date);
-            if (AuthorOf(lastInside) != author || (string?)lastInside.Attribute(W.date) != date)
+            var dateUtc = DateUtcOf(before);
+            if (AuthorOf(lastInside) != author
+                || (string?)lastInside.Attribute(W.date) != date
+                || DateUtcOf(lastInside) != dateUtc)
                 continue;
 
             var family = isInsert
@@ -1029,16 +1344,126 @@ internal static class RevisionOps
             || MoveRangeNames.Contains(name)
             || StructuredRangeNames.Contains(name)
             || UnsupportedRangeNames.Contains(name)
+            || UnsupportedConflictNames.Contains(name)
             || PropsChangeNames.Contains(name)
             || name == W.cellIns || name == W.cellDel || name == W.cellMerge
             || name == W.numberingChange || name == W.delText || name == W.delInstrText;
     }
+
+    /// <summary>
+    /// Count physical live carriers before registry allocation. Deletion payload text counts only
+    /// when orphaned; inside a claimed wrapper it is data, not a second revision operation.
+    /// </summary>
+    internal static bool IsNativeRevisionCarrierForInventory(XElement element) =>
+        RevisionIdBearingNames.Contains(element.Name)
+        || UnsupportedConflictNames.Contains(element.Name)
+        || ((element.Name == W.delText || element.Name == W.delInstrText)
+            && !element.Ancestors().Any(ancestor =>
+                ancestor.Name == W.del || ancestor.Name == W.moveFrom));
 
     private static bool IsClaimedDeletionPayload(
         XElement marker, IReadOnlySet<XElement> represented) =>
         (marker.Name == W.delText || marker.Name == W.delInstrText)
         && (marker.Ancestors(W.del).Any(represented.Contains)
             || marker.Ancestors(W.moveFrom).Any(represented.Contains));
+
+    /// <summary>
+    /// Coalesce only property revisions that have a concrete table-operation topology. This
+    /// preserves one-operation/one-entry semantics for row shading and column-width edits without
+    /// folding unrelated run or paragraph formatting merely because Word reused a timestamp.
+    /// </summary>
+    private static void CoalesceTablePropertyGroups(List<RevisionGroup> groups, int partIndex)
+    {
+        var propertyGroups = groups.Where(group => group.PartIndex == partIndex
+                && group.Family == RevisionFamily.PropertiesChange
+                && group.Units.Count > 0
+                && group.Units.All(unit => unit.Kind == UnitKind.PropsChange)
+                && group.Units[0].Table is not null)
+            .ToList();
+
+        foreach (var byStamp in propertyGroups.GroupBy(group => new
+        {
+            Table = group.Units[0].Table,
+            group.Author,
+            group.Date,
+            group.DateUtc,
+        }))
+        {
+            var remaining = byStamp.Where(groups.Contains).ToList();
+            var tableLevel = remaining.Where(group => group.Units.All(unit =>
+                    unit.Element.Name == W.tblGridChange
+                    || unit.Element.Name == W.tblPrChange
+                    || unit.Element.Name == W.tblPrExChange))
+                .ToList();
+            var tableCells = byStamp.Key.Table!.Descendants(W.tc).ToHashSet();
+            var changedCells = remaining.SelectMany(group => group.Units)
+                .Where(unit => unit.Element.Name == W.tcPrChange)
+                .Select(unit => unit.MarkedCell)
+                .Where(cell => cell is not null)
+                .Select(cell => cell!)
+                .ToHashSet();
+            bool completeColumnWidthTopology = tableCells.Count > 0
+                && tableCells.SetEquals(changedCells)
+                && tableLevel.Any(group => group.Units.Any(unit =>
+                    unit.Element.Name == W.tblGridChange))
+                && tableLevel.Any(group => group.Units.Any(unit =>
+                    unit.Element.Name == W.tblPrChange));
+            if (completeColumnWidthTopology)
+            {
+                var structural = remaining.Where(group => group.Units.All(unit =>
+                        unit.Element.Name == W.tblGridChange
+                        || unit.Element.Name == W.tblPrChange
+                        || unit.Element.Name == W.tblPrExChange
+                        || unit.Element.Name == W.trPrChange
+                        || unit.Element.Name == W.tcPrChange))
+                    .ToList();
+                MergeGroups(structural, groups);
+                remaining = remaining.Except(structural).ToList();
+            }
+
+            foreach (var sameKind in remaining.GroupBy(group => group.Units[0].Element.Name))
+            {
+                var candidates = sameKind.Where(group =>
+                        group.Units.All(unit => unit.MarkedCell is not null))
+                    .ToList();
+                while (candidates.Count > 0)
+                {
+                    var component = new List<RevisionGroup> { candidates[0] };
+                    candidates.RemoveAt(0);
+                    bool changed;
+                    do
+                    {
+                        changed = false;
+                        for (int index = candidates.Count - 1; index >= 0; index--)
+                        {
+                            if (!component.SelectMany(group => group.Units).Any(left =>
+                                    candidates[index].Units.Any(right =>
+                                        CellsStructurallyAdjacent(left, right))))
+                                continue;
+                            component.Add(candidates[index]);
+                            candidates.RemoveAt(index);
+                            changed = true;
+                        }
+                    }
+                    while (changed);
+                    MergeGroups(component, groups);
+                }
+            }
+        }
+    }
+
+    private static void MergeGroups(
+        IReadOnlyList<RevisionGroup> source, List<RevisionGroup> allGroups)
+    {
+        if (source.Count < 2) return;
+        var target = source[0];
+        foreach (var group in source.Skip(1))
+        {
+            target.Units.AddRange(group.Units);
+            target.RangeMarkers.AddRange(group.RangeMarkers);
+            allGroups.Remove(group);
+        }
+    }
 
     /// <summary>
     /// Word records one cell-structure action as live cell marks plus associated table,
@@ -1058,18 +1483,39 @@ internal static class RevisionOps
         {
             if (byTable.Key is null) continue;
             var tableCellGroups = byTable.ToList();
+            var markedCells = tableCellGroups.SelectMany(group => group.Units)
+                .Select(unit => unit.MarkedCell)
+                .Where(cell => cell is not null)
+                .Select(cell => cell!)
+                .ToHashSet();
             var candidates = groups.Where(g => g.PartIndex == partIndex
                 && !tableCellGroups.Contains(g)
                 && g.Units.Count > 0
-                && g.Units.All(u => ReferenceEquals(u.Table, byTable.Key)))
+                && g.Units.All(u => ReferenceEquals(u.Table, byTable.Key))
+                && g.Units.All(unit => unit.Element.Name == W.tblGridChange
+                    || unit.Element.Name == W.tblPrChange
+                    || unit.Element.Name == W.tblPrExChange
+                    || unit.Element.Name == W.tcPrChange
+                    || unit.Element.AncestorsAndSelf(W.tc).Any(markedCells.Contains)))
                 .ToList();
 
             foreach (var candidate in candidates)
             {
+                var candidateCells = candidate.Units
+                    .SelectMany(unit => unit.Element.AncestorsAndSelf(W.tc))
+                    .ToHashSet();
                 var matches = tableCellGroups.Where(c =>
-                    c.Author == candidate.Author && c.Date == candidate.Date).ToList();
+                    c.Author == candidate.Author && c.Date == candidate.Date
+                    && c.DateUtc == candidate.DateUtc
+                    && (candidate.Units.All(unit => unit.Element.Name == W.tblGridChange)
+                        || candidate.Units.All(unit => unit.Element.Name == W.tblPrChange
+                            || unit.Element.Name == W.tblPrExChange)
+                        || (candidateCells.Count > 0 && c.Units.Any(unit =>
+                            unit.MarkedCell is not null
+                            && candidateCells.Contains(unit.MarkedCell))))).ToList();
                 if (matches.Count == 0 && candidate.Units.All(u => u.Element.Name == W.tblGridChange)
-                    && candidate.Author == "unknown" && candidate.Date is null)
+                    && string.IsNullOrEmpty(candidate.Author) && candidate.Date is null
+                    && candidate.DateUtc is null)
                 {
                     matches = tableCellGroups;
                 }
@@ -1106,7 +1552,8 @@ internal static class RevisionOps
             var wrapper = structured.Units[0].StructuredWrapper;
             if (wrapper is null) continue;
             var candidates = groups.Where(g => g != structured && g.PartIndex == partIndex
-                && g.Type == structured.Type && g.Author == structured.Author && g.Date == structured.Date
+                && g.Type == structured.Type && g.Author == structured.Author
+                && g.Date == structured.Date && g.DateUtc == structured.DateUtc
                 && g.Units.Count > 0
                 && g.Units.All(u => u.Element.AncestorsAndSelf().Contains(wrapper)))
                 .ToList();
@@ -1260,14 +1707,17 @@ internal static class RevisionOps
             : null;
     }
 
-    private static IReadOnlyList<string> ConstituentKeys(RevisionGroup group)
+    internal static IReadOnlyList<string> ConstituentKeys(RevisionGroup group)
     {
         var keys = group.Units.Select(u =>
-                u.Element.Name.NamespaceName + ":" + u.Element.Name.LocalName + ":"
-                + (u.NativeId ?? ElementPath(u.Element)))
+                "kind=" + u.Kind + ":" + u.Element.Name.NamespaceName + ":"
+                + u.Element.Name.LocalName + ":"
+                + (u.NativeId ?? ElementPath(u.Element))
+                + (u.MoveName is null ? "" : ":name=" + u.MoveName))
             .Concat(group.RangeMarkers.Select(m =>
                 m.Name.NamespaceName + ":" + m.Name.LocalName + ":"
-                + ((string?)m.Attribute(W.id) ?? ElementPath(m))))
+                + ((string?)m.Attribute(W.id) ?? ElementPath(m))
+                + ((string?)m.Attribute(W.name) is { } name ? ":name=" + name : "")))
             .Distinct(StringComparer.Ordinal)
             .OrderBy(k => k, StringComparer.Ordinal)
             .ToList();
@@ -1287,9 +1737,15 @@ internal static class RevisionOps
 
     // ─── Listing text ───────────────────────────────────────────────────
 
-    internal static string GroupText(RevisionGroup g)
+    internal static string GroupText(RevisionGroup g) =>
+        GroupText(g, int.MaxValue, out _);
+
+    internal static string GroupText(
+        RevisionGroup g, long maximumCharacters, out bool complete)
     {
         var sb = new StringBuilder();
+        int maximum = (int)Math.Min(int.MaxValue, Math.Max(0, maximumCharacters));
+        complete = true;
         // A move pair carries the same text on both sides; render the source side only.
         bool moveFromOnly = g.Type == TypeMove
             && g.Units.Any(u => u.Element.Name == W.moveFrom);
@@ -1299,48 +1755,73 @@ internal static class RevisionOps
             switch (u.Kind)
             {
                 case UnitKind.Content:
-                    AppendVisibleText(u.Element, u.Element.Name == W.del ? W.delText : W.t, sb);
+                    if (!AppendVisibleText(
+                            u.Element,
+                            u.Element.Name == W.del ? W.delText : W.t,
+                            sb,
+                            maximum))
+                        complete = false;
                     break;
                 case UnitKind.ParaMark:
-                    sb.Append('¶');
+                    if (sb.Length >= maximum) complete = false;
+                    else sb.Append('¶');
                     break;
                 case UnitKind.PropsChange:
                     if (u.Element.Name == W.rPrChange
                         && u.Element.Parent?.Parent is { } run && run.Name == W.r)
-                        AppendVisibleText(run, W.t, sb);
+                        complete &= AppendVisibleText(run, W.t, sb, maximum);
                     else if (u.Element.Name == W.pPrChange
                         && u.Element.Parent?.Parent is { } para && para.Name == W.p)
-                        AppendVisibleText(para, W.t, sb);
+                        complete &= AppendVisibleText(para, W.t, sb, maximum);
                     break;
                 case UnitKind.CellMark:
                     if (u.MarkedCell is { } cell)
-                        AppendVisibleText(cell, u.Family == RevisionFamily.CellDelete ? W.delText : W.t, sb);
+                        complete &= AppendVisibleText(
+                            cell,
+                            u.Family == RevisionFamily.CellDelete ? W.delText : W.t,
+                            sb,
+                            maximum);
                     break;
                 case UnitKind.NumberingPropertiesInsert:
                 case UnitKind.NumberingChange:
                     if (u.Paragraph is { } numberedParagraph)
-                        AppendVisibleText(numberedParagraph, W.t, sb);
+                        complete &= AppendVisibleText(numberedParagraph, W.t, sb, maximum);
                     break;
                 case UnitKind.StructuredRange:
                     if (u.StructuredWrapper is { } wrapper)
-                        AppendVisibleText(wrapper, W.t, sb);
+                        complete &= AppendVisibleText(wrapper, W.t, sb, maximum);
                     break;
             }
+            if (!complete) break;
         }
         return sb.ToString();
     }
 
-    private static void AppendVisibleText(XElement el, XName textName, StringBuilder sb)
+    private static bool AppendVisibleText(
+        XElement el, XName textName, StringBuilder sb, int maximumCharacters)
     {
         foreach (var child in el.Elements())
         {
             var n = child.Name;
             if (n == W.pPr || n == W.rPr || n == W.trPr || n == W.tcPr || n == W.tblPr) continue;
-            if (n == textName) { sb.Append(child.Value); continue; }
-            if (n == W.tab) { sb.Append('\t'); continue; }
-            if (n == W.br || n == W.cr) { sb.Append('\n'); continue; }
-            if (child.HasElements) AppendVisibleText(child, textName, sb);
+            if (n == textName)
+            {
+                var value = child.Value;
+                if (sb.Length > maximumCharacters - value.Length) return false;
+                sb.Append(value);
+                continue;
+            }
+            if (n == W.tab || n == W.br || n == W.cr)
+            {
+                if (sb.Length >= maximumCharacters) return false;
+                sb.Append(n == W.tab ? '\t' : '\n');
+                continue;
+            }
+            if (child.HasElements
+                && !AppendVisibleText(child, textName, sb, maximumCharacters))
+                return false;
         }
+        return true;
     }
 
     // ─── Resolution ─────────────────────────────────────────────────────
@@ -1352,7 +1833,11 @@ internal static class RevisionOps
     /// elements (<c>w:p</c>/<c>w:tr</c>/<c>w:tbl</c>) the resolution detached, so the caller
     /// can report their anchors as removed.
     /// </summary>
-    internal static List<XElement> Apply(RevisionGroup g, bool accept)
+    internal static List<XElement> Apply(
+        RevisionGroup g,
+        bool accept,
+        bool preserveUnrelatedMarkup = false,
+        IReadOnlyCollection<string>? protectedEmptyContainerKeys = null)
     {
         if (g.ResolutionStatus != RevisionResolutionStatus.Supported)
             throw new InvalidOperationException(g.Diagnostic?.Message
@@ -1372,8 +1857,8 @@ internal static class RevisionOps
         foreach (var u in g.Units.Where(u => u.Kind == UnitKind.PropsChange))
         {
             if (Detached(u.Element)) continue;
-            if (accept) AcceptProps(u.Element);
-            else RejectProps(u.Element);
+            if (accept) AcceptProps(u.Element, g.PartUri, protectedEmptyContainerKeys);
+            else RejectProps(u.Element, g.PartUri, protectedEmptyContainerKeys);
         }
 
         foreach (var u in g.Units.Where(u => u.Kind == UnitKind.Content))
@@ -1390,7 +1875,8 @@ internal static class RevisionOps
         {
             if (Detached(u.Element)) continue;
             bool rowSurvives = u.Type == TypeInsert ? accept : !accept;
-            if (rowSurvives) StripRowMark(u.Element);
+            if (rowSurvives) StripRowMark(
+                u.Element, g.PartUri, protectedEmptyContainerKeys);
             else RemoveRow(u.MarkedRow!, removedBlocks);
         }
 
@@ -1401,13 +1887,19 @@ internal static class RevisionOps
             if (accept)
                 u.Element.Remove();
             else if (numPr?.Name == W.numPr)
+            {
+                var propertyParent = numPr.Parent;
                 numPr.Remove();
+                RemoveEmptyPropertyAncestors(
+                    propertyParent, g.PartUri, protectedEmptyContainerKeys);
+            }
         }
 
         foreach (var u in g.Units.Where(u => u.Kind == UnitKind.NumberingChange))
             if (!Detached(u.Element)) u.Element.Remove();
 
-        ResolveCellStructure(g, accept, removedBlocks);
+        ResolveCellStructure(
+            g, accept, removedBlocks, protectedEmptyContainerKeys);
 
         // If resolving this revision removes an SDT envelope, expose its paragraphs before
         // resolving their pilcrows. A last paragraph inside w:sdtContent can then coalesce with
@@ -1427,7 +1919,10 @@ internal static class RevisionOps
             touchedParagraphs.Add(u.Paragraph);
             if (ContentSurvives(u.Element.Name, accept))
             {
+                var markerParent = u.Element.Parent;
                 u.Element.Remove();
+                RemoveEmptyPropertyAncestors(
+                    markerParent, g.PartUri, protectedEmptyContainerKeys);
             }
             else
             {
@@ -1462,17 +1957,21 @@ internal static class RevisionOps
             }
         }
 
-        foreach (var p in touchedParagraphs)
-        {
-            if (Detached(p)) continue;
-            CleanParagraphHusks(p);
-        }
+        if (!preserveUnrelatedMarkup)
+            foreach (var p in touchedParagraphs)
+            {
+                if (Detached(p)) continue;
+                CleanParagraphHusks(p);
+            }
 
         return removedBlocks;
     }
 
     private static void ResolveCellStructure(
-        RevisionGroup group, bool accept, List<XElement> removedElements)
+        RevisionGroup group,
+        bool accept,
+        List<XElement> removedElements,
+        IReadOnlyCollection<string>? protectedEmptyContainerKeys)
     {
         var cellUnits = group.Units.Where(u => u.Kind == UnitKind.CellMark).ToList();
         if (cellUnits.Count == 0) return;
@@ -1482,7 +1981,13 @@ internal static class RevisionOps
             if (accept)
             {
                 foreach (var unit in cellUnits)
-                    if (!Detached(unit.Element)) unit.Element.Remove();
+                    if (!Detached(unit.Element))
+                    {
+                        var markerParent = unit.Element.Parent;
+                        unit.Element.Remove();
+                        RemoveEmptyPropertyAncestors(
+                            markerParent, group.PartUri, protectedEmptyContainerKeys);
+                    }
             }
             else
             {
@@ -1501,7 +2006,13 @@ internal static class RevisionOps
                 AcceptDeletedCells(cellUnits, removedElements);
             else
                 foreach (var unit in cellUnits)
-                    if (!Detached(unit.Element)) unit.Element.Remove();
+                    if (!Detached(unit.Element))
+                    {
+                        var markerParent = unit.Element.Parent;
+                        unit.Element.Remove();
+                        RemoveEmptyPropertyAncestors(
+                            markerParent, group.PartUri, protectedEmptyContainerKeys);
+                    }
         }
         else if (group.Family == RevisionFamily.CellMerge)
         {
@@ -1543,13 +2054,15 @@ internal static class RevisionOps
             var structuralName = group.Family == RevisionFamily.CellInsert ? W.cellIns
                 : group.Family == RevisionFamily.CellDelete ? W.cellDel
                 : W.cellMerge;
-            foreach (var table in cellUnits.Select(u => u.Table).Where(t => t is not null)
-                .Select(t => t!).Distinct())
+            foreach (var cell in cellUnits.Select(u => u.MarkedCell).Where(c => c is not null)
+                .Select(c => c!).Distinct())
             {
-                foreach (var marker in table.Descendants()
-                    .Where(e => e.Name == structuralName)
+                var directMarkers = cell.Element(W.tcPr)?.Elements(structuralName)
                     .Where(e => AuthorOf(e) == group.Author
-                        && (string?)e.Attribute(W.date) == group.Date).ToList())
+                        && (string?)e.Attribute(W.date) == group.Date
+                        && DateUtcOf(e) == group.DateUtc).ToList();
+                if (directMarkers is null) continue;
+                foreach (var marker in directMarkers)
                     marker.Remove();
             }
         }
@@ -1654,8 +2167,9 @@ internal static class RevisionOps
         if (wrapperSurvives) return;
 
         var content = wrapper.Element(W.sdtContent);
-        var nodes = content?.Nodes().Where(n => n is not XElement e
-            || !StructuredRangeNames.Contains(e.Name)).ToList() ?? new List<XNode>();
+        // Preserve every payload node, including independently owned nested range revisions.
+        // The caller removes only this group's four exact marker objects after unwrapping.
+        var nodes = content?.Nodes().ToList() ?? new List<XNode>();
         foreach (var node in nodes) node.Remove();
         wrapper.ReplaceWith(nodes);
         removedElements.Add(wrapper);
@@ -1718,22 +2232,34 @@ internal static class RevisionOps
     private static bool Detached(XElement e) => e.Document is null;
 
     /// <summary>Whether <paramref name="paragraph"/>'s container would still hold a
-    /// block-level child (<c>w:p</c> or <c>w:tbl</c>) after removing it. Every OOXML
+    /// block-level child after removing it. Every OOXML
     /// paragraph container requires at least one, so the check is deliberately
     /// container-agnostic rather than a list of parent names: removing the last block-level
     /// child is a content-model violation wherever it happens.</summary>
     private static bool HasSurvivingBlockSibling(XElement paragraph) =>
         paragraph.Parent is { } container
-        && container.Elements().Any(sibling => !ReferenceEquals(sibling, paragraph)
-            && (sibling.Name == W.p || sibling.Name == W.tbl));
+        && (container.Name == W.body
+            || container.Elements().Any(sibling => !ReferenceEquals(sibling, paragraph)
+                && (sibling.Name == W.p || sibling.Name == W.tbl || sibling.Name == W.sdt
+                    || sibling.Name == W.customXml || sibling.Name == W.altChunk)));
 
     private static void UnwrapWrapper(XElement wrapper, bool restoreDeleted)
     {
         if (restoreDeleted)
         {
-            foreach (var dt in wrapper.Descendants(W.delText).ToList())
+            foreach (var dt in wrapper.Descendants(W.delText)
+                .Where(text => ReferenceEquals(
+                    text.Ancestors().FirstOrDefault(ancestor =>
+                        RevWrapperNames.Contains(ancestor.Name)),
+                    wrapper))
+                .ToList())
                 dt.ReplaceWith(new XElement(W.t, dt.Attributes(), dt.Nodes()));
-            foreach (var di in wrapper.Descendants(W.delInstrText).ToList())
+            foreach (var di in wrapper.Descendants(W.delInstrText)
+                .Where(text => ReferenceEquals(
+                    text.Ancestors().FirstOrDefault(ancestor =>
+                        RevWrapperNames.Contains(ancestor.Name)),
+                    wrapper))
+                .ToList())
                 di.ReplaceWith(new XElement(W.instrText, di.Attributes(), di.Nodes()));
         }
         // Detach the children before re-adding so they are MOVED, not cloned — a nested
@@ -1749,26 +2275,27 @@ internal static class RevisionOps
         var parent = wrapper.Parent;
         wrapper.Remove();
         // Collapse a hyperlink shell left with no content (mirrors RevisionProcessor's
-        // wholly-deleted-hyperlink rule); bookmarks inside it are preserved.
+        // wholly-deleted-hyperlink rule); range markers and reference-only runs are
+        // transparent and are preserved at the hyperlink's former position.
         while (parent is not null && parent.Name == W.hyperlink
-            && !parent.Elements().Any(e =>
-                e.Name != W.bookmarkStart && e.Name != W.bookmarkEnd && e.Name != W.proofErr))
+            && parent.Elements().All(IsIgnorableBetween))
         {
             var grandParent = parent.Parent;
-            var bookmarks = parent.Elements()
-                .Where(e => e.Name == W.bookmarkStart || e.Name == W.bookmarkEnd)
-                .ToList();
-            foreach (var b in bookmarks) b.Remove();
-            parent.ReplaceWith(bookmarks);
+            var survivingNodes = parent.Nodes().ToList();
+            foreach (var node in survivingNodes) node.Remove();
+            parent.ReplaceWith(survivingNodes);
             parent = grandParent;
         }
     }
 
-    private static void StripRowMark(XElement mark)
+    private static void StripRowMark(
+        XElement mark,
+        string partUri,
+        IReadOnlyCollection<string>? protectedEmptyContainerKeys)
     {
         var trPr = mark.Parent;
         mark.Remove();
-        if (trPr is not null && !trPr.HasElements && !trPr.HasAttributes) trPr.Remove();
+        RemoveEmptyPropertyAncestors(trPr, partUri, protectedEmptyContainerKeys);
     }
 
     private static void RemoveRow(XElement tr, List<XElement> removedBlocks)
@@ -1791,19 +2318,27 @@ internal static class RevisionOps
     private static XElement? MergeParagraphWithNext(XElement p)
     {
         XElement? next = null;
+        var boundaryNodes = new List<XElement>();
         foreach (var e in p.ElementsAfterSelf())
         {
-            if (IgnorableBetween.Contains(e.Name)) continue;
-            if (e.Name == W.p) next = e;
-            break;
+            if (e.Name == W.p)
+            {
+                next = e;
+                break;
+            }
+            if (!IsIgnorableBetween(e)) break;
+            boundaryNodes.Add(e);
         }
         if (next is null) return null;
 
-        var content = p.Elements().Where(e => e.Name != W.pPr).ToList();
-        foreach (var c in content) c.Remove();
+        var prefix = p.Nodes()
+            .Where(node => node is not XElement element || element.Name != W.pPr)
+            .Concat(boundaryNodes.Cast<XNode>())
+            .ToList();
+        foreach (var node in prefix) node.Remove();
         var nextPPr = next.Element(W.pPr);
-        if (nextPPr is not null) nextPPr.AddAfterSelf(content);
-        else next.AddFirst(content);
+        if (nextPPr is not null) nextPPr.AddAfterSelf(prefix);
+        else next.AddFirst(prefix);
         p.Remove();
         return p;
     }
@@ -1813,12 +2348,17 @@ internal static class RevisionOps
         var pPr = p.Element(W.pPr);
         if (pPr is null) return;
         var rPr = pPr.Element(W.rPr);
-        if (rPr is not null && !rPr.HasElements && HasNoSemanticAttributes(rPr)) rPr.Remove();
-        if (!pPr.HasElements && HasNoSemanticAttributes(pPr)) pPr.Remove();
+        if (rPr is not null && !rPr.HasElements && HasNoSemanticNodes(rPr)
+            && HasNoSemanticAttributes(rPr)) rPr.Remove();
+        if (!pPr.HasElements && HasNoSemanticNodes(pPr)
+            && HasNoSemanticAttributes(pPr)) pPr.Remove();
     }
 
     private static bool HasNoSemanticAttributes(XElement element) =>
         element.Attributes().All(a => a.IsNamespaceDeclaration || a.Name == PtOpenXml.Unid);
+
+    private static bool HasNoSemanticNodes(XElement element) =>
+        element.Nodes().All(node => node is XText text && string.IsNullOrWhiteSpace(text.Value));
 
     // ─── Format-change resolution ───────────────────────────────────────
 
@@ -1832,14 +2372,52 @@ internal static class RevisionOps
         W.rPr, W.pPr, W.trPr, W.tcPr, W.tblPrEx,
     };
 
-    private static void AcceptProps(XElement change)
+    internal static bool IsRemovableEmptyPropertyContainer(XName name) =>
+        RemovableEmptyPropertyContainers.Contains(name);
+
+    internal static bool IsEmptyRemovablePropertyContainer(XElement element) =>
+        RemovableEmptyPropertyContainers.Contains(element.Name)
+        && !element.HasElements
+        && HasNoSemanticNodes(element)
+        && HasNoSemanticAttributes(element);
+
+    internal static IReadOnlyList<string> EmptyPropertyContainerKeys(
+        string partUri, XElement element)
+    {
+        var prefix = partUri + "|" + element.Name.NamespaceName + ":"
+            + element.Name.LocalName + "|";
+        var anchorOwner = element.AncestorsAndSelf()
+            .FirstOrDefault(candidate => candidate.Attribute(PtOpenXml.Unid) is not null)
+            ?? element.Parent?.DescendantsAndSelf()
+                .FirstOrDefault(candidate => candidate.Attribute(PtOpenXml.Unid) is not null);
+        var keys = new List<string> { prefix + "path=" + ElementPath(element) };
+        if ((string?)anchorOwner?.Attribute(PtOpenXml.Unid) is { } unid)
+            keys.Add(prefix + "anchor=" + unid);
+        return keys;
+    }
+
+    private static void AcceptProps(
+        XElement change,
+        string partUri,
+        IReadOnlyCollection<string>? protectedEmptyContainerKeys)
     {
         var parent = change.Parent;
         change.Remove();
-        if (parent is not null && !parent.HasElements && HasNoSemanticAttributes(parent)
-            && RemovableEmptyPropertyContainers.Contains(parent.Name))
+        RemoveEmptyPropertyAncestors(parent, partUri, protectedEmptyContainerKeys);
+    }
+
+    private static void RemoveEmptyPropertyAncestors(
+        XElement? element,
+        string partUri,
+        IReadOnlyCollection<string>? protectedEmptyContainerKeys)
+    {
+        while (element is not null && IsEmptyRemovablePropertyContainer(element)
+            && !EmptyPropertyContainerKeys(partUri, element).Any(key =>
+                protectedEmptyContainerKeys?.Contains(key) == true))
         {
-            parent.Remove();
+            var parent = element.Parent;
+            element.Remove();
+            element = parent;
         }
     }
 
@@ -1847,62 +2425,80 @@ internal static class RevisionOps
     /// the children the change's CT_*Base inner schema excludes (revision marks on a
     /// paragraph-mark rPr, header/footer references on sectPr, rPr/sectPr on pPr, row
     /// marks on trPr, cell revision marks on tcPr) in their schema position.</summary>
-    private static void RejectProps(XElement change)
+    private static void RejectProps(
+        XElement change,
+        string partUri,
+        IReadOnlyCollection<string>? protectedEmptyContainerKeys)
     {
         var parent = change.Parent;
         if (parent is null) { change.Remove(); return; }
         var stored = change.Elements().FirstOrDefault();
-        var storedChildren = stored?.Elements().Select(e => new XElement(e)).ToList()
-            ?? new List<XElement>();
+        var storedNodes = stored?.Nodes().Select(CloneNode).ToList()
+            ?? new List<XNode>();
+        var storedAttributes = stored?.Attributes()
+            .Where(attribute => !attribute.IsNamespaceDeclaration
+                && attribute.Name != PtOpenXml.Unid)
+            .Select(attribute => new XAttribute(attribute))
+            .ToList() ?? new List<XAttribute>();
         change.Remove();
+
+        // The archived property shell is the complete before-image, including attributes such
+        // as sectPr rsid values. Keep only projection metadata on the live shell, then restore
+        // every semantic attribute from the stored state.
+        parent.Attributes()
+            .Where(attribute => !attribute.IsNamespaceDeclaration
+                && attribute.Name != PtOpenXml.Unid)
+            .Remove();
+        parent.Add(storedAttributes);
 
         var pn = parent.Name;
         if (pn == W.rPr)
         {
             // CT_ParaRPr: ins/del/moveFrom/moveTo precede the property set.
             var marks = DetachAll(parent.Elements().Where(e => RevWrapperNames.Contains(e.Name)));
-            parent.ReplaceNodes(marks, storedChildren);
+            parent.ReplaceNodes(marks, storedNodes);
         }
         else if (pn == W.pPr)
         {
             // CT_PPr: base props, then rPr, then sectPr (pPrChange's stored pPr is CT_PPrBase).
             var rPr = DetachAll(parent.Elements(W.rPr));
             var sectPr = DetachAll(parent.Elements(W.sectPr));
-            parent.ReplaceNodes(storedChildren, rPr, sectPr);
+            parent.ReplaceNodes(storedNodes, rPr, sectPr);
         }
         else if (pn == W.sectPr)
         {
             // CT_SectPr: header/footer references come first (excluded from CT_SectPrBase).
             var refs = DetachAll(parent.Elements()
                 .Where(e => e.Name == W.headerReference || e.Name == W.footerReference));
-            parent.ReplaceNodes(refs, storedChildren);
+            parent.ReplaceNodes(refs, storedNodes);
         }
         else if (pn == W.trPr)
         {
             // CT_TrPr: base props, then ins/del row marks.
             var marks = DetachAll(parent.Elements().Where(e => e.Name == W.ins || e.Name == W.del));
-            parent.ReplaceNodes(storedChildren, marks);
+            parent.ReplaceNodes(storedNodes, marks);
         }
         else if (pn == W.tcPr)
         {
             // CT_TcPr: base props, then cellIns/cellDel/cellMerge.
             var cellRevs = DetachAll(parent.Elements()
                 .Where(e => e.Name == W.cellIns || e.Name == W.cellDel || e.Name == W.cellMerge));
-            parent.ReplaceNodes(storedChildren, cellRevs);
+            parent.ReplaceNodes(storedNodes, cellRevs);
         }
         else
         {
             // tblPr, tblGrid, tblPrEx — the stored element is the whole property set.
-            parent.ReplaceNodes(storedChildren);
+            parent.ReplaceNodes(storedNodes);
         }
 
         // A change whose stored old property set was empty leaves an empty husk —
         // remove it (Word writes no empty rPr/pPr), mirroring AcceptProps. tblPr/tblGrid
         // are excluded: see RemovableEmptyPropertyContainers.
-        if (!parent.HasElements && HasNoSemanticAttributes(parent)
-            && RemovableEmptyPropertyContainers.Contains(pn))
+        if (IsEmptyRemovablePropertyContainer(parent))
         {
-            parent.Remove();
+            if (!EmptyPropertyContainerKeys(partUri, parent).Any(key =>
+                    protectedEmptyContainerKeys?.Contains(key) == true))
+                parent.Remove();
         }
     }
 
@@ -1912,4 +2508,20 @@ internal static class RevisionOps
         foreach (var e in list) e.Remove();
         return list;
     }
+
+    private static XNode CloneNode(XNode node) => node switch
+    {
+        XElement element => new XElement(element),
+        XText text => new XText(text.Value),
+        XComment comment => new XComment(comment.Value),
+        XProcessingInstruction instruction =>
+            new XProcessingInstruction(instruction.Target, instruction.Data),
+        XDocumentType documentType => new XDocumentType(
+            documentType.Name,
+            documentType.PublicId,
+            documentType.SystemId,
+            documentType.InternalSubset),
+        _ => throw new InvalidOperationException(
+            $"Unsupported XML node in revision before-image: {node.NodeType}."),
+    };
 }

--- a/Docxodus/Internal/RevisionOps.cs
+++ b/Docxodus/Internal/RevisionOps.cs
@@ -1866,7 +1866,13 @@ internal static class RevisionOps
             if (Detached(u.Element)) continue;
             if (u.Paragraph is not null) touchedParagraphs.Add(u.Paragraph);
             if (ContentSurvives(u.Element.Name, accept))
-                UnwrapWrapper(u.Element, restoreDeleted: u.Element.Name == W.del);
+                // A surviving w:del OR w:moveFrom un-deletes its payload: the comparison
+                // engine serializes move-source text as w:delText (delete-grade), so a
+                // rejected move must restore it exactly like a rejected deletion — the
+                // reject-all transform converts every delText unconditionally, and leaving
+                // it strands the text as orphaned w:delText once the wrapper is gone.
+                UnwrapWrapper(u.Element, restoreDeleted:
+                    u.Element.Name == W.del || u.Element.Name == W.moveFrom);
             else
                 RemoveContentWrapper(u.Element);
         }

--- a/Docxodus/Internal/RevisionRegistry.cs
+++ b/Docxodus/Internal/RevisionRegistry.cs
@@ -52,15 +52,23 @@ internal sealed class RevisionRegistry
                 "unresolved_revision",
                 "The revision cannot be resolved safely.");
 
-    internal List<XElement> Resolve(RevisionOps.RevisionGroup group, bool accept) =>
-        RevisionOps.Apply(group, accept);
+    internal List<XElement> Resolve(
+        RevisionOps.RevisionGroup group,
+        bool accept,
+        bool preserveUnrelatedMarkup = false,
+        IReadOnlyCollection<string>? protectedEmptyContainerKeys = null) =>
+        RevisionOps.Apply(
+            group, accept, preserveUnrelatedMarkup, protectedEmptyContainerKeys);
 
     /// <summary>
     /// Resolve every currently live revision through the same selective resolver used
     /// by individual operations. Rebuild after every group so newly exposed archived
     /// revisions are handled and detached nested groups disappear naturally.
     /// </summary>
-    internal List<XElement> ResolveAll(bool accept)
+    internal List<XElement> ResolveAll(
+        bool accept,
+        bool preserveUnrelatedMarkup = false,
+        IReadOnlyCollection<string>? protectedEmptyContainerKeys = null)
     {
         var removed = new List<XElement>();
         var registry = this;
@@ -81,7 +89,8 @@ internal sealed class RevisionRegistry
                 throw new InvalidOperationException(
                     "Bulk revision resolution made no progress; the document was left unchanged.");
 
-            removed.AddRange(registry.Resolve(next, accept));
+            removed.AddRange(registry.Resolve(
+                next, accept, preserveUnrelatedMarkup, protectedEmptyContainerKeys));
             registry = Build(_parts);
         }
 

--- a/Docxodus/Verification/PackageDelta.cs
+++ b/Docxodus/Verification/PackageDelta.cs
@@ -24,6 +24,12 @@ internal sealed record PackageDeltaChange
 {
     required internal PackageDeltaChangeKind Kind { get; init; }
     required internal ChangeLocation Location { get; init; }
+    /// <summary>
+    /// Zero-based occurrence within entries sharing a URI or relationships sharing an owner/ID.
+    /// Keeping this structural key explicit lets policy adapters consume the shared delta without
+    /// parsing its human-readable property path.
+    /// </summary>
+    required internal int Occurrence { get; init; }
     internal VerificationDigest? BeforeDigest { get; init; }
     internal VerificationDigest? AfterDigest { get; init; }
     internal string? BeforeValue { get; init; }
@@ -98,6 +104,7 @@ internal static class PackageDelta
             changes.Add(new PackageDeltaChange
             {
                 Kind = kind,
+                Occurrence = key.Occurrence,
                 Location = new ChangeLocation
                 {
                     EntryUri = key.Uri,
@@ -141,6 +148,7 @@ internal static class PackageDelta
             changes.Add(new PackageDeltaChange
             {
                 Kind = kind,
+                Occurrence = key.Occurrence,
                 Location = new ChangeLocation
                 {
                     OwnerUri = key.OwnerUri,

--- a/Docxodus/Verification/PackageManifest.cs
+++ b/Docxodus/Verification/PackageManifest.cs
@@ -228,6 +228,16 @@ public sealed record PackageAnnotationCounts
 /// <summary>High-signal package and renderer facts derived without opening a mutable SDK package.</summary>
 public sealed record PackageManifestFacts
 {
+    /// <summary>
+    /// Exact physical tracked-change carriers found during the bounded manifest XML pass. This is
+    /// intentionally internal: schema-v1's public revision counts describe logical families, while
+    /// proof admission needs a conservative carrier count before constructing a mutable session.
+    /// </summary>
+    internal long NativeRevisionCarrierCount { get; init; }
+
+    /// <summary>Whether any physical tracked-change carrier uses the strict Word namespace.</summary>
+    internal bool HasStrictRevisionMarkup { get; init; }
+
     public string? MainDocumentUri { get; init; }
     public bool IsStrictOoxml { get; init; }
     public bool IsMacroEnabled { get; init; }

--- a/Docxodus/Verification/PackageManifestGenerator.cs
+++ b/Docxodus/Verification/PackageManifestGenerator.cs
@@ -35,6 +35,8 @@ public static class PackageManifestGenerator
         "http://purl.oclc.org/ooxml/wordprocessingml/main";
     private const string Word2012Namespace =
         "http://schemas.microsoft.com/office/word/2012/wordml";
+    private const string Word2010Namespace =
+        "http://schemas.microsoft.com/office/word/2010/wordml";
     private static readonly AsciiCaseInsensitiveComparer PartNameComparer =
         AsciiCaseInsensitiveComparer.Instance;
     private static readonly uint[] Crc32Table = CreateCrc32Table();
@@ -908,6 +910,8 @@ public static class PackageManifestGenerator
         var resolvedComments = 0;
         var people = 0;
         var annotations = 0;
+        long nativeRevisionCarrierCount = 0;
+        var hasStrictRevisionMarkup = false;
         var isStrict = relationships.Any(relationship =>
             OpenXmlRelationshipVocabulary.IsStrictOfficeType(relationship.Type));
 
@@ -922,6 +926,13 @@ public static class PackageManifestGenerator
             var storyElements = IsWordprocessingStoryPart(work)
                 ? wordElements
                 : new List<XElement>();
+            var revisionCarriers = isWordPart
+                ? elements.Where(IsNativeRevisionCarrier).ToList()
+                : new List<XElement>();
+            nativeRevisionCarrierCount = checked(
+                nativeRevisionCarrierCount + revisionCarriers.Count);
+            hasStrictRevisionMarkup |= revisionCarriers.Any(element =>
+                element.Name.NamespaceName == StrictWordNamespace);
             isStrict |= isWordPart && wordElements.Any(element =>
                 element.Name.NamespaceName == StrictWordNamespace);
             paragraphCount += storyElements.Count(element => element.Name.LocalName == "p");
@@ -991,6 +1002,8 @@ public static class PackageManifestGenerator
         };
         return new PackageManifestFacts
         {
+            NativeRevisionCarrierCount = nativeRevisionCarrierCount,
+            HasStrictRevisionMarkup = hasStrictRevisionMarkup,
             MainDocumentUri = mainDocumentUri,
             IsStrictOoxml = isStrict,
             IsMacroEnabled = works.Any(work =>
@@ -1855,6 +1868,37 @@ public static class PackageManifestGenerator
         "numberingChange" or "pPrChange" or "rPrChange" or "sectPrChange"
         or "tblGridChange" or "tblPrChange" or "tblPrExChange" or "tcPrChange"
         or "trPrChange";
+
+    private static bool IsNativeRevisionCarrier(XElement element)
+    {
+        if (element.Name.NamespaceName == Word2010Namespace)
+        {
+            return element.Name.LocalName is "conflictIns" or "conflictDel"
+                or "customXmlConflictInsRangeStart" or "customXmlConflictInsRangeEnd"
+                or "customXmlConflictDelRangeStart" or "customXmlConflictDelRangeEnd";
+        }
+
+        if (!IsWordprocessingElement(element))
+            return false;
+
+        var localName = element.Name.LocalName;
+        if (localName is "delText" or "delInstrText")
+        {
+            return !element.Ancestors().Any(ancestor =>
+                IsWordprocessingElement(ancestor)
+                && ancestor.Name.LocalName is "del" or "moveFrom");
+        }
+
+        return localName is "ins" or "del" or "moveFrom" or "moveTo"
+            or "moveFromRangeStart" or "moveFromRangeEnd"
+            or "moveToRangeStart" or "moveToRangeEnd"
+            or "customXmlInsRangeStart" or "customXmlInsRangeEnd"
+            or "customXmlDelRangeStart" or "customXmlDelRangeEnd"
+            or "customXmlMoveFromRangeStart" or "customXmlMoveFromRangeEnd"
+            or "customXmlMoveToRangeStart" or "customXmlMoveToRangeEnd"
+            or "cellIns" or "cellDel" or "cellMerge"
+            || IsPropertyRevisionName(localName);
+    }
 
     private static bool IsCustomXmlRevisionRangeStart(string localName) => localName is
         "customXmlInsRangeStart" or "customXmlDelRangeStart"

--- a/Docxodus/Verification/RedlineReversibilityProof.cs
+++ b/Docxodus/Verification/RedlineReversibilityProof.cs
@@ -130,6 +130,7 @@ public sealed record RedlineProofPathResult
     required public bool Equivalent { get; init; }
     required public IReadOnlyList<string> RequestedRevisionIds { get; init; }
     required public IReadOnlyList<string> ResolvedRevisionIds { get; init; }
+    required public IReadOnlyList<string> ImplicitlyResolvedRevisionIds { get; init; }
     required public IReadOnlyList<RedlineRevisionIdentity> SurvivingPreExistingRevisions { get; init; }
     required public bool PreExistingRevisionsPreserved { get; init; }
     required public RedlineModeledSemanticComparison ModeledSemantic { get; init; }

--- a/Docxodus/Verification/RedlineReversibilityProof.cs
+++ b/Docxodus/Verification/RedlineReversibilityProof.cs
@@ -1,0 +1,201 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Docxodus.Verification;
+
+/// <summary>How a revision in a redline relates to the selected baseline.</summary>
+public enum RedlineRevisionDisposition
+{
+    PreExisting,
+    Generated,
+    Conflicted,
+}
+
+/// <summary>The proof path that was evaluated.</summary>
+public enum RedlineProofDirection
+{
+    AcceptToFinal,
+    RejectToBaseline,
+}
+
+/// <summary>How a package entry differs from the path's expected document.</summary>
+public enum RedlinePackageDivergenceKind
+{
+    Added,
+    Removed,
+    Modified,
+}
+
+/// <summary>
+/// Settings for <see cref="RedlineReversibilityVerifier.Prove"/>. Package limits are shared with
+/// package-manifest generation; proof verification never opens a package that fails that preflight.
+/// </summary>
+public sealed record RedlineReversibilityProofOptions
+{
+    public PackageManifestOptions PackageManifestOptions { get; init; } = new();
+
+    /// <summary>
+    /// Require identical ZIP bytes in addition to modeled and normalized whole-package equality.
+    /// This is normally false because harmless ZIP timestamps, order, and compression may differ.
+    /// </summary>
+    public bool RequireExactPackageBytes { get; init; }
+}
+
+/// <summary>A stable, part-qualified identity for one native Word revision.</summary>
+public sealed record RedlineRevisionIdentity
+{
+    required public string Id { get; init; }
+    required public string PartUri { get; init; }
+    required public string Scope { get; init; }
+    required public string Type { get; init; }
+    required public RevisionFamily Family { get; init; }
+    required public IReadOnlyList<string> ConstituentIds { get; init; }
+    required public string Author { get; init; }
+    public string? Date { get; init; }
+    required public string Text { get; init; }
+    public string? AnchorId { get; init; }
+    required public IReadOnlyList<string> AffectedAnchorIds { get; init; }
+    required public RevisionResolutionStatus ResolutionStatus { get; init; }
+    public RevisionDiagnostic? Diagnostic { get; init; }
+}
+
+/// <summary>Classification of a baseline/redline revision identity pair.</summary>
+public sealed record RedlineRevisionClassification
+{
+    required public RedlineRevisionDisposition Disposition { get; init; }
+    public RedlineRevisionIdentity? Baseline { get; init; }
+    public RedlineRevisionIdentity? Redline { get; init; }
+    required public string Reason { get; init; }
+}
+
+/// <summary>Input or output package identity recorded by the proof.</summary>
+public sealed record RedlineProofPackageIdentity
+{
+    required public VerificationDigest RawPackageBytesDigest { get; init; }
+    public VerificationDigest? OrderedOpcContentDigest { get; init; }
+    public VerificationDigest? NormalizedWholePackageDigest { get; init; }
+}
+
+/// <summary>
+/// Modeled semantic comparison result. The semantic schema and change count are explicit so a
+/// caller never mistakes an empty modeled change set for complete package equality.
+/// </summary>
+public sealed record RedlineModeledSemanticComparison
+{
+    required public bool Available { get; init; }
+    public bool? Equivalent { get; init; }
+    public string? Schema { get; init; }
+    public int? ChangeCount { get; init; }
+    public string? Diagnostic { get; init; }
+}
+
+/// <summary>One added, removed, or modified package entry.</summary>
+public sealed record RedlinePackageDivergence
+{
+    required public RedlinePackageDivergenceKind Kind { get; init; }
+    required public string PartUri { get; init; }
+    required public int Occurrence { get; init; }
+    public string? AnchorId { get; init; }
+    required public IReadOnlyList<string> ApplicableRevisionIds { get; init; }
+    public VerificationDigest? ExpectedRawDigest { get; init; }
+    public VerificationDigest? ActualRawDigest { get; init; }
+    public VerificationDigest? ExpectedNormalizedDigest { get; init; }
+    public VerificationDigest? ActualNormalizedDigest { get; init; }
+    required public bool UnknownOrUnmodeled { get; init; }
+}
+
+/// <summary>A structured, actionable proof finding.</summary>
+public sealed record RedlineProofFinding
+{
+    required public string Code { get; init; }
+    required public VerificationFindingSeverity Severity { get; init; }
+    required public string Message { get; init; }
+    public RedlineProofDirection? Direction { get; init; }
+    public ChangeLocation? Location { get; init; }
+    public string? AnchorId { get; init; }
+    required public IReadOnlyList<string> RevisionIds { get; init; }
+    public string? Remediation { get; init; }
+}
+
+/// <summary>Result of accepting or rejecting only the generated revision set.</summary>
+public sealed record RedlineProofPathResult
+{
+    required public RedlineProofDirection Direction { get; init; }
+    required public bool Completed { get; init; }
+    required public bool Equivalent { get; init; }
+    required public IReadOnlyList<string> RequestedRevisionIds { get; init; }
+    required public IReadOnlyList<string> ResolvedRevisionIds { get; init; }
+    required public IReadOnlyList<RedlineRevisionIdentity> SurvivingPreExistingRevisions { get; init; }
+    required public bool PreExistingRevisionsPreserved { get; init; }
+    required public RedlineModeledSemanticComparison ModeledSemantic { get; init; }
+    required public bool NormalizedWholePackageEquivalent { get; init; }
+    required public bool OrderedOpcContentEquivalent { get; init; }
+    required public bool ExactPackageBytesEquivalent { get; init; }
+    required public RedlineProofPackageIdentity ExpectedPackage { get; init; }
+    public RedlineProofPackageIdentity? ActualPackage { get; init; }
+    public RedlinePackageDivergence? FirstDivergence { get; init; }
+    required public IReadOnlyList<RedlinePackageDivergence> Divergences { get; init; }
+    required public IReadOnlyList<RedlineProofFinding> Findings { get; init; }
+}
+
+/// <summary>
+/// Versioned, receipt-embeddable proof that generated changes accept to the intended final and
+/// reject to the selected baseline without consuming pre-existing review state.
+/// </summary>
+public sealed record RedlineReversibilityProof
+{
+    public const string SchemaId =
+        "https://docxodus.dev/schemas/verification/redline-reversibility-proof/v1";
+
+    public string Schema { get; init; } = SchemaId;
+    public int SchemaVersion { get; init; } = 1;
+    required public bool Success { get; init; }
+    required public bool RequireExactPackageBytes { get; init; }
+    required public RedlineProofPackageIdentity BaselinePackage { get; init; }
+    required public RedlineProofPackageIdentity IntendedFinalPackage { get; init; }
+    required public RedlineProofPackageIdentity RedlinePackage { get; init; }
+    required public IReadOnlyList<RedlineRevisionClassification> RevisionClassifications { get; init; }
+    public RedlineProofPathResult? AcceptToFinal { get; init; }
+    public RedlineProofPathResult? RejectToBaseline { get; init; }
+    required public IReadOnlyList<RedlineProofFinding> Findings { get; init; }
+
+    /// <summary>Serialize the canonical, compact proof JSON used by delivery receipts.</summary>
+    public string ToCanonicalJson() => JsonSerializer.Serialize(this, JsonOptions.Canonical);
+
+    /// <summary>Serialize proof JSON, optionally indented for a human-viewable artifact.</summary>
+    public string ToJson(bool indented = true) => JsonSerializer.Serialize(
+        this, indented ? JsonOptions.Indented : JsonOptions.Canonical);
+
+    private static class JsonOptions
+    {
+        internal static readonly JsonSerializerOptions Canonical = Create(indented: false);
+        internal static readonly JsonSerializerOptions Indented = Create(indented: true);
+
+        private static JsonSerializerOptions Create(bool indented)
+        {
+            var options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = indented,
+            };
+            options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+            return options;
+        }
+    }
+}
+
+/// <summary>
+/// Proof metadata plus the two concrete output packages. Package bytes are deliberately outside
+/// the JSON proof so a delivery receipt embeds hashes and structured evidence rather than base64.
+/// </summary>
+public sealed record RedlineReversibilityProofRun
+{
+    required public RedlineReversibilityProof Proof { get; init; }
+    public byte[]? AcceptedPackageBytes { get; init; }
+    public byte[]? RejectedPackageBytes { get; init; }
+}

--- a/Docxodus/Verification/RedlineReversibilityProof.cs
+++ b/Docxodus/Verification/RedlineReversibilityProof.cs
@@ -40,6 +40,14 @@ public sealed record RedlineReversibilityProofOptions
     public PackageManifestOptions PackageManifestOptions { get; init; } = new();
 
     /// <summary>
+    /// Maximum native revision elements accepted in either the baseline or redline package.
+    /// Selective resolution rebuilds the live registry after every operation, so this explicit
+    /// bound prevents adversarial revision inventories from turning both proof paths into
+    /// unbounded quadratic work. Raise it only for a reviewed, trusted workflow.
+    /// </summary>
+    public int MaxRevisionElements { get; init; } = 1_000;
+
+    /// <summary>
     /// Require identical ZIP bytes in addition to modeled and normalized whole-package equality.
     /// This is normally false because harmless ZIP timestamps, order, and compression may differ.
     /// </summary>

--- a/Docxodus/Verification/RedlineReversibilityProof.cs
+++ b/Docxodus/Verification/RedlineReversibilityProof.cs
@@ -106,6 +106,13 @@ public sealed record RedlinePackageDivergence
     public VerificationDigest? ActualRawDigest { get; init; }
     public VerificationDigest? ExpectedNormalizedDigest { get; init; }
     public VerificationDigest? ActualNormalizedDigest { get; init; }
+    /// <summary>Whether the semantic change set reports a modeled change for this part.</summary>
+    required public bool HasModeledSemanticChange { get; init; }
+    /// <summary>
+    /// Whether the normalized entry difference may contain content outside the modeled semantic
+    /// projection. This is deliberately conservative because a modeled change in one part does
+    /// not prove that every other change in that part was modeled.
+    /// </summary>
     required public bool UnknownOrUnmodeled { get; init; }
 }
 

--- a/Docxodus/Verification/RedlineReversibilityProof.cs
+++ b/Docxodus/Verification/RedlineReversibilityProof.cs
@@ -5,6 +5,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text;
 
 namespace Docxodus.Verification;
 
@@ -12,6 +13,7 @@ namespace Docxodus.Verification;
 public enum RedlineRevisionDisposition
 {
     PreExisting,
+    IntendedFinalPreExisting,
     Generated,
     Conflicted,
 }
@@ -40,12 +42,43 @@ public sealed record RedlineReversibilityProofOptions
     public PackageManifestOptions PackageManifestOptions { get; init; } = new();
 
     /// <summary>
-    /// Maximum native revision elements accepted in either the baseline or redline package.
+    /// Maximum aggregate raw bytes accepted across the baseline, intended-final, and redline
+    /// packages. This admission check runs before package inspection or session construction.
+    /// </summary>
+    public long MaxPackageBytes { get; init; } = 100L * 1024 * 1024;
+
+    /// <summary>
+    /// Maximum native revision elements accepted in any baseline, intended-final, redline, or
+    /// live path-output package.
     /// Selective resolution rebuilds the live registry after every operation, so this explicit
     /// bound prevents adversarial revision inventories from turning both proof paths into
     /// unbounded quadratic work. Raise it only for a reviewed, trusted workflow.
     /// </summary>
     public int MaxRevisionElements { get; init; } = 1_000;
+
+    /// <summary>Maximum semantic changes produced while comparing either proof path.</summary>
+    public int MaxSemanticChanges { get; init; } = 25_000;
+
+    /// <summary>Maximum package-delta records inspected for either proof path.</summary>
+    public int MaxPackageChanges { get; init; } = 25_000;
+
+    /// <summary>
+    /// Maximum ordinary findings retained across the complete proof. If this limit is exceeded,
+    /// one additional fail-closed resource finding is emitted and later findings are suppressed.
+    /// </summary>
+    public int MaxFindings { get; init; } = 10_000;
+
+    /// <summary>
+    /// Maximum aggregate constituent-ID, constituent-key, and affected-anchor records retained
+    /// while constructing each baseline, intended-final, redline, or live path inventory.
+    /// </summary>
+    public int MaxRevisionEvidenceItems { get; init; } = 25_000;
+
+    /// <summary>
+    /// Maximum aggregate characters retained from revision identities, including authors, text,
+    /// IDs, anchors, scopes, dates, and diagnostics.
+    /// </summary>
+    public long MaxEvidenceTextCharacters { get; init; } = 4L * 1024 * 1024;
 
     /// <summary>
     /// Require identical ZIP bytes in addition to modeled and normalized whole-package equality.
@@ -63,8 +96,10 @@ public sealed record RedlineRevisionIdentity
     required public string Type { get; init; }
     required public RevisionFamily Family { get; init; }
     required public IReadOnlyList<string> ConstituentIds { get; init; }
+    required public IReadOnlyList<string> ConstituentKeys { get; init; }
     required public string Author { get; init; }
     public string? Date { get; init; }
+    public string? DateUtc { get; init; }
     required public string Text { get; init; }
     public string? AnchorId { get; init; }
     required public IReadOnlyList<string> AffectedAnchorIds { get; init; }
@@ -77,6 +112,7 @@ public sealed record RedlineRevisionClassification
 {
     required public RedlineRevisionDisposition Disposition { get; init; }
     public RedlineRevisionIdentity? Baseline { get; init; }
+    public RedlineRevisionIdentity? IntendedFinal { get; init; }
     public RedlineRevisionIdentity? Redline { get; init; }
     required public string Reason { get; init; }
 }
@@ -152,6 +188,11 @@ public sealed record RedlineProofPathResult
     required public bool NormalizedWholePackageEquivalent { get; init; }
     required public bool OrderedOpcContentEquivalent { get; init; }
     required public bool ExactPackageBytesEquivalent { get; init; }
+    /// <summary>
+    /// Whether the complete bounded package delta was available. A false value never exposes a
+    /// potentially misleading prefix of divergences.
+    /// </summary>
+    required public bool DivergenceAnalysisCompleted { get; init; }
     required public RedlineProofPackageIdentity ExpectedPackage { get; init; }
     public RedlineProofPackageIdentity? ActualPackage { get; init; }
     public RedlinePackageDivergence? FirstDivergence { get; init; }
@@ -180,29 +221,55 @@ public sealed record RedlineReversibilityProof
     public RedlineProofPathResult? RejectToBaseline { get; init; }
     required public IReadOnlyList<RedlineProofFinding> Findings { get; init; }
 
+    /// <summary>Serialize the canonical, compact proof bytes used by delivery receipts.</summary>
+    public byte[] ToCanonicalUtf8Bytes() => JsonSerializer.SerializeToUtf8Bytes(
+        this, JsonOptions.Canonical.RedlineReversibilityProof);
+
     /// <summary>Serialize the canonical, compact proof JSON used by delivery receipts.</summary>
-    public string ToCanonicalJson() => JsonSerializer.Serialize(this, JsonOptions.Canonical);
+    public string ToCanonicalJson() => Encoding.UTF8.GetString(ToCanonicalUtf8Bytes());
 
     /// <summary>Serialize proof JSON, optionally indented for a human-viewable artifact.</summary>
     public string ToJson(bool indented = true) => JsonSerializer.Serialize(
-        this, indented ? JsonOptions.Indented : JsonOptions.Canonical);
+        this, (indented ? JsonOptions.Indented : JsonOptions.Canonical)
+            .RedlineReversibilityProof);
 
     private static class JsonOptions
     {
-        internal static readonly JsonSerializerOptions Canonical = Create(indented: false);
-        internal static readonly JsonSerializerOptions Indented = Create(indented: true);
+        internal static readonly RedlineReversibilityProofJsonContext Canonical =
+            Create(indented: false);
+        internal static readonly RedlineReversibilityProofJsonContext Indented =
+            Create(indented: true);
 
-        private static JsonSerializerOptions Create(bool indented)
+        private static RedlineReversibilityProofJsonContext Create(bool indented)
         {
             var options = new JsonSerializerOptions
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                 WriteIndented = indented,
             };
-            options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
-            return options;
+            options.Converters.Add(new JsonStringEnumConverter<RedlineRevisionDisposition>(
+                JsonNamingPolicy.CamelCase));
+            options.Converters.Add(new JsonStringEnumConverter<RedlineProofDirection>(
+                JsonNamingPolicy.CamelCase));
+            options.Converters.Add(new JsonStringEnumConverter<RedlinePackageDivergenceKind>(
+                JsonNamingPolicy.CamelCase));
+            options.Converters.Add(new JsonStringEnumConverter<RevisionFamily>(
+                JsonNamingPolicy.CamelCase));
+            options.Converters.Add(new JsonStringEnumConverter<RevisionResolutionStatus>(
+                JsonNamingPolicy.CamelCase));
+            options.Converters.Add(new JsonStringEnumConverter<VerificationFindingSeverity>(
+                JsonNamingPolicy.CamelCase));
+            return new RedlineReversibilityProofJsonContext(options);
         }
     }
+}
+
+/// <summary>Trim/AOT-safe metadata for the durable redline-proof wire contract.</summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(RedlineReversibilityProof))]
+internal partial class RedlineReversibilityProofJsonContext : JsonSerializerContext
+{
 }
 
 /// <summary>

--- a/Docxodus/Verification/RedlineReversibilityVerifier.cs
+++ b/Docxodus/Verification/RedlineReversibilityVerifier.cs
@@ -25,9 +25,10 @@ public static class RedlineReversibilityVerifier
         ArgumentNullException.ThrowIfNull(intendedFinalBytes);
         ArgumentNullException.ThrowIfNull(redlineBytes);
         options ??= new RedlineReversibilityProofOptions();
-        ArgumentNullException.ThrowIfNull(options.PackageManifestOptions);
-        if (options.MaxRevisionElements <= 0)
-            throw new ArgumentOutOfRangeException(nameof(options.MaxRevisionElements));
+        ValidateOptions(options);
+        ValidatePackageByteBudget(
+            baselineBytes, intendedFinalBytes, redlineBytes, options.MaxPackageBytes);
+        var findingBudget = new ProofFindingBudget(options.MaxFindings);
 
         var baselineManifest = PackageManifestGenerator.Generate(
             baselineBytes, options.PackageManifestOptions);
@@ -37,9 +38,9 @@ public static class RedlineReversibilityVerifier
             redlineBytes, options.PackageManifestOptions);
         var sharedFindings = new List<RedlineProofFinding>();
 
-        AppendManifestErrors(sharedFindings, "baseline", baselineManifest);
-        AppendManifestErrors(sharedFindings, "intendedFinal", finalManifest);
-        AppendManifestErrors(sharedFindings, "redline", redlineManifest);
+        AppendManifestErrors(sharedFindings, findingBudget, "baseline", baselineManifest);
+        AppendManifestErrors(sharedFindings, findingBudget, "intendedFinal", finalManifest);
+        AppendManifestErrors(sharedFindings, findingBudget, "redline", redlineManifest);
         if (!baselineManifest.IsValid || !finalManifest.IsValid || !redlineManifest.IsValid)
         {
             return BuildRun(
@@ -55,10 +56,34 @@ public static class RedlineReversibilityVerifier
                 null);
         }
 
+        bool strictRevisionMarkupSupported = AppendStrictRevisionFinding(
+            sharedFindings, findingBudget, "baseline", baselineManifest);
+        strictRevisionMarkupSupported &= AppendStrictRevisionFinding(
+            sharedFindings, findingBudget, "intendedFinal", finalManifest);
+        strictRevisionMarkupSupported &= AppendStrictRevisionFinding(
+            sharedFindings, findingBudget, "redline", redlineManifest);
+        if (!strictRevisionMarkupSupported)
+        {
+            return BuildRun(
+                options,
+                baselineManifest,
+                finalManifest,
+                redlineManifest,
+                Array.Empty<RedlineRevisionClassification>(),
+                null,
+                null,
+                sharedFindings,
+                null,
+                null);
+        }
+
         bool revisionInventoryWithinLimit = AppendRevisionLimitFinding(
-            sharedFindings, "baseline", baselineManifest, options.MaxRevisionElements);
+            sharedFindings, findingBudget, "baseline", baselineManifest, options.MaxRevisionElements);
         revisionInventoryWithinLimit &= AppendRevisionLimitFinding(
-            sharedFindings, "redline", redlineManifest, options.MaxRevisionElements);
+            sharedFindings, findingBudget, "intendedFinal", finalManifest,
+            options.MaxRevisionElements);
+        revisionInventoryWithinLimit &= AppendRevisionLimitFinding(
+            sharedFindings, findingBudget, "redline", redlineManifest, options.MaxRevisionElements);
         if (!revisionInventoryWithinLimit)
         {
             return BuildRun(
@@ -75,20 +100,44 @@ public static class RedlineReversibilityVerifier
         }
 
         IReadOnlyList<RevisionListEntry> baselineRevisions;
+        IReadOnlyList<RevisionListEntry> finalRevisions;
         IReadOnlyList<RevisionListEntry> redlineRevisions;
+        long baselineNativeRevisionElements;
+        long finalNativeRevisionElements;
+        long redlineNativeRevisionElements;
+        bool baselineInventoryComplete;
+        bool finalInventoryComplete;
+        bool redlineInventoryComplete;
+        bool baselineEvidenceComplete;
+        bool finalEvidenceComplete;
+        bool redlineEvidenceComplete;
         try
         {
             using var baseline = OpenProofSession(baselineBytes);
-            baselineRevisions = baseline.ListRevisions();
+            (baselineRevisions, baselineNativeRevisionElements, baselineInventoryComplete,
+                baselineEvidenceComplete) = baseline.GetRevisionInventory(
+                    options.MaxRevisionElements,
+                    options.MaxRevisionEvidenceItems,
+                    options.MaxEvidenceTextCharacters);
+            using var intendedFinal = OpenProofSession(intendedFinalBytes);
+            (finalRevisions, finalNativeRevisionElements, finalInventoryComplete,
+                finalEvidenceComplete) = intendedFinal.GetRevisionInventory(
+                    options.MaxRevisionElements,
+                    options.MaxRevisionEvidenceItems,
+                    options.MaxEvidenceTextCharacters);
             using var redline = OpenProofSession(redlineBytes);
-            redlineRevisions = redline.ListRevisions();
+            (redlineRevisions, redlineNativeRevisionElements, redlineInventoryComplete,
+                redlineEvidenceComplete) = redline.GetRevisionInventory(
+                    options.MaxRevisionElements,
+                    options.MaxRevisionEvidenceItems,
+                    options.MaxEvidenceTextCharacters);
         }
         catch (Exception ex) when (DeliverableExceptionBoundary.IsRecoverable(ex))
         {
-            sharedFindings.Add(Finding(
+            findingBudget.Add(sharedFindings, Finding(
                 "revision_inventory_failed",
                 VerificationFindingSeverity.Error,
-                $"The baseline or redline revision inventory could not be opened ({ex.GetType().Name}).",
+                $"A baseline, intended-final, or redline revision inventory could not be opened ({ex.GetType().Name}).",
                 remediation: "Supply a valid WordprocessingML document whose tracked-change markup is supported."));
             return BuildRun(
                 options,
@@ -103,10 +152,51 @@ public static class RedlineReversibilityVerifier
                 null);
         }
 
-        bool liveInventoryWithinLimit = AppendLiveRevisionLimitFinding(
-            sharedFindings, "baseline", baselineRevisions.Count, options.MaxRevisionElements);
+        bool liveInventoryWithinLimit = baselineInventoryComplete
+            && finalInventoryComplete && redlineInventoryComplete;
+        if (!baselineEvidenceComplete || !finalEvidenceComplete || !redlineEvidenceComplete)
+        {
+            liveInventoryWithinLimit = false;
+            findingBudget.Add(sharedFindings, Finding(
+                "revision_evidence_limit_exceeded",
+                VerificationFindingSeverity.Error,
+                "A revision inventory exceeded the configured evidence budget while it was being constructed.",
+                new ChangeLocation { PropertyPath = "revisionClassifications" },
+                remediation: "Reduce tracked-change evidence or deliberately raise the revision evidence limits."));
+        }
         liveInventoryWithinLimit &= AppendLiveRevisionLimitFinding(
-            sharedFindings, "redline", redlineRevisions.Count, options.MaxRevisionElements);
+            sharedFindings, findingBudget, "baseline", baselineRevisions.Count,
+            options.MaxRevisionElements);
+        liveInventoryWithinLimit &= AppendLiveRevisionLimitFinding(
+            sharedFindings, findingBudget, "intendedFinal", finalRevisions.Count,
+            options.MaxRevisionElements);
+        liveInventoryWithinLimit &= AppendLiveRevisionLimitFinding(
+            sharedFindings, findingBudget, "redline", redlineRevisions.Count,
+            options.MaxRevisionElements);
+        liveInventoryWithinLimit &= AppendNativeRevisionLimitFinding(
+            sharedFindings, findingBudget, "baseline", baselineNativeRevisionElements,
+            options.MaxRevisionElements);
+        liveInventoryWithinLimit &= AppendNativeRevisionLimitFinding(
+            sharedFindings, findingBudget, "intendedFinal", finalNativeRevisionElements,
+            options.MaxRevisionElements);
+        liveInventoryWithinLimit &= AppendNativeRevisionLimitFinding(
+            sharedFindings, findingBudget, "redline", redlineNativeRevisionElements,
+            options.MaxRevisionElements);
+        liveInventoryWithinLimit &= AppendRevisionInventoryCoverageFinding(
+            sharedFindings, findingBudget, "baseline", baselineManifest,
+            baselineNativeRevisionElements);
+        liveInventoryWithinLimit &= AppendRevisionInventoryCoverageFinding(
+            sharedFindings, findingBudget, "intendedFinal", finalManifest,
+            finalNativeRevisionElements);
+        liveInventoryWithinLimit &= AppendRevisionInventoryCoverageFinding(
+            sharedFindings, findingBudget, "redline", redlineManifest,
+            redlineNativeRevisionElements);
+        liveInventoryWithinLimit &= AppendRevisionEvidenceLimitFinding(
+            sharedFindings,
+            findingBudget,
+            baselineRevisions.Concat(finalRevisions).ToArray(),
+            redlineRevisions,
+            options);
         if (!liveInventoryWithinLimit)
         {
             return BuildRun(
@@ -122,24 +212,39 @@ public static class RedlineReversibilityVerifier
                 null);
         }
 
-        var classifications = Classify(baselineRevisions, redlineRevisions, sharedFindings);
+        var classifications = Classify(
+            baselineRevisions,
+            finalRevisions,
+            redlineRevisions,
+            sharedFindings,
+            findingBudget);
         var generated = classifications
             .Where(item => item.Disposition == RedlineRevisionDisposition.Generated
                 && item.Redline is not null)
             .Select(item => item.Redline!)
             .OrderBy(RevisionSortKey, StringComparer.Ordinal)
             .ToArray();
-        var preExisting = classifications
-            .Where(item => item.Disposition == RedlineRevisionDisposition.PreExisting
-                && item.Baseline is not null)
-            .Select(item => item.Baseline!)
+        var intendedFinalExclusive = classifications
+            .Where(item => item.Disposition
+                    == RedlineRevisionDisposition.IntendedFinalPreExisting
+                && item.Redline is not null)
+            .Select(item => item.Redline!)
+            .OrderBy(RevisionSortKey, StringComparer.Ordinal)
+            .ToArray();
+        var preExisting = baselineRevisions
+            .Select(ToIdentity)
+            .OrderBy(RevisionSortKey, StringComparer.Ordinal)
+            .ToArray();
+        var acceptPreExisting = preExisting.Concat(finalRevisions.Select(ToIdentity))
+            .GroupBy(RevisionSortKey, StringComparer.Ordinal)
+            .Select(group => group.First())
             .OrderBy(RevisionSortKey, StringComparer.Ordinal)
             .ToArray();
 
         foreach (var revision in generated.Where(item =>
                      item.ResolutionStatus != RevisionResolutionStatus.Supported))
         {
-            sharedFindings.Add(Finding(
+            findingBudget.Add(sharedFindings, Finding(
                 "generated_revision_not_resolvable",
                 VerificationFindingSeverity.Error,
                 $"Generated revision '{revision.Id}' is {revision.ResolutionStatus.ToString().ToLowerInvariant()}.",
@@ -174,8 +279,10 @@ public static class RedlineReversibilityVerifier
             intendedFinalBytes,
             finalManifest,
             generated,
-            preExisting,
-            options);
+            acceptPreExisting,
+            Array.Empty<RedlineRevisionIdentity>(),
+            options,
+            findingBudget);
         var reject = EvaluatePath(
             RedlineProofDirection.RejectToBaseline,
             accept: false,
@@ -184,7 +291,9 @@ public static class RedlineReversibilityVerifier
             baselineManifest,
             generated,
             preExisting,
-            options);
+            intendedFinalExclusive,
+            options,
+            findingBudget);
 
         return BuildRun(
             options,
@@ -207,45 +316,168 @@ public static class RedlineReversibilityVerifier
         PackageManifest expectedManifest,
         IReadOnlyList<RedlineRevisionIdentity> generated,
         IReadOnlyList<RedlineRevisionIdentity> preExisting,
-        RedlineReversibilityProofOptions options)
+        IReadOnlyList<RedlineRevisionIdentity> endpointExclusive,
+        RedlineReversibilityProofOptions options,
+        ProofFindingBudget findingBudget)
     {
         var findings = new List<RedlineProofFinding>();
         var requestedIds = generated.Select(item => item.Id).ToArray();
-        var resolvedIds = new List<string>(requestedIds.Length);
-        var implicitlyResolvedIds = new List<string>();
+        var explicitlyResolved = new HashSet<string>(StringComparer.Ordinal);
+        var implicitlyResolved = new HashSet<string>(StringComparer.Ordinal);
+        var generatedOwnership = IndexRevisionOwnership(generated);
+        var pendingOwnershipKeys = generatedOwnership.Keys.ToHashSet(StringComparer.Ordinal);
         byte[]? outputBytes = null;
         IReadOnlyList<RevisionListEntry> survivingEntries = Array.Empty<RevisionListEntry>();
         bool completed = true;
+        bool stopResolution = false;
 
         try
         {
-            using var session = OpenProofSession(redlineBytes);
+            using var expectedSession = OpenProofSession(expectedBytes);
+            IReadOnlyList<int> protectedNumberingIds = accept
+                ? Array.Empty<int>()
+                : expectedSession.DefinedNumberingIds();
+            IReadOnlyList<int> protectedAbstractNumberingIds = accept
+                ? Array.Empty<int>()
+                : expectedSession.DefinedAbstractNumberingIds();
+            var protectedRelationshipKeys = expectedSession.RevisionRelationshipKeys();
+            var protectedEmptyContainerKeys =
+                expectedSession.EmptyRevisionPropertyContainerKeys();
+            using var session = OpenProofSession(
+                redlineBytes,
+                proofSafeResolution: true,
+                protectedNumberingIds: protectedNumberingIds,
+                protectedAbstractNumberingIds: protectedAbstractNumberingIds,
+                protectedRelationshipKeys: protectedRelationshipKeys,
+                protectedEmptyContainerKeys: protectedEmptyContainerKeys);
             foreach (var requested in generated)
             {
-                var current = session.ListRevisions()
-                    .SingleOrDefault(item => string.Equals(item.Id, requested.Id, StringComparison.Ordinal));
-                if (current is null)
+                var requestedKeys = RevisionOwnershipKeys(requested)
+                    .Where(pendingOwnershipKeys.Contains).ToArray();
+                while (requestedKeys.Length > 0)
                 {
-                    var liveRevisions = session.ListRevisions().Select(ToIdentity).ToArray();
-                    var overlapping = liveRevisions.FirstOrDefault(item =>
-                        RevisionOverlaps(requested, item));
-                    if (overlapping is not null)
+                    var liveInventory = session.GetRevisionInventory(
+                        options.MaxRevisionElements,
+                        options.MaxRevisionEvidenceItems,
+                        options.MaxEvidenceTextCharacters);
+                    var liveEntries = liveInventory.Entries;
+                    if (!liveInventory.EvidenceComplete)
                     {
                         completed = false;
-                        findings.Add(Finding(
-                            "generated_revision_identity_changed",
+                        findingBudget.Add(findings, Finding(
+                            "revision_evidence_limit_exceeded",
                             VerificationFindingSeverity.Error,
-                            $"Generated revision '{requested.Id}' changed identity to '{overlapping.Id}' during resolution.",
-                            new ChangeLocation { EntryUri = requested.PartUri },
-                            requested.AnchorId,
-                            new[] { requested.Id, overlapping.Id },
-                            "Regenerate a redline whose generated revision identities remain stable during selective resolution.",
-                            direction));
+                            $"The {DirectionName(direction)} live inventory exceeded the configured evidence budget.",
+                            new ChangeLocation { PropertyPath = "proofPath/revisionInventory" },
+                            revisionIds: new[] { requested.Id },
+                            remediation: "Reduce tracked-change evidence or deliberately raise the revision evidence limits.",
+                            direction: direction));
+                        stopResolution = true;
+                        break;
+                    }
+                    if (!liveInventory.Complete
+                        || liveEntries.Count > options.MaxRevisionElements
+                        || liveInventory.NativeElementCount > options.MaxRevisionElements)
+                    {
+                        completed = false;
+                        findingBudget.Add(findings, Finding(
+                            "revision_inventory_limit_exceeded_during_resolution",
+                            VerificationFindingSeverity.Error,
+                            $"The {DirectionName(direction)} live revision inventory exceeded "
+                                + "the configured limit during selective resolution.",
+                            new ChangeLocation { PropertyPath = "proofPath/revisionInventory" },
+                            revisionIds: new[] { requested.Id },
+                            remediation: "Regenerate a redline whose live revision topology remains bounded.",
+                            direction: direction));
+                        stopResolution = true;
                         break;
                     }
 
-                    implicitlyResolvedIds.Add(requested.Id);
-                    findings.Add(Finding(
+                    var liveRevisions = liveEntries.Select(ToIdentity)
+                        .OrderBy(RevisionSortKey, StringComparer.Ordinal).ToArray();
+                    var current = liveRevisions.FirstOrDefault(item =>
+                        RevisionOwnershipKeys(item).Intersect(
+                            requestedKeys, StringComparer.Ordinal).Any());
+                    if (current is null)
+                    {
+                        // A previously resolved atomic envelope can consume nested generated
+                        // carriers. They are accounted for below as implicit resolutions.
+                        pendingOwnershipKeys.ExceptWith(requestedKeys);
+                        break;
+                    }
+
+                    var currentKeys = RevisionOwnershipKeys(current);
+                    bool exclusivelyPendingGenerated = currentKeys.All(key =>
+                        pendingOwnershipKeys.Contains(key)
+                        && generatedOwnership.TryGetValue(key, out var owners)
+                        && owners.Count == 1
+                        && OwnershipEquivalent(owners[0], current));
+                    if (!exclusivelyPendingGenerated)
+                    {
+                        completed = false;
+                        findingBudget.Add(findings, Finding(
+                            "generated_revision_ownership_changed",
+                            VerificationFindingSeverity.Error,
+                            $"Live revision '{current.Id}' regrouped generated carriers with "
+                                + "foreign or changed revision ownership during resolution.",
+                            new ChangeLocation { EntryUri = current.PartUri },
+                            current.AnchorId,
+                            new[] { requested.Id, current.Id }
+                                .Distinct(StringComparer.Ordinal).ToArray(),
+                            "Regenerate a redline whose live groups contain only unchanged generated carriers.",
+                            direction));
+                        stopResolution = true;
+                        break;
+                    }
+
+                    if (current.ResolutionStatus != RevisionResolutionStatus.Supported)
+                    {
+                        completed = false;
+                        findingBudget.Add(findings, Finding(
+                            "generated_revision_became_unresolvable",
+                            VerificationFindingSeverity.Error,
+                            $"Generated revision '{requested.Id}' became {current.ResolutionStatus.ToString().ToLowerInvariant()} during resolution.",
+                            new ChangeLocation { EntryUri = current.PartUri },
+                            current.AnchorId,
+                            new[] { requested.Id, current.Id }
+                                .Distinct(StringComparer.Ordinal).ToArray(),
+                            "Regenerate a redline whose generated revision groups can be resolved independently.",
+                            direction));
+                        stopResolution = true;
+                        break;
+                    }
+
+                    var edit = accept
+                        ? session.AcceptRevision(current.Id)
+                        : session.RejectRevision(current.Id);
+                    if (!edit.Success)
+                    {
+                        completed = false;
+                        findingBudget.Add(findings, Finding(
+                            "generated_revision_resolution_failed",
+                            VerificationFindingSeverity.Error,
+                            $"Revision '{current.Id}' could not be {(accept ? "accepted" : "rejected")}: " +
+                            (edit.Error?.Message ?? "unknown resolver failure"),
+                            new ChangeLocation { EntryUri = current.PartUri },
+                            current.AnchorId,
+                            new[] { requested.Id, current.Id }
+                                .Distinct(StringComparer.Ordinal).ToArray(),
+                            "Inspect the revision topology and regenerate the comparison redline.",
+                            direction));
+                        stopResolution = true;
+                        break;
+                    }
+                    explicitlyResolved.Add(requested.Id);
+                    pendingOwnershipKeys.ExceptWith(currentKeys);
+                    requestedKeys = RevisionOwnershipKeys(requested)
+                        .Where(pendingOwnershipKeys.Contains).ToArray();
+                }
+
+                if (stopResolution) break;
+                if (!explicitlyResolved.Contains(requested.Id))
+                {
+                    implicitlyResolved.Add(requested.Id);
+                    findingBudget.Add(findings, Finding(
                         "generated_revision_consumed_by_resolution",
                         VerificationFindingSeverity.Info,
                         $"Generated revision '{requested.Id}' was consumed while resolving a linked generated revision.",
@@ -254,52 +486,72 @@ public static class RedlineReversibilityVerifier
                         new[] { requested.Id },
                         "No action is required when the path output matches its target and no generated revisions survive.",
                         direction));
-                    continue;
                 }
-
-                if (current.ResolutionStatus != RevisionResolutionStatus.Supported)
-                {
-                    completed = false;
-                    findings.Add(Finding(
-                        "generated_revision_became_unresolvable",
-                        VerificationFindingSeverity.Error,
-                        $"Generated revision '{requested.Id}' became {current.ResolutionStatus.ToString().ToLowerInvariant()} during resolution.",
-                        new ChangeLocation { EntryUri = current.PartUri },
-                        current.AnchorId,
-                        new[] { requested.Id },
-                        "Regenerate a redline whose generated revision groups can be resolved independently.",
-                        direction));
-                    break;
-                }
-
-                var edit = accept
-                    ? session.AcceptRevision(requested.Id)
-                    : session.RejectRevision(requested.Id);
-                if (!edit.Success)
-                {
-                    completed = false;
-                    findings.Add(Finding(
-                        "generated_revision_resolution_failed",
-                        VerificationFindingSeverity.Error,
-                        $"Revision '{requested.Id}' could not be {(accept ? "accepted" : "rejected")}: " +
-                        (edit.Error?.Message ?? "unknown resolver failure"),
-                        new ChangeLocation { EntryUri = current.PartUri },
-                        current.AnchorId,
-                        new[] { requested.Id },
-                        "Inspect the revision topology and regenerate the comparison redline.",
-                        direction));
-                    break;
-                }
-                resolvedIds.Add(requested.Id);
             }
 
-            survivingEntries = session.ListRevisions();
+            var survivingInventory = session.GetRevisionInventory(
+                options.MaxRevisionElements,
+                options.MaxRevisionEvidenceItems,
+                options.MaxEvidenceTextCharacters);
+            survivingEntries = survivingInventory.Entries;
+            bool survivingInventoryWithinLimit = survivingInventory.Complete
+                && survivingInventory.EvidenceComplete;
+            if (!survivingInventory.EvidenceComplete)
+            {
+                findingBudget.Add(findings, Finding(
+                    "revision_evidence_limit_exceeded",
+                    VerificationFindingSeverity.Error,
+                    $"The {DirectionName(direction)} output inventory exceeded the configured evidence budget.",
+                    new ChangeLocation { PropertyPath = "proofPath/revisionInventory" },
+                    revisionIds: Array.Empty<string>(),
+                    remediation: "Reduce tracked-change evidence or deliberately raise the revision evidence limits.",
+                    direction: direction));
+            }
+            survivingInventoryWithinLimit &= AppendLiveRevisionLimitFinding(
+                findings,
+                findingBudget,
+                "proofOutput",
+                survivingEntries.Count,
+                options.MaxRevisionElements,
+                direction);
+            survivingInventoryWithinLimit &= AppendNativeRevisionLimitFinding(
+                findings,
+                findingBudget,
+                "proofOutput",
+                survivingInventory.NativeElementCount,
+                options.MaxRevisionElements,
+                direction);
+            survivingInventoryWithinLimit &= AppendRevisionEvidenceLimitFinding(
+                findings,
+                findingBudget,
+                Array.Empty<RevisionListEntry>(),
+                survivingEntries,
+                options,
+                direction);
+            if (!survivingInventoryWithinLimit)
+            {
+                completed = false;
+                survivingEntries = Array.Empty<RevisionListEntry>();
+            }
             outputBytes = session.Save(persistAnchorIds: false);
+            if (outputBytes.LongLength > options.MaxPackageBytes)
+            {
+                completed = false;
+                findingBudget.Add(findings, Finding(
+                    "proof_output_package_limit_exceeded",
+                    VerificationFindingSeverity.Error,
+                    $"The {DirectionName(direction)} output exceeds the configured raw package budget.",
+                    new ChangeLocation { PropertyPath = "proofPath/outputPackage" },
+                    revisionIds: Array.Empty<string>(),
+                    remediation: "Reduce the package or deliberately raise MaxPackageBytes.",
+                    direction: direction));
+                outputBytes = null;
+            }
         }
         catch (Exception ex) when (DeliverableExceptionBoundary.IsRecoverable(ex))
         {
             completed = false;
-            findings.Add(Finding(
+            findingBudget.Add(findings, Finding(
                 "proof_path_execution_failed",
                 VerificationFindingSeverity.Error,
                 $"The {DirectionName(direction)} path failed ({ex.GetType().Name}).",
@@ -320,7 +572,7 @@ public static class RedlineReversibilityVerifier
         if (survivingGenerated.Length > 0)
         {
             completed = false;
-            findings.Add(Finding(
+            findingBudget.Add(findings, Finding(
                 "generated_revisions_survived_resolution",
                 VerificationFindingSeverity.Error,
                 $"The {DirectionName(direction)} path left {survivingGenerated.Length} generated revision(s) unresolved.",
@@ -328,10 +580,30 @@ public static class RedlineReversibilityVerifier
                 remediation: "Inspect the generated revision topology and selective resolver results.",
                 direction: direction));
         }
-        if (resolvedIds.Count + implicitlyResolvedIds.Count != requestedIds.Length)
+        var resolvedIds = requestedIds.Where(explicitlyResolved.Contains).ToArray();
+        var implicitlyResolvedIds = requestedIds.Where(implicitlyResolved.Contains).ToArray();
+        if (resolvedIds.Length + implicitlyResolvedIds.Length != requestedIds.Length
+            || pendingOwnershipKeys.Count > 0)
             completed = false;
         bool preExistingPreserved = VerifyPreExisting(
-            direction, preExisting, surviving, findings);
+            direction, preExisting, surviving, findings, findingBudget);
+        if (endpointExclusive.Count > 0)
+        {
+            var survivingOwnership = IndexRevisionOwnership(surviving);
+            foreach (var revision in endpointExclusive.Where(revision =>
+                         RevisionOwnershipKeys(revision).Any(survivingOwnership.ContainsKey)))
+            {
+                findingBudget.Add(findings, Finding(
+                    "intended_final_revision_survived_reject_path",
+                    VerificationFindingSeverity.Error,
+                    $"Intended-final-only revision '{revision.Id}' survived the reject-to-baseline path.",
+                    new ChangeLocation { EntryUri = revision.PartUri },
+                    revision.AnchorId,
+                    new[] { revision.Id },
+                    "Generate a comparison envelope that removes final-only review state on rejection, or choose compatible endpoint review state.",
+                    direction));
+            }
+        }
 
         if (outputBytes is null)
         {
@@ -350,6 +622,7 @@ public static class RedlineReversibilityVerifier
                     NormalizedWholePackageEquivalent = false,
                     OrderedOpcContentEquivalent = false,
                     ExactPackageBytesEquivalent = false,
+                    DivergenceAnalysisCompleted = false,
                     ExpectedPackage = ToPackageIdentity(expectedManifest),
                     ActualPackage = null,
                     FirstDivergence = null,
@@ -361,14 +634,15 @@ public static class RedlineReversibilityVerifier
 
         var actualManifest = PackageManifestGenerator.Generate(
             outputBytes, options.PackageManifestOptions);
-        AppendManifestErrors(findings, "proofOutput", actualManifest, direction);
+        AppendManifestErrors(findings, findingBudget, "proofOutput", actualManifest, direction);
         if (!actualManifest.IsValid)
             completed = false;
 
         var semantic = CompareModeledSemantics(
             expectedBytes,
             outputBytes,
-            options.PackageManifestOptions);
+            options.PackageManifestOptions,
+            options.MaxSemanticChanges);
         bool normalizedEquivalent = DigestEquals(
             expectedManifest.NormalizedSemanticDigest,
             actualManifest.NormalizedSemanticDigest);
@@ -378,15 +652,31 @@ public static class RedlineReversibilityVerifier
         bool rawEquivalent = DigestEquals(
             expectedManifest.RawPackageBytesDigest,
             actualManifest.RawPackageBytesDigest);
-        var divergences = CompareEntries(
+        var divergenceEvaluation = CompareEntries(
             expectedManifest,
             actualManifest,
             generated,
-            semantic.ModeledPartUris);
+            semantic.ModeledChanges,
+            options.MaxPackageChanges);
+        var divergences = divergenceEvaluation.Divergences;
         var firstDivergence = divergences.FirstOrDefault();
+        var firstNormalizedDivergence = divergences.FirstOrDefault(divergence =>
+            divergence.UnknownOrUnmodeled);
+        if (!divergenceEvaluation.Completed)
+        {
+            completed = false;
+            findingBudget.Add(findings, Finding(
+                "package_divergence_limit_exceeded",
+                VerificationFindingSeverity.Error,
+                "Package comparison exceeded the configured change-record budget.",
+                new ChangeLocation { PropertyPath = "proofPath/divergences" },
+                revisionIds: Array.Empty<string>(),
+                remediation: "Reduce the package delta or deliberately raise MaxPackageChanges.",
+                direction: direction));
+        }
         if (!semantic.Comparison.Available)
         {
-            findings.Add(Finding(
+            findingBudget.Add(findings, Finding(
                 "modeled_semantic_comparison_unavailable",
                 VerificationFindingSeverity.Error,
                 semantic.Comparison.Diagnostic
@@ -401,13 +691,12 @@ public static class RedlineReversibilityVerifier
             var firstSemanticAnchor = firstSemanticChange?.RightAnchor
                 ?? firstSemanticChange?.LeftAnchor;
             var applicableRevisionIds = firstSemanticChange is null
-                || firstSemanticAnchor is null
                 ? Array.Empty<string>()
-                : generated.Where(revision => RevisionAppliesToSemanticChange(
-                        revision, firstSemanticChange, firstSemanticAnchor))
+                : ApplicableRevisionsForSemanticChange(
+                        generated, firstSemanticChange, semantic.ModeledChanges)
                     .Select(revision => revision.Id)
                     .ToArray();
-            findings.Add(Finding(
+            findingBudget.Add(findings, Finding(
                 "modeled_semantic_mismatch",
                 VerificationFindingSeverity.Error,
                 $"The {DirectionName(direction)} output has "
@@ -427,19 +716,21 @@ public static class RedlineReversibilityVerifier
 
         if (!normalizedEquivalent)
         {
-            findings.Add(Finding(
+            findingBudget.Add(findings, Finding(
                 "normalized_whole_package_mismatch",
                 VerificationFindingSeverity.Error,
                 $"The {DirectionName(direction)} output differs from its expected document after package normalization.",
-                firstDivergence is null ? null : new ChangeLocation { EntryUri = firstDivergence.PartUri },
-                firstDivergence?.AnchorId,
-                firstDivergence?.ApplicableRevisionIds ?? requestedIds,
+                firstNormalizedDivergence is null
+                    ? null
+                    : new ChangeLocation { EntryUri = firstNormalizedDivergence.PartUri },
+                firstNormalizedDivergence?.AnchorId,
+                firstNormalizedDivergence?.ApplicableRevisionIds ?? requestedIds,
                 "Inspect the first divergent part and the listed generated revisions.",
                 direction));
         }
         if (!opcEquivalent)
         {
-            findings.Add(Finding(
+            findingBudget.Add(findings, Finding(
                 "ordered_opc_content_mismatch",
                 normalizedEquivalent ? VerificationFindingSeverity.Info : VerificationFindingSeverity.Error,
                 "Exact uncompressed OPC entry bytes differ from the expected document.",
@@ -453,13 +744,13 @@ public static class RedlineReversibilityVerifier
         }
         if (!rawEquivalent)
         {
-            findings.Add(Finding(
+            findingBudget.Add(findings, Finding(
                 "raw_package_bytes_mismatch",
                 options.RequireExactPackageBytes
                     ? VerificationFindingSeverity.Error
                     : VerificationFindingSeverity.Info,
                 "ZIP package bytes differ from the expected document.",
-                revisionIds: requestedIds,
+                revisionIds: Array.Empty<string>(),
                 remediation: options.RequireExactPackageBytes
                     ? "Reproduce the exact expected ZIP container or disable the explicit exact-byte policy."
                     : "No action is required when normalized package identity is equal.",
@@ -471,6 +762,7 @@ public static class RedlineReversibilityVerifier
             && semantic.Comparison.Available
             && semantic.Comparison.Equivalent == true
             && normalizedEquivalent
+            && divergenceEvaluation.Completed
             && (!options.RequireExactPackageBytes || rawEquivalent)
             && findings.All(item => item.Severity != VerificationFindingSeverity.Error);
         return new PathEvaluation(
@@ -488,9 +780,10 @@ public static class RedlineReversibilityVerifier
                 NormalizedWholePackageEquivalent = normalizedEquivalent,
                 OrderedOpcContentEquivalent = opcEquivalent,
                 ExactPackageBytesEquivalent = rawEquivalent,
+                DivergenceAnalysisCompleted = divergenceEvaluation.Completed,
                 ExpectedPackage = ToPackageIdentity(expectedManifest),
                 ActualPackage = ToPackageIdentity(actualManifest),
-                FirstDivergence = firstDivergence,
+                FirstDivergence = firstNormalizedDivergence ?? firstDivergence,
                 Divergences = divergences,
                 Findings = findings,
             },
@@ -499,73 +792,88 @@ public static class RedlineReversibilityVerifier
 
     private static IReadOnlyList<RedlineRevisionClassification> Classify(
         IReadOnlyList<RevisionListEntry> baselineEntries,
+        IReadOnlyList<RevisionListEntry> finalEntries,
         IReadOnlyList<RevisionListEntry> redlineEntries,
-        List<RedlineProofFinding> findings)
+        List<RedlineProofFinding> findings,
+        ProofFindingBudget findingBudget)
     {
         var baseline = baselineEntries.Select(ToIdentity)
             .OrderBy(RevisionSortKey, StringComparer.Ordinal).ToArray();
+        var intendedFinal = finalEntries.Select(ToIdentity)
+            .OrderBy(RevisionSortKey, StringComparer.Ordinal).ToArray();
         var redline = redlineEntries.Select(ToIdentity)
             .OrderBy(RevisionSortKey, StringComparer.Ordinal).ToArray();
-        var baselineById = baseline.GroupBy(item => item.Id, StringComparer.Ordinal)
-            .ToDictionary(group => group.Key, group => group.ToArray(), StringComparer.Ordinal);
-        var redlineById = redline.GroupBy(item => item.Id, StringComparer.Ordinal)
-            .ToDictionary(group => group.Key, group => group.ToArray(), StringComparer.Ordinal);
+        var baselineOwnership = IndexRevisionOwnership(baseline);
+        var finalOwnership = IndexRevisionOwnership(intendedFinal);
+        var redlineOwnership = IndexRevisionOwnership(redline);
 
-        foreach (var duplicate in baselineById.Where(item => item.Value.Length != 1))
-            findings.Add(DuplicateIdentityFinding("baseline", duplicate.Key, duplicate.Value));
-        foreach (var duplicate in redlineById.Where(item => item.Value.Length != 1))
-            findings.Add(DuplicateIdentityFinding("redline", duplicate.Key, duplicate.Value));
+        AppendDuplicateOwnershipFindings(
+            findings, findingBudget, "baseline", baselineOwnership);
+        AppendDuplicateOwnershipFindings(
+            findings, findingBudget, "intendedFinal", finalOwnership);
+        AppendDuplicateOwnershipFindings(
+            findings, findingBudget, "redline", redlineOwnership);
 
         var results = new List<RedlineRevisionClassification>();
-        var matchedBaselineIds = new HashSet<string>(StringComparer.Ordinal);
+        var matchedBaselineKeys = new HashSet<string>(StringComparer.Ordinal);
         foreach (var redlineRevision in redline)
         {
-            if (redlineById[redlineRevision.Id].Length != 1)
+            var keys = RevisionOwnershipKeys(redlineRevision);
+            var baselineMatches = OwnershipMatches(keys, baselineOwnership);
+            if (baselineMatches.Count > 0)
             {
-                results.Add(new RedlineRevisionClassification
-                {
-                    Disposition = RedlineRevisionDisposition.Conflicted,
-                    Redline = redlineRevision,
-                    Reason = "The redline contains a duplicate stable revision identity.",
-                });
-                continue;
-            }
-
-            if (baselineById.TryGetValue(redlineRevision.Id, out var sameId)
-                && sameId.Length == 1)
-            {
-                var baselineRevision = sameId[0];
-                matchedBaselineIds.Add(baselineRevision.Id);
-                bool unchanged = IdentityEquivalent(baselineRevision, redlineRevision);
+                foreach (var key in keys.Where(baselineOwnership.ContainsKey))
+                    matchedBaselineKeys.Add(key);
+                bool unchanged = RevisionOwnershipPreserved(
+                    redlineRevision, baselineOwnership);
                 results.Add(new RedlineRevisionClassification
                 {
                     Disposition = unchanged
                         ? RedlineRevisionDisposition.PreExisting
                         : RedlineRevisionDisposition.Conflicted,
-                    Baseline = baselineRevision,
+                    Baseline = baselineMatches[0],
                     Redline = redlineRevision,
                     Reason = unchanged
-                        ? "The complete part-qualified revision identity is unchanged from the baseline."
-                        : "A baseline revision reused its stable ID but changed identity or location.",
+                        ? "Every part-qualified native constituent remains owned by baseline review markup."
+                        : "The redline mixes, duplicates, or rewrites native constituents owned by baseline review markup.",
                 });
                 if (!unchanged)
-                    findings.Add(RevisionConflictFinding(baselineRevision, redlineRevision));
+                    findingBudget.Add(findings,
+                        RevisionConflictFinding(baselineMatches[0], redlineRevision));
                 continue;
             }
 
-            var overlaps = baseline.Where(item => RevisionOverlaps(item, redlineRevision)).ToArray();
-            if (overlaps.Length > 0)
+            var finalMatches = OwnershipMatches(keys, finalOwnership);
+            if (finalMatches.Count > 0)
             {
-                foreach (var overlap in overlaps)
-                    matchedBaselineIds.Add(overlap.Id);
+                bool unchanged = RevisionOwnershipPreserved(
+                    redlineRevision, finalOwnership);
                 results.Add(new RedlineRevisionClassification
                 {
-                    Disposition = RedlineRevisionDisposition.Conflicted,
-                    Baseline = overlaps[0],
+                    Disposition = unchanged
+                        ? RedlineRevisionDisposition.IntendedFinalPreExisting
+                        : RedlineRevisionDisposition.Conflicted,
+                    IntendedFinal = finalMatches[0],
                     Redline = redlineRevision,
-                    Reason = "The redline revision overlaps native constituent IDs owned by baseline review markup.",
+                    Reason = unchanged
+                        ? "The revision belongs to intended-final review state absent from the selected baseline."
+                        : "The redline mixes, duplicates, or rewrites native constituents owned by intended-final review state.",
                 });
-                findings.Add(RevisionConflictFinding(overlaps[0], redlineRevision));
+                findingBudget.Add(findings, Finding(
+                    unchanged
+                        ? "intended_final_revision_not_in_baseline"
+                        : "intended_final_revision_identity_conflict",
+                    unchanged
+                        ? VerificationFindingSeverity.Info
+                        : VerificationFindingSeverity.Error,
+                    unchanged
+                        ? $"Intended-final revision '{finalMatches[0].Id}' is review state, not a generated comparison revision."
+                        : $"Redline revision '{redlineRevision.Id}' conflicts with intended-final review state.",
+                    new ChangeLocation { EntryUri = redlineRevision.PartUri },
+                    redlineRevision.AnchorId,
+                    new[] { finalMatches[0].Id, redlineRevision.Id }
+                        .Distinct(StringComparer.Ordinal).ToArray(),
+                    "Choose a baseline/final policy with compatible pre-existing review state before generating the redline."));
                 continue;
             }
 
@@ -573,11 +881,12 @@ public static class RedlineReversibilityVerifier
             {
                 Disposition = RedlineRevisionDisposition.Generated,
                 Redline = redlineRevision,
-                Reason = "The part-qualified native revision identity is absent from the baseline.",
+                Reason = "Every part-qualified native constituent is absent from both input review inventories.",
             });
         }
 
-        foreach (var missing in baseline.Where(item => !matchedBaselineIds.Contains(item.Id)))
+        foreach (var missing in baseline.Where(item =>
+                     RevisionOwnershipKeys(item).Any(key => !matchedBaselineKeys.Contains(key))))
         {
             results.Add(new RedlineRevisionClassification
             {
@@ -585,7 +894,7 @@ public static class RedlineReversibilityVerifier
                 Baseline = missing,
                 Reason = "A pre-existing baseline revision is missing from the redline.",
             });
-            findings.Add(Finding(
+            findingBudget.Add(findings, Finding(
                 "preexisting_revision_missing_from_redline",
                 VerificationFindingSeverity.Error,
                 $"Baseline revision '{missing.Id}' is absent from the redline.",
@@ -595,9 +904,30 @@ public static class RedlineReversibilityVerifier
                 "Regenerate the redline while preserving the selected baseline review state."));
         }
 
+        foreach (var missing in intendedFinal.Where(item =>
+                     !RevisionOwnershipPreserved(item, redlineOwnership)))
+        {
+            results.Add(new RedlineRevisionClassification
+            {
+                Disposition = RedlineRevisionDisposition.Conflicted,
+                IntendedFinal = missing,
+                Reason = "Pre-existing intended-final review state is missing or rewritten in the redline.",
+            });
+            findingBudget.Add(findings, Finding(
+                "intended_final_revision_missing_from_redline",
+                VerificationFindingSeverity.Error,
+                $"Intended-final revision '{missing.Id}' is absent or changed in the redline.",
+                new ChangeLocation { EntryUri = missing.PartUri },
+                missing.AnchorId,
+                new[] { missing.Id },
+                "Regenerate the redline without losing intended-final review state."));
+        }
+
         return results
-            .OrderBy(item => item.Redline?.PartUri ?? item.Baseline?.PartUri, StringComparer.Ordinal)
-            .ThenBy(item => item.Redline?.Id ?? item.Baseline?.Id, StringComparer.Ordinal)
+            .OrderBy(item => item.Redline?.PartUri ?? item.Baseline?.PartUri
+                ?? item.IntendedFinal?.PartUri, StringComparer.Ordinal)
+            .ThenBy(item => item.Redline?.Id ?? item.Baseline?.Id
+                ?? item.IntendedFinal?.Id, StringComparer.Ordinal)
             .ToArray();
     }
 
@@ -605,19 +935,17 @@ public static class RedlineReversibilityVerifier
         RedlineProofDirection direction,
         IReadOnlyList<RedlineRevisionIdentity> expected,
         IReadOnlyList<RedlineRevisionIdentity> actual,
-        List<RedlineProofFinding> findings)
+        List<RedlineProofFinding> findings,
+        ProofFindingBudget findingBudget)
     {
-        var actualById = actual.GroupBy(item => item.Id, StringComparer.Ordinal)
-            .ToDictionary(group => group.Key, group => group.ToArray(), StringComparer.Ordinal);
+        var actualOwnership = IndexRevisionOwnership(actual);
         bool preserved = true;
         foreach (var revision in expected)
         {
-            if (!actualById.TryGetValue(revision.Id, out var candidates)
-                || candidates.Length != 1
-                || !IdentityEquivalent(revision, candidates[0]))
+            if (!RevisionOwnershipPreserved(revision, actualOwnership))
             {
                 preserved = false;
-                findings.Add(Finding(
+                findingBudget.Add(findings, Finding(
                     "preexisting_revision_not_preserved",
                     VerificationFindingSeverity.Error,
                     $"Pre-existing revision '{revision.Id}' did not survive the {DirectionName(direction)} path unchanged.",
@@ -631,18 +959,24 @@ public static class RedlineReversibilityVerifier
         return preserved;
     }
 
-    private static IReadOnlyList<RedlinePackageDivergence> CompareEntries(
+    private static PackageDivergenceEvaluation CompareEntries(
         PackageManifest expected,
         PackageManifest actual,
         IReadOnlyList<RedlineRevisionIdentity> generated,
-        IReadOnlyCollection<string> modeledPartUris)
+        IReadOnlyList<SemanticChange> modeledChanges,
+        int maximumChanges)
     {
+        var packageDelta = PackageDelta.Compare(expected, actual, maximumChanges);
+        if (!packageDelta.Complete)
+            return new PackageDivergenceEvaluation(
+                false, Array.Empty<RedlinePackageDivergence>());
+
         var expectedByKey = expected.Entries.ToDictionary(
             item => (item.Uri, item.Occurrence), item => item);
         var actualByKey = actual.Entries.ToDictionary(
             item => (item.Uri, item.Occurrence), item => item);
         var divergences = new List<RedlinePackageDivergence>();
-        foreach (var change in PackageDelta.Compare(expected, actual).Where(change =>
+        foreach (var change in packageDelta.Changes.Where(change =>
                      change.Kind is PackageDeltaChangeKind.EntryAdded
                          or PackageDeltaChangeKind.EntryRemoved
                          or PackageDeltaChangeKind.EntryModified))
@@ -661,7 +995,13 @@ public static class RedlineReversibilityVerifier
                 _ => throw new ArgumentOutOfRangeException(nameof(change), change.Kind, null),
             };
 
-            var relevant = generated.Where(item => RevisionAppliesToPart(item, partUri))
+            var relevantModeledChanges = modeledChanges.Where(item =>
+                    ModeledPartUris(item).Contains(partUri, StringComparer.Ordinal))
+                .ToArray();
+            var relevant = relevantModeledChanges
+                .SelectMany(change => ApplicableRevisionsForSemanticChange(
+                    generated, change, relevantModeledChanges))
+                .Distinct()
                 .OrderBy(RevisionSortKey, StringComparer.Ordinal).ToArray();
             bool normalizedDifferent = expectedEntry is null || actualEntry is null
                 || !string.Equals(expectedEntry.ContentType, actualEntry.ContentType, StringComparison.Ordinal)
@@ -673,24 +1013,25 @@ public static class RedlineReversibilityVerifier
                 Kind = kind,
                 PartUri = partUri,
                 Occurrence = change.Occurrence,
-                AnchorId = relevant.Select(item => item.AnchorId)
+                AnchorId = relevantModeledChanges.Select(item =>
+                        item.RightAnchor ?? item.LeftAnchor)
                     .FirstOrDefault(item => item is not null),
                 ApplicableRevisionIds = relevant.Select(item => item.Id).ToArray(),
                 ExpectedRawDigest = expectedEntry?.RawBytesDigest,
                 ActualRawDigest = actualEntry?.RawBytesDigest,
                 ExpectedNormalizedDigest = expectedEntry?.NormalizedXmlDigest,
                 ActualNormalizedDigest = actualEntry?.NormalizedXmlDigest,
-                HasModeledSemanticChange = modeledPartUris.Contains(partUri),
+                HasModeledSemanticChange = relevantModeledChanges.Length > 0,
                 // A change set identifies modeled facts, not a complete residual projection for
                 // an arbitrary XML part. Even when that same part has a modeled change, retain the
                 // normalized divergence as potentially unmodeled instead of overclaiming coverage.
                 UnknownOrUnmodeled = normalizedDifferent,
             });
         }
-        return divergences
+        return new PackageDivergenceEvaluation(true, divergences
             .OrderBy(item => item.PartUri, StringComparer.Ordinal)
             .ThenBy(item => item.Occurrence)
-            .ToArray();
+            .ToArray());
     }
 
     private static bool RevisionAppliesToPart(RedlineRevisionIdentity revision, string partUri)
@@ -706,17 +1047,111 @@ public static class RedlineReversibilityVerifier
             StringComparison.Ordinal);
     }
 
-    private static bool RevisionAppliesToSemanticChange(
-        RedlineRevisionIdentity revision,
+    private static IReadOnlyList<RedlineRevisionIdentity> ApplicableRevisionsForSemanticChange(
+        IReadOnlyList<RedlineRevisionIdentity> generated,
         SemanticChange change,
-        string? changeAnchor)
+        IReadOnlyList<SemanticChange> allChanges)
     {
-        if (!RevisionAppliesToPart(revision, change.PartUri)) return false;
-        // A part match alone does not prove that a generated revision caused this semantic change.
-        // Only claim a revision when the semantic anchor matches its primary or affected anchors.
-        return changeAnchor is not null
-            && (string.Equals(revision.AnchorId, changeAnchor, StringComparison.Ordinal)
-                || revision.AffectedAnchorIds.Contains(changeAnchor, StringComparer.Ordinal));
+        var candidates = generated.Where(revision =>
+                RevisionAppliesToPart(revision, change.PartUri))
+            .ToArray();
+        var changeAnchor = change.RightAnchor ?? change.LeftAnchor;
+        var direct = changeAnchor is null
+            ? Array.Empty<RedlineRevisionIdentity>()
+            : candidates.Where(revision => RevisionAnchorIds(revision)
+                    .Contains(changeAnchor, StringComparer.Ordinal))
+                .ToArray();
+        if (direct.Length > 0) return direct;
+
+        // Resolved-output anchors are content-derived and therefore need not equal the redline's
+        // tracked paragraph anchor. Use the semantic before/after text as a conservative seed,
+        // then include the sibling del/ins carriers at that same redline location. If text points
+        // at more than one location, make no attribution rather than overclaiming causality.
+        var relatedChanges = allChanges.Where(candidate =>
+                string.Equals(candidate.PartUri, change.PartUri, StringComparison.Ordinal)
+                && SemanticChangesShareLocation(change, candidate))
+            .ToArray();
+        var semanticStrings = relatedChanges.SelectMany(candidate =>
+                SemanticStrings(candidate.After))
+            .Select(value => value.Trim())
+            .Where(value => value.Length >= 2 && value.Any(char.IsLetterOrDigit))
+            .Distinct(StringComparer.Ordinal).ToArray();
+        var scored = candidates.Select(revision => new
+            {
+                Revision = revision,
+                Score = semanticStrings.Where(value => revision.Text.Contains(
+                        value, StringComparison.Ordinal))
+                    .Select(value => value.Length).DefaultIfEmpty().Max(),
+            })
+            .Where(item => item.Score > 0).ToArray();
+        if (scored.Length == 0)
+        {
+            semanticStrings = relatedChanges.SelectMany(candidate =>
+                    SemanticStrings(candidate.Before))
+                .Select(value => value.Trim())
+                .Where(value => value.Length >= 2 && value.Any(char.IsLetterOrDigit))
+                .Distinct(StringComparer.Ordinal).ToArray();
+            scored = candidates.Select(revision => new
+                {
+                    Revision = revision,
+                    Score = semanticStrings.Where(value => revision.Text.Contains(
+                            value, StringComparison.Ordinal))
+                        .Select(value => value.Length).DefaultIfEmpty().Max(),
+                })
+                .Where(item => item.Score > 0).ToArray();
+        }
+        int bestScore = scored.Select(item => item.Score).DefaultIfEmpty().Max();
+        var seeds = scored.Where(item => item.Score == bestScore)
+            .Select(item => item.Revision).ToArray();
+        var seedLocations = seeds.Select(RevisionLocationKey)
+            .Where(key => key is not null).Distinct(StringComparer.Ordinal).ToArray();
+        if (seedLocations.Length != 1)
+            return candidates.Length == 1 ? candidates : Array.Empty<RedlineRevisionIdentity>();
+
+        var location = seedLocations[0]!;
+        return candidates.Where(revision =>
+                string.Equals(RevisionLocationKey(revision), location, StringComparison.Ordinal))
+            .OrderBy(RevisionSortKey, StringComparer.Ordinal).ToArray();
+    }
+
+    private static bool SemanticChangesShareLocation(
+        SemanticChange left, SemanticChange right)
+    {
+        var leftAnchors = new[] { left.RightAnchor, left.LeftAnchor }
+            .Where(anchor => anchor is not null).Select(anchor => anchor!).ToArray();
+        return leftAnchors.Length > 0
+            && new[] { right.RightAnchor, right.LeftAnchor }
+                .Where(anchor => anchor is not null).Select(anchor => anchor!)
+                .Intersect(leftAnchors, StringComparer.Ordinal).Any();
+    }
+
+    private static IEnumerable<string> RevisionAnchorIds(RedlineRevisionIdentity revision) =>
+        revision.AnchorId is null
+            ? revision.AffectedAnchorIds
+            : new[] { revision.AnchorId }.Concat(revision.AffectedAnchorIds);
+
+    private static string? RevisionLocationKey(RedlineRevisionIdentity revision)
+    {
+        var anchors = RevisionAnchorIds(revision).Distinct(StringComparer.Ordinal)
+            .OrderBy(value => value, StringComparer.Ordinal).ToArray();
+        return anchors.Length == 0
+            ? null
+            : revision.PartUri + "\n" + string.Join("\n", anchors);
+    }
+
+    private static IEnumerable<string> SemanticStrings(SemanticValue root)
+    {
+        var pending = new Stack<SemanticValue>();
+        pending.Push(root);
+        int visited = 0;
+        while (pending.Count > 0 && visited++ < 10_000)
+        {
+            var value = pending.Pop();
+            if (value.Kind == SemanticValueKind.String && value.StringValue is { } text)
+                yield return text;
+            foreach (var item in value.Items) pending.Push(item);
+            foreach (var property in value.Properties) pending.Push(property.Value);
+        }
     }
 
     private static RedlineRevisionIdentity ToIdentity(RevisionListEntry entry) => new()
@@ -727,8 +1162,10 @@ public static class RedlineReversibilityVerifier
         Type = entry.Type,
         Family = entry.Family,
         ConstituentIds = entry.ConstituentIds.OrderBy(item => item, StringComparer.Ordinal).ToArray(),
+        ConstituentKeys = entry.ConstituentKeys.OrderBy(item => item, StringComparer.Ordinal).ToArray(),
         Author = entry.Author,
         Date = entry.Date,
+        DateUtc = entry.DateUtc,
         Text = entry.Text,
         AnchorId = entry.AnchorId,
         AffectedAnchorIds = entry.AffectedAnchors.Select(item => item.Id)
@@ -737,29 +1174,97 @@ public static class RedlineReversibilityVerifier
         Diagnostic = entry.Diagnostic,
     };
 
-    private static bool IdentityEquivalent(
+    private static bool OwnershipEquivalent(
         RedlineRevisionIdentity left,
         RedlineRevisionIdentity right) =>
-        string.Equals(left.Id, right.Id, StringComparison.Ordinal)
-        && string.Equals(left.PartUri, right.PartUri, StringComparison.Ordinal)
-        && string.Equals(left.Scope, right.Scope, StringComparison.Ordinal)
+        string.Equals(left.PartUri, right.PartUri, StringComparison.Ordinal)
         && string.Equals(left.Type, right.Type, StringComparison.Ordinal)
-        && left.Family == right.Family
-        && left.ConstituentIds.SequenceEqual(right.ConstituentIds, StringComparer.Ordinal)
         && string.Equals(left.Author, right.Author, StringComparison.Ordinal)
         && string.Equals(left.Date, right.Date, StringComparison.Ordinal)
-        && string.Equals(left.Text, right.Text, StringComparison.Ordinal)
-        && string.Equals(left.AnchorId, right.AnchorId, StringComparison.Ordinal)
-        && left.AffectedAnchorIds.SequenceEqual(right.AffectedAnchorIds, StringComparer.Ordinal)
-        && left.ResolutionStatus == right.ResolutionStatus
-        && Equals(left.Diagnostic, right.Diagnostic);
+        && string.Equals(left.DateUtc, right.DateUtc, StringComparison.Ordinal)
+        && left.ResolutionStatus == right.ResolutionStatus;
+
+    private static bool RevisionOwnershipPreserved(
+        RedlineRevisionIdentity expected,
+        IReadOnlyDictionary<string, List<RedlineRevisionIdentity>> actualOwnership)
+    {
+        var keys = RevisionOwnershipKeys(expected);
+        if (keys.Any(key => !actualOwnership.TryGetValue(key, out var candidates)
+                || candidates.Count != 1
+                || !OwnershipEquivalent(expected, candidates[0])))
+            return false;
+
+        if (expected.Family is not (RevisionFamily.Move
+            or RevisionFamily.ContentControlInsert
+            or RevisionFamily.ContentControlDelete))
+            return true;
+
+        var actualGroups = keys.SelectMany(key => actualOwnership[key]).Distinct().ToArray();
+        return actualGroups.Length == 1
+            && actualGroups[0].Family == expected.Family
+            && RevisionOwnershipKeys(actualGroups[0]).ToHashSet(StringComparer.Ordinal)
+                .SetEquals(keys);
+    }
+
+    private static IReadOnlyList<string> RevisionOwnershipKeys(
+        RedlineRevisionIdentity revision) => revision.ConstituentKeys.Count == 0
+        ? new[] { revision.PartUri + "\ngroup:" + revision.Id }
+        : revision.ConstituentKeys.Select(key => revision.PartUri + "\nnative:" + key)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(key => key, StringComparer.Ordinal)
+            .ToArray();
+
+    private static Dictionary<string, List<RedlineRevisionIdentity>> IndexRevisionOwnership(
+        IEnumerable<RedlineRevisionIdentity> revisions)
+    {
+        var result = new Dictionary<string, List<RedlineRevisionIdentity>>(StringComparer.Ordinal);
+        foreach (var revision in revisions)
+        {
+            foreach (var key in RevisionOwnershipKeys(revision))
+            {
+                if (!result.TryGetValue(key, out var owners))
+                    result[key] = owners = new List<RedlineRevisionIdentity>();
+                owners.Add(revision);
+            }
+        }
+        return result;
+    }
+
+    private static IReadOnlyList<RedlineRevisionIdentity> OwnershipMatches(
+        IReadOnlyList<string> keys,
+        IReadOnlyDictionary<string, List<RedlineRevisionIdentity>> ownership) =>
+        keys.Where(ownership.ContainsKey)
+            .SelectMany(key => ownership[key])
+            .Distinct()
+            .OrderBy(RevisionSortKey, StringComparer.Ordinal)
+            .ToArray();
+
+    private static void AppendDuplicateOwnershipFindings(
+        List<RedlineProofFinding> findings,
+        ProofFindingBudget findingBudget,
+        string inputName,
+        IReadOnlyDictionary<string, List<RedlineRevisionIdentity>> ownership)
+    {
+        foreach (var duplicate in ownership.Where(item => item.Value.Count != 1))
+        {
+            var identities = duplicate.Value.OrderBy(RevisionSortKey, StringComparer.Ordinal).ToArray();
+            findingBudget.Add(findings, Finding(
+                "duplicate_native_revision_ownership",
+                VerificationFindingSeverity.Error,
+                $"The {inputName} inventory assigns one native constituent to multiple revision groups.",
+                new ChangeLocation { EntryUri = identities[0].PartUri },
+                identities[0].AnchorId,
+                identities.Select(item => item.Id).Distinct(StringComparer.Ordinal).ToArray(),
+                "Repair ambiguous native revision ownership before proving reversibility."));
+        }
+    }
 
     private static bool RevisionOverlaps(
         RedlineRevisionIdentity baseline,
         RedlineRevisionIdentity redline) =>
         string.Equals(baseline.PartUri, redline.PartUri, StringComparison.Ordinal)
-        && baseline.ConstituentIds.Intersect(
-            redline.ConstituentIds, StringComparer.Ordinal).Any();
+        && baseline.ConstituentKeys.Intersect(
+            redline.ConstituentKeys, StringComparer.Ordinal).Any();
 
     private static string RevisionSortKey(RedlineRevisionIdentity item) =>
         item.PartUri + "\n" + item.Family + "\n" + item.Id;
@@ -789,6 +1294,7 @@ public static class RedlineReversibilityVerifier
 
     private static void AppendManifestErrors(
         List<RedlineProofFinding> target,
+        ProofFindingBudget findingBudget,
         string inputName,
         PackageManifest manifest,
         RedlineProofDirection? direction = null)
@@ -796,7 +1302,7 @@ public static class RedlineReversibilityVerifier
         foreach (var finding in manifest.Findings.Where(item =>
                      item.Severity == VerificationFindingSeverity.Error))
         {
-            target.Add(Finding(
+            findingBudget.Add(target, Finding(
                 "package_" + finding.Code,
                 finding.Severity,
                 $"{inputName}: {finding.Message}",
@@ -809,15 +1315,16 @@ public static class RedlineReversibilityVerifier
 
     private static bool AppendRevisionLimitFinding(
         List<RedlineProofFinding> target,
+        ProofFindingBudget findingBudget,
         string inputName,
         PackageManifest manifest,
         int maximum)
     {
-        int actual = manifest.Facts.Revisions.Total;
+        long actual = manifest.Facts.NativeRevisionCarrierCount;
         if (actual <= maximum)
             return true;
 
-        target.Add(Finding(
+        findingBudget.Add(target, Finding(
             "revision_element_limit_exceeded",
             VerificationFindingSeverity.Error,
             $"The {inputName} package contains "
@@ -829,16 +1336,37 @@ public static class RedlineReversibilityVerifier
         return false;
     }
 
+    private static bool AppendStrictRevisionFinding(
+        List<RedlineProofFinding> target,
+        ProofFindingBudget findingBudget,
+        string inputName,
+        PackageManifest manifest)
+    {
+        if (!manifest.Facts.IsStrictOoxml || !manifest.Facts.HasStrictRevisionMarkup)
+            return true;
+
+        findingBudget.Add(target, Finding(
+            "unsupported_strict_revision_markup",
+            VerificationFindingSeverity.Error,
+            $"The {inputName} package contains strict-namespace tracked revision markup, "
+                + "which the selective native resolver does not support.",
+            new ChangeLocation { PropertyPath = inputName + "/revisions" },
+            remediation: "Convert the document to transitional WordprocessingML before proving reversibility."));
+        return false;
+    }
+
     private static bool AppendLiveRevisionLimitFinding(
         List<RedlineProofFinding> target,
+        ProofFindingBudget findingBudget,
         string inputName,
         int actual,
-        int maximum)
+        int maximum,
+        RedlineProofDirection? direction = null)
     {
         if (actual <= maximum)
             return true;
 
-        target.Add(Finding(
+        findingBudget.Add(target, Finding(
             "revision_inventory_limit_exceeded",
             VerificationFindingSeverity.Error,
             $"The {inputName} live revision inventory contains "
@@ -846,17 +1374,127 @@ public static class RedlineReversibilityVerifier
                 + $"the proof limit is "
                 + $"{maximum.ToString(System.Globalization.CultureInfo.InvariantCulture)}.",
             new ChangeLocation { PropertyPath = inputName + "/revisionInventory" },
-            remediation: "Reduce tracked-change markup or explicitly raise MaxRevisionElements for a reviewed input."));
+            remediation: "Reduce tracked-change markup or explicitly raise MaxRevisionElements for a reviewed input.",
+            direction: direction));
         return false;
+    }
+
+    private static bool AppendNativeRevisionLimitFinding(
+        List<RedlineProofFinding> target,
+        ProofFindingBudget findingBudget,
+        string inputName,
+        long actual,
+        int maximum,
+        RedlineProofDirection? direction = null)
+    {
+        if (actual <= maximum)
+            return true;
+
+        findingBudget.Add(target, Finding(
+            "revision_element_limit_exceeded",
+            VerificationFindingSeverity.Error,
+            $"The {inputName} live inventory contains "
+                + $"{actual.ToString(System.Globalization.CultureInfo.InvariantCulture)} native revision "
+                + $"element(s); the proof limit is "
+                + $"{maximum.ToString(System.Globalization.CultureInfo.InvariantCulture)}.",
+            new ChangeLocation { PropertyPath = inputName + "/revisions" },
+            remediation: "Reduce tracked-change markup or explicitly raise MaxRevisionElements for a reviewed input.",
+            direction: direction));
+        return false;
+    }
+
+    private static bool AppendRevisionInventoryCoverageFinding(
+        List<RedlineProofFinding> target,
+        ProofFindingBudget findingBudget,
+        string inputName,
+        PackageManifest manifest,
+        long inventoried)
+    {
+        var physical = manifest.Facts.NativeRevisionCarrierCount;
+        if (physical == inventoried)
+            return true;
+
+        findingBudget.Add(target, Finding(
+            "unsupported_revision_part",
+            VerificationFindingSeverity.Error,
+            $"The {inputName} package contains {physical} physical revision carrier(s), "
+                + $"but the native registry inventoried {inventoried}; at least one carrier "
+                + "is in an unmodeled Wordprocessing part.",
+            new ChangeLocation { PropertyPath = inputName + "/revisionInventory" },
+            remediation: "Remove tracked markup from unsupported parts or extend the native registry before proving reversibility."));
+        return false;
+    }
+
+    private static bool AppendRevisionEvidenceLimitFinding(
+        List<RedlineProofFinding> target,
+        ProofFindingBudget findingBudget,
+        IReadOnlyList<RevisionListEntry> baseline,
+        IReadOnlyList<RevisionListEntry> redline,
+        RedlineReversibilityProofOptions options,
+        RedlineProofDirection? direction = null)
+    {
+        long textCharacters = 0;
+        int evidenceItems = 0;
+        foreach (var revision in baseline.Concat(redline))
+        {
+            if (!TryAddCount(ref evidenceItems, revision.ConstituentIds.Count,
+                    options.MaxRevisionEvidenceItems)
+                || !TryAddCount(ref evidenceItems, revision.ConstituentKeys.Count,
+                    options.MaxRevisionEvidenceItems)
+                || !TryAddCount(ref evidenceItems, revision.AffectedAnchors.Count,
+                    options.MaxRevisionEvidenceItems)
+                || !TryAddText(ref textCharacters, options.MaxEvidenceTextCharacters,
+                    revision.Id, revision.PartUri, revision.Scope, revision.Type, revision.Author,
+                    revision.Date, revision.DateUtc, revision.Text, revision.AnchorId,
+                    revision.Diagnostic?.Code, revision.Diagnostic?.Message)
+                || revision.ConstituentIds.Any(item =>
+                    !TryAddText(ref textCharacters, options.MaxEvidenceTextCharacters, item))
+                || revision.ConstituentKeys.Any(item =>
+                    !TryAddText(ref textCharacters, options.MaxEvidenceTextCharacters, item))
+                || revision.AffectedAnchors.Any(item =>
+                    !TryAddText(ref textCharacters, options.MaxEvidenceTextCharacters, item.Id)))
+            {
+                findingBudget.Add(target, Finding(
+                    "revision_evidence_limit_exceeded",
+                    VerificationFindingSeverity.Error,
+                    "The revision evidence exceeds the configured output budget.",
+                    new ChangeLocation { PropertyPath = "revisionClassifications" },
+                    remediation: "Reduce tracked-change evidence or deliberately raise the revision evidence limits.",
+                    direction: direction));
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static bool TryAddCount(ref int current, int value, int maximum)
+    {
+        if (value < 0 || current > maximum - value)
+            return false;
+        current += value;
+        return true;
+    }
+
+    private static bool TryAddText(ref long current, long maximum, params string?[] values)
+    {
+        foreach (var value in values)
+        {
+            if (value is null) continue;
+            if (current > maximum - value.Length)
+                return false;
+            current += value.Length;
+        }
+        return true;
     }
 
     internal static IReadOnlyList<RedlineRevisionIdentity> SelectSurvivingPreExisting(
         IReadOnlyList<RedlineRevisionIdentity> preExisting,
         IReadOnlyList<RedlineRevisionIdentity> surviving)
     {
-        var preExistingIds = preExisting.Select(item => item.Id)
+        var preExistingOwnership = preExisting.SelectMany(RevisionOwnershipKeys)
             .ToHashSet(StringComparer.Ordinal);
-        return surviving.Where(item => preExistingIds.Contains(item.Id))
+        return surviving.Where(item => RevisionOwnershipKeys(item)
+                .Any(preExistingOwnership.Contains))
             .OrderBy(RevisionSortKey, StringComparer.Ordinal)
             .ToArray();
     }
@@ -927,26 +1565,80 @@ public static class RedlineReversibilityVerifier
         && string.Equals(left.Algorithm, right.Algorithm, StringComparison.Ordinal)
         && string.Equals(left.Value, right.Value, StringComparison.Ordinal);
 
-    private static DocxSession OpenProofSession(byte[] bytes) => new(bytes, new DocxSessionSettings
+    private static DocxSession OpenProofSession(
+        byte[] bytes,
+        bool proofSafeResolution = false,
+        IReadOnlyList<int>? protectedNumberingIds = null,
+        IReadOnlyList<int>? protectedAbstractNumberingIds = null,
+        IReadOnlyCollection<string>? protectedRelationshipKeys = null,
+        IReadOnlyCollection<string>? protectedEmptyContainerKeys = null) =>
+        new(bytes, new DocxSessionSettings
     {
         UndoDepth = 1,
         UndoMemoryBudgetBytes = 128L * 1024 * 1024,
         PersistAnchorIds = false,
         EmitMarkdownPatch = false,
         CaptureInitialProjection = false,
+        ProofSafeRevisionResolution = proofSafeResolution,
+        ProtectedRevisionNumberingIds = protectedNumberingIds ?? Array.Empty<int>(),
+        ProtectedRevisionAbstractNumberingIds = protectedAbstractNumberingIds
+            ?? Array.Empty<int>(),
+        ProtectedRevisionRelationshipKeys = protectedRelationshipKeys
+            ?? Array.Empty<string>(),
+        ProtectedRevisionEmptyContainerKeys = protectedEmptyContainerKeys
+            ?? Array.Empty<string>(),
     });
+
+    private static void ValidateOptions(RedlineReversibilityProofOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options.PackageManifestOptions);
+        options.PackageManifestOptions.Validate();
+        if (options.MaxPackageBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(options.MaxPackageBytes));
+        if (options.MaxRevisionElements <= 0)
+            throw new ArgumentOutOfRangeException(nameof(options.MaxRevisionElements));
+        if (options.MaxSemanticChanges <= 0)
+            throw new ArgumentOutOfRangeException(nameof(options.MaxSemanticChanges));
+        if (options.MaxPackageChanges <= 0)
+            throw new ArgumentOutOfRangeException(nameof(options.MaxPackageChanges));
+        if (options.MaxFindings <= 0)
+            throw new ArgumentOutOfRangeException(nameof(options.MaxFindings));
+        if (options.MaxRevisionEvidenceItems <= 0)
+            throw new ArgumentOutOfRangeException(nameof(options.MaxRevisionEvidenceItems));
+        if (options.MaxEvidenceTextCharacters <= 0)
+            throw new ArgumentOutOfRangeException(nameof(options.MaxEvidenceTextCharacters));
+    }
+
+    private static void ValidatePackageByteBudget(
+        byte[] baselineBytes,
+        byte[] intendedFinalBytes,
+        byte[] redlineBytes,
+        long maximumBytes)
+    {
+        long baselineLength = baselineBytes.LongLength;
+        long finalLength = intendedFinalBytes.LongLength;
+        long redlineLength = redlineBytes.LongLength;
+        if (baselineLength > maximumBytes
+            || finalLength > maximumBytes - baselineLength
+            || redlineLength > maximumBytes - baselineLength - finalLength)
+            throw new ArgumentException(
+                "Aggregate baseline, intended-final, and redline bytes exceed the proof budget.",
+                nameof(redlineBytes));
+    }
 
     private static ModeledSemanticEvaluation CompareModeledSemantics(
         byte[] expectedBytes,
         byte[] actualBytes,
-        PackageManifestOptions packageOptions)
+        PackageManifestOptions packageOptions,
+        int maximumChanges)
     {
         try
         {
-            var changes = SemanticDiff.Compare(
+            var changes = SemanticDiff.CompareBounded(
                 new WmlDocument("expected.docx", expectedBytes),
                 new WmlDocument("actual.docx", actualBytes),
-                new SemanticDiffOptions { PackageOptions = packageOptions });
+                new SemanticDiffOptions { PackageOptions = packageOptions },
+                maximumChanges);
             var modeledChanges = changes.Changes
                 .Where(change => change.Family != SemanticChangeFamily.OpaquePackagePart)
                 .ToArray();
@@ -959,8 +1651,7 @@ public static class RedlineReversibilityVerifier
                     ChangeCount = modeledChanges.Length,
                     Diagnostic = null,
                 },
-                modeledChanges.SelectMany(ModeledPartUris)
-                    .ToHashSet(StringComparer.Ordinal),
+                modeledChanges,
                 modeledChanges.FirstOrDefault(change =>
                     change.RightAnchor is not null || change.LeftAnchor is not null)
                     ?? modeledChanges.FirstOrDefault());
@@ -970,7 +1661,7 @@ public static class RedlineReversibilityVerifier
             return new ModeledSemanticEvaluation(
                 SemanticUnavailable(
                     $"The versioned semantic comparison failed ({ex.GetType().Name})."),
-                Array.Empty<string>(),
+                Array.Empty<SemanticChange>(),
                 null);
         }
     }
@@ -1018,6 +1709,43 @@ public static class RedlineReversibilityVerifier
 
     private sealed record ModeledSemanticEvaluation(
         RedlineModeledSemanticComparison Comparison,
-        IReadOnlyCollection<string> ModeledPartUris,
+        IReadOnlyList<SemanticChange> ModeledChanges,
         SemanticChange? FirstModeledChange);
+
+    private sealed record PackageDivergenceEvaluation(
+        bool Completed,
+        IReadOnlyList<RedlinePackageDivergence> Divergences);
+
+    private sealed class ProofFindingBudget
+    {
+        private readonly int _maximum;
+        private int _retained;
+        private bool _reportedExhaustion;
+
+        internal ProofFindingBudget(int maximum) => _maximum = maximum;
+
+        internal void Add(
+            List<RedlineProofFinding> target,
+            RedlineProofFinding finding)
+        {
+            if (_retained < _maximum)
+            {
+                target.Add(finding);
+                _retained++;
+                return;
+            }
+            if (_reportedExhaustion)
+                return;
+
+            _reportedExhaustion = true;
+            target.Add(Finding(
+                "proof_finding_limit_exceeded",
+                VerificationFindingSeverity.Error,
+                "The proof exceeded the configured finding budget; later findings were suppressed.",
+                new ChangeLocation { PropertyPath = "findings" },
+                revisionIds: Array.Empty<string>(),
+                remediation: "Reduce proof complexity or deliberately raise MaxFindings.",
+                direction: finding.Direction));
+        }
+    }
 }

--- a/Docxodus/Verification/RedlineReversibilityVerifier.cs
+++ b/Docxodus/Verification/RedlineReversibilityVerifier.cs
@@ -1269,18 +1269,6 @@ public static class RedlineReversibilityVerifier
     private static string RevisionSortKey(RedlineRevisionIdentity item) =>
         item.PartUri + "\n" + item.Family + "\n" + item.Id;
 
-    private static RedlineProofFinding DuplicateIdentityFinding(
-        string inputName,
-        string id,
-        IReadOnlyList<RedlineRevisionIdentity> identities) => Finding(
-        "duplicate_revision_identity",
-        VerificationFindingSeverity.Error,
-        $"The {inputName} revision inventory contains duplicate stable ID '{id}'.",
-        new ChangeLocation { EntryUri = identities[0].PartUri },
-        identities[0].AnchorId,
-        new[] { id },
-        "Repair ambiguous native revision IDs before proving reversibility.");
-
     private static RedlineProofFinding RevisionConflictFinding(
         RedlineRevisionIdentity baseline,
         RedlineRevisionIdentity redline) => Finding(

--- a/Docxodus/Verification/RedlineReversibilityVerifier.cs
+++ b/Docxodus/Verification/RedlineReversibilityVerifier.cs
@@ -26,6 +26,8 @@ public static class RedlineReversibilityVerifier
         ArgumentNullException.ThrowIfNull(redlineBytes);
         options ??= new RedlineReversibilityProofOptions();
         ArgumentNullException.ThrowIfNull(options.PackageManifestOptions);
+        if (options.MaxRevisionElements <= 0)
+            throw new ArgumentOutOfRangeException(nameof(options.MaxRevisionElements));
 
         var baselineManifest = PackageManifestGenerator.Generate(
             baselineBytes, options.PackageManifestOptions);
@@ -53,6 +55,25 @@ public static class RedlineReversibilityVerifier
                 null);
         }
 
+        bool revisionInventoryWithinLimit = AppendRevisionLimitFinding(
+            sharedFindings, "baseline", baselineManifest, options.MaxRevisionElements);
+        revisionInventoryWithinLimit &= AppendRevisionLimitFinding(
+            sharedFindings, "redline", redlineManifest, options.MaxRevisionElements);
+        if (!revisionInventoryWithinLimit)
+        {
+            return BuildRun(
+                options,
+                baselineManifest,
+                finalManifest,
+                redlineManifest,
+                Array.Empty<RedlineRevisionClassification>(),
+                null,
+                null,
+                sharedFindings,
+                null,
+                null);
+        }
+
         IReadOnlyList<RevisionListEntry> baselineRevisions;
         IReadOnlyList<RevisionListEntry> redlineRevisions;
         try
@@ -62,13 +83,32 @@ public static class RedlineReversibilityVerifier
             using var redline = OpenProofSession(redlineBytes);
             redlineRevisions = redline.ListRevisions();
         }
-        catch (Exception ex) when (!IsFatal(ex))
+        catch (Exception ex) when (DeliverableExceptionBoundary.IsRecoverable(ex))
         {
             sharedFindings.Add(Finding(
                 "revision_inventory_failed",
                 VerificationFindingSeverity.Error,
                 $"The baseline or redline revision inventory could not be opened ({ex.GetType().Name}).",
                 remediation: "Supply a valid WordprocessingML document whose tracked-change markup is supported."));
+            return BuildRun(
+                options,
+                baselineManifest,
+                finalManifest,
+                redlineManifest,
+                Array.Empty<RedlineRevisionClassification>(),
+                null,
+                null,
+                sharedFindings,
+                null,
+                null);
+        }
+
+        bool liveInventoryWithinLimit = AppendLiveRevisionLimitFinding(
+            sharedFindings, "baseline", baselineRevisions.Count, options.MaxRevisionElements);
+        liveInventoryWithinLimit &= AppendLiveRevisionLimitFinding(
+            sharedFindings, "redline", redlineRevisions.Count, options.MaxRevisionElements);
+        if (!liveInventoryWithinLimit)
+        {
             return BuildRun(
                 options,
                 baselineManifest,
@@ -256,7 +296,7 @@ public static class RedlineReversibilityVerifier
             survivingEntries = session.ListRevisions();
             outputBytes = session.Save(persistAnchorIds: false);
         }
-        catch (Exception ex) when (!IsFatal(ex))
+        catch (Exception ex) when (DeliverableExceptionBoundary.IsRecoverable(ex))
         {
             completed = false;
             findings.Add(Finding(
@@ -272,6 +312,7 @@ public static class RedlineReversibilityVerifier
             .Select(ToIdentity)
             .OrderBy(RevisionSortKey, StringComparer.Ordinal)
             .ToArray();
+        var survivingPreExisting = SelectSurvivingPreExisting(preExisting, surviving);
         var survivingGenerated = generated.Where(requested => surviving.Any(item =>
                 string.Equals(item.Id, requested.Id, StringComparison.Ordinal)
                 || RevisionOverlaps(requested, item)))
@@ -303,7 +344,7 @@ public static class RedlineReversibilityVerifier
                     RequestedRevisionIds = requestedIds,
                     ResolvedRevisionIds = resolvedIds,
                     ImplicitlyResolvedRevisionIds = implicitlyResolvedIds,
-                    SurvivingPreExistingRevisions = surviving,
+                    SurvivingPreExistingRevisions = survivingPreExisting,
                     PreExistingRevisionsPreserved = preExistingPreserved,
                     ModeledSemantic = SemanticUnavailable(),
                     NormalizedWholePackageEquivalent = false,
@@ -441,7 +482,7 @@ public static class RedlineReversibilityVerifier
                 RequestedRevisionIds = requestedIds,
                 ResolvedRevisionIds = resolvedIds,
                 ImplicitlyResolvedRevisionIds = implicitlyResolvedIds,
-                SurvivingPreExistingRevisions = surviving,
+                SurvivingPreExistingRevisions = survivingPreExisting,
                 PreExistingRevisionsPreserved = preExistingPreserved,
                 ModeledSemantic = semantic.Comparison,
                 NormalizedWholePackageEquivalent = normalizedEquivalent,
@@ -600,27 +641,27 @@ public static class RedlineReversibilityVerifier
             item => (item.Uri, item.Occurrence), item => item);
         var actualByKey = actual.Entries.ToDictionary(
             item => (item.Uri, item.Occurrence), item => item);
-        var keys = expectedByKey.Keys.Concat(actualByKey.Keys).Distinct()
-            .OrderBy(item => item.Uri, StringComparer.Ordinal)
-            .ThenBy(item => item.Occurrence)
-            .ToArray();
         var divergences = new List<RedlinePackageDivergence>();
-        foreach (var key in keys)
+        foreach (var change in PackageDelta.Compare(expected, actual).Where(change =>
+                     change.Kind is PackageDeltaChangeKind.EntryAdded
+                         or PackageDeltaChangeKind.EntryRemoved
+                         or PackageDeltaChangeKind.EntryModified))
         {
+            var partUri = change.Location.EntryUri
+                ?? throw new InvalidOperationException(
+                    "A package entry delta must identify its entry URI.");
+            var key = (Uri: partUri, change.Occurrence);
             expectedByKey.TryGetValue(key, out var expectedEntry);
             actualByKey.TryGetValue(key, out var actualEntry);
-            var kind = expectedEntry is null
-                ? RedlinePackageDivergenceKind.Added
-                : actualEntry is null
-                    ? RedlinePackageDivergenceKind.Removed
-                    : RedlinePackageDivergenceKind.Modified;
-            if (expectedEntry is not null && actualEntry is not null
-                && string.Equals(expectedEntry.ContentType, actualEntry.ContentType, StringComparison.Ordinal)
-                && DigestEquals(expectedEntry.RawBytesDigest, actualEntry.RawBytesDigest)
-                && DigestEquals(expectedEntry.NormalizedXmlDigest, actualEntry.NormalizedXmlDigest))
-                continue;
+            var kind = change.Kind switch
+            {
+                PackageDeltaChangeKind.EntryAdded => RedlinePackageDivergenceKind.Added,
+                PackageDeltaChangeKind.EntryRemoved => RedlinePackageDivergenceKind.Removed,
+                PackageDeltaChangeKind.EntryModified => RedlinePackageDivergenceKind.Modified,
+                _ => throw new ArgumentOutOfRangeException(nameof(change), change.Kind, null),
+            };
 
-            var relevant = generated.Where(item => RevisionAppliesToPart(item, key.Uri))
+            var relevant = generated.Where(item => RevisionAppliesToPart(item, partUri))
                 .OrderBy(RevisionSortKey, StringComparer.Ordinal).ToArray();
             bool normalizedDifferent = expectedEntry is null || actualEntry is null
                 || !string.Equals(expectedEntry.ContentType, actualEntry.ContentType, StringComparison.Ordinal)
@@ -630,8 +671,8 @@ public static class RedlineReversibilityVerifier
             divergences.Add(new RedlinePackageDivergence
             {
                 Kind = kind,
-                PartUri = key.Uri,
-                Occurrence = key.Occurrence,
+                PartUri = partUri,
+                Occurrence = change.Occurrence,
                 AnchorId = relevant.Select(item => item.AnchorId)
                     .FirstOrDefault(item => item is not null),
                 ApplicableRevisionIds = relevant.Select(item => item.Id).ToArray(),
@@ -639,14 +680,17 @@ public static class RedlineReversibilityVerifier
                 ActualRawDigest = actualEntry?.RawBytesDigest,
                 ExpectedNormalizedDigest = expectedEntry?.NormalizedXmlDigest,
                 ActualNormalizedDigest = actualEntry?.NormalizedXmlDigest,
-                HasModeledSemanticChange = modeledPartUris.Contains(key.Uri),
+                HasModeledSemanticChange = modeledPartUris.Contains(partUri),
                 // A change set identifies modeled facts, not a complete residual projection for
                 // an arbitrary XML part. Even when that same part has a modeled change, retain the
                 // normalized divergence as potentially unmodeled instead of overclaiming coverage.
                 UnknownOrUnmodeled = normalizedDifferent,
             });
         }
-        return divergences;
+        return divergences
+            .OrderBy(item => item.PartUri, StringComparer.Ordinal)
+            .ThenBy(item => item.Occurrence)
+            .ToArray();
     }
 
     private static bool RevisionAppliesToPart(RedlineRevisionIdentity revision, string partUri)
@@ -763,6 +807,60 @@ public static class RedlineReversibilityVerifier
         }
     }
 
+    private static bool AppendRevisionLimitFinding(
+        List<RedlineProofFinding> target,
+        string inputName,
+        PackageManifest manifest,
+        int maximum)
+    {
+        int actual = manifest.Facts.Revisions.Total;
+        if (actual <= maximum)
+            return true;
+
+        target.Add(Finding(
+            "revision_element_limit_exceeded",
+            VerificationFindingSeverity.Error,
+            $"The {inputName} package contains "
+                + $"{actual.ToString(System.Globalization.CultureInfo.InvariantCulture)} native revision "
+                + $"element(s); the proof limit is "
+                + $"{maximum.ToString(System.Globalization.CultureInfo.InvariantCulture)}.",
+            new ChangeLocation { PropertyPath = inputName + "/revisions" },
+            remediation: "Reduce tracked-change markup or explicitly raise MaxRevisionElements for a reviewed input."));
+        return false;
+    }
+
+    private static bool AppendLiveRevisionLimitFinding(
+        List<RedlineProofFinding> target,
+        string inputName,
+        int actual,
+        int maximum)
+    {
+        if (actual <= maximum)
+            return true;
+
+        target.Add(Finding(
+            "revision_inventory_limit_exceeded",
+            VerificationFindingSeverity.Error,
+            $"The {inputName} live revision inventory contains "
+                + $"{actual.ToString(System.Globalization.CultureInfo.InvariantCulture)} entries; "
+                + $"the proof limit is "
+                + $"{maximum.ToString(System.Globalization.CultureInfo.InvariantCulture)}.",
+            new ChangeLocation { PropertyPath = inputName + "/revisionInventory" },
+            remediation: "Reduce tracked-change markup or explicitly raise MaxRevisionElements for a reviewed input."));
+        return false;
+    }
+
+    internal static IReadOnlyList<RedlineRevisionIdentity> SelectSurvivingPreExisting(
+        IReadOnlyList<RedlineRevisionIdentity> preExisting,
+        IReadOnlyList<RedlineRevisionIdentity> surviving)
+    {
+        var preExistingIds = preExisting.Select(item => item.Id)
+            .ToHashSet(StringComparer.Ordinal);
+        return surviving.Where(item => preExistingIds.Contains(item.Id))
+            .OrderBy(RevisionSortKey, StringComparer.Ordinal)
+            .ToArray();
+    }
+
     private static RedlineProofFinding Finding(
         string code,
         VerificationFindingSeverity severity,
@@ -867,7 +965,7 @@ public static class RedlineReversibilityVerifier
                     change.RightAnchor is not null || change.LeftAnchor is not null)
                     ?? modeledChanges.FirstOrDefault());
         }
-        catch (Exception ex) when (!IsFatal(ex))
+        catch (Exception ex) when (DeliverableExceptionBoundary.IsRecoverable(ex))
         {
             return new ModeledSemanticEvaluation(
                 SemanticUnavailable(
@@ -915,9 +1013,6 @@ public static class RedlineReversibilityVerifier
         RedlineProofDirection.AcceptToFinal => "accept-to-final",
         _ => "reject-to-baseline",
     };
-
-    private static bool IsFatal(Exception exception) => exception is
-        OutOfMemoryException or StackOverflowException or AccessViolationException;
 
     private sealed record PathEvaluation(RedlineProofPathResult Result, byte[]? OutputBytes);
 

--- a/Docxodus/Verification/RedlineReversibilityVerifier.cs
+++ b/Docxodus/Verification/RedlineReversibilityVerifier.cs
@@ -1,0 +1,791 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+namespace Docxodus.Verification;
+
+/// <summary>
+/// Proves the two generated-redline resolution paths without accepting or rejecting unrelated
+/// review markup. Package inspection is performed before the Open XML SDK opens any input.
+/// </summary>
+public static class RedlineReversibilityVerifier
+{
+    /// <summary>
+    /// Accept only generated revisions and compare with <paramref name="intendedFinalBytes"/>;
+    /// reject only generated revisions and compare with <paramref name="baselineBytes"/>.
+    /// </summary>
+    public static RedlineReversibilityProofRun Prove(
+        byte[] baselineBytes,
+        byte[] intendedFinalBytes,
+        byte[] redlineBytes,
+        RedlineReversibilityProofOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(baselineBytes);
+        ArgumentNullException.ThrowIfNull(intendedFinalBytes);
+        ArgumentNullException.ThrowIfNull(redlineBytes);
+        options ??= new RedlineReversibilityProofOptions();
+        ArgumentNullException.ThrowIfNull(options.PackageManifestOptions);
+
+        var baselineManifest = PackageManifestGenerator.Generate(
+            baselineBytes, options.PackageManifestOptions);
+        var finalManifest = PackageManifestGenerator.Generate(
+            intendedFinalBytes, options.PackageManifestOptions);
+        var redlineManifest = PackageManifestGenerator.Generate(
+            redlineBytes, options.PackageManifestOptions);
+        var sharedFindings = new List<RedlineProofFinding>();
+
+        AppendManifestErrors(sharedFindings, "baseline", baselineManifest);
+        AppendManifestErrors(sharedFindings, "intendedFinal", finalManifest);
+        AppendManifestErrors(sharedFindings, "redline", redlineManifest);
+        if (!baselineManifest.IsValid || !finalManifest.IsValid || !redlineManifest.IsValid)
+        {
+            return BuildRun(
+                options,
+                baselineManifest,
+                finalManifest,
+                redlineManifest,
+                Array.Empty<RedlineRevisionClassification>(),
+                null,
+                null,
+                sharedFindings,
+                null,
+                null);
+        }
+
+        IReadOnlyList<RevisionListEntry> baselineRevisions;
+        IReadOnlyList<RevisionListEntry> redlineRevisions;
+        try
+        {
+            using var baseline = OpenProofSession(baselineBytes);
+            baselineRevisions = baseline.ListRevisions();
+            using var redline = OpenProofSession(redlineBytes);
+            redlineRevisions = redline.ListRevisions();
+        }
+        catch (Exception ex) when (!IsFatal(ex))
+        {
+            sharedFindings.Add(Finding(
+                "revision_inventory_failed",
+                VerificationFindingSeverity.Error,
+                $"The baseline or redline revision inventory could not be opened ({ex.GetType().Name}).",
+                remediation: "Supply a valid WordprocessingML document whose tracked-change markup is supported."));
+            return BuildRun(
+                options,
+                baselineManifest,
+                finalManifest,
+                redlineManifest,
+                Array.Empty<RedlineRevisionClassification>(),
+                null,
+                null,
+                sharedFindings,
+                null,
+                null);
+        }
+
+        var classifications = Classify(baselineRevisions, redlineRevisions, sharedFindings);
+        var generated = classifications
+            .Where(item => item.Disposition == RedlineRevisionDisposition.Generated
+                && item.Redline is not null)
+            .Select(item => item.Redline!)
+            .OrderBy(RevisionSortKey, StringComparer.Ordinal)
+            .ToArray();
+        var preExisting = classifications
+            .Where(item => item.Disposition == RedlineRevisionDisposition.PreExisting
+                && item.Baseline is not null)
+            .Select(item => item.Baseline!)
+            .OrderBy(RevisionSortKey, StringComparer.Ordinal)
+            .ToArray();
+
+        foreach (var revision in generated.Where(item =>
+                     item.ResolutionStatus != RevisionResolutionStatus.Supported))
+        {
+            sharedFindings.Add(Finding(
+                "generated_revision_not_resolvable",
+                VerificationFindingSeverity.Error,
+                $"Generated revision '{revision.Id}' is {revision.ResolutionStatus.ToString().ToLowerInvariant()}.",
+                new ChangeLocation { EntryUri = revision.PartUri },
+                revision.AnchorId,
+                new[] { revision.Id },
+                "Regenerate the redline with supported, unambiguous native revision markup."));
+        }
+
+        var classificationFailed = classifications.Any(item =>
+                item.Disposition == RedlineRevisionDisposition.Conflicted)
+            || generated.Any(item => item.ResolutionStatus != RevisionResolutionStatus.Supported);
+        if (classificationFailed)
+        {
+            return BuildRun(
+                options,
+                baselineManifest,
+                finalManifest,
+                redlineManifest,
+                classifications,
+                null,
+                null,
+                sharedFindings,
+                null,
+                null);
+        }
+
+        var accept = EvaluatePath(
+            RedlineProofDirection.AcceptToFinal,
+            accept: true,
+            redlineBytes,
+            intendedFinalBytes,
+            finalManifest,
+            generated,
+            preExisting,
+            options);
+        var reject = EvaluatePath(
+            RedlineProofDirection.RejectToBaseline,
+            accept: false,
+            redlineBytes,
+            baselineBytes,
+            baselineManifest,
+            generated,
+            preExisting,
+            options);
+
+        return BuildRun(
+            options,
+            baselineManifest,
+            finalManifest,
+            redlineManifest,
+            classifications,
+            accept.Result,
+            reject.Result,
+            sharedFindings,
+            accept.OutputBytes,
+            reject.OutputBytes);
+    }
+
+    private static PathEvaluation EvaluatePath(
+        RedlineProofDirection direction,
+        bool accept,
+        byte[] redlineBytes,
+        byte[] expectedBytes,
+        PackageManifest expectedManifest,
+        IReadOnlyList<RedlineRevisionIdentity> generated,
+        IReadOnlyList<RedlineRevisionIdentity> preExisting,
+        RedlineReversibilityProofOptions options)
+    {
+        var findings = new List<RedlineProofFinding>();
+        var requestedIds = generated.Select(item => item.Id).ToArray();
+        var resolvedIds = new List<string>(requestedIds.Length);
+        byte[]? outputBytes = null;
+        IReadOnlyList<RevisionListEntry> survivingEntries = Array.Empty<RevisionListEntry>();
+        bool completed = true;
+
+        try
+        {
+            using var session = OpenProofSession(redlineBytes);
+            foreach (var requested in generated)
+            {
+                var current = session.ListRevisions()
+                    .SingleOrDefault(item => string.Equals(item.Id, requested.Id, StringComparison.Ordinal));
+                if (current is null)
+                {
+                    completed = false;
+                    findings.Add(Finding(
+                        "generated_revision_disappeared",
+                        VerificationFindingSeverity.Error,
+                        $"Generated revision '{requested.Id}' disappeared before it could be resolved.",
+                        new ChangeLocation { EntryUri = requested.PartUri },
+                        requested.AnchorId,
+                        new[] { requested.Id },
+                        "Regenerate a redline without nested or overlapping generated revision groups.",
+                        direction));
+                    break;
+                }
+
+                if (current.ResolutionStatus != RevisionResolutionStatus.Supported)
+                {
+                    completed = false;
+                    findings.Add(Finding(
+                        "generated_revision_became_unresolvable",
+                        VerificationFindingSeverity.Error,
+                        $"Generated revision '{requested.Id}' became {current.ResolutionStatus.ToString().ToLowerInvariant()} during resolution.",
+                        new ChangeLocation { EntryUri = current.PartUri },
+                        current.AnchorId,
+                        new[] { requested.Id },
+                        "Regenerate a redline whose generated revision groups can be resolved independently.",
+                        direction));
+                    break;
+                }
+
+                var edit = accept
+                    ? session.AcceptRevision(requested.Id)
+                    : session.RejectRevision(requested.Id);
+                if (!edit.Success)
+                {
+                    completed = false;
+                    findings.Add(Finding(
+                        "generated_revision_resolution_failed",
+                        VerificationFindingSeverity.Error,
+                        $"Revision '{requested.Id}' could not be {(accept ? "accepted" : "rejected")}: " +
+                        (edit.Error?.Message ?? "unknown resolver failure"),
+                        new ChangeLocation { EntryUri = current.PartUri },
+                        current.AnchorId,
+                        new[] { requested.Id },
+                        "Inspect the revision topology and regenerate the comparison redline.",
+                        direction));
+                    break;
+                }
+                resolvedIds.Add(requested.Id);
+            }
+
+            survivingEntries = session.ListRevisions();
+            outputBytes = session.Save(persistAnchorIds: false);
+        }
+        catch (Exception ex) when (!IsFatal(ex))
+        {
+            completed = false;
+            findings.Add(Finding(
+                "proof_path_execution_failed",
+                VerificationFindingSeverity.Error,
+                $"The {DirectionName(direction)} path failed ({ex.GetType().Name}).",
+                revisionIds: requestedIds,
+                remediation: "Inspect the redline package and its native revision topology.",
+                direction: direction));
+        }
+
+        var surviving = survivingEntries
+            .Select(ToIdentity)
+            .OrderBy(RevisionSortKey, StringComparer.Ordinal)
+            .ToArray();
+        bool preExistingPreserved = VerifyPreExisting(
+            direction, preExisting, surviving, findings);
+
+        if (outputBytes is null)
+        {
+            return new PathEvaluation(
+                new RedlineProofPathResult
+                {
+                    Direction = direction,
+                    Completed = false,
+                    Equivalent = false,
+                    RequestedRevisionIds = requestedIds,
+                    ResolvedRevisionIds = resolvedIds,
+                    SurvivingPreExistingRevisions = surviving,
+                    PreExistingRevisionsPreserved = preExistingPreserved,
+                    ModeledSemantic = SemanticUnavailable(),
+                    NormalizedWholePackageEquivalent = false,
+                    OrderedOpcContentEquivalent = false,
+                    ExactPackageBytesEquivalent = false,
+                    ExpectedPackage = ToPackageIdentity(expectedManifest),
+                    ActualPackage = null,
+                    FirstDivergence = null,
+                    Divergences = Array.Empty<RedlinePackageDivergence>(),
+                    Findings = findings,
+                },
+                null);
+        }
+
+        var actualManifest = PackageManifestGenerator.Generate(
+            outputBytes, options.PackageManifestOptions);
+        AppendManifestErrors(findings, "proofOutput", actualManifest, direction);
+        if (!actualManifest.IsValid)
+            completed = false;
+
+        var semantic = CompareModeledSemantics(expectedBytes, outputBytes);
+        if (!semantic.Available)
+        {
+            findings.Add(Finding(
+                "modeled_semantic_comparison_unavailable",
+                VerificationFindingSeverity.Error,
+                semantic.Diagnostic ?? "The versioned modeled semantic comparer is unavailable.",
+                revisionIds: requestedIds,
+                remediation: "Run the proof with the semantic-diff component available.",
+                direction: direction));
+        }
+        else if (semantic.Equivalent != true)
+        {
+            findings.Add(Finding(
+                "modeled_semantic_mismatch",
+                VerificationFindingSeverity.Error,
+                $"The {DirectionName(direction)} output has {semantic.ChangeCount ?? 0} modeled semantic change(s).",
+                revisionIds: requestedIds,
+                remediation: "Inspect the semantic change set and applicable generated revisions.",
+                direction: direction));
+        }
+
+        bool normalizedEquivalent = DigestEquals(
+            expectedManifest.NormalizedSemanticDigest,
+            actualManifest.NormalizedSemanticDigest);
+        bool opcEquivalent = DigestEquals(
+            expectedManifest.OrderedOpcContentDigest,
+            actualManifest.OrderedOpcContentDigest);
+        bool rawEquivalent = DigestEquals(
+            expectedManifest.RawPackageBytesDigest,
+            actualManifest.RawPackageBytesDigest);
+        var divergences = CompareEntries(
+            expectedManifest,
+            actualManifest,
+            generated,
+            modeledPartUris: Array.Empty<string>());
+        var firstDivergence = divergences.FirstOrDefault();
+
+        if (!normalizedEquivalent)
+        {
+            findings.Add(Finding(
+                "normalized_whole_package_mismatch",
+                VerificationFindingSeverity.Error,
+                $"The {DirectionName(direction)} output differs from its expected document after package normalization.",
+                firstDivergence is null ? null : new ChangeLocation { EntryUri = firstDivergence.PartUri },
+                firstDivergence?.AnchorId,
+                firstDivergence?.ApplicableRevisionIds ?? requestedIds,
+                "Inspect the first divergent part and the listed generated revisions.",
+                direction));
+        }
+        if (!opcEquivalent)
+        {
+            findings.Add(Finding(
+                "ordered_opc_content_mismatch",
+                normalizedEquivalent ? VerificationFindingSeverity.Info : VerificationFindingSeverity.Error,
+                "Exact uncompressed OPC entry bytes differ from the expected document.",
+                firstDivergence is null ? null : new ChangeLocation { EntryUri = firstDivergence.PartUri },
+                firstDivergence?.AnchorId,
+                firstDivergence?.ApplicableRevisionIds ?? requestedIds,
+                normalizedEquivalent
+                    ? "No action is required when only documented XML serialization differs."
+                    : "Inspect the divergent package entries.",
+                direction));
+        }
+        if (!rawEquivalent)
+        {
+            findings.Add(Finding(
+                "raw_package_bytes_mismatch",
+                options.RequireExactPackageBytes
+                    ? VerificationFindingSeverity.Error
+                    : VerificationFindingSeverity.Info,
+                "ZIP package bytes differ from the expected document.",
+                revisionIds: requestedIds,
+                remediation: options.RequireExactPackageBytes
+                    ? "Reproduce the exact expected ZIP container or disable the explicit exact-byte policy."
+                    : "No action is required when normalized package identity is equal.",
+                direction: direction));
+        }
+
+        bool equivalent = completed
+            && preExistingPreserved
+            && semantic.Available
+            && semantic.Equivalent == true
+            && normalizedEquivalent
+            && (!options.RequireExactPackageBytes || rawEquivalent)
+            && findings.All(item => item.Severity != VerificationFindingSeverity.Error);
+        return new PathEvaluation(
+            new RedlineProofPathResult
+            {
+                Direction = direction,
+                Completed = completed,
+                Equivalent = equivalent,
+                RequestedRevisionIds = requestedIds,
+                ResolvedRevisionIds = resolvedIds,
+                SurvivingPreExistingRevisions = surviving,
+                PreExistingRevisionsPreserved = preExistingPreserved,
+                ModeledSemantic = semantic,
+                NormalizedWholePackageEquivalent = normalizedEquivalent,
+                OrderedOpcContentEquivalent = opcEquivalent,
+                ExactPackageBytesEquivalent = rawEquivalent,
+                ExpectedPackage = ToPackageIdentity(expectedManifest),
+                ActualPackage = ToPackageIdentity(actualManifest),
+                FirstDivergence = firstDivergence,
+                Divergences = divergences,
+                Findings = findings,
+            },
+            outputBytes);
+    }
+
+    private static IReadOnlyList<RedlineRevisionClassification> Classify(
+        IReadOnlyList<RevisionListEntry> baselineEntries,
+        IReadOnlyList<RevisionListEntry> redlineEntries,
+        List<RedlineProofFinding> findings)
+    {
+        var baseline = baselineEntries.Select(ToIdentity)
+            .OrderBy(RevisionSortKey, StringComparer.Ordinal).ToArray();
+        var redline = redlineEntries.Select(ToIdentity)
+            .OrderBy(RevisionSortKey, StringComparer.Ordinal).ToArray();
+        var baselineById = baseline.GroupBy(item => item.Id, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.ToArray(), StringComparer.Ordinal);
+        var redlineById = redline.GroupBy(item => item.Id, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.ToArray(), StringComparer.Ordinal);
+
+        foreach (var duplicate in baselineById.Where(item => item.Value.Length != 1))
+            findings.Add(DuplicateIdentityFinding("baseline", duplicate.Key, duplicate.Value));
+        foreach (var duplicate in redlineById.Where(item => item.Value.Length != 1))
+            findings.Add(DuplicateIdentityFinding("redline", duplicate.Key, duplicate.Value));
+
+        var results = new List<RedlineRevisionClassification>();
+        var matchedBaselineIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var redlineRevision in redline)
+        {
+            if (redlineById[redlineRevision.Id].Length != 1)
+            {
+                results.Add(new RedlineRevisionClassification
+                {
+                    Disposition = RedlineRevisionDisposition.Conflicted,
+                    Redline = redlineRevision,
+                    Reason = "The redline contains a duplicate stable revision identity.",
+                });
+                continue;
+            }
+
+            if (baselineById.TryGetValue(redlineRevision.Id, out var sameId)
+                && sameId.Length == 1)
+            {
+                var baselineRevision = sameId[0];
+                matchedBaselineIds.Add(baselineRevision.Id);
+                bool unchanged = IdentityEquivalent(baselineRevision, redlineRevision);
+                results.Add(new RedlineRevisionClassification
+                {
+                    Disposition = unchanged
+                        ? RedlineRevisionDisposition.PreExisting
+                        : RedlineRevisionDisposition.Conflicted,
+                    Baseline = baselineRevision,
+                    Redline = redlineRevision,
+                    Reason = unchanged
+                        ? "The complete part-qualified revision identity is unchanged from the baseline."
+                        : "A baseline revision reused its stable ID but changed identity or location.",
+                });
+                if (!unchanged)
+                    findings.Add(RevisionConflictFinding(baselineRevision, redlineRevision));
+                continue;
+            }
+
+            var overlaps = baseline.Where(item => RevisionOverlaps(item, redlineRevision)).ToArray();
+            if (overlaps.Length > 0)
+            {
+                foreach (var overlap in overlaps)
+                    matchedBaselineIds.Add(overlap.Id);
+                results.Add(new RedlineRevisionClassification
+                {
+                    Disposition = RedlineRevisionDisposition.Conflicted,
+                    Baseline = overlaps[0],
+                    Redline = redlineRevision,
+                    Reason = "The redline revision overlaps native constituent IDs owned by baseline review markup.",
+                });
+                findings.Add(RevisionConflictFinding(overlaps[0], redlineRevision));
+                continue;
+            }
+
+            results.Add(new RedlineRevisionClassification
+            {
+                Disposition = RedlineRevisionDisposition.Generated,
+                Redline = redlineRevision,
+                Reason = "The part-qualified native revision identity is absent from the baseline.",
+            });
+        }
+
+        foreach (var missing in baseline.Where(item => !matchedBaselineIds.Contains(item.Id)))
+        {
+            results.Add(new RedlineRevisionClassification
+            {
+                Disposition = RedlineRevisionDisposition.Conflicted,
+                Baseline = missing,
+                Reason = "A pre-existing baseline revision is missing from the redline.",
+            });
+            findings.Add(Finding(
+                "preexisting_revision_missing_from_redline",
+                VerificationFindingSeverity.Error,
+                $"Baseline revision '{missing.Id}' is absent from the redline.",
+                new ChangeLocation { EntryUri = missing.PartUri },
+                missing.AnchorId,
+                new[] { missing.Id },
+                "Regenerate the redline while preserving the selected baseline review state."));
+        }
+
+        return results
+            .OrderBy(item => item.Redline?.PartUri ?? item.Baseline?.PartUri, StringComparer.Ordinal)
+            .ThenBy(item => item.Redline?.Id ?? item.Baseline?.Id, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static bool VerifyPreExisting(
+        RedlineProofDirection direction,
+        IReadOnlyList<RedlineRevisionIdentity> expected,
+        IReadOnlyList<RedlineRevisionIdentity> actual,
+        List<RedlineProofFinding> findings)
+    {
+        var actualById = actual.GroupBy(item => item.Id, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.ToArray(), StringComparer.Ordinal);
+        bool preserved = true;
+        foreach (var revision in expected)
+        {
+            if (!actualById.TryGetValue(revision.Id, out var candidates)
+                || candidates.Length != 1
+                || !IdentityEquivalent(revision, candidates[0]))
+            {
+                preserved = false;
+                findings.Add(Finding(
+                    "preexisting_revision_not_preserved",
+                    VerificationFindingSeverity.Error,
+                    $"Pre-existing revision '{revision.Id}' did not survive the {DirectionName(direction)} path unchanged.",
+                    new ChangeLocation { EntryUri = revision.PartUri },
+                    revision.AnchorId,
+                    new[] { revision.Id },
+                    "Do not resolve or rewrite revision markup owned by the baseline.",
+                    direction));
+            }
+        }
+        return preserved;
+    }
+
+    private static IReadOnlyList<RedlinePackageDivergence> CompareEntries(
+        PackageManifest expected,
+        PackageManifest actual,
+        IReadOnlyList<RedlineRevisionIdentity> generated,
+        IReadOnlyCollection<string> modeledPartUris)
+    {
+        var expectedByKey = expected.Entries.ToDictionary(
+            item => (item.Uri, item.Occurrence), item => item);
+        var actualByKey = actual.Entries.ToDictionary(
+            item => (item.Uri, item.Occurrence), item => item);
+        var keys = expectedByKey.Keys.Concat(actualByKey.Keys).Distinct()
+            .OrderBy(item => item.Uri, StringComparer.Ordinal)
+            .ThenBy(item => item.Occurrence)
+            .ToArray();
+        var divergences = new List<RedlinePackageDivergence>();
+        foreach (var key in keys)
+        {
+            expectedByKey.TryGetValue(key, out var expectedEntry);
+            actualByKey.TryGetValue(key, out var actualEntry);
+            var kind = expectedEntry is null
+                ? RedlinePackageDivergenceKind.Added
+                : actualEntry is null
+                    ? RedlinePackageDivergenceKind.Removed
+                    : RedlinePackageDivergenceKind.Modified;
+            if (expectedEntry is not null && actualEntry is not null
+                && string.Equals(expectedEntry.ContentType, actualEntry.ContentType, StringComparison.Ordinal)
+                && DigestEquals(expectedEntry.RawBytesDigest, actualEntry.RawBytesDigest)
+                && DigestEquals(expectedEntry.NormalizedXmlDigest, actualEntry.NormalizedXmlDigest))
+                continue;
+
+            var relevant = generated.Where(item => RevisionAppliesToPart(item, key.Uri))
+                .OrderBy(RevisionSortKey, StringComparer.Ordinal).ToArray();
+            bool normalizedDifferent = expectedEntry is null || actualEntry is null
+                || !string.Equals(expectedEntry.ContentType, actualEntry.ContentType, StringComparison.Ordinal)
+                || !DigestEquals(expectedEntry.NormalizedXmlDigest, actualEntry.NormalizedXmlDigest)
+                || (!expectedEntry.IsXml && !DigestEquals(
+                    expectedEntry.RawBytesDigest, actualEntry.RawBytesDigest));
+            divergences.Add(new RedlinePackageDivergence
+            {
+                Kind = kind,
+                PartUri = key.Uri,
+                Occurrence = key.Occurrence,
+                AnchorId = relevant.Select(item => item.AnchorId)
+                    .FirstOrDefault(item => item is not null),
+                ApplicableRevisionIds = relevant.Select(item => item.Id).ToArray(),
+                ExpectedRawDigest = expectedEntry?.RawBytesDigest,
+                ActualRawDigest = actualEntry?.RawBytesDigest,
+                ExpectedNormalizedDigest = expectedEntry?.NormalizedXmlDigest,
+                ActualNormalizedDigest = actualEntry?.NormalizedXmlDigest,
+                UnknownOrUnmodeled = normalizedDifferent
+                    && !modeledPartUris.Contains(key.Uri),
+            });
+        }
+        return divergences;
+    }
+
+    private static bool RevisionAppliesToPart(RedlineRevisionIdentity revision, string partUri)
+    {
+        if (string.Equals(revision.PartUri, partUri, StringComparison.Ordinal))
+            return true;
+        var slash = revision.PartUri.LastIndexOf('/');
+        var ownerDirectory = slash < 0 ? "/" : revision.PartUri[..(slash + 1)];
+        var ownerName = slash < 0 ? revision.PartUri : revision.PartUri[(slash + 1)..];
+        return string.Equals(
+            partUri,
+            $"{ownerDirectory}_rels/{ownerName}.rels",
+            StringComparison.Ordinal);
+    }
+
+    private static RedlineRevisionIdentity ToIdentity(RevisionListEntry entry) => new()
+    {
+        Id = entry.Id,
+        PartUri = entry.PartUri,
+        Scope = entry.Scope,
+        Type = entry.Type,
+        Family = entry.Family,
+        ConstituentIds = entry.ConstituentIds.OrderBy(item => item, StringComparer.Ordinal).ToArray(),
+        Author = entry.Author,
+        Date = entry.Date,
+        Text = entry.Text,
+        AnchorId = entry.AnchorId,
+        AffectedAnchorIds = entry.AffectedAnchors.Select(item => item.Id)
+            .Distinct(StringComparer.Ordinal).OrderBy(item => item, StringComparer.Ordinal).ToArray(),
+        ResolutionStatus = entry.ResolutionStatus,
+        Diagnostic = entry.Diagnostic,
+    };
+
+    private static bool IdentityEquivalent(
+        RedlineRevisionIdentity left,
+        RedlineRevisionIdentity right) =>
+        string.Equals(left.Id, right.Id, StringComparison.Ordinal)
+        && string.Equals(left.PartUri, right.PartUri, StringComparison.Ordinal)
+        && string.Equals(left.Scope, right.Scope, StringComparison.Ordinal)
+        && string.Equals(left.Type, right.Type, StringComparison.Ordinal)
+        && left.Family == right.Family
+        && left.ConstituentIds.SequenceEqual(right.ConstituentIds, StringComparer.Ordinal)
+        && string.Equals(left.Author, right.Author, StringComparison.Ordinal)
+        && string.Equals(left.Date, right.Date, StringComparison.Ordinal)
+        && string.Equals(left.Text, right.Text, StringComparison.Ordinal)
+        && string.Equals(left.AnchorId, right.AnchorId, StringComparison.Ordinal)
+        && left.AffectedAnchorIds.SequenceEqual(right.AffectedAnchorIds, StringComparer.Ordinal)
+        && left.ResolutionStatus == right.ResolutionStatus
+        && Equals(left.Diagnostic, right.Diagnostic);
+
+    private static bool RevisionOverlaps(
+        RedlineRevisionIdentity baseline,
+        RedlineRevisionIdentity redline) =>
+        string.Equals(baseline.PartUri, redline.PartUri, StringComparison.Ordinal)
+        && baseline.ConstituentIds.Intersect(
+            redline.ConstituentIds, StringComparer.Ordinal).Any();
+
+    private static string RevisionSortKey(RedlineRevisionIdentity item) =>
+        item.PartUri + "\n" + item.Family + "\n" + item.Id;
+
+    private static RedlineProofFinding DuplicateIdentityFinding(
+        string inputName,
+        string id,
+        IReadOnlyList<RedlineRevisionIdentity> identities) => Finding(
+        "duplicate_revision_identity",
+        VerificationFindingSeverity.Error,
+        $"The {inputName} revision inventory contains duplicate stable ID '{id}'.",
+        new ChangeLocation { EntryUri = identities[0].PartUri },
+        identities[0].AnchorId,
+        new[] { id },
+        "Repair ambiguous native revision IDs before proving reversibility.");
+
+    private static RedlineProofFinding RevisionConflictFinding(
+        RedlineRevisionIdentity baseline,
+        RedlineRevisionIdentity redline) => Finding(
+        "preexisting_revision_identity_conflict",
+        VerificationFindingSeverity.Error,
+        $"Redline revision '{redline.Id}' conflicts with baseline revision '{baseline.Id}'.",
+        new ChangeLocation { EntryUri = redline.PartUri },
+        redline.AnchorId,
+        new[] { baseline.Id, redline.Id }.Distinct(StringComparer.Ordinal).ToArray(),
+        "Regenerate the redline without reusing or rewriting baseline revision identities.");
+
+    private static void AppendManifestErrors(
+        List<RedlineProofFinding> target,
+        string inputName,
+        PackageManifest manifest,
+        RedlineProofDirection? direction = null)
+    {
+        foreach (var finding in manifest.Findings.Where(item =>
+                     item.Severity == VerificationFindingSeverity.Error))
+        {
+            target.Add(Finding(
+                "package_" + finding.Code,
+                finding.Severity,
+                $"{inputName}: {finding.Message}",
+                finding.Location,
+                revisionIds: Array.Empty<string>(),
+                remediation: "Repair or replace the unsafe package before running the proof.",
+                direction: direction));
+        }
+    }
+
+    private static RedlineProofFinding Finding(
+        string code,
+        VerificationFindingSeverity severity,
+        string message,
+        ChangeLocation? location = null,
+        string? anchorId = null,
+        IReadOnlyList<string>? revisionIds = null,
+        string? remediation = null,
+        RedlineProofDirection? direction = null) => new()
+    {
+        Code = code,
+        Severity = severity,
+        Message = message,
+        Direction = direction,
+        Location = location,
+        AnchorId = anchorId,
+        RevisionIds = revisionIds ?? Array.Empty<string>(),
+        Remediation = remediation,
+    };
+
+    private static RedlineReversibilityProofRun BuildRun(
+        RedlineReversibilityProofOptions options,
+        PackageManifest baseline,
+        PackageManifest intendedFinal,
+        PackageManifest redline,
+        IReadOnlyList<RedlineRevisionClassification> classifications,
+        RedlineProofPathResult? accept,
+        RedlineProofPathResult? reject,
+        IReadOnlyList<RedlineProofFinding> findings,
+        byte[]? acceptedBytes,
+        byte[]? rejectedBytes)
+    {
+        bool success = accept?.Equivalent == true
+            && reject?.Equivalent == true
+            && findings.All(item => item.Severity != VerificationFindingSeverity.Error);
+        return new RedlineReversibilityProofRun
+        {
+            Proof = new RedlineReversibilityProof
+            {
+                Success = success,
+                RequireExactPackageBytes = options.RequireExactPackageBytes,
+                BaselinePackage = ToPackageIdentity(baseline),
+                IntendedFinalPackage = ToPackageIdentity(intendedFinal),
+                RedlinePackage = ToPackageIdentity(redline),
+                RevisionClassifications = classifications,
+                AcceptToFinal = accept,
+                RejectToBaseline = reject,
+                Findings = findings,
+            },
+            AcceptedPackageBytes = acceptedBytes,
+            RejectedPackageBytes = rejectedBytes,
+        };
+    }
+
+    private static RedlineProofPackageIdentity ToPackageIdentity(PackageManifest manifest) => new()
+    {
+        RawPackageBytesDigest = manifest.RawPackageBytesDigest,
+        OrderedOpcContentDigest = manifest.OrderedOpcContentDigest,
+        NormalizedWholePackageDigest = manifest.NormalizedSemanticDigest,
+    };
+
+    private static bool DigestEquals(VerificationDigest? left, VerificationDigest? right) =>
+        left is not null && right is not null
+        && string.Equals(left.Algorithm, right.Algorithm, StringComparison.Ordinal)
+        && string.Equals(left.Value, right.Value, StringComparison.Ordinal);
+
+    private static DocxSession OpenProofSession(byte[] bytes) => new(bytes, new DocxSessionSettings
+    {
+        UndoDepth = 1,
+        UndoMemoryBudgetBytes = 128L * 1024 * 1024,
+        PersistAnchorIds = false,
+        EmitMarkdownPatch = false,
+        CaptureInitialProjection = false,
+    });
+
+    // Replaced by the schema-v1 semantic comparer when #457 is stacked into this branch. Keeping
+    // the dependency unavailable (and therefore proof-failing) is deliberate: normalized package
+    // equality must never be mislabeled as modeled semantic evidence.
+    private static RedlineModeledSemanticComparison CompareModeledSemantics(
+        byte[] expectedBytes,
+        byte[] actualBytes) => SemanticUnavailable();
+
+    private static RedlineModeledSemanticComparison SemanticUnavailable() => new()
+    {
+        Available = false,
+        Equivalent = null,
+        Schema = null,
+        ChangeCount = null,
+        Diagnostic = "The versioned semantic diff dependency is not present on this branch.",
+    };
+
+    private static string DirectionName(RedlineProofDirection direction) => direction switch
+    {
+        RedlineProofDirection.AcceptToFinal => "accept-to-final",
+        _ => "reject-to-baseline",
+    };
+
+    private static bool IsFatal(Exception exception) => exception is
+        OutOfMemoryException or StackOverflowException or AccessViolationException;
+
+    private sealed record PathEvaluation(RedlineProofPathResult Result, byte[]? OutputBytes);
+}

--- a/Docxodus/Verification/RedlineReversibilityVerifier.cs
+++ b/Docxodus/Verification/RedlineReversibilityVerifier.cs
@@ -172,6 +172,7 @@ public static class RedlineReversibilityVerifier
         var findings = new List<RedlineProofFinding>();
         var requestedIds = generated.Select(item => item.Id).ToArray();
         var resolvedIds = new List<string>(requestedIds.Length);
+        var implicitlyResolvedIds = new List<string>();
         byte[]? outputBytes = null;
         IReadOnlyList<RevisionListEntry> survivingEntries = Array.Empty<RevisionListEntry>();
         bool completed = true;
@@ -185,17 +186,35 @@ public static class RedlineReversibilityVerifier
                     .SingleOrDefault(item => string.Equals(item.Id, requested.Id, StringComparison.Ordinal));
                 if (current is null)
                 {
-                    completed = false;
+                    var liveRevisions = session.ListRevisions().Select(ToIdentity).ToArray();
+                    var overlapping = liveRevisions.FirstOrDefault(item =>
+                        RevisionOverlaps(requested, item));
+                    if (overlapping is not null)
+                    {
+                        completed = false;
+                        findings.Add(Finding(
+                            "generated_revision_identity_changed",
+                            VerificationFindingSeverity.Error,
+                            $"Generated revision '{requested.Id}' changed identity to '{overlapping.Id}' during resolution.",
+                            new ChangeLocation { EntryUri = requested.PartUri },
+                            requested.AnchorId,
+                            new[] { requested.Id, overlapping.Id },
+                            "Regenerate a redline whose generated revision identities remain stable during selective resolution.",
+                            direction));
+                        break;
+                    }
+
+                    implicitlyResolvedIds.Add(requested.Id);
                     findings.Add(Finding(
-                        "generated_revision_disappeared",
-                        VerificationFindingSeverity.Error,
-                        $"Generated revision '{requested.Id}' disappeared before it could be resolved.",
+                        "generated_revision_consumed_by_resolution",
+                        VerificationFindingSeverity.Info,
+                        $"Generated revision '{requested.Id}' was consumed while resolving a linked generated revision.",
                         new ChangeLocation { EntryUri = requested.PartUri },
                         requested.AnchorId,
                         new[] { requested.Id },
-                        "Regenerate a redline without nested or overlapping generated revision groups.",
+                        "No action is required when the path output matches its target and no generated revisions survive.",
                         direction));
-                    break;
+                    continue;
                 }
 
                 if (current.ResolutionStatus != RevisionResolutionStatus.Supported)
@@ -253,6 +272,23 @@ public static class RedlineReversibilityVerifier
             .Select(ToIdentity)
             .OrderBy(RevisionSortKey, StringComparer.Ordinal)
             .ToArray();
+        var survivingGenerated = generated.Where(requested => surviving.Any(item =>
+                string.Equals(item.Id, requested.Id, StringComparison.Ordinal)
+                || RevisionOverlaps(requested, item)))
+            .ToArray();
+        if (survivingGenerated.Length > 0)
+        {
+            completed = false;
+            findings.Add(Finding(
+                "generated_revisions_survived_resolution",
+                VerificationFindingSeverity.Error,
+                $"The {DirectionName(direction)} path left {survivingGenerated.Length} generated revision(s) unresolved.",
+                revisionIds: survivingGenerated.Select(item => item.Id).ToArray(),
+                remediation: "Inspect the generated revision topology and selective resolver results.",
+                direction: direction));
+        }
+        if (resolvedIds.Count + implicitlyResolvedIds.Count != requestedIds.Length)
+            completed = false;
         bool preExistingPreserved = VerifyPreExisting(
             direction, preExisting, surviving, findings);
 
@@ -266,6 +302,7 @@ public static class RedlineReversibilityVerifier
                     Equivalent = false,
                     RequestedRevisionIds = requestedIds,
                     ResolvedRevisionIds = resolvedIds,
+                    ImplicitlyResolvedRevisionIds = implicitlyResolvedIds,
                     SurvivingPreExistingRevisions = surviving,
                     PreExistingRevisionsPreserved = preExistingPreserved,
                     ModeledSemantic = SemanticUnavailable(),
@@ -381,6 +418,7 @@ public static class RedlineReversibilityVerifier
                 Equivalent = equivalent,
                 RequestedRevisionIds = requestedIds,
                 ResolvedRevisionIds = resolvedIds,
+                ImplicitlyResolvedRevisionIds = implicitlyResolvedIds,
                 SurvivingPreExistingRevisions = surviving,
                 PreExistingRevisionsPreserved = preExistingPreserved,
                 ModeledSemantic = semantic,

--- a/Docxodus/Verification/RedlineReversibilityVerifier.cs
+++ b/Docxodus/Verification/RedlineReversibilityVerifier.cs
@@ -324,28 +324,10 @@ public static class RedlineReversibilityVerifier
         if (!actualManifest.IsValid)
             completed = false;
 
-        var semantic = CompareModeledSemantics(expectedBytes, outputBytes);
-        if (!semantic.Available)
-        {
-            findings.Add(Finding(
-                "modeled_semantic_comparison_unavailable",
-                VerificationFindingSeverity.Error,
-                semantic.Diagnostic ?? "The versioned modeled semantic comparer is unavailable.",
-                revisionIds: requestedIds,
-                remediation: "Run the proof with the semantic-diff component available.",
-                direction: direction));
-        }
-        else if (semantic.Equivalent != true)
-        {
-            findings.Add(Finding(
-                "modeled_semantic_mismatch",
-                VerificationFindingSeverity.Error,
-                $"The {DirectionName(direction)} output has {semantic.ChangeCount ?? 0} modeled semantic change(s).",
-                revisionIds: requestedIds,
-                remediation: "Inspect the semantic change set and applicable generated revisions.",
-                direction: direction));
-        }
-
+        var semantic = CompareModeledSemantics(
+            expectedBytes,
+            outputBytes,
+            options.PackageManifestOptions);
         bool normalizedEquivalent = DigestEquals(
             expectedManifest.NormalizedSemanticDigest,
             actualManifest.NormalizedSemanticDigest);
@@ -359,8 +341,48 @@ public static class RedlineReversibilityVerifier
             expectedManifest,
             actualManifest,
             generated,
-            modeledPartUris: Array.Empty<string>());
+            semantic.ModeledPartUris);
         var firstDivergence = divergences.FirstOrDefault();
+        if (!semantic.Comparison.Available)
+        {
+            findings.Add(Finding(
+                "modeled_semantic_comparison_unavailable",
+                VerificationFindingSeverity.Error,
+                semantic.Comparison.Diagnostic
+                    ?? "The versioned modeled semantic comparer is unavailable.",
+                revisionIds: requestedIds,
+                remediation: "Run the proof with the semantic-diff component available.",
+                direction: direction));
+        }
+        else if (semantic.Comparison.Equivalent != true)
+        {
+            var firstSemanticChange = semantic.FirstModeledChange;
+            var firstSemanticAnchor = firstSemanticChange?.RightAnchor
+                ?? firstSemanticChange?.LeftAnchor;
+            var applicableRevisionIds = firstSemanticChange is null
+                || firstSemanticAnchor is null
+                ? Array.Empty<string>()
+                : generated.Where(revision => RevisionAppliesToSemanticChange(
+                        revision, firstSemanticChange, firstSemanticAnchor))
+                    .Select(revision => revision.Id)
+                    .ToArray();
+            findings.Add(Finding(
+                "modeled_semantic_mismatch",
+                VerificationFindingSeverity.Error,
+                $"The {DirectionName(direction)} output has "
+                    + $"{semantic.Comparison.ChangeCount ?? 0} modeled semantic change(s).",
+                firstSemanticChange is null
+                    ? null
+                    : new ChangeLocation
+                    {
+                        EntryUri = firstSemanticChange.PartUri,
+                        PropertyPath = firstSemanticChange.Path,
+                    },
+                firstSemanticAnchor,
+                applicableRevisionIds,
+                remediation: "Inspect the semantic change set and applicable generated revisions.",
+                direction: direction));
+        }
 
         if (!normalizedEquivalent)
         {
@@ -405,8 +427,8 @@ public static class RedlineReversibilityVerifier
 
         bool equivalent = completed
             && preExistingPreserved
-            && semantic.Available
-            && semantic.Equivalent == true
+            && semantic.Comparison.Available
+            && semantic.Comparison.Equivalent == true
             && normalizedEquivalent
             && (!options.RequireExactPackageBytes || rawEquivalent)
             && findings.All(item => item.Severity != VerificationFindingSeverity.Error);
@@ -421,7 +443,7 @@ public static class RedlineReversibilityVerifier
                 ImplicitlyResolvedRevisionIds = implicitlyResolvedIds,
                 SurvivingPreExistingRevisions = surviving,
                 PreExistingRevisionsPreserved = preExistingPreserved,
-                ModeledSemantic = semantic,
+                ModeledSemantic = semantic.Comparison,
                 NormalizedWholePackageEquivalent = normalizedEquivalent,
                 OrderedOpcContentEquivalent = opcEquivalent,
                 ExactPackageBytesEquivalent = rawEquivalent,
@@ -617,8 +639,11 @@ public static class RedlineReversibilityVerifier
                 ActualRawDigest = actualEntry?.RawBytesDigest,
                 ExpectedNormalizedDigest = expectedEntry?.NormalizedXmlDigest,
                 ActualNormalizedDigest = actualEntry?.NormalizedXmlDigest,
-                UnknownOrUnmodeled = normalizedDifferent
-                    && !modeledPartUris.Contains(key.Uri),
+                HasModeledSemanticChange = modeledPartUris.Contains(key.Uri),
+                // A change set identifies modeled facts, not a complete residual projection for
+                // an arbitrary XML part. Even when that same part has a modeled change, retain the
+                // normalized divergence as potentially unmodeled instead of overclaiming coverage.
+                UnknownOrUnmodeled = normalizedDifferent,
             });
         }
         return divergences;
@@ -635,6 +660,19 @@ public static class RedlineReversibilityVerifier
             partUri,
             $"{ownerDirectory}_rels/{ownerName}.rels",
             StringComparison.Ordinal);
+    }
+
+    private static bool RevisionAppliesToSemanticChange(
+        RedlineRevisionIdentity revision,
+        SemanticChange change,
+        string? changeAnchor)
+    {
+        if (!RevisionAppliesToPart(revision, change.PartUri)) return false;
+        // A part match alone does not prove that a generated revision caused this semantic change.
+        // Only claim a revision when the semantic anchor matches its primary or affected anchors.
+        return changeAnchor is not null
+            && (string.Equals(revision.AnchorId, changeAnchor, StringComparison.Ordinal)
+                || revision.AffectedAnchorIds.Contains(changeAnchor, StringComparer.Ordinal));
     }
 
     private static RedlineRevisionIdentity ToIdentity(RevisionListEntry entry) => new()
@@ -800,21 +838,77 @@ public static class RedlineReversibilityVerifier
         CaptureInitialProjection = false,
     });
 
-    // Replaced by the schema-v1 semantic comparer when #457 is stacked into this branch. Keeping
-    // the dependency unavailable (and therefore proof-failing) is deliberate: normalized package
-    // equality must never be mislabeled as modeled semantic evidence.
-    private static RedlineModeledSemanticComparison CompareModeledSemantics(
+    private static ModeledSemanticEvaluation CompareModeledSemantics(
         byte[] expectedBytes,
-        byte[] actualBytes) => SemanticUnavailable();
+        byte[] actualBytes,
+        PackageManifestOptions packageOptions)
+    {
+        try
+        {
+            var changes = SemanticDiff.Compare(
+                new WmlDocument("expected.docx", expectedBytes),
+                new WmlDocument("actual.docx", actualBytes),
+                new SemanticDiffOptions { PackageOptions = packageOptions });
+            var modeledChanges = changes.Changes
+                .Where(change => change.Family != SemanticChangeFamily.OpaquePackagePart)
+                .ToArray();
+            return new ModeledSemanticEvaluation(
+                new RedlineModeledSemanticComparison
+                {
+                    Available = true,
+                    Equivalent = modeledChanges.Length == 0,
+                    Schema = changes.Schema,
+                    ChangeCount = modeledChanges.Length,
+                    Diagnostic = null,
+                },
+                modeledChanges.SelectMany(ModeledPartUris)
+                    .ToHashSet(StringComparer.Ordinal),
+                modeledChanges.FirstOrDefault(change =>
+                    change.RightAnchor is not null || change.LeftAnchor is not null)
+                    ?? modeledChanges.FirstOrDefault());
+        }
+        catch (Exception ex) when (!IsFatal(ex))
+        {
+            return new ModeledSemanticEvaluation(
+                SemanticUnavailable(
+                    $"The versioned semantic comparison failed ({ex.GetType().Name})."),
+                Array.Empty<string>(),
+                null);
+        }
+    }
 
-    private static RedlineModeledSemanticComparison SemanticUnavailable() => new()
+    private static RedlineModeledSemanticComparison SemanticUnavailable(
+        string diagnostic = "The versioned semantic comparison did not run.") => new()
     {
         Available = false,
         Equivalent = null,
         Schema = null,
         ChangeCount = null,
-        Diagnostic = "The versioned semantic diff dependency is not present on this branch.",
+        Diagnostic = diagnostic,
     };
+
+    private static IEnumerable<string> ModeledPartUris(SemanticChange change)
+    {
+        // Opaque-part digests make a difference visible, but do not claim that Docxodus
+        // understands its semantics. Keep those divergences explicitly marked unmodeled.
+        if (change.Family == SemanticChangeFamily.OpaquePackagePart)
+            yield break;
+
+        yield return change.PartUri;
+        if (change.Family != SemanticChangeFamily.Relationship)
+            yield break;
+
+        if (string.Equals(change.PartUri, "/", StringComparison.Ordinal))
+        {
+            yield return "/_rels/.rels";
+            yield break;
+        }
+
+        int slash = change.PartUri.LastIndexOf('/');
+        string directory = slash <= 0 ? "/" : change.PartUri[..(slash + 1)];
+        string name = slash < 0 ? change.PartUri : change.PartUri[(slash + 1)..];
+        yield return $"{directory}_rels/{name}.rels";
+    }
 
     private static string DirectionName(RedlineProofDirection direction) => direction switch
     {
@@ -826,4 +920,9 @@ public static class RedlineReversibilityVerifier
         OutOfMemoryException or StackOverflowException or AccessViolationException;
 
     private sealed record PathEvaluation(RedlineProofPathResult Result, byte[]? OutputBytes);
+
+    private sealed record ModeledSemanticEvaluation(
+        RedlineModeledSemanticComparison Comparison,
+        IReadOnlyCollection<string> ModeledPartUris,
+        SemanticChange? FirstModeledChange);
 }

--- a/docs/architecture/redline_reversibility_proof.md
+++ b/docs/architecture/redline_reversibility_proof.md
@@ -79,7 +79,9 @@ separately and is not required unless the caller explicitly requests it.
 The proof reports, and never conflates, four layers:
 
 1. **Modeled semantic equivalence** uses the versioned semantic change set. An empty
-   change set proves equality only for that schema's modeled surface.
+   modeled change projection proves equality only for that schema's understood surface.
+   `OpaquePackagePart` changes remain visible in the underlying change set but are
+   excluded from this layer and reported as unknown/unmodeled package divergences.
 2. **Normalized whole-package equivalence** uses the package manifest's normalized
    XML/binary identity. This covers document text and formatting, lists, tables,
    sections, headers/footers, notes, comments, bookmarks, fields, content controls,
@@ -91,7 +93,10 @@ The proof reports, and never conflates, four layers:
 
 If modeled semantics match but normalized package identity differs, the result is not
 called equivalent. The divergent manifest entries are emitted as unknown/unmodeled
-package differences. This is the guard against silently losing unsupported content.
+package differences. A divergence also states whether the semantic change set has a
+modeled change in that part, but this never claims the modeled projection exhaustively
+explains every XML node in the part. This conservative residual rule is the guard
+against silently losing unsupported content mixed into an otherwise modeled part.
 
 ## Result and receipt embedding
 

--- a/docs/architecture/redline_reversibility_proof.md
+++ b/docs/architecture/redline_reversibility_proof.md
@@ -17,7 +17,13 @@ The operation takes three immutable byte arrays:
 - `redline`: the native tracked-change document being proved.
 
 Optional proof settings carry the shared package-inspection limits and exact-byte
-policy.
+policy. They also cap native revision elements per baseline/redline input; selective
+resolution rebuilds the live registry after each generated operation, so over-budget
+inventories fail before either path executes.
+
+The cheap manifest-fact preflight is followed by a cap on the exact live registry,
+covering malformed and unsupported marker families that are intentionally absent
+from the manifest's high-signal revision summary.
 
 The caller chooses the baseline policy before invoking the proof. For example, a
 workflow that deliberately accepted all prior revisions supplies that accepted
@@ -110,6 +116,11 @@ it does not reinterpret or flatten proof fields.
 ## Dependency boundary
 
 The implementation consumes the package manifest and shared inspection limits from
-#456 and the semantic change set from #457. It does not define another ZIP reader,
-XML normalizer, digest profile, location vocabulary, or safety policy. The delivery
-receipt from #458 consumes the proof but is not a dependency of proof generation.
+#456, the semantic change set from #457, and the policy-neutral package delta from
+#463. Redline-specific divergence evidence adapts that shared delta instead of
+defining another package comparator, and proof-stage exception filters use the same
+recoverable-exception boundary so cancellation and process-fatal exceptions propagate.
+It does not define another ZIP reader, XML normalizer, digest profile, location
+vocabulary, or package-inspection safety policy. Its one additional safety policy is
+the proof-specific revision-work cap described above. The delivery receipt from #458
+consumes the proof but is not a dependency of proof generation.

--- a/docs/architecture/redline_reversibility_proof.md
+++ b/docs/architecture/redline_reversibility_proof.md
@@ -17,9 +17,12 @@ The operation takes three immutable byte arrays:
 - `redline`: the native tracked-change document being proved.
 
 Optional proof settings carry the shared package-inspection limits and exact-byte
-policy. They also cap native revision elements per baseline/redline input; selective
-resolution rebuilds the live registry after each generated operation, so over-budget
-inventories fail before either path executes.
+policy. A raw aggregate-byte admission gate runs before package inspection. The
+settings also cap physical native revision carriers in each of baseline, intended
+final, redline, and each live path output; selective resolution rebuilds the live
+registry after each generated operation, so over-budget inventories fail before
+either path executes. Separate limits bound retained findings, revision evidence,
+semantic changes, package divergences, and evidence text.
 
 The cheap manifest-fact preflight is followed by a cap on the exact live registry,
 covering malformed and unsupported marker families that are intentionally absent
@@ -34,14 +37,25 @@ revisions to manufacture a match.
 ## Generated-revision ownership
 
 Revision ownership is established from the live, part-qualified revision registry,
-not from author names alone. A stable identity contains the owning part, revision
-family, and native constituent IDs. The proof inventories baseline, final, and
-redline revisions, then classifies the redline inventory as:
+not from author names alone. Each native carrier key includes the owning part,
+carrier role and QName, canonical numeric ID, and move name where applicable; its
+ownership stamp includes type, author, legacy date, UTC date, and resolution status.
+Content-derived text, anchors, and ordinal story labels are evidence, not ownership
+keys. The proof inventories baseline, final, and redline revisions, then classifies
+the redline inventory as:
 
 - `preExisting`: an unchanged identity already present in the selected baseline;
+- `intendedFinalPreExisting`: unchanged review state owned by the intended final but
+  absent from the baseline;
 - `generated`: an identity present only in the redline;
-- `conflicted`: an identity that overlaps a baseline identity but changes its family,
-  constituents, resolution status, or package location.
+- `conflicted`: an identity that overlaps endpoint-owned native carriers but changes
+  their ownership stamp, role, topology, or package location.
+
+Ordinary adjacent Word wrappers can split or merge into different presentation
+groups when a generated separator is inserted or resolved. Ownership therefore
+follows their individual native carriers. Topology-bearing move pairs and structured
+content-control envelopes additionally require their exact logical carrier set and
+family to remain intact.
 
 Every generated revision must be selectively resolvable. A malformed, ambiguous,
 unsupported, or ownership-conflicted revision fails closed. Pre-existing identities
@@ -61,6 +75,13 @@ example, paragraph-mark and paragraph-property markup that Word treats as one
 closure). The proof records that sibling separately as implicitly resolved only when
 none of its native constituents remain live. A changed identity or surviving
 constituent still fails closed, and target equivalence remains mandatory.
+
+Proof-mode resolution avoids global cleanup. It removes only relationships nominated
+by the selected revision and proven unreferenced afterward, protects baseline-owned
+numbering definitions, and correlates optional empty property shells with the
+expected endpoint by part plus stable anchor/path identity. Unrelated orphan
+relationships, XML nodes, and package parts therefore remain visible to whole-package
+comparison rather than being normalized away.
 
 Each path records:
 
@@ -112,6 +133,9 @@ Serialization is deterministic. It includes algorithm-labelled input/output dige
 revision classifications, both path results, part divergences, and findings. The
 delivery receipt embeds this object as a value and includes its canonical JSON digest;
 it does not reinterpret or flatten proof fields.
+
+The checked-in schema is
+[`docs/schemas/redline-reversibility-proof-v1.schema.json`](../schemas/redline-reversibility-proof-v1.schema.json).
 
 ## Dependency boundary
 

--- a/docs/architecture/redline_reversibility_proof.md
+++ b/docs/architecture/redline_reversibility_proof.md
@@ -50,9 +50,15 @@ selective resolver exposed by `DocxSession`. Resolution is deterministic and reb
 the live registry after every operation, because resolving an outer revision can
 expose or detach nested markup.
 
+Resolving one native revision can atomically consume a linked generated sibling (for
+example, paragraph-mark and paragraph-property markup that Word treats as one
+closure). The proof records that sibling separately as implicitly resolved only when
+none of its native constituents remain live. A changed identity or surviving
+constituent still fails closed, and target equivalence remains mandatory.
+
 Each path records:
 
-- the generated revision IDs requested and successfully resolved;
+- the generated revision IDs requested, explicitly resolved, and implicitly consumed;
 - the surviving pre-existing revision identities;
 - the actual output package identity;
 - the expected package identity;

--- a/docs/architecture/redline_reversibility_proof.md
+++ b/docs/architecture/redline_reversibility_proof.md
@@ -1,0 +1,104 @@
+# Redline reversibility proof
+
+Issue #464 turns the informal `Accept(Compare(left, right))` / `Reject(...)`
+round-trip claim into a versioned verification result. The proof is deliberately
+stronger than a body-text assertion: it resolves only revisions attributed to the
+generated comparison, preserves pre-existing review state, and compares the complete
+package on both paths.
+
+## Inputs and baseline policy
+
+The operation takes three immutable byte arrays:
+
+- `baseline`: the exact document version that rejecting generated revisions must
+  recover;
+- `intendedFinal`: the exact document version that accepting generated revisions must
+  recover;
+- `redline`: the native tracked-change document being proved.
+
+Optional proof settings carry the shared package-inspection limits and exact-byte
+policy.
+
+The caller chooses the baseline policy before invoking the proof. For example, a
+workflow that deliberately accepted all prior revisions supplies that accepted
+document as `baseline`; a workflow that preserves prior review state supplies the
+review-bearing document. The proof never silently accepts or rejects pre-existing
+revisions to manufacture a match.
+
+## Generated-revision ownership
+
+Revision ownership is established from the live, part-qualified revision registry,
+not from author names alone. A stable identity contains the owning part, revision
+family, and native constituent IDs. The proof inventories baseline, final, and
+redline revisions, then classifies the redline inventory as:
+
+- `preExisting`: an unchanged identity already present in the selected baseline;
+- `generated`: an identity present only in the redline;
+- `conflicted`: an identity that overlaps a baseline identity but changes its family,
+  constituents, resolution status, or package location.
+
+Every generated revision must be selectively resolvable. A malformed, ambiguous,
+unsupported, or ownership-conflicted revision fails closed. Pre-existing identities
+must remain live and unchanged after both proof paths. This avoids the unsafe shortcut
+of calling accept-all/reject-all on a redline that contains older review markup.
+
+## Two resolution paths
+
+The operation clones `redline` twice. It accepts each generated revision in the first
+clone and rejects each generated revision in the second clone through the same
+selective resolver exposed by `DocxSession`. Resolution is deterministic and rebuilds
+the live registry after every operation, because resolving an outer revision can
+expose or detach nested markup.
+
+Each path records:
+
+- the generated revision IDs requested and successfully resolved;
+- the surviving pre-existing revision identities;
+- the actual output package identity;
+- the expected package identity;
+- modeled semantic equivalence;
+- normalized whole-package equivalence;
+- ordered OPC-content equivalence;
+- exact package-byte equivalence;
+- every divergent part and the first divergent part/anchor;
+- structured findings and the revision IDs relevant to a failure.
+
+The proof succeeds only when accept-to-final and reject-to-baseline are both
+normalized-whole-package equivalent and all generated revisions resolve without
+altering pre-existing review identities. Exact package-byte equivalence is reported
+separately and is not required unless the caller explicitly requests it.
+
+## Equivalence layers
+
+The proof reports, and never conflates, four layers:
+
+1. **Modeled semantic equivalence** uses the versioned semantic change set. An empty
+   change set proves equality only for that schema's modeled surface.
+2. **Normalized whole-package equivalence** uses the package manifest's normalized
+   XML/binary identity. This covers document text and formatting, lists, tables,
+   sections, headers/footers, notes, comments, bookmarks, fields, content controls,
+   relationships, media, and opaque vendor parts while ignoring only documented XML
+   serialization choices.
+3. **Ordered OPC-content equivalence** compares exact uncompressed entry bytes while
+   ignoring ZIP entry order, timestamp, and compression choices.
+4. **Raw package-byte equivalence** compares the supplied ZIP byte arrays exactly.
+
+If modeled semantics match but normalized package identity differs, the result is not
+called equivalent. The divergent manifest entries are emitted as unknown/unmodeled
+package differences. This is the guard against silently losing unsupported content.
+
+## Result and receipt embedding
+
+The canonical JSON schema is
+`https://docxodus.dev/schemas/verification/redline-reversibility-proof/v1`.
+Serialization is deterministic. It includes algorithm-labelled input/output digests,
+revision classifications, both path results, part divergences, and findings. The
+delivery receipt embeds this object as a value and includes its canonical JSON digest;
+it does not reinterpret or flatten proof fields.
+
+## Dependency boundary
+
+The implementation consumes the package manifest and shared inspection limits from
+#456 and the semantic change set from #457. It does not define another ZIP reader,
+XML normalizer, digest profile, location vocabulary, or safety policy. The delivery
+receipt from #458 consumes the proof but is not a dependency of proof generation.

--- a/docs/schemas/redline-reversibility-proof-v1.schema.json
+++ b/docs/schemas/redline-reversibility-proof-v1.schema.json
@@ -1,0 +1,356 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docxodus.dev/schemas/verification/redline-reversibility-proof/v1",
+  "title": "Docxodus redline reversibility proof v1",
+  "description": "The deterministic JSON representation emitted by RedlineReversibilityProof.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "schemaVersion",
+    "success",
+    "requireExactPackageBytes",
+    "baselinePackage",
+    "intendedFinalPackage",
+    "redlinePackage",
+    "revisionClassifications",
+    "acceptToFinal",
+    "rejectToBaseline",
+    "findings"
+  ],
+  "properties": {
+    "schema": {
+      "const": "https://docxodus.dev/schemas/verification/redline-reversibility-proof/v1"
+    },
+    "schemaVersion": { "const": 1 },
+    "success": { "type": "boolean" },
+    "requireExactPackageBytes": { "type": "boolean" },
+    "baselinePackage": { "$ref": "#/$defs/packageIdentity" },
+    "intendedFinalPackage": { "$ref": "#/$defs/packageIdentity" },
+    "redlinePackage": { "$ref": "#/$defs/packageIdentity" },
+    "revisionClassifications": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/revisionClassification" }
+    },
+    "acceptToFinal": { "$ref": "#/$defs/nullablePath" },
+    "rejectToBaseline": { "$ref": "#/$defs/nullablePath" },
+    "findings": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/finding" }
+    }
+  },
+  "$defs": {
+    "nullableString": { "type": ["string", "null"] },
+    "digest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "value"],
+      "properties": {
+        "algorithm": { "const": "SHA-256" },
+        "value": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      }
+    },
+    "nullableDigest": {
+      "oneOf": [
+        { "$ref": "#/$defs/digest" },
+        { "type": "null" }
+      ]
+    },
+    "packageIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "rawPackageBytesDigest",
+        "orderedOpcContentDigest",
+        "normalizedWholePackageDigest"
+      ],
+      "properties": {
+        "rawPackageBytesDigest": { "$ref": "#/$defs/digest" },
+        "orderedOpcContentDigest": { "$ref": "#/$defs/nullableDigest" },
+        "normalizedWholePackageDigest": { "$ref": "#/$defs/nullableDigest" }
+      }
+    },
+    "location": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "entryUri",
+        "ownerUri",
+        "relationshipId",
+        "targetUri",
+        "propertyPath"
+      ],
+      "properties": {
+        "entryUri": { "$ref": "#/$defs/nullableString" },
+        "ownerUri": { "$ref": "#/$defs/nullableString" },
+        "relationshipId": { "$ref": "#/$defs/nullableString" },
+        "targetUri": { "$ref": "#/$defs/nullableString" },
+        "propertyPath": { "$ref": "#/$defs/nullableString" }
+      }
+    },
+    "nullableLocation": {
+      "oneOf": [
+        { "$ref": "#/$defs/location" },
+        { "type": "null" }
+      ]
+    },
+    "diagnostic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message"],
+      "properties": {
+        "code": { "type": "string", "minLength": 1 },
+        "message": { "type": "string", "minLength": 1 }
+      }
+    },
+    "nullableDiagnostic": {
+      "oneOf": [
+        { "$ref": "#/$defs/diagnostic" },
+        { "type": "null" }
+      ]
+    },
+    "revisionIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "partUri",
+        "scope",
+        "type",
+        "family",
+        "constituentIds",
+        "constituentKeys",
+        "author",
+        "date",
+        "dateUtc",
+        "text",
+        "anchorId",
+        "affectedAnchorIds",
+        "resolutionStatus",
+        "diagnostic"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "partUri": { "type": "string", "pattern": "^/" },
+        "scope": { "type": "string", "minLength": 1 },
+        "type": { "type": "string", "minLength": 1 },
+        "family": {
+          "enum": [
+            "contentInsert",
+            "contentDelete",
+            "move",
+            "paragraphMark",
+            "rowInsert",
+            "rowDelete",
+            "cellInsert",
+            "cellDelete",
+            "cellMerge",
+            "contentControlInsert",
+            "contentControlDelete",
+            "numberingPropertiesInsert",
+            "numberingChange",
+            "propertiesChange",
+            "unsupported"
+          ]
+        },
+        "constituentIds": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "constituentKeys": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "author": { "type": "string" },
+        "date": { "$ref": "#/$defs/nullableString" },
+        "dateUtc": { "$ref": "#/$defs/nullableString" },
+        "text": { "type": "string" },
+        "anchorId": { "$ref": "#/$defs/nullableString" },
+        "affectedAnchorIds": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "resolutionStatus": {
+          "enum": ["supported", "unsupported", "malformed", "ambiguous"]
+        },
+        "diagnostic": { "$ref": "#/$defs/nullableDiagnostic" }
+      }
+    },
+    "nullableRevisionIdentity": {
+      "oneOf": [
+        { "$ref": "#/$defs/revisionIdentity" },
+        { "type": "null" }
+      ]
+    },
+    "revisionClassification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["disposition", "baseline", "intendedFinal", "redline", "reason"],
+      "properties": {
+        "disposition": {
+          "enum": ["preExisting", "intendedFinalPreExisting", "generated", "conflicted"]
+        },
+        "baseline": { "$ref": "#/$defs/nullableRevisionIdentity" },
+        "intendedFinal": { "$ref": "#/$defs/nullableRevisionIdentity" },
+        "redline": { "$ref": "#/$defs/nullableRevisionIdentity" },
+        "reason": { "type": "string", "minLength": 1 }
+      }
+    },
+    "modeledSemantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["available", "equivalent", "schema", "changeCount", "diagnostic"],
+      "properties": {
+        "available": { "type": "boolean" },
+        "equivalent": { "type": ["boolean", "null"] },
+        "schema": { "$ref": "#/$defs/nullableString" },
+        "changeCount": { "type": ["integer", "null"], "minimum": 0 },
+        "diagnostic": { "$ref": "#/$defs/nullableString" }
+      }
+    },
+    "divergence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "partUri",
+        "occurrence",
+        "anchorId",
+        "applicableRevisionIds",
+        "expectedRawDigest",
+        "actualRawDigest",
+        "expectedNormalizedDigest",
+        "actualNormalizedDigest",
+        "hasModeledSemanticChange",
+        "unknownOrUnmodeled"
+      ],
+      "properties": {
+        "kind": { "enum": ["added", "removed", "modified"] },
+        "partUri": { "type": "string", "pattern": "^/" },
+        "occurrence": { "type": "integer", "minimum": 0 },
+        "anchorId": { "$ref": "#/$defs/nullableString" },
+        "applicableRevisionIds": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "expectedRawDigest": { "$ref": "#/$defs/nullableDigest" },
+        "actualRawDigest": { "$ref": "#/$defs/nullableDigest" },
+        "expectedNormalizedDigest": { "$ref": "#/$defs/nullableDigest" },
+        "actualNormalizedDigest": { "$ref": "#/$defs/nullableDigest" },
+        "hasModeledSemanticChange": { "type": "boolean" },
+        "unknownOrUnmodeled": { "type": "boolean" }
+      }
+    },
+    "nullableDivergence": {
+      "oneOf": [
+        { "$ref": "#/$defs/divergence" },
+        { "type": "null" }
+      ]
+    },
+    "finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "severity",
+        "message",
+        "direction",
+        "location",
+        "anchorId",
+        "revisionIds",
+        "remediation"
+      ],
+      "properties": {
+        "code": { "type": "string", "pattern": "^[a-z0-9_]+$" },
+        "severity": { "enum": ["info", "warning", "error"] },
+        "message": { "type": "string", "minLength": 1 },
+        "direction": {
+          "oneOf": [
+            { "enum": ["acceptToFinal", "rejectToBaseline"] },
+            { "type": "null" }
+          ]
+        },
+        "location": { "$ref": "#/$defs/nullableLocation" },
+        "anchorId": { "$ref": "#/$defs/nullableString" },
+        "revisionIds": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "remediation": { "$ref": "#/$defs/nullableString" }
+      }
+    },
+    "path": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "direction",
+        "completed",
+        "equivalent",
+        "requestedRevisionIds",
+        "resolvedRevisionIds",
+        "implicitlyResolvedRevisionIds",
+        "survivingPreExistingRevisions",
+        "preExistingRevisionsPreserved",
+        "modeledSemantic",
+        "normalizedWholePackageEquivalent",
+        "orderedOpcContentEquivalent",
+        "exactPackageBytesEquivalent",
+        "divergenceAnalysisCompleted",
+        "expectedPackage",
+        "actualPackage",
+        "firstDivergence",
+        "divergences",
+        "findings"
+      ],
+      "properties": {
+        "direction": { "enum": ["acceptToFinal", "rejectToBaseline"] },
+        "completed": { "type": "boolean" },
+        "equivalent": { "type": "boolean" },
+        "requestedRevisionIds": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "resolvedRevisionIds": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "implicitlyResolvedRevisionIds": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "survivingPreExistingRevisions": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/revisionIdentity" }
+        },
+        "preExistingRevisionsPreserved": { "type": "boolean" },
+        "modeledSemantic": { "$ref": "#/$defs/modeledSemantic" },
+        "normalizedWholePackageEquivalent": { "type": "boolean" },
+        "orderedOpcContentEquivalent": { "type": "boolean" },
+        "exactPackageBytesEquivalent": { "type": "boolean" },
+        "divergenceAnalysisCompleted": { "type": "boolean" },
+        "expectedPackage": { "$ref": "#/$defs/packageIdentity" },
+        "actualPackage": {
+          "oneOf": [
+            { "$ref": "#/$defs/packageIdentity" },
+            { "type": "null" }
+          ]
+        },
+        "firstDivergence": { "$ref": "#/$defs/nullableDivergence" },
+        "divergences": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/divergence" }
+        },
+        "findings": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/finding" }
+        }
+      }
+    },
+    "nullablePath": {
+      "oneOf": [
+        { "$ref": "#/$defs/path" },
+        { "type": "null" }
+      ]
+    }
+  }
+}

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -2142,8 +2142,15 @@ export interface RevisionListEntry {
   type: SessionRevisionType;
   family: RevisionFamily;
   constituentIds: string[];
+  /**
+   * QName-qualified native carrier identities. Unlike `constituentIds`, these
+   * distinguish revision roles which legally use the same numeric `w:id` value.
+   */
+  constituentKeys: string[];
   author: string;
   date?: string;
+  /** The `w16du:dateUtc` timestamp, when the markup carries one. */
+  dateUtc?: string;
   text: string;
   partUri: string;
   scope: string;

--- a/python/src/docx_scalpel/types.py
+++ b/python/src/docx_scalpel/types.py
@@ -2672,7 +2672,8 @@ class RevisionListEntry:
     ``Session.list_revisions``.
 
     ``id`` is an opaque, deterministic ``rev2-…`` identity; ``constituent_ids`` exposes
-    the native Word ids. ``family`` identifies the exact atomic operation while ``type``
+    the native Word ids and ``constituent_keys`` their QName-qualified identities,
+    which stay distinct where roles legally reuse a numeric id. ``family`` identifies the exact atomic operation while ``type``
     is its coarse display class. Part/scope and every affected anchor are included.
     Unsafe native topology remains listed through ``resolution_status`` and
     ``diagnostic`` and fails closed when resolution is requested.
@@ -2683,7 +2684,9 @@ class RevisionListEntry:
     author: str
     family: str = "unsupported"
     constituent_ids: tuple[str, ...] = ()
+    constituent_keys: tuple[str, ...] = ()
     date: str | None = None
+    date_utc: str | None = None
     text: str = ""
     part_uri: str = ""
     scope: str = ""
@@ -2699,8 +2702,10 @@ class RevisionListEntry:
             type=d.get("type", ""),
             family=d.get("family", "unsupported"),
             constituent_ids=tuple(d.get("constituentIds", ())),
+            constituent_keys=tuple(d.get("constituentKeys", ())),
             author=d.get("author", "unknown"),
             date=d.get("date"),
+            date_utc=d.get("dateUtc"),
             text=d.get("text", ""),
             part_uri=d.get("partUri", ""),
             scope=d.get("scope", ""),

--- a/python/tests/test_revisions.py
+++ b/python/tests/test_revisions.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import io
 import zipfile
 
-from docx_scalpel import DocxSession, TrackedChangeMode, open_session
+from docx_scalpel import DocxSession, RevisionListEntry, TrackedChangeMode, open_session
 
 
 def _first_body_paragraph(session: DocxSession) -> str:
@@ -39,6 +39,11 @@ def test_list_revisions_reads_markup_identity(tour_plan_bytes: bytes) -> None:
         assert all(r.id.startswith("rev2-") for r in revisions)
         assert {r.family for r in revisions} == {"content_delete", "content_insert"}
         assert all(r.constituent_ids for r in revisions)
+        assert all(r.constituent_keys for r in revisions)
+        # Keys disambiguate carrier roles that may legally reuse a numeric id,
+        # so they are unique across the registry even where ids are not.
+        all_keys = [k for r in revisions for k in r.constituent_keys]
+        assert len(all_keys) == len(set(all_keys))
         assert all(r.part_uri == "/word/document.xml" for r in revisions)
         assert all(r.scope == "body" for r in revisions)
         assert all(r.affected_anchors for r in revisions)
@@ -114,3 +119,26 @@ def test_bulk_resolution_is_undoable(tour_plan_bytes: bytes) -> None:
             assert session.list_revisions() == ()
             assert session.undo()
             assert [r.id for r in session.list_revisions()] == before
+
+
+def test_revision_list_entry_wire_keeps_constituent_keys_and_date_utc() -> None:
+    """The typed client must surface constituentKeys/dateUtc, not drop them."""
+    entry = RevisionListEntry._from_wire(
+        {
+            "id": "rev2-abc",
+            "type": "insert",
+            "family": "content_insert",
+            "constituentIds": ["1"],
+            "constituentKeys": ["content:/word/document.xml:w:ins:1"],
+            "author": "Reviewer",
+            "date": "2026-01-01T00:00:00Z",
+            "dateUtc": "2026-01-01T05:00:00Z",
+            "text": "hi",
+            "partUri": "/word/document.xml",
+            "scope": "body",
+            "affectedAnchors": [],
+            "resolutionStatus": "supported",
+        }
+    )
+    assert entry.constituent_keys == ("content:/word/document.xml:w:ins:1",)
+    assert entry.date_utc == "2026-01-01T05:00:00Z"


### PR DESCRIPTION
## Summary

- define an embeddable redline reversibility proof contract with deterministic evidence
- accept/reject generated revision families across document stories and compare them with the intended final/baseline documents
- distinguish modeled semantic equality, exact package equality, and conservative unknown residual differences
- report the first divergent part/anchor and only the revision IDs actually correlated with that location
- cover pre-existing revisions, moves, formatting, lists, tables, sections, headers/footers, notes, comments, bookmarks, and multi-author cases
- consume #463's shared package delta and recoverable-exception boundary, with bounded revision work and fail-closed live-inventory enforcement

## Stack

This draft is based on `agent/issue-463-deliverable-verification` (PR #496), exact head `3e722c38`, which is green and includes the corrected #493 foundation.

## Verification

- 131 passed / 0 failed / 0 skipped in the final Release dependency-stack run
- 20 passed / 0 failed / 0 skipped in the focused redline-proof run
- `git diff --check` passes
- independent post-#463 review approved with no remaining blocker, high, or medium findings
- review fixes cover shared package comparison, cancellation/fatal propagation, exact surviving-pre-existing evidence, and manifest-plus-live revision budgets

Viewable local evidence is retained at `/tmp/docxodus-464-artifacts/index.html`, including the complete post-#463 patch, final TRXs, checksums, and useful review-blocked green snapshots.

Closes #464
