### PR TITLE
Add hash-addressed delivery change receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Deterministic delivery change receipts (#458).** Added a versioned, canonical JSON
+  receipt that binds source/delivered package identities to every supplied mutation transaction,
+  normalized requests, explicit undo/redo lineage, requested/derived/unexpected package-change
+  attribution, required typed semantic evidence, optional validation/reversibility evidence, and
+  independently hashed clean DOCX, review DOCX, HTML, PDF, image, and report artifacts. Exactly
+  one clean DOCX must match the delivered raw package bytes, while exact #457 canonical semantic
+  bytes cover the source-to-delivered comparison and every state-changing transaction. Privacy
+  profiles support hash-only, structural-summary, and full-evidence output. Page citations are
+  accepted only when their exact PageMap bytes project the claimed coordinates for a reachable
+  document version/package digest and match the render fingerprint and artifact. Undo/redo is
+  checked as a LIFO state machine, and any indexed package attribution may point only to a
+  successful retained operation. Failed atomic receipts retain the complete requested-operation
+  list with explicit not-executed/rolled-back status, while a genuinely successful no-op may retain
+  an empty edit-result list. Strict typed semantic reconstruction, authoritative clean-DOCX inventory
+  recomputation, portable path normalization, canonical collection-order checks, aggregate object
+  budgets, stream-charged JSON collections, and capped canonical writers fail closed under forged or
+  oversized input. The portable verifier detects receipt,
+  record, artifact, semantic, lineage, and citation-binding tampering. See
+  [`docs/architecture/delivery_change_receipt.md`](docs/architecture/delivery_change_receipt.md).
 - **Deterministic, non-mutating DOCX package manifests (#456).** Added a versioned
   verification artifact that inventories every OPC entry and content type, preserves duplicate
   occurrences, resolves every package/part relationship, reports dangling references and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -412,6 +412,14 @@ All notable changes to this project will be documented in this file.
   recompile.
 
 ### Changed
+- **A batch step whose mutation records no edits is now a successful no-op (#458).**
+  `MutationBatchStep.Mutation` may return an empty edit-result list; previously the
+  step failed with `internal_error` and rolled an atomic batch back. This means an
+  edit that matches nothing (for example a `replace_text_range` whose search text
+  is stale) no longer blocks the rest of the batch — callers that need "this edit
+  must land" semantics should pass `ExpectedMatchCount` (or a preflight) so a
+  zero-match step fails explicitly instead of vacuously succeeding. Delivery
+  receipts record such steps as portable no-op evidence.
 - **A footnote too long for its page now keeps flowing instead of being clipped.**
   Browser pagination reserves at most 60% of the body height for the note band; a
   note whose tail did not fit there used to be handed to the next page whole and

--- a/Docxodus.Tests/DeliveryChangeReceiptTests.cs
+++ b/Docxodus.Tests/DeliveryChangeReceiptTests.cs
@@ -723,7 +723,9 @@ public class DeliveryChangeReceiptTests
             pdfBytes,
             unreachablePageMap);
 
-        Assert.Equal("unreachable_citation_document",
+        // The page-map/pdf artifacts are bound to the same unreachable identity, so the
+        // artifact-level reachability guard fires first at build time.
+        Assert.Equal("unreachable_artifact_document",
             Assert.Throws<DeliveryReceiptValidationException>(
                 () => unreachableBuilder.Build()).Code);
 
@@ -2676,6 +2678,105 @@ public class DeliveryChangeReceiptTests
             .GetProperty("created").GetString();
         Assert.NotNull(evidenceCreated);
         Assert.EndsWith("Z", evidenceCreated, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DCR047_UnboundEvidenceRoleArtifacts_AreRejectedAtBuildAndVerify()
+    {
+        var forgedBytes = Encoding.UTF8.GetBytes(
+            "{\"schema\":\"docxodus.semantic-changes\",\"totally\":\"forged\"}");
+
+        var edit = SingleEdit("Unbound evidence artifact.");
+        var forgedBuilder = Builder(edit);
+        AddTransactionWithSemantic(forgedBuilder, edit);
+        forgedBuilder.AddArtifact(DeliveryArtifactInput.Available(
+            "forged-semantic", DeliveryArtifactRole.SemanticDiff,
+            "application/json", forgedBytes));
+        Assert.Equal("unbound_evidence_artifact",
+            Assert.Throws<DeliveryReceiptValidationException>(
+                () => forgedBuilder.Build()).Code);
+
+        var reportBuilder = Builder(edit);
+        AddTransactionWithSemantic(reportBuilder, edit);
+        reportBuilder.AddArtifact(DeliveryArtifactInput.Available(
+            "orphan-report", DeliveryArtifactRole.ValidationReport,
+            "application/json", forgedBytes));
+        Assert.Equal("unbound_evidence_artifact",
+            Assert.Throws<DeliveryReceiptValidationException>(
+                () => reportBuilder.Build()).Code);
+
+        var builder = Builder(edit);
+        AddTransactionWithSemantic(builder, edit);
+        var receipt = builder.Build();
+        var payload = JsonNode.Parse(receipt.ToJson())!["payload"]!.AsObject();
+        var artifacts = payload["artifacts"]!.AsArray();
+        var template = artifacts.Single(item =>
+            item!["role"]!.GetValue<string>() == "semanticDiff")!;
+        var forged = JsonNode.Parse(template.ToJsonString())!.AsObject();
+        forged["artifactId"] = "zz-forged";
+        forged["byteLength"] = forgedBytes.Length;
+        var forgedDigest = Digest(forgedBytes);
+        forged["digest"] = new JsonObject
+        {
+            ["algorithm"] = forgedDigest.Algorithm,
+            ["value"] = forgedDigest.Value,
+        };
+        artifacts.Add(forged);
+        var artifactBytes = RequiredArtifactBytes(edit);
+        artifactBytes["zz-forged"] = forgedBytes;
+
+        var result = DeliveryChangeReceiptVerifier.VerifyJson(
+            RehashPayloadJson(payload), artifactBytes);
+
+        Assert.False(result.IsValid);
+        Assert.Contains("unbound_evidence_artifact:zz-forged", result.Findings);
+    }
+
+    [Fact]
+    public void DCR048_ReviewBoundRenderArtifacts_VerifyAndFabricatedIdentitiesFailAtBuild()
+    {
+        var edit = SingleEdit("Review render binding.");
+        var redlineBytes = DocxDiff.Compare(
+            new WmlDocument("before.docx", edit.BeforeBytes),
+            new WmlDocument("after.docx", edit.AfterBytes)).DocumentByteArray;
+        var redlineManifest = Manifest(redlineBytes);
+        var redlineIdentity = DeliveryDocumentIdentity.FromManifest(
+            redlineManifest, edit.Result.ResultVersion);
+        var pdf = Encoding.ASCII.GetBytes("%PDF-1.7\nreview render\n%%EOF");
+
+        var builder = Builder(edit);
+        AddTransactionWithSemantic(builder, edit);
+        builder.AddArtifact(DeliveryArtifactInput.Available(
+            "review-docx", DeliveryArtifactRole.ReviewDocx,
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            redlineBytes) with
+        {
+            Document = redlineIdentity,
+            RelativePath = "delivery/review.docx",
+        });
+        builder.AddArtifact(DeliveryArtifactInput.Available(
+            "review-pdf", DeliveryArtifactRole.Pdf, "application/pdf", pdf) with
+        {
+            Document = redlineIdentity,
+        });
+        var receipt = builder.Build();
+        var artifactBytes = RequiredArtifactBytes(edit);
+        artifactBytes["review-docx"] = redlineBytes;
+        artifactBytes["review-pdf"] = pdf;
+        var result = DeliveryChangeReceiptVerifier.Verify(receipt, artifactBytes);
+        Assert.True(result.IsValid, string.Join("; ", result.Findings));
+
+        var rogueBuilder = Builder(edit);
+        AddTransactionWithSemantic(rogueBuilder, edit);
+        rogueBuilder.AddArtifact(DeliveryArtifactInput.Available(
+            "rogue-pdf", DeliveryArtifactRole.Pdf, "application/pdf", pdf) with
+        {
+            Document = DeliveryDocumentIdentity.FromManifest(
+                redlineManifest, edit.Result.ResultVersion),
+        });
+        Assert.Equal("unreachable_artifact_document",
+            Assert.Throws<DeliveryReceiptValidationException>(
+                () => rogueBuilder.Build()).Code);
     }
 
     private static DeliveryChangeReceipt BuildWithProfile(

--- a/Docxodus.Tests/DeliveryChangeReceiptTests.cs
+++ b/Docxodus.Tests/DeliveryChangeReceiptTests.cs
@@ -1,0 +1,2042 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Docxodus.Verification;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+public class DeliveryChangeReceiptTests
+{
+    [Fact]
+    public void DCR001_SingleEdit_ProducesDeterministicVerifiableReceipt()
+    {
+        var edit = SingleEdit("Replacement clause.", tracked: true);
+        var builder = Builder(edit);
+        var entryId = AddTransactionWithSemantic(builder, edit);
+
+        var first = builder.Build();
+        var second = builder.Build();
+
+        Assert.Equal(first.ReceiptDigest, second.ReceiptDigest);
+        Assert.Equal(first.ToJson(), second.ToJson());
+        Assert.Equal(DeliveryChangeReceiptPayload.SchemaId, first.Payload.Schema);
+        var entry = Assert.Single(first.Payload.Transactions);
+        Assert.Equal(entryId, entry.EntryId);
+        Assert.Equal(DeliveryTransactionStatus.Committed, entry.Status);
+        Assert.Single(entry.Operations);
+        Assert.Contains(entry.AuthoredChanges,
+            change => change.EntityKind == DeliveryAuthoredEntityKind.Revision
+                && change.Author == "Receipt Author");
+        Assert.True(DeliveryChangeReceiptVerifier.Verify(first,
+            RequiredArtifactBytes(edit)).IsValid);
+        Assert.True(DeliveryChangeReceiptVerifier.VerifyJson(first.ToJsonBytes(),
+            RequiredArtifactBytes(edit)).IsValid);
+    }
+
+    [Fact]
+    public void DCR002_AtomicBatch_RetainsNormalizedStepOrderAndOneVersionTransition()
+    {
+        var source = DocxSessionTests.BuildDS001_SimpleTwoParagraphs();
+        using var session = Open(source);
+        var anchors = BodyParagraphs(session);
+        var beforeBytes = session.Save();
+        var beforeManifest = Manifest(beforeBytes);
+        var operations = new[]
+        {
+            DeliveryNormalizedOperation.Create("docx_edit", "replace_text",
+                JsonSerializer.Serialize(new { anchorId = anchors[0], markdown = "First changed." })),
+            DeliveryNormalizedOperation.Create("docx_edit", "replace_text",
+                JsonSerializer.Serialize(new { anchorId = anchors[1], markdown = "Second changed." })),
+        };
+        var result = session.ExecuteBatch(new[]
+        {
+            new MutationBatchStep("docx_edit", "replace_text",
+                s => s.ReplaceText(anchors[0], "First changed.")),
+            new MutationBatchStep("docx_edit", "replace_text",
+                s => s.ReplaceText(anchors[1], "Second changed.")),
+        });
+        var afterBytes = session.Save();
+        var afterManifest = Manifest(afterBytes);
+        var contribution = DeliveryTransactionContribution.FromMutationBatchResult(
+            result, beforeManifest, afterManifest, operations);
+        var builder = new DeliveryChangeReceiptBuilder(beforeManifest, result.BaseVersion)
+            .SetDeliveredDocument(afterManifest, result.ResultVersion);
+        AddCleanDocx(builder, afterBytes, afterManifest, result.ResultVersion);
+        builder.AddSemanticChangeSet(DeliverySemanticChangeSetInput.ForSourceToDelivered(
+            SemanticChanges(beforeBytes, afterBytes)));
+        var entryId = builder.AddTransaction(contribution);
+        AddTransactionSemantic(
+            builder, entryId, beforeBytes, afterBytes, "semantic-source-to-delivered");
+
+        var receipt = builder.Build();
+
+        var entry = Assert.Single(receipt.Payload.Transactions);
+        Assert.Equal(result.BaseVersion + 1, result.ResultVersion);
+        Assert.Equal(new[] { 0, 1 }, entry.Operations.Select(operation => operation.Index));
+        Assert.Equal(new[] { "First changed.", "Second changed." },
+            operations.Select(operation =>
+                operation.Arguments.GetProperty("markdown").GetString()));
+        Assert.Equal(DeliveryTransactionStatus.Committed, entry.Status);
+    }
+
+    [Fact]
+    public void DCR003_RetryIdentity_DeduplicatesAndConflictingFingerprintFails()
+    {
+        var fingerprint = Fingerprint("retry request");
+        var identity = new DeliveryTransactionIdentity
+        {
+            TransactionId = "delivery-42",
+            RequestFingerprint = fingerprint,
+        };
+        var edit = SingleEdit("Retry-safe replacement.", identity: identity);
+        var builder = Builder(edit);
+
+        var firstId = AddTransactionWithSemantic(builder, edit);
+        var retryId = builder.AddTransaction(edit.Contribution);
+
+        Assert.Equal(firstId, retryId);
+        Assert.Single(builder.Build().Payload.Transactions);
+
+        var conflict = SingleEdit("Retry-safe replacement.", identity: identity with
+        {
+            RequestFingerprint = Fingerprint("different request"),
+        });
+        var error = Assert.Throws<DeliveryReceiptValidationException>(
+            () => builder.AddTransaction(conflict.Contribution));
+        Assert.Equal("transaction_conflict", error.Code);
+    }
+
+    [Fact]
+    public void DCR004_UndoRedo_AreLineageEventsNotDuplicateTransactions()
+    {
+        var source = DocxSessionTests.BuildDS001_SimpleTwoParagraphs();
+        using var session = Open(source);
+        var anchor = BodyParagraphs(session)[0];
+        var sourceBytes = session.Save();
+        var sourceManifest = Manifest(sourceBytes);
+        var operation = DeliveryNormalizedOperation.Create("docx_edit", "replace_text",
+            JsonSerializer.Serialize(new { anchorId = anchor, markdown = "Lineage edit." }));
+        var result = session.ExecuteBatch(new[]
+        {
+            new MutationBatchStep("docx_edit", "replace_text",
+                s => s.ReplaceText(anchor, "Lineage edit.")),
+        });
+        var appliedBytes = session.Save();
+        var appliedManifest = Manifest(appliedBytes);
+        var contribution = DeliveryTransactionContribution.FromMutationBatchResult(
+            result, sourceManifest, appliedManifest, new[] { operation });
+
+        Assert.True(session.Undo());
+        var undoVersion = session.Version;
+        var undoBytes = session.Save();
+        var undoManifest = Manifest(undoBytes);
+        Assert.True(session.Redo());
+        var redoVersion = session.Version;
+        var redoBytes = session.Save();
+        var redoManifest = Manifest(redoBytes);
+
+        var builder = new DeliveryChangeReceiptBuilder(sourceManifest, result.BaseVersion);
+        var entryId = builder.AddTransaction(contribution);
+        builder.AddLineageEvent(DeliveryLineageEventInput.FromManifests(
+            DeliveryLineageAction.Undo, entryId,
+            appliedManifest, result.ResultVersion, undoManifest, undoVersion));
+        builder.AddLineageEvent(DeliveryLineageEventInput.FromManifests(
+            DeliveryLineageAction.Redo, entryId,
+            undoManifest, undoVersion, redoManifest, redoVersion));
+        builder.SetDeliveredDocument(redoManifest, redoVersion);
+        AddCleanDocx(builder, redoBytes, redoManifest, redoVersion);
+        builder.AddSemanticChangeSet(DeliverySemanticChangeSetInput.ForSourceToDelivered(
+            SemanticChanges(sourceBytes, redoBytes)));
+        AddTransactionSemantic(
+            builder, entryId, sourceBytes, appliedBytes, "semantic-transaction-1");
+
+        var receipt = builder.Build();
+
+        Assert.Single(receipt.Payload.Transactions);
+        Assert.Equal(new[] { DeliveryLineageAction.Undo, DeliveryLineageAction.Redo },
+            receipt.Payload.Lineage.Select(value => value.Action));
+        Assert.All(receipt.Payload.Lineage,
+            value => Assert.Equal(entryId, value.AffectedEntryId));
+        Assert.Equal(redoVersion, receipt.Payload.DeliveredDocument.DocumentVersion);
+    }
+
+    [Fact]
+    public void DCR012_EditAfterUndo_RetainsOneCrossStreamChronology()
+    {
+        var source = DocxSessionTests.BuildDS001_SimpleTwoParagraphs();
+        using var session = Open(source);
+        var firstAnchor = BodyParagraphs(session)[0];
+        var sourceBytes = session.Save();
+        var sourceManifest = Manifest(sourceBytes);
+        var firstOperation = DeliveryNormalizedOperation.Create("docx_edit", "replace_text",
+            JsonSerializer.Serialize(new { anchorId = firstAnchor, markdown = "First edit." }));
+        var firstResult = session.ExecuteBatch(new[]
+        {
+            new MutationBatchStep("docx_edit", "replace_text",
+                s => s.ReplaceText(firstAnchor, "First edit.")),
+        });
+        var firstBytes = session.Save();
+        var firstManifest = Manifest(firstBytes);
+        var firstContribution = DeliveryTransactionContribution.FromMutationBatchResult(
+            firstResult, sourceManifest, firstManifest, new[] { firstOperation });
+
+        var builder = new DeliveryChangeReceiptBuilder(sourceManifest, firstResult.BaseVersion);
+        var firstEntryId = builder.AddTransaction(firstContribution);
+        Assert.True(session.Undo());
+        var undoVersion = session.Version;
+        var undoBytes = session.Save();
+        var undoManifest = Manifest(undoBytes);
+        builder.AddLineageEvent(DeliveryLineageEventInput.FromManifests(
+            DeliveryLineageAction.Undo, firstEntryId,
+            firstManifest, firstResult.ResultVersion, undoManifest, undoVersion));
+
+        var secondAnchor = BodyParagraphs(session)[1];
+        var secondOperation = DeliveryNormalizedOperation.Create("docx_edit", "replace_text",
+            JsonSerializer.Serialize(new { anchorId = secondAnchor, markdown = "Second edit." }));
+        var secondResult = session.ExecuteBatch(new[]
+        {
+            new MutationBatchStep("docx_edit", "replace_text",
+                s => s.ReplaceText(secondAnchor, "Second edit.")),
+        });
+        var deliveredBytes = session.Save();
+        var deliveredManifest = Manifest(deliveredBytes);
+        var secondEntryId = builder.AddTransaction(
+            DeliveryTransactionContribution.FromMutationBatchResult(
+            secondResult, undoManifest, deliveredManifest, new[] { secondOperation }));
+        builder.SetDeliveredDocument(deliveredManifest, secondResult.ResultVersion);
+        AddCleanDocx(
+            builder, deliveredBytes, deliveredManifest, secondResult.ResultVersion);
+        builder.AddSemanticChangeSet(DeliverySemanticChangeSetInput.ForSourceToDelivered(
+            SemanticChanges(sourceBytes, deliveredBytes)));
+        AddTransactionSemantic(
+            builder, firstEntryId, sourceBytes, firstBytes, "semantic-transaction-1");
+        AddTransactionSemantic(
+            builder, secondEntryId, undoBytes, deliveredBytes, "semantic-transaction-2");
+
+        var receipt = builder.Build();
+        var chronology = receipt.Payload.Transactions
+            .Select(transaction => (transaction.Sequence, Kind: "transaction"))
+            .Concat(receipt.Payload.Lineage
+                .Select(lineageEvent => (lineageEvent.Sequence, Kind: "undo")))
+            .OrderBy(value => value.Sequence)
+            .ToArray();
+
+        Assert.Equal(new[]
+        {
+            (0L, "transaction"),
+            (1L, "undo"),
+            (2L, "transaction"),
+        }, chronology);
+        Assert.True(DeliveryChangeReceiptVerifier.Verify(
+            receipt, new Dictionary<string, byte[]>
+            {
+                ["clean-docx"] = deliveredBytes,
+                ["semantic-source-to-delivered"] =
+                    SemanticChanges(sourceBytes, deliveredBytes).ToCanonicalUtf8Bytes(),
+                ["semantic-transaction-1"] =
+                    SemanticChanges(sourceBytes, firstBytes).ToCanonicalUtf8Bytes(),
+                ["semantic-transaction-2"] =
+                    SemanticChanges(undoBytes, deliveredBytes).ToCanonicalUtf8Bytes(),
+            }).IsValid);
+    }
+
+    [Fact]
+    public void DCR005_PrivacyProfiles_RedactBeforeCanonicalization()
+    {
+        const string secret = "CONFIDENTIAL-CUSTOMER-TERM-9381";
+        var edit = SingleEdit(secret, tracked: true);
+
+        var hashOnly = BuildWithProfile(edit, DeliveryReceiptPrivacyProfile.HashOnly);
+        var summary = BuildWithProfile(edit, DeliveryReceiptPrivacyProfile.HashAndSummary);
+        var full = BuildWithProfile(edit, DeliveryReceiptPrivacyProfile.FullEvidence);
+
+        Assert.DoesNotContain(secret, hashOnly.ToJson(), StringComparison.Ordinal);
+        Assert.DoesNotContain(secret, summary.ToJson(), StringComparison.Ordinal);
+        Assert.Contains(secret, full.ToJson(), StringComparison.Ordinal);
+        Assert.NotEqual(hashOnly.ReceiptDigest, summary.ReceiptDigest);
+        Assert.NotEqual(summary.ReceiptDigest, full.ReceiptDigest);
+        Assert.Null(hashOnly.Payload.Transactions[0].Operations[0].ArgumentsSummary);
+        Assert.NotNull(summary.Payload.Transactions[0].Operations[0].ArgumentsSummary);
+        Assert.NotNull(full.Payload.Transactions[0].Operations[0].Arguments);
+    }
+
+    [Fact]
+    public void DCR006_Attribution_ReportsRequestedDerivedAndUnexpectedWithoutHidingChanges()
+    {
+        var source = DocxSessionTests.BuildDS001_SimpleTwoParagraphs();
+        using var session = Open(source);
+        var anchor = BodyParagraphs(session)[0];
+        var beforeBytes = session.Save();
+        var beforeManifest = Manifest(beforeBytes);
+        var operation = DeliveryNormalizedOperation.Create("docx_link", "add",
+            JsonSerializer.Serialize(new
+            {
+                anchorId = anchor,
+                start = 0,
+                length = 5,
+                target = "https://example.test/receipt",
+            }));
+        var result = session.ExecuteBatch(new[]
+        {
+            new MutationBatchStep("docx_link", "add", s => s.AddHyperlink(
+                anchor, new CharSpan(0, 5),
+                new HyperlinkTarget(HyperlinkKind.External, "https://example.test/receipt"))),
+        });
+        Assert.True(result.Success);
+        var afterBytes = session.Save();
+        var afterManifest = Manifest(afterBytes);
+        var contribution = DeliveryTransactionContribution.FromMutationBatchResult(
+            result, beforeManifest, afterManifest, new[] { operation });
+        var addedRelationship = afterManifest.Relationships.Single(relationship =>
+            !beforeManifest.Relationships.Any(before =>
+                before.OwnerUri == relationship.OwnerUri && before.Id == relationship.Id));
+        var builder = new DeliveryChangeReceiptBuilder(beforeManifest, result.BaseVersion)
+            .SetDeliveredDocument(afterManifest, result.ResultVersion);
+        var entryId = builder.AddTransaction(contribution);
+        AddCleanDocx(builder, afterBytes, afterManifest, result.ResultVersion);
+        builder.AddSemanticChangeSet(DeliverySemanticChangeSetInput.ForSourceToDelivered(
+            SemanticChanges(beforeBytes, afterBytes)));
+        AddTransactionSemantic(
+            builder, entryId, beforeBytes, afterBytes, "semantic-source-to-delivered");
+        builder.AddAttributionRule(new DeliveryChangeAttributionRule
+        {
+            Kind = DeliveryPackageChangeKind.PartModified,
+            EntryUri = "/word/document.xml",
+            Disposition = DeliveryChangeDisposition.UserRequested,
+            TransactionEntryId = entryId,
+            RequestedOperationIndex = 0,
+        });
+        builder.AddAttributionRule(new DeliveryChangeAttributionRule
+        {
+            Kind = DeliveryPackageChangeKind.RelationshipAdded,
+            OwnerUri = addedRelationship.OwnerUri,
+            RelationshipId = addedRelationship.Id,
+            Disposition = DeliveryChangeDisposition.Derived,
+            TransactionEntryId = entryId,
+            RequestedOperationIndex = 0,
+            Derivation = "External hyperlink relationship required by requested hyperlink.",
+        });
+
+        var receipt = builder.Build();
+
+        Assert.Contains(receipt.Payload.PackageChanges,
+            change => change.Disposition == DeliveryChangeDisposition.UserRequested);
+        Assert.Contains(receipt.Payload.PackageChanges,
+            change => change.Disposition == DeliveryChangeDisposition.Derived);
+        Assert.Contains(receipt.Payload.PackageChanges,
+            change => change.Disposition == DeliveryChangeDisposition.Unexpected);
+        Assert.True(receipt.Payload.HasUnexpectedChanges);
+        builder.FailOnUnexpectedChanges = true;
+        Assert.Equal("unexpected_package_change",
+            Assert.Throws<DeliveryReceiptValidationException>(() => builder.Build()).Code);
+    }
+
+    [Fact]
+    public void DCR007_MultiArtifactRedlineAndPageCitation_VerifyIndependently()
+    {
+        var edit = SingleEdit("Changed for redline delivery.");
+        var redlineBytes = DocxDiff.Compare(
+            new WmlDocument("before.docx", edit.BeforeBytes),
+            new WmlDocument("after.docx", edit.AfterBytes)).DocumentByteArray;
+        var redlineIdentity = DeliveryDocumentIdentity.FromManifest(
+            Manifest(redlineBytes), edit.Result.ResultVersion);
+        var deliveredIdentity = DeliveryDocumentIdentity.FromManifest(
+            edit.AfterManifest, edit.Result.ResultVersion);
+        var htmlBytes = Encoding.UTF8.GetBytes("<main>Changed for delivery.</main>");
+        var pdfBytes = Encoding.ASCII.GetBytes("%PDF-1.7\nreceipt pagination fixture\n%%EOF");
+        var validationBytes = Encoding.UTF8.GetBytes("{\"valid\":true}");
+        var reversibilityBytes = Encoding.UTF8.GetBytes("{\"roundTrip\":\"verified\"}");
+        const string renderer = "chromium-140|fonts-v3|pagination-v1";
+        var semanticBytes = SemanticChanges(
+            edit.BeforeBytes, edit.AfterBytes).ToCanonicalUtf8Bytes();
+        var pageMapBytes = PageMapBytes(
+            edit.AnchorId, edit.Result.ResultVersion, renderer);
+        var pageMapDigest = Digest(pageMapBytes);
+
+        var builder = Builder(edit);
+        AddTransactionWithSemantic(builder, edit);
+        builder.AddArtifact(DeliveryArtifactInput.Available(
+            "review-docx", DeliveryArtifactRole.ReviewDocx,
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            redlineBytes) with
+        {
+            Document = redlineIdentity,
+            RelativePath = "delivery/review.docx",
+        });
+        builder.AddArtifact(DeliveryArtifactInput.Available(
+            "delivery-html", DeliveryArtifactRole.Html, "text/html", htmlBytes));
+        builder.AddArtifact(DeliveryArtifactInput.Available(
+            "delivery-page-map", DeliveryArtifactRole.PageMap,
+            "application/json", pageMapBytes) with
+        {
+            Document = deliveredIdentity,
+            RendererFingerprint = renderer,
+        });
+        builder.AddArtifact(DeliveryArtifactInput.Available(
+            "delivery-pdf", DeliveryArtifactRole.Pdf, "application/pdf", pdfBytes) with
+        {
+            Document = deliveredIdentity,
+            RendererFingerprint = renderer,
+            PageMapDigest = pageMapDigest,
+            RelativePath = "delivery/document.pdf",
+        });
+        builder.AddArtifact(DeliveryArtifactInput.Available(
+            "validation", DeliveryArtifactRole.ValidationReport,
+            "application/json", validationBytes));
+        builder.AddArtifact(DeliveryArtifactInput.Available(
+            "reversibility", DeliveryArtifactRole.ReversibilityProof,
+            "application/json", reversibilityBytes));
+        builder.AddEvidence(new DeliveryEvidenceReference
+        {
+            Kind = DeliveryEvidenceKind.ValidationResult,
+            Schema = "https://docxodus.dev/schemas/verification/validation-result/v1",
+            Digest = Digest(validationBytes),
+            ArtifactId = "validation",
+            Summary = "Package validation passed.",
+        });
+        builder.AddEvidence(new DeliveryEvidenceReference
+        {
+            Kind = DeliveryEvidenceKind.RedlineReversibility,
+            Schema = "https://docxodus.dev/schemas/verification/redline-proof/v1",
+            Digest = Digest(reversibilityBytes),
+            ArtifactId = "reversibility",
+            Summary = "Redline reversibility verified.",
+        });
+        builder.AddPageCitation(new DeliveryPageCitationInput
+        {
+            Citation = Citation(edit.AnchorId, edit.Result.ResultVersion, renderer),
+            Scope = "body",
+            Document = deliveredIdentity,
+            PageMapDigest = pageMapDigest,
+            PageMapArtifactId = "delivery-page-map",
+            RenderArtifactId = "delivery-pdf",
+        });
+
+        var receipt = builder.Build();
+        var artifacts = new Dictionary<string, byte[]>
+        {
+            ["clean-docx"] = edit.AfterBytes,
+            ["review-docx"] = redlineBytes,
+            ["delivery-html"] = htmlBytes,
+            ["delivery-page-map"] = pageMapBytes,
+            ["delivery-pdf"] = pdfBytes,
+            ["validation"] = validationBytes,
+            ["reversibility"] = reversibilityBytes,
+            ["semantic-source-to-delivered"] = semanticBytes,
+        };
+        var verification = DeliveryChangeReceiptVerifier.Verify(receipt, artifacts);
+
+        Assert.True(verification.IsValid, string.Join(",", verification.Findings));
+        Assert.Equal(artifacts.Keys.OrderBy(value => value, StringComparer.Ordinal),
+            verification.Artifacts.Select(artifact => artifact.ArtifactId));
+        Assert.All(verification.Artifacts,
+            artifact => Assert.Equal(DeliveryArtifactVerificationStatus.Verified, artifact.Status));
+        Assert.Single(receipt.Payload.PageCitations);
+        Assert.Contains(receipt.Payload.SemanticChangeSets,
+            evidence => evidence.Scope == DeliverySemanticComparisonScope.SourceToDelivered
+                && evidence.Schema == SemanticChangeSet.CurrentSchema);
+        Assert.Contains(receipt.Payload.Artifacts,
+            artifact => artifact.Role == DeliveryArtifactRole.ReviewDocx);
+    }
+
+    [Fact]
+    public void DCR008_TamperedReceiptArtifactAndMissingArtifact_AreDetected()
+    {
+        var edit = SingleEdit("Tamper target.");
+        var pdf = Encoding.ASCII.GetBytes("%PDF-1.7\noriginal\n%%EOF");
+        var builder = Builder(edit);
+        AddTransactionWithSemantic(builder, edit);
+        builder.AddArtifact(DeliveryArtifactInput.Available(
+            "pdf", DeliveryArtifactRole.Pdf, "application/pdf", pdf));
+        var receipt = builder.Build();
+        var goodBytes = RequiredArtifactBytes(edit);
+        goodBytes["pdf"] = pdf;
+
+        var good = DeliveryChangeReceiptVerifier.Verify(receipt, goodBytes);
+        Assert.True(good.IsValid);
+
+        var tamperedArtifact = pdf.ToArray();
+        tamperedArtifact[10] ^= 0x01;
+        var tamperedBytes = RequiredArtifactBytes(edit);
+        tamperedBytes["pdf"] = tamperedArtifact;
+        var artifactResult = DeliveryChangeReceiptVerifier.Verify(receipt, tamperedBytes);
+        Assert.False(artifactResult.IsValid);
+        Assert.Equal(DeliveryArtifactVerificationStatus.DigestMismatch,
+            Assert.Single(artifactResult.Artifacts,
+                artifact => artifact.ArtifactId == "pdf").Status);
+
+        var missing = DeliveryChangeReceiptVerifier.Verify(receipt,
+            new Dictionary<string, byte[]>());
+        Assert.False(missing.IsValid);
+        Assert.Equal(DeliveryArtifactVerificationStatus.Missing,
+            Assert.Single(missing.Artifacts,
+                artifact => artifact.ArtifactId == "pdf").Status);
+
+        var tamperedReceipt = receipt.ToJson().Replace(
+            "hashAndSummary", "fullEvidence", StringComparison.Ordinal);
+        var receiptResult = DeliveryChangeReceiptVerifier.VerifyJson(
+            tamperedReceipt, goodBytes);
+        Assert.False(receiptResult.IsValid);
+        Assert.False(receiptResult.ReceiptDigestValid);
+    }
+
+    [Fact]
+    public void DCR009_PageCitation_RejectsRendererPackageAndContinuousMismatches()
+    {
+        var edit = SingleEdit("Citation target.");
+        var identity = DeliveryDocumentIdentity.FromManifest(
+            edit.AfterManifest, edit.Result.ResultVersion);
+        var pdf = Encoding.ASCII.GetBytes("%PDF-1.7\nfixture\n%%EOF");
+        var pageMapBytes = PageMapBytes(
+            edit.AnchorId, edit.Result.ResultVersion, "renderer-A");
+        var pageMapDigest = Digest(pageMapBytes);
+        var builder = Builder(edit);
+        AddTransactionWithSemantic(builder, edit);
+        builder.AddArtifact(DeliveryArtifactInput.Available(
+            "pdf", DeliveryArtifactRole.Pdf, "application/pdf", pdf) with
+        {
+            Document = identity,
+            RendererFingerprint = "renderer-A",
+            PageMapDigest = pageMapDigest,
+        });
+        builder.AddArtifact(DeliveryArtifactInput.Available(
+            "page-map", DeliveryArtifactRole.PageMap, "application/json", pageMapBytes) with
+        {
+            Document = identity,
+            RendererFingerprint = "renderer-A",
+        });
+        builder.AddPageCitation(new DeliveryPageCitationInput
+        {
+            Citation = Citation(edit.AnchorId, edit.Result.ResultVersion, "renderer-B"),
+            Scope = "body",
+            Document = identity,
+            PageMapDigest = pageMapDigest,
+            PageMapArtifactId = "page-map",
+            RenderArtifactId = "pdf",
+        });
+
+        Assert.Equal("citation_render_binding_mismatch",
+            Assert.Throws<DeliveryReceiptValidationException>(() => builder.Build()).Code);
+
+        var continuous = Builder(edit);
+        AddTransactionWithSemantic(continuous, edit);
+        continuous.AddArtifact(DeliveryArtifactInput.Available(
+            "pdf", DeliveryArtifactRole.Pdf, "application/pdf", pdf) with
+        {
+            Document = identity,
+            RendererFingerprint = "renderer-A",
+            PageMapDigest = pageMapDigest,
+        });
+        continuous.AddArtifact(DeliveryArtifactInput.Available(
+            "page-map", DeliveryArtifactRole.PageMap, "application/json", pageMapBytes) with
+        {
+            Document = identity,
+            RendererFingerprint = "renderer-A",
+        });
+        continuous.AddPageCitation(new DeliveryPageCitationInput
+        {
+            Citation = Citation(edit.AnchorId, edit.Result.ResultVersion, "renderer-A") with
+            {
+                Availability = PageMapAvailability.Unavailable,
+                UnavailableReason = PageCitationUnavailableReason.ContinuousMode,
+                Pages = Array.Empty<PageMapPage>(),
+                Fragments = Array.Empty<PageMapFragment>(),
+            },
+            Scope = "body",
+            Document = identity,
+            PageMapDigest = pageMapDigest,
+            PageMapArtifactId = "page-map",
+            RenderArtifactId = "pdf",
+        });
+        Assert.Equal("unavailable_page_citation",
+            Assert.Throws<DeliveryReceiptValidationException>(() => continuous.Build()).Code);
+    }
+
+    [Fact]
+    public void DCR010_OperationCanonicalization_SortsObjectsAndRejectsDuplicateKeys()
+    {
+        var left = DeliveryNormalizedOperation.Create("tool", "action", "{\"z\":1,\"a\":2}");
+        var right = DeliveryNormalizedOperation.Create("tool", "action", "{ \"a\":2, \"z\":1 }");
+
+        Assert.Equal(left.ArgumentsDigest, right.ArgumentsDigest);
+        Assert.Equal("invalid_operation_arguments",
+            Assert.Throws<DeliveryReceiptValidationException>(() =>
+                DeliveryNormalizedOperation.Create("tool", "action", "{\"a\":1,\"a\":2}"))
+                .Code);
+    }
+
+    [Fact]
+    public void DCR011_UnavailableArtifact_IsPortableButCannotMasqueradeAsHashedOutput()
+    {
+        var edit = SingleEdit("Unavailable artifact.");
+        var builder = Builder(edit);
+        AddTransactionWithSemantic(builder, edit);
+        builder.AddArtifact(DeliveryArtifactInput.Unavailable(
+            "pdf", DeliveryArtifactRole.Pdf, "application/pdf", "renderer unavailable") with
+        {
+            RelativePath = "delivery/document.pdf",
+        });
+
+        var receipt = builder.Build();
+        var verification = DeliveryChangeReceiptVerifier.Verify(
+            receipt, RequiredArtifactBytes(edit));
+
+        Assert.True(verification.IsValid);
+        var artifact = Assert.Single(receipt.Payload.Artifacts,
+            value => value.ArtifactId == "pdf");
+        Assert.Null(artifact.Digest);
+        Assert.Null(artifact.ByteLength);
+        Assert.Equal(DeliveryArtifactVerificationStatus.Unavailable,
+            Assert.Single(verification.Artifacts,
+                value => value.ArtifactId == "pdf").Status);
+        Assert.Equal("unsafe_artifact_path",
+            Assert.Throws<DeliveryReceiptValidationException>(() => Builder(edit).AddArtifact(
+                DeliveryArtifactInput.Unavailable("bad", DeliveryArtifactRole.Pdf,
+                    "application/pdf", "none") with { RelativePath = "../escape.pdf" })).Code);
+    }
+
+    [Fact]
+    public void DCR013_RehashedMalformedContract_IsRejectedIndependentlyOfEnvelopeDigest()
+    {
+        var edit = SingleEdit("Malformed contract target.");
+        var builder = Builder(edit);
+        AddTransactionWithSemantic(builder, edit);
+        var original = builder.Build();
+        var malformedPayload = original.Payload with
+        {
+            Transactions = new[]
+            {
+                original.Payload.Transactions[0] with
+                {
+                    Status = DeliveryTransactionStatus.Failed,
+                },
+            },
+        };
+        var malformed = new DeliveryChangeReceipt
+        {
+            Payload = malformedPayload,
+            ReceiptDigest = Digest(
+                DeliveryChangeReceiptSerializer.SerializePayload(malformedPayload)),
+        };
+
+        var verification = DeliveryChangeReceiptVerifier.Verify(
+            malformed, RequiredArtifactBytes(edit));
+
+        Assert.True(verification.ReceiptDigestValid);
+        Assert.False(verification.ContractValid);
+        Assert.False(verification.IsValid);
+        Assert.Contains("failed_transaction_changed_document", verification.Findings);
+    }
+
+    [Fact]
+    public void DCR014_PageCitation_RequiresReachableStateAndExactPageMapProjection()
+    {
+        const string renderer = "chromium-140|fonts-v3|pagination-v1";
+        var edit = SingleEdit("Citation reachability target.");
+        var deliveredIdentity = DeliveryDocumentIdentity.FromManifest(
+            edit.AfterManifest, edit.Result.ResultVersion);
+        var pdfBytes = Encoding.ASCII.GetBytes("%PDF-1.7\nreachable citation\n%%EOF");
+        var pageMapBytes = PageMapBytes(
+            edit.AnchorId, edit.Result.ResultVersion, renderer);
+
+        var validBuilder = Builder(edit);
+        AddTransactionWithSemantic(validBuilder, edit);
+        AddPaginatedCitation(
+            validBuilder,
+            deliveredIdentity,
+            Citation(edit.AnchorId, edit.Result.ResultVersion, renderer),
+            pdfBytes,
+            pageMapBytes);
+        var validReceipt = validBuilder.Build();
+        var originalCitation = Assert.Single(validReceipt.Payload.PageCitations);
+        var forgedCitation = originalCitation with
+        {
+            Fragments = originalCitation.Fragments.Select(fragment => fragment with
+            {
+                Geometry = fragment.Geometry with { X = fragment.Geometry.X + 1 },
+            }).ToArray(),
+        };
+        var forged = Rehash(validReceipt.Payload with
+        {
+            PageCitations = new[] { forgedCitation },
+        });
+        var artifacts = RequiredArtifactBytes(edit);
+        artifacts["pdf"] = pdfBytes;
+        artifacts["page-map"] = pageMapBytes;
+
+        var verification = DeliveryChangeReceiptVerifier.Verify(forged, artifacts);
+
+        Assert.True(verification.ReceiptDigestValid);
+        Assert.False(verification.CitationBindingsValid);
+        Assert.Contains(
+            $"citation_page_map_projection_mismatch:{edit.AnchorId}",
+            verification.Findings);
+
+        var unreachableVersion = edit.Result.ResultVersion + 1;
+        var unreachableIdentity = deliveredIdentity with
+        {
+            DocumentVersion = unreachableVersion,
+        };
+        var unreachablePageMap = PageMapBytes(
+            edit.AnchorId, unreachableVersion, renderer);
+        var unreachableBuilder = Builder(edit);
+        AddTransactionWithSemantic(unreachableBuilder, edit);
+        AddPaginatedCitation(
+            unreachableBuilder,
+            unreachableIdentity,
+            Citation(edit.AnchorId, unreachableVersion, renderer),
+            pdfBytes,
+            unreachablePageMap);
+
+        Assert.Equal("unreachable_citation_document",
+            Assert.Throws<DeliveryReceiptValidationException>(
+                () => unreachableBuilder.Build()).Code);
+
+        var duplicatePropertyPageMap = Encoding.UTF8.GetBytes(
+            Encoding.UTF8.GetString(pageMapBytes).Insert(1, "\"schemaVersion\":1,"));
+        foreach (var invalidPageMap in new[]
+                 {
+                     duplicatePropertyPageMap,
+                     new byte[] { 0xff, 0xfe, 0xfd },
+                 })
+        {
+            var invalidMapBuilder = Builder(edit);
+            AddTransactionWithSemantic(invalidMapBuilder, edit);
+            AddPaginatedCitation(
+                invalidMapBuilder,
+                deliveredIdentity,
+                Citation(edit.AnchorId, edit.Result.ResultVersion, renderer),
+                pdfBytes,
+                invalidPageMap);
+            Assert.Equal("invalid_page_map_artifact",
+                Assert.Throws<DeliveryReceiptValidationException>(
+                    () => invalidMapBuilder.Build()).Code);
+        }
+    }
+
+    [Fact]
+    public void DCR015_CleanDocx_IsMandatoryAndExactlyMatchesDeliveredDocument()
+    {
+        var edit = SingleEdit("Clean artifact target.");
+        Assert.Equal("invalid_package_manifest",
+            Assert.Throws<DeliveryReceiptValidationException>(() =>
+                new DeliveryChangeReceiptBuilder(
+                    edit.BeforeManifest with { IsValid = false },
+                    edit.Result.BaseVersion)).Code);
+        var missing = new DeliveryChangeReceiptBuilder(
+            edit.BeforeManifest, edit.Result.BaseVersion)
+            .SetDeliveredDocument(edit.AfterManifest, edit.Result.ResultVersion);
+        var missingEntryId = missing.AddTransaction(edit.Contribution);
+        missing.AddSemanticChangeSet(DeliverySemanticChangeSetInput.ForSourceToDelivered(
+            SemanticChanges(edit.BeforeBytes, edit.AfterBytes)));
+        AddTransactionSemantic(
+            missing, missingEntryId, edit.BeforeBytes, edit.AfterBytes,
+            "semantic-source-to-delivered");
+
+        Assert.Equal("missing_clean_docx",
+            Assert.Throws<DeliveryReceiptValidationException>(() => missing.Build()).Code);
+
+        var validBuilder = Builder(edit);
+        AddTransactionWithSemantic(validBuilder, edit);
+        var valid = validBuilder.Build();
+        var forgedArtifacts = valid.Payload.Artifacts.Select(artifact =>
+            artifact.Role == DeliveryArtifactRole.CleanDocx
+                ? artifact with
+                {
+                    DocumentVersion = edit.Result.ResultVersion + 1,
+                }
+                : artifact).ToArray();
+        var forged = Rehash(valid.Payload with { Artifacts = forgedArtifacts });
+
+        var verification = DeliveryChangeReceiptVerifier.Verify(
+            forged, RequiredArtifactBytes(edit));
+
+        Assert.True(verification.ReceiptDigestValid);
+        Assert.False(verification.ContractValid);
+        Assert.Contains("clean_docx_delivery_mismatch", verification.Findings);
+    }
+
+    [Fact]
+    public void DCR016_Lineage_EnforcesLifoOrderVersionStepsAndNoOpRedoPreservation()
+    {
+        var edit = SingleEdit("Lineage invariant target.");
+
+        (DeliveryChangeReceiptBuilder Builder, string EntryId) BareBuilder()
+        {
+            var builder = new DeliveryChangeReceiptBuilder(
+                edit.BeforeManifest, edit.Result.BaseVersion);
+            return (builder, builder.AddTransaction(edit.Contribution));
+        }
+
+        var (redoFirst, redoFirstEntryId) = BareBuilder();
+        redoFirst.AddLineageEvent(DeliveryLineageEventInput.FromManifests(
+            DeliveryLineageAction.Redo,
+            redoFirstEntryId,
+            edit.AfterManifest,
+            edit.Result.ResultVersion,
+            edit.AfterManifest,
+            edit.Result.ResultVersion + 1));
+        redoFirst.SetDeliveredDocument(
+            edit.AfterManifest, edit.Result.ResultVersion + 1);
+        Assert.Equal("invalid_redo_order",
+            Assert.Throws<DeliveryReceiptValidationException>(() => redoFirst.Build()).Code);
+
+        var (repeatedUndo, repeatedUndoEntryId) = BareBuilder();
+        repeatedUndo.AddLineageEvent(DeliveryLineageEventInput.FromManifests(
+            DeliveryLineageAction.Undo,
+            repeatedUndoEntryId,
+            edit.AfterManifest,
+            edit.Result.ResultVersion,
+            edit.BeforeManifest,
+            edit.Result.ResultVersion + 1));
+        repeatedUndo.AddLineageEvent(DeliveryLineageEventInput.FromManifests(
+            DeliveryLineageAction.Undo,
+            repeatedUndoEntryId,
+            edit.BeforeManifest,
+            edit.Result.ResultVersion + 1,
+            edit.BeforeManifest,
+            edit.Result.ResultVersion + 2));
+        repeatedUndo.SetDeliveredDocument(
+            edit.BeforeManifest, edit.Result.ResultVersion + 2);
+        Assert.Equal("invalid_undo_order",
+            Assert.Throws<DeliveryReceiptValidationException>(() => repeatedUndo.Build()).Code);
+
+        var (skippedVersion, skippedVersionEntryId) = BareBuilder();
+        skippedVersion.AddLineageEvent(DeliveryLineageEventInput.FromManifests(
+            DeliveryLineageAction.Undo,
+            skippedVersionEntryId,
+            edit.AfterManifest,
+            edit.Result.ResultVersion,
+            edit.BeforeManifest,
+            edit.Result.ResultVersion + 2));
+        skippedVersion.SetDeliveredDocument(
+            edit.BeforeManifest, edit.Result.ResultVersion + 2);
+        Assert.Equal("invalid_lineage_version",
+            Assert.Throws<DeliveryReceiptValidationException>(() => skippedVersion.Build()).Code);
+
+        using (var session = Open(edit.BeforeBytes))
+        {
+            var anchors = BodyParagraphs(session);
+            var sourceBytes = session.Save();
+            var sourceManifest = Manifest(sourceBytes);
+            var firstOperation = DeliveryNormalizedOperation.Create(
+                "docx_edit", "replace_text",
+                JsonSerializer.Serialize(new
+                {
+                    anchorId = anchors[0],
+                    markdown = "First stacked edit.",
+                }));
+            var firstResult = session.ExecuteBatch(new[]
+            {
+                new MutationBatchStep("docx_edit", "replace_text",
+                    s => s.ReplaceText(anchors[0], "First stacked edit.")),
+            });
+            var firstBytes = session.Save();
+            var firstManifest = Manifest(firstBytes);
+            var secondOperation = DeliveryNormalizedOperation.Create(
+                "docx_edit", "replace_text",
+                JsonSerializer.Serialize(new
+                {
+                    anchorId = anchors[1],
+                    markdown = "Second stacked edit.",
+                }));
+            var secondResult = session.ExecuteBatch(new[]
+            {
+                new MutationBatchStep("docx_edit", "replace_text",
+                    s => s.ReplaceText(anchors[1], "Second stacked edit.")),
+            });
+            var secondBytes = session.Save();
+            var secondManifest = Manifest(secondBytes);
+            var nonLifo = new DeliveryChangeReceiptBuilder(
+                sourceManifest, firstResult.BaseVersion);
+            var firstEntryId = nonLifo.AddTransaction(
+                DeliveryTransactionContribution.FromMutationBatchResult(
+                    firstResult,
+                    sourceManifest,
+                    firstManifest,
+                    new[] { firstOperation }));
+            _ = nonLifo.AddTransaction(
+                DeliveryTransactionContribution.FromMutationBatchResult(
+                    secondResult,
+                    firstManifest,
+                    secondManifest,
+                    new[] { secondOperation }));
+            nonLifo.AddLineageEvent(DeliveryLineageEventInput.FromManifests(
+                DeliveryLineageAction.Undo,
+                firstEntryId,
+                secondManifest,
+                secondResult.ResultVersion,
+                sourceManifest,
+                secondResult.ResultVersion + 1));
+            nonLifo.SetDeliveredDocument(
+                sourceManifest, secondResult.ResultVersion + 1);
+
+            Assert.Equal("invalid_undo_order",
+                Assert.Throws<DeliveryReceiptValidationException>(() => nonLifo.Build()).Code);
+        }
+
+        var (noOpHistory, noOpHistoryEntryId) = BareBuilder();
+        noOpHistory.AddLineageEvent(DeliveryLineageEventInput.FromManifests(
+            DeliveryLineageAction.Undo,
+            noOpHistoryEntryId,
+            edit.AfterManifest,
+            edit.Result.ResultVersion,
+            edit.BeforeManifest,
+            edit.Result.ResultVersion + 1));
+        var noOpResult = new MutationBatchResult
+        {
+            Mode = MutationBatchMode.Atomic,
+            Success = true,
+            RolledBack = false,
+            BaseVersion = edit.Result.ResultVersion + 1,
+            ResultVersion = edit.Result.ResultVersion + 1,
+        };
+        _ = noOpHistory.AddTransaction(
+            DeliveryTransactionContribution.FromMutationBatchResult(
+                noOpResult,
+                edit.BeforeManifest,
+                edit.BeforeManifest,
+                Array.Empty<DeliveryNormalizedOperation>()));
+        noOpHistory.AddLineageEvent(DeliveryLineageEventInput.FromManifests(
+            DeliveryLineageAction.Redo,
+            noOpHistoryEntryId,
+            edit.BeforeManifest,
+            edit.Result.ResultVersion + 1,
+            edit.AfterManifest,
+            edit.Result.ResultVersion + 2));
+        noOpHistory.SetDeliveredDocument(
+            edit.AfterManifest, edit.Result.ResultVersion + 2);
+        AddCleanDocx(
+            noOpHistory,
+            edit.AfterBytes,
+            edit.AfterManifest,
+            edit.Result.ResultVersion + 2);
+        noOpHistory.AddSemanticChangeSet(
+            DeliverySemanticChangeSetInput.ForSourceToDelivered(
+                SemanticChanges(edit.BeforeBytes, edit.AfterBytes)));
+        AddTransactionSemantic(
+            noOpHistory,
+            noOpHistoryEntryId,
+            edit.BeforeBytes,
+            edit.AfterBytes,
+            "semantic-source-to-delivered");
+        var validNoOpHistory = noOpHistory.Build();
+        Assert.True(DeliveryChangeReceiptVerifier.Verify(
+            validNoOpHistory, RequiredArtifactBytes(edit)).IsValid);
+
+        var forgedLineage = validNoOpHistory.Payload.Lineage
+            .Select((lineageEvent, index) => index == 0
+                ? lineageEvent with
+                {
+                    AfterDocument = lineageEvent.AfterDocument with
+                    {
+                        DocumentVersion = lineageEvent.AfterDocument.DocumentVersion + 1,
+                    },
+                }
+                : lineageEvent)
+            .ToArray();
+        var forged = Rehash(validNoOpHistory.Payload with { Lineage = forgedLineage });
+        var verification = DeliveryChangeReceiptVerifier.Verify(
+            forged, RequiredArtifactBytes(edit));
+        Assert.True(verification.ReceiptDigestValid);
+        Assert.Contains("invalid_lineage_version", verification.Findings);
+    }
+
+    [Fact]
+    public void DCR017_Attribution_RejectsFailedOrRolledBackRequestedOperations()
+    {
+        var source = DocxSessionTests.BuildDS001_SimpleTwoParagraphs();
+        using var session = Open(source);
+        var anchor = BodyParagraphs(session)[0];
+        var beforeBytes = session.Save();
+        var beforeManifest = Manifest(beforeBytes);
+        var operations = new[]
+        {
+            DeliveryNormalizedOperation.Create(
+                "docx_edit", "replace_text",
+                JsonSerializer.Serialize(new
+                {
+                    anchorId = anchor,
+                    markdown = "Retained best-effort edit.",
+                })),
+            DeliveryNormalizedOperation.Create(
+                "docx_edit", "replace_text",
+                JsonSerializer.Serialize(new
+                {
+                    anchorId = "p:body:missing",
+                    markdown = "Must fail.",
+                })),
+        };
+        var result = session.ExecuteBatch(new[]
+        {
+            new MutationBatchStep("docx_edit", "replace_text",
+                s => s.ReplaceText(anchor, "Retained best-effort edit.")),
+            new MutationBatchStep("docx_edit", "replace_text",
+                s => s.ReplaceText("p:body:missing", "Must fail.")),
+        }, MutationBatchMode.BestEffort);
+        Assert.False(result.Success);
+        Assert.False(result.Steps[1].Success);
+        var afterBytes = session.Save();
+        var afterManifest = Manifest(afterBytes);
+        var contribution = DeliveryTransactionContribution.FromMutationBatchResult(
+            result, beforeManifest, afterManifest, operations);
+
+        DeliveryChangeReceiptBuilder BuilderWithAttribution(
+            int operationIndex,
+            DeliveryChangeDisposition disposition = DeliveryChangeDisposition.UserRequested)
+        {
+            var builder = new DeliveryChangeReceiptBuilder(
+                beforeManifest, result.BaseVersion)
+                .SetDeliveredDocument(afterManifest, result.ResultVersion);
+            var entryId = builder.AddTransaction(contribution);
+            AddCleanDocx(builder, afterBytes, afterManifest, result.ResultVersion);
+            builder.AddSemanticChangeSet(
+                DeliverySemanticChangeSetInput.ForSourceToDelivered(
+                    SemanticChanges(beforeBytes, afterBytes)));
+            AddTransactionSemantic(
+                builder,
+                entryId,
+                beforeBytes,
+                afterBytes,
+                "semantic-source-to-delivered");
+            builder.AddAttributionRule(new DeliveryChangeAttributionRule
+            {
+                Kind = DeliveryPackageChangeKind.PartModified,
+                EntryUri = "/word/document.xml",
+                Disposition = disposition,
+                TransactionEntryId = entryId,
+                RequestedOperationIndex = operationIndex,
+                Derivation = disposition == DeliveryChangeDisposition.Derived
+                    ? "Derived from the retained request."
+                    : null,
+            });
+            return builder;
+        }
+
+        Assert.Equal("invalid_attribution_operation",
+            Assert.Throws<DeliveryReceiptValidationException>(
+                () => BuilderWithAttribution(1).Build()).Code);
+        Assert.Equal("invalid_attribution_operation",
+            Assert.Throws<DeliveryReceiptValidationException>(() =>
+                BuilderWithAttribution(
+                    1, DeliveryChangeDisposition.Derived).Build()).Code);
+
+        var valid = BuilderWithAttribution(0).Build();
+        Assert.Contains(valid.Payload.PackageChanges,
+            change => change.Disposition == DeliveryChangeDisposition.UserRequested);
+        var forgedChanges = valid.Payload.PackageChanges.Select(change =>
+            change.Disposition == DeliveryChangeDisposition.UserRequested
+                ? change with { RequestedOperationIndex = 1 }
+                : change).ToArray();
+        var forged = Rehash(valid.Payload with { PackageChanges = forgedChanges });
+        var artifacts = new Dictionary<string, byte[]>
+        {
+            ["clean-docx"] = afterBytes,
+            ["semantic-source-to-delivered"] =
+                SemanticChanges(beforeBytes, afterBytes).ToCanonicalUtf8Bytes(),
+        };
+
+        var verification = DeliveryChangeReceiptVerifier.Verify(forged, artifacts);
+
+        Assert.True(verification.ReceiptDigestValid);
+        Assert.Contains("invalid_package_change_attribution", verification.Findings);
+    }
+
+    [Fact]
+    public void DCR018_SemanticChangeSets_RequireTypedExactAggregateAndTransactionCoverage()
+    {
+        var edit = SingleEdit("Semantic coverage target.");
+
+        var missingAggregate = new DeliveryChangeReceiptBuilder(
+            edit.BeforeManifest, edit.Result.BaseVersion)
+            .SetDeliveredDocument(edit.AfterManifest, edit.Result.ResultVersion);
+        var missingAggregateEntryId = missingAggregate.AddTransaction(edit.Contribution);
+        AddCleanDocx(
+            missingAggregate,
+            edit.AfterBytes,
+            edit.AfterManifest,
+            edit.Result.ResultVersion);
+        AddTransactionSemantic(
+            missingAggregate,
+            missingAggregateEntryId,
+            edit.BeforeBytes,
+            edit.AfterBytes,
+            "semantic-transaction-1");
+        Assert.Equal("missing_source_to_delivered_semantic_evidence",
+            Assert.Throws<DeliveryReceiptValidationException>(
+                () => missingAggregate.Build()).Code);
+
+        var missingTransaction = new DeliveryChangeReceiptBuilder(
+            edit.BeforeManifest, edit.Result.BaseVersion)
+            .SetDeliveredDocument(edit.AfterManifest, edit.Result.ResultVersion);
+        _ = missingTransaction.AddTransaction(edit.Contribution);
+        AddCleanDocx(
+            missingTransaction,
+            edit.AfterBytes,
+            edit.AfterManifest,
+            edit.Result.ResultVersion);
+        missingTransaction.AddSemanticChangeSet(
+            DeliverySemanticChangeSetInput.ForSourceToDelivered(
+                SemanticChanges(edit.BeforeBytes, edit.AfterBytes)));
+        Assert.Equal("semantic_transaction_coverage_mismatch",
+            Assert.Throws<DeliveryReceiptValidationException>(
+                () => missingTransaction.Build()).Code);
+
+        var genericEvidence = Builder(edit);
+        Assert.Equal("semantic_evidence_requires_typed_factory",
+            Assert.Throws<DeliveryReceiptValidationException>(() =>
+                genericEvidence.AddEvidence(new DeliveryEvidenceReference
+                {
+                    Kind = DeliveryEvidenceKind.SemanticChangeSet,
+                    Schema = SemanticChangeSet.CurrentSchema,
+                    Digest = Digest(Encoding.UTF8.GetBytes("not semantic evidence")),
+                })).Code);
+
+        var validBuilder = Builder(edit);
+        AddTransactionWithSemantic(validBuilder, edit);
+        var valid = validBuilder.Build();
+        var forgedBindings = valid.Payload.SemanticChangeSets.Select(binding =>
+            binding.Scope == DeliverySemanticComparisonScope.SourceToDelivered
+                ? binding with
+                {
+                    BeforeDocument = valid.Payload.DeliveredDocument,
+                    Schema = "https://docxodus.dev/schemas/semantic-change-set/forged",
+                    SchemaVersion = SemanticChangeSet.CurrentSchemaVersion + 1,
+                }
+                : binding).ToArray();
+        var forged = Rehash(valid.Payload with { SemanticChangeSets = forgedBindings });
+
+        var forgedVerification = DeliveryChangeReceiptVerifier.Verify(
+            forged, RequiredArtifactBytes(edit));
+
+        Assert.True(forgedVerification.ReceiptDigestValid);
+        Assert.Contains("semantic_binding_identity_mismatch", forgedVerification.Findings);
+        Assert.Contains("unsupported_semantic_change_set", forgedVerification.Findings);
+        Assert.Contains(
+            "semantic_artifact_binding_mismatch:semantic-source-to-delivered",
+            forgedVerification.Findings);
+
+        var tamperedArtifacts = RequiredArtifactBytes(edit);
+        tamperedArtifacts["semantic-source-to-delivered"][^1] ^= 0x01;
+        var byteVerification = DeliveryChangeReceiptVerifier.Verify(valid, tamperedArtifacts);
+        Assert.Contains(
+            "semantic_artifact_binding_mismatch:semantic-source-to-delivered",
+            byteVerification.Findings);
+    }
+
+    [Fact]
+    public void DCR019_SemanticArtifacts_MustBeCompleteTypedCanonicalBytes()
+    {
+        var edit = SingleEdit("Strict semantic bytes.");
+        var builder = Builder(edit);
+        AddTransactionWithSemantic(builder, edit);
+        var valid = builder.Build();
+        var canonical = RequiredArtifactBytes(edit)["semantic-source-to-delivered"];
+
+        DeliveryReceiptVerificationResult VerifyVariant(byte[] bytes, int changeCount)
+        {
+            var digest = Digest(bytes);
+            var artifacts = valid.Payload.Artifacts.Select(artifact =>
+                artifact.ArtifactId == "semantic-source-to-delivered"
+                    ? artifact with { Digest = digest, ByteLength = bytes.LongLength }
+                    : artifact).ToArray();
+            var bindings = valid.Payload.SemanticChangeSets.Select(binding =>
+                binding.ArtifactId == "semantic-source-to-delivered"
+                    ? binding with { Digest = digest, ChangeCount = changeCount }
+                    : binding).ToArray();
+            var forged = Rehash(valid.Payload with
+            {
+                Artifacts = artifacts,
+                SemanticChangeSets = bindings,
+            });
+            var supplied = RequiredArtifactBytes(edit);
+            supplied["semantic-source-to-delivered"] = bytes;
+            return DeliveryChangeReceiptVerifier.Verify(forged, supplied);
+        }
+
+        var whitespaceVariant = canonical.Concat(new byte[] { (byte)'\n' }).ToArray();
+        var whitespaceVerification = VerifyVariant(
+            whitespaceVariant, valid.Payload.SemanticChangeSets[0].ChangeCount);
+        Assert.True(whitespaceVerification.ReceiptDigestValid);
+        Assert.Contains("invalid_semantic_change_set", whitespaceVerification.Findings);
+        Assert.Contains(
+            "semantic_artifact_binding_mismatch:semantic-source-to-delivered",
+            whitespaceVerification.Findings);
+
+        var nullChange = Encoding.UTF8.GetBytes(
+            $"{{\"schema\":\"{SemanticChangeSet.CurrentSchema}\","
+            + $"\"schemaVersion\":{SemanticChangeSet.CurrentSchemaVersion},"
+            + "\"changeCount\":1,\"changes\":[null]}");
+        var nullVerification = VerifyVariant(nullChange, changeCount: 1);
+        Assert.True(nullVerification.ReceiptDigestValid);
+        Assert.Contains("invalid_semantic_change_set", nullVerification.Findings);
+        Assert.Contains(
+            "semantic_artifact_binding_mismatch:semantic-source-to-delivered",
+            nullVerification.Findings);
+    }
+
+    [Fact]
+    public void DCR020_CleanDocx_IdentityIsRecomputedFromExactWordPackageBytes()
+    {
+        var sourceBytes = DocxSessionTests.BuildDS001_SimpleTwoParagraphs();
+        var manifest = Manifest(sourceBytes);
+        const long version = 0;
+        var arbitrary = Encoding.UTF8.GetBytes("not a DOCX package");
+        var identity = DeliveryDocumentIdentity.FromManifest(manifest, version);
+
+        var rejectingBuilder = new DeliveryChangeReceiptBuilder(manifest, version)
+            .SetDeliveredDocument(manifest, version);
+        var rejected = Assert.Throws<DeliveryReceiptValidationException>(() =>
+            rejectingBuilder.AddArtifact(DeliveryArtifactInput.Available(
+                "clean-docx",
+                DeliveryArtifactRole.CleanDocx,
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                arbitrary) with { Document = identity }));
+        Assert.Equal("invalid_clean_docx", rejected.Code);
+
+        var builder = new DeliveryChangeReceiptBuilder(manifest, version)
+            .SetDeliveredDocument(manifest, version);
+        AddCleanDocx(builder, sourceBytes, manifest, version);
+        var emptySemantic = new SemanticChangeSet(Array.Empty<SemanticChange>());
+        builder.AddSemanticChangeSet(
+            DeliverySemanticChangeSetInput.ForSourceToDelivered(emptySemantic));
+        var valid = builder.Build();
+
+        var forgedDigest = Digest(arbitrary);
+        var forgedIdentity = valid.Payload.DeliveredDocument with
+        {
+            RawPackageBytesDigest = forgedDigest,
+        };
+        var artifacts = valid.Payload.Artifacts.Select(artifact =>
+            artifact.Role == DeliveryArtifactRole.CleanDocx
+                ? artifact with
+                {
+                    ByteLength = arbitrary.LongLength,
+                    Digest = forgedDigest,
+                    PackageDigest = forgedDigest,
+                }
+                : artifact).ToArray();
+        var semanticBindings = valid.Payload.SemanticChangeSets.Select(binding => binding with
+        {
+            BeforeDocument = forgedIdentity,
+            AfterDocument = forgedIdentity,
+        }).ToArray();
+        var forged = Rehash(valid.Payload with
+        {
+            SourceDocument = forgedIdentity,
+            DeliveredDocument = forgedIdentity,
+            Artifacts = artifacts,
+            SemanticChangeSets = semanticBindings,
+        });
+        var supplied = new Dictionary<string, byte[]>
+        {
+            ["clean-docx"] = arbitrary,
+            ["semantic-source-to-delivered"] = emptySemantic.ToCanonicalUtf8Bytes(),
+        };
+
+        var verification = DeliveryChangeReceiptVerifier.Verify(forged, supplied);
+
+        Assert.True(verification.ReceiptDigestValid);
+        Assert.Contains("clean_docx_delivery_mismatch", verification.Findings);
+        Assert.False(verification.IsValid);
+    }
+
+    [Fact]
+    public void DCR021_VerifierRejectsDerivedFailedAttributionAndContradictoryResults()
+    {
+        var edit = SingleEdit("Attribution invariant.");
+        var builder = Builder(edit);
+        var entryId = AddTransactionWithSemantic(builder, edit);
+        builder.AddAttributionRule(new DeliveryChangeAttributionRule
+        {
+            Kind = DeliveryPackageChangeKind.PartModified,
+            EntryUri = "/word/document.xml",
+            Disposition = DeliveryChangeDisposition.Derived,
+            TransactionEntryId = entryId,
+            RequestedOperationIndex = 0,
+            Derivation = "Derived package representation.",
+        });
+        var valid = builder.Build();
+        Assert.Contains(valid.Payload.PackageChanges,
+            change => change.Disposition == DeliveryChangeDisposition.Derived);
+
+        var transaction = Assert.Single(valid.Payload.Transactions);
+        var operation = Assert.Single(transaction.Operations);
+        var failedAttributionTransaction = transaction with
+        {
+            Operations = new[]
+            {
+                operation with
+                {
+                    ExecutionStatus = DeliveryOperationExecutionStatus.Failed,
+                    Success = false,
+                },
+            },
+        };
+        var failedAttribution = Rehash(valid.Payload with
+        {
+            Transactions = new[] { failedAttributionTransaction },
+        });
+        var attributionVerification = DeliveryChangeReceiptVerifier.Verify(
+            failedAttribution, RequiredArtifactBytes(edit));
+        Assert.Contains(
+            "invalid_package_change_attribution", attributionVerification.Findings);
+        Assert.Contains("transaction_outcome_mismatch", attributionVerification.Findings);
+
+        var result = Assert.Single(operation.Results);
+        var contradictoryTransaction = transaction with
+        {
+            Operations = new[]
+            {
+                operation with
+                {
+                    Results = new[] { result with { Success = false } },
+                },
+            },
+        };
+        var contradictory = Rehash(valid.Payload with
+        {
+            Transactions = new[] { contradictoryTransaction },
+        });
+        var resultVerification = DeliveryChangeReceiptVerifier.Verify(
+            contradictory, RequiredArtifactBytes(edit));
+        Assert.Contains("operation_success_mismatch", resultVerification.Findings);
+        Assert.Contains("invalid_operation_result", resultVerification.Findings);
+    }
+
+    [Fact]
+    public void DCR022_FailedAtomicBatch_RetainsFullRequestWithExplicitAbsentOperations()
+    {
+        (DeliveryChangeReceipt Receipt, Dictionary<string, byte[]> Artifacts) BuildFailure(
+            bool preflightFailure)
+        {
+            var source = DocxSessionTests.BuildDS001_SimpleTwoParagraphs();
+            using var session = Open(source);
+            var anchors = BodyParagraphs(session);
+            var beforeBytes = session.Save();
+            var beforeManifest = Manifest(beforeBytes);
+            var operations = new[]
+            {
+                DeliveryNormalizedOperation.Create("docx_edit", "first", "{}"),
+                DeliveryNormalizedOperation.Create("docx_edit", "failure", "{}"),
+                DeliveryNormalizedOperation.Create("docx_edit", "later", "{}"),
+            };
+            var steps = new[]
+            {
+                new MutationBatchStep("docx_edit", "first",
+                    s => s.ReplaceText(anchors[0], "Temporary atomic edit.")),
+                new MutationBatchStep("docx_edit", "failure",
+                    s => s.ReplaceText("p:body:missing", "Must fail."),
+                    preflightFailure
+                        ? _ => new EditError(EditErrorCode.AnchorNotFound, "preflight failure")
+                        : null),
+                new MutationBatchStep("docx_edit", "later",
+                    s => s.ReplaceText(anchors[1], "Must not execute.")),
+            };
+            var result = session.ExecuteBatch(steps, MutationBatchMode.Atomic);
+            Assert.False(result.Success);
+            var afterBytes = session.Save();
+            var afterManifest = Manifest(afterBytes);
+            var contribution = DeliveryTransactionContribution.FromMutationBatchResult(
+                result, beforeManifest, afterManifest, operations);
+            var builder = new DeliveryChangeReceiptBuilder(
+                beforeManifest, result.BaseVersion)
+                .SetDeliveredDocument(afterManifest, result.ResultVersion);
+            _ = builder.AddTransaction(contribution);
+            AddCleanDocx(builder, afterBytes, afterManifest, result.ResultVersion);
+            var semantic = SemanticChanges(beforeBytes, afterBytes);
+            builder.AddSemanticChangeSet(
+                DeliverySemanticChangeSetInput.ForSourceToDelivered(semantic));
+            return (builder.Build(), new Dictionary<string, byte[]>
+            {
+                ["clean-docx"] = afterBytes,
+                ["semantic-source-to-delivered"] = semantic.ToCanonicalUtf8Bytes(),
+            });
+        }
+
+        var executed = BuildFailure(preflightFailure: false);
+        Assert.Equal(new[]
+        {
+            DeliveryOperationExecutionStatus.SucceededRolledBack,
+            DeliveryOperationExecutionStatus.FailedRolledBack,
+            DeliveryOperationExecutionStatus.NotExecuted,
+        }, executed.Receipt.Payload.Transactions[0].Operations
+            .Select(operation => operation.ExecutionStatus));
+        Assert.True(DeliveryChangeReceiptVerifier.Verify(
+            executed.Receipt, executed.Artifacts).IsValid);
+
+        var preflight = BuildFailure(preflightFailure: true);
+        Assert.Equal(new[]
+        {
+            DeliveryOperationExecutionStatus.NotExecuted,
+            DeliveryOperationExecutionStatus.FailedRolledBack,
+            DeliveryOperationExecutionStatus.NotExecuted,
+        }, preflight.Receipt.Payload.Transactions[0].Operations
+            .Select(operation => operation.ExecutionStatus));
+        Assert.True(DeliveryChangeReceiptVerifier.Verify(
+            preflight.Receipt, preflight.Artifacts).IsValid);
+    }
+
+    [Fact]
+    public void DCR023_ResourceLimitsRejectBeforeUnboundedArtifactOrJsonProcessing()
+    {
+        var defaults = new DeliveryReceiptLimits();
+        Assert.Equal(16 * 1024 * 1024, defaults.MaxReceiptJsonBytes);
+        Assert.Equal(64 * 1024 * 1024, defaults.MaxSemanticEvidenceBytes);
+        Assert.Equal(64 * 1024 * 1024, defaults.MaxPageMapBytes);
+        Assert.Equal(256 * 1024 * 1024, defaults.MaxArtifactBytes);
+        Assert.Equal(512L * 1024 * 1024, defaults.MaxTotalArtifactBytes);
+        Assert.Equal(128, defaults.MaxJsonDepth);
+        Assert.Equal(100_000, defaults.MaxCollectionItems);
+        Assert.Equal(10_000, defaults.MaxTransactions);
+        Assert.Equal(10_000, defaults.MaxOperationsPerTransaction);
+        Assert.Equal(1_024, defaults.MaxArtifacts);
+        Assert.Equal(1024 * 1024, defaults.MaxStringLength);
+
+        var edit = SingleEdit("Resource limits.");
+        var smallArtifactBuilder = new DeliveryChangeReceiptBuilder(
+            edit.BeforeManifest,
+            edit.Result.BaseVersion,
+            limits: new DeliveryReceiptLimits { MaxArtifactBytes = 8 })
+            .SetDeliveredDocument(edit.AfterManifest, edit.Result.ResultVersion);
+        Assert.Equal("artifact_resource_limit",
+            Assert.Throws<DeliveryReceiptValidationException>(() => AddCleanDocx(
+                smallArtifactBuilder,
+                edit.AfterBytes,
+                edit.AfterManifest,
+                edit.Result.ResultVersion)).Code);
+
+        var builder = Builder(edit);
+        AddTransactionWithSemantic(builder, edit);
+        var valid = builder.Build();
+        var artifacts = RequiredArtifactBytes(edit);
+        var receiptLimit = DeliveryChangeReceiptVerifier.VerifyJson(
+            valid.ToJsonBytes(), artifacts, new DeliveryReceiptVerificationOptions
+            {
+                Limits = new DeliveryReceiptLimits { MaxReceiptJsonBytes = 128 },
+            });
+        Assert.Contains("receipt_resource_limit", receiptLimit.Findings);
+
+        var semanticLimit = DeliveryChangeReceiptVerifier.Verify(
+            valid, artifacts, new DeliveryReceiptVerificationOptions
+            {
+                Limits = new DeliveryReceiptLimits { MaxSemanticEvidenceBytes = 1 },
+            });
+        Assert.Contains("semantic_resource_limit", semanticLimit.Findings);
+
+        var pageMapBytes = Encoding.UTF8.GetBytes("{}");
+        var pageBuilder = Builder(edit);
+        AddTransactionWithSemantic(pageBuilder, edit);
+        pageBuilder.AddArtifact(DeliveryArtifactInput.Available(
+            "bounded-page-map", DeliveryArtifactRole.PageMap,
+            "application/json", pageMapBytes));
+        var pageReceipt = pageBuilder.Build();
+        var pageArtifacts = RequiredArtifactBytes(edit);
+        pageArtifacts["bounded-page-map"] = pageMapBytes;
+        var pageLimit = DeliveryChangeReceiptVerifier.Verify(
+            pageReceipt, pageArtifacts, new DeliveryReceiptVerificationOptions
+            {
+                Limits = new DeliveryReceiptLimits { MaxPageMapBytes = 1 },
+            });
+        Assert.Contains("page_map_resource_limit", pageLimit.Findings);
+
+        long suppliedBytes = artifacts.Values.Sum(value => value.LongLength);
+        var totalLimit = DeliveryChangeReceiptVerifier.Verify(
+            valid, artifacts, new DeliveryReceiptVerificationOptions
+            {
+                Limits = new DeliveryReceiptLimits
+                {
+                    MaxTotalArtifactBytes = suppliedBytes - 1,
+                },
+            });
+        Assert.Contains("artifact_resource_limit", totalLimit.Findings);
+    }
+
+    [Fact]
+    public void DCR024_RehashedArrayReorderingAndDuplicatesAreRejected()
+    {
+        var edit = SingleEdit("Canonical collection ordering.", tracked: true);
+        var builder = Builder(edit);
+        AddTransactionWithSemantic(builder, edit);
+        builder.AddWarning("first receipt warning");
+        builder.AddWarning("second receipt warning");
+        builder.AddEvidence(new DeliveryEvidenceReference
+        {
+            Kind = DeliveryEvidenceKind.ValidationResult,
+            Schema = "https://example.test/validation/v1",
+            Digest = Digest(Encoding.UTF8.GetBytes("validation")),
+            Summary = "validation evidence",
+        });
+        builder.AddEvidence(new DeliveryEvidenceReference
+        {
+            Kind = DeliveryEvidenceKind.RedlineReversibility,
+            Schema = "https://example.test/reversibility/v1",
+            Digest = Digest(Encoding.UTF8.GetBytes("reversibility")),
+            Summary = "reversibility evidence",
+        });
+        var valid = builder.Build();
+        Assert.True(valid.Payload.Artifacts.Count >= 2);
+        Assert.True(valid.Payload.PackageChanges.Count >= 1);
+        Assert.Equal(2, valid.Payload.Evidence.Count);
+        Assert.Equal(2, valid.Payload.Warnings.Count);
+
+        var transaction = Assert.Single(valid.Payload.Transactions);
+        var authored = Assert.IsType<DeliveryAuthoredChange>(
+            transaction.AuthoredChanges.First());
+        var operation = Assert.Single(transaction.Operations);
+        var operationResult = Assert.Single(operation.Results);
+        var objectChange = Assert.Single(operationResult.ObjectChanges);
+        var duplicateAuthored = authored with
+        {
+            AffectedAnchorIds = new[]
+            {
+                "p:body:duplicate",
+                "p:body:duplicate",
+            },
+        };
+        var duplicateResult = operationResult with
+        {
+            ObjectChanges = new[] { objectChange, objectChange },
+        };
+        var forgedTransaction = transaction with
+        {
+            Operations = new[]
+            {
+                operation with { Results = new[] { duplicateResult } },
+            },
+            AuthoredChanges = new[] { duplicateAuthored, duplicateAuthored },
+        };
+        var citation = new DeliveryPageCitation
+        {
+            AnchorId = edit.AnchorId,
+            Scope = "body",
+            DocumentVersion = valid.Payload.DeliveredDocument.DocumentVersion,
+            PackageDigest = valid.Payload.DeliveredDocument.RawPackageBytesDigest,
+            RendererFingerprint = "forged-renderer",
+            PageMapDigest = Digest(Encoding.UTF8.GetBytes("map")),
+            PageMapArtifactId = "missing-page-map",
+            RenderArtifactId = "missing-render",
+            RenderArtifactDigest = Digest(Encoding.UTF8.GetBytes("render")),
+        };
+        var firstPackageChange = valid.Payload.PackageChanges[0];
+        var duplicateLineage = new DeliveryLineageEvent
+        {
+            Sequence = 1,
+            Action = DeliveryLineageAction.Undo,
+            AffectedEntryId = transaction.EntryId,
+            BeforeDocument = valid.Payload.DeliveredDocument,
+            AfterDocument = valid.Payload.DeliveredDocument,
+        };
+        var forged = Rehash(valid.Payload with
+        {
+            Transactions = new[] { forgedTransaction, forgedTransaction },
+            Lineage = new[] { duplicateLineage, duplicateLineage },
+            PackageChanges = new[] { firstPackageChange, firstPackageChange },
+            Artifacts = valid.Payload.Artifacts.Reverse().ToArray(),
+            PageCitations = new[] { citation, citation },
+            Evidence = valid.Payload.Evidence.Reverse().ToArray(),
+            Warnings = valid.Payload.Warnings.Reverse().ToArray(),
+        });
+
+        var verification = DeliveryChangeReceiptVerifier.Verify(
+            forged, RequiredArtifactBytes(edit));
+
+        Assert.True(verification.ReceiptDigestValid);
+        Assert.Contains("transaction_order_mismatch", verification.Findings);
+        Assert.Contains("lineage_order_mismatch", verification.Findings);
+        Assert.Contains("artifact_order_mismatch", verification.Findings);
+        Assert.Contains("package_change_order_mismatch", verification.Findings);
+        Assert.Contains("citation_order_mismatch", verification.Findings);
+        Assert.Contains("evidence_order_mismatch", verification.Findings);
+        Assert.Contains("warning_order_mismatch", verification.Findings);
+        Assert.Contains("authored_change_order_mismatch", verification.Findings);
+        Assert.Contains("affected_anchor_order_mismatch", verification.Findings);
+        Assert.Contains("object_change_order_mismatch", verification.Findings);
+        Assert.False(verification.IsValid);
+    }
+
+    [Fact]
+    public void DCR025_CleanDocxInventory_IsTheAuthoritativeDeliveredManifest()
+    {
+        var edit = SingleEdit("Authoritative clean package inventory.");
+        var expectedBuilder = Builder(edit);
+        AddTransactionWithSemantic(expectedBuilder, edit);
+        var expected = expectedBuilder.Build();
+        var forgedManifest = edit.AfterManifest with
+        {
+            Entries = Array.Empty<PackageManifestEntry>(),
+            Relationships = Array.Empty<PackageRelationship>(),
+        };
+        var actualBuilder = new DeliveryChangeReceiptBuilder(
+            edit.BeforeManifest, edit.Result.BaseVersion)
+            .SetDeliveredDocument(forgedManifest, edit.Result.ResultVersion);
+        AddCleanDocx(
+            actualBuilder, edit.AfterBytes, forgedManifest, edit.Result.ResultVersion);
+        actualBuilder.AddSemanticChangeSet(
+            DeliverySemanticChangeSetInput.ForSourceToDelivered(
+                SemanticChanges(edit.BeforeBytes, edit.AfterBytes)));
+        AddTransactionWithSemantic(actualBuilder, edit);
+
+        var actual = actualBuilder.Build();
+
+        Assert.NotEmpty(actual.Payload.PackageChanges);
+        Assert.Equal(expected.Payload.PackageChanges, actual.Payload.PackageChanges);
+        Assert.True(DeliveryChangeReceiptVerifier.Verify(
+            actual, RequiredArtifactBytes(edit)).IsValid);
+    }
+
+    [Fact]
+    public void DCR026_ObjectAndTypedSemanticResourceLimits_FailClosedBeforeOutput()
+    {
+        var edit = SingleEdit("Bound object serialization.");
+        var validBuilder = Builder(edit);
+        AddTransactionWithSemantic(validBuilder, edit);
+        var valid = validBuilder.Build();
+        var artifacts = RequiredArtifactBytes(edit);
+        var objectLimit = DeliveryChangeReceiptVerifier.Verify(
+            valid, artifacts, new DeliveryReceiptVerificationOptions
+            {
+                Limits = new DeliveryReceiptLimits { MaxReceiptJsonBytes = 512 },
+            });
+        Assert.Contains("receipt_resource_limit", objectLimit.Findings);
+
+        var bounded = Assert.Throws<DeliveryReceiptValidationException>(() =>
+            DeliveryReceiptCanonicalJson.SerializeCanonicalBounded(
+                new { Value = new string('x', 4_096) },
+                new DeliveryReceiptLimits { MaxReceiptJsonBytes = 128 },
+                128,
+                "receipt_resource_limit"));
+        Assert.Equal("receipt_resource_limit", bounded.Code);
+
+        var originalOperation = Assert.Single(edit.Contribution.Operations);
+        var oversizedResult = edit.Result with
+        {
+            Steps = new[]
+            {
+                new MutationBatchStepResult(
+                    0,
+                    originalOperation.Tool,
+                    originalOperation.Action,
+                    new[]
+                    {
+                        new EditResult
+                        {
+                            Success = true,
+                            Patch = new MarkdownPatch(
+                                edit.AnchorId, new string('z', 80 * 1024)),
+                        },
+                    },
+                    false),
+            },
+            Failure = null,
+        };
+        var oversizedContribution =
+            DeliveryTransactionContribution.FromMutationBatchResult(
+                oversizedResult,
+                edit.BeforeManifest,
+                edit.AfterManifest,
+                new[] { originalOperation });
+        var resultBuilder = new DeliveryChangeReceiptBuilder(
+            edit.BeforeManifest,
+            edit.Result.BaseVersion,
+            limits: new DeliveryReceiptLimits { MaxReceiptJsonBytes = 64 * 1024 });
+        Assert.Equal("receipt_resource_limit",
+            Assert.Throws<DeliveryReceiptValidationException>(() =>
+                resultBuilder.AddTransaction(oversizedContribution)).Code);
+
+        SemanticValue deepValue = SemanticValue.String("leaf");
+        for (int i = 0; i < 4; i++)
+            deepValue = SemanticValue.Array(new[] { deepValue });
+        var deepSet = SemanticSet(deepValue);
+        var deepBuilder = new DeliveryChangeReceiptBuilder(
+            edit.BeforeManifest,
+            edit.Result.BaseVersion,
+            limits: new DeliveryReceiptLimits { MaxJsonDepth = 8 });
+        Assert.Equal("semantic_resource_limit",
+            Assert.Throws<DeliveryReceiptValidationException>(() =>
+                deepBuilder.AddSemanticChangeSet(
+                    DeliverySemanticChangeSetInput.ForSourceToDelivered(deepSet))).Code);
+
+        var aggregateSet = SemanticSet(SemanticValue.String(new string('y', 256)));
+        var aggregateBuilder = new DeliveryChangeReceiptBuilder(
+            edit.BeforeManifest,
+            edit.Result.BaseVersion,
+            limits: new DeliveryReceiptLimits { MaxSemanticEvidenceBytes = 512 });
+        Assert.Equal("semantic_resource_limit",
+            Assert.Throws<DeliveryReceiptValidationException>(() =>
+                aggregateBuilder.AddSemanticChangeSet(
+                    DeliverySemanticChangeSetInput.ForSourceToDelivered(aggregateSet))).Code);
+    }
+
+    [Fact]
+    public void DCR027_ActualEmptySuccessfulStep_ProducesPortableNoOpEvidence()
+    {
+        var source = DocxSessionTests.BuildDS001_SimpleTwoParagraphs();
+        using var session = Open(source);
+        var beforeBytes = session.Save();
+        var beforeManifest = Manifest(beforeBytes);
+        var operation = DeliveryNormalizedOperation.Create("docx_edit", "no_op", "{}");
+        var result = session.ExecuteBatch(new[]
+        {
+            new MutationBatchStep(
+                "docx_edit", "no_op", _ => Array.Empty<EditResult>()),
+        });
+        var afterBytes = session.Save();
+        var afterManifest = Manifest(afterBytes);
+        var contribution = DeliveryTransactionContribution.FromMutationBatchResult(
+            result, beforeManifest, afterManifest, new[] { operation });
+        var builder = new DeliveryChangeReceiptBuilder(beforeManifest, result.BaseVersion)
+            .SetDeliveredDocument(afterManifest, result.ResultVersion);
+        AddCleanDocx(builder, afterBytes, afterManifest, result.ResultVersion);
+        var semantic = SemanticChanges(beforeBytes, afterBytes);
+        builder.AddSemanticChangeSet(
+            DeliverySemanticChangeSetInput.ForSourceToDelivered(semantic));
+        builder.AddTransaction(contribution);
+
+        var receipt = builder.Build();
+        var transaction = Assert.Single(receipt.Payload.Transactions);
+        var operationEvidence = Assert.Single(transaction.Operations);
+        var supplied = new Dictionary<string, byte[]>
+        {
+            ["clean-docx"] = afterBytes,
+            ["semantic-source-to-delivered"] = semantic.ToCanonicalUtf8Bytes(),
+        };
+
+        Assert.True(result.Success);
+        Assert.Equal(result.BaseVersion, result.ResultVersion);
+        Assert.Equal(DeliveryTransactionStatus.Committed, transaction.Status);
+        Assert.Equal(DeliveryOperationExecutionStatus.Succeeded,
+            operationEvidence.ExecutionStatus);
+        Assert.Empty(operationEvidence.Results);
+        Assert.True(DeliveryChangeReceiptVerifier.Verify(receipt, supplied).IsValid);
+        Assert.True(DeliveryChangeReceiptVerifier.VerifyJson(
+            receipt.ToJsonBytes(), supplied).IsValid);
+    }
+
+    [Fact]
+    public void DCR028_ArtifactPaths_AreNormalizedAndRootFormsArePortable()
+    {
+        var edit = SingleEdit("Portable artifact paths.");
+        var builder = Builder(edit);
+        AddTransactionWithSemantic(builder, edit);
+        builder.AddArtifact(DeliveryArtifactInput.Unavailable(
+            "pdf", DeliveryArtifactRole.Pdf, "application/pdf", "renderer unavailable") with
+        {
+            RelativePath = @"delivery\document.pdf",
+        });
+
+        var receipt = builder.Build();
+
+        Assert.Equal("delivery/document.pdf", Assert.Single(
+            receipt.Payload.Artifacts, artifact => artifact.ArtifactId == "pdf").RelativePath);
+        Assert.True(DeliveryChangeReceiptVerifier.Verify(
+            receipt, RequiredArtifactBytes(edit)).IsValid);
+
+        var invalidBuilder = new DeliveryChangeReceiptBuilder(
+            edit.BeforeManifest, edit.Result.BaseVersion);
+        foreach (var path in new[]
+        {
+            "/tmp/document.pdf",
+            @"\\server\share\document.pdf",
+            @"\rooted\document.pdf",
+            @"C:\temp\document.pdf",
+            @"C:relative\document.pdf",
+            "../escape.pdf",
+            "delivery//document.pdf",
+        })
+        {
+            Assert.Equal("unsafe_artifact_path",
+                Assert.Throws<DeliveryReceiptValidationException>(() =>
+                    invalidBuilder.AddArtifact(DeliveryArtifactInput.Unavailable(
+                        "bad", DeliveryArtifactRole.Pdf, "application/pdf", "none") with
+                    {
+                        RelativePath = path,
+                    })).Code);
+        }
+    }
+
+    [Fact]
+    public void DCR029_CollectionLimits_AreChargedBeforeJsonItemsAreRetained()
+    {
+        var receiptLimits = new DeliveryReceiptLimits
+        {
+            MaxCollectionItems = 3,
+            MaxReceiptJsonBytes = 4 * 1024,
+        };
+        foreach (var json in new[]
+        {
+            "[0,0,0,0]",
+            "{\"a\":0,\"b\":0,\"c\":0,\"d\":0}",
+        })
+        {
+            Assert.Equal("receipt_resource_limit",
+                Assert.Throws<DeliveryReceiptValidationException>(() =>
+                    DeliveryReceiptCanonicalJson.CanonicalizeBounded(
+                        Encoding.UTF8.GetBytes(json),
+                        receiptLimits,
+                        receiptLimits.MaxReceiptJsonBytes,
+                        "receipt_resource_limit")).Code);
+        }
+
+        var array = SemanticValue.Array(Enumerable.Repeat(SemanticValue.Absent, 8));
+        var semanticBytes = SemanticSet(array).ToCanonicalUtf8Bytes();
+        var semanticLimits = new DeliveryReceiptLimits
+        {
+            MaxCollectionItems = 20,
+            MaxSemanticEvidenceBytes = 64 * 1024,
+        };
+        Assert.Equal("semantic_resource_limit",
+            Assert.Throws<DeliveryReceiptValidationException>(() =>
+                DeliverySemanticChangeSetAdapter.InspectExact(
+                    semanticBytes, semanticLimits)).Code);
+    }
+
+    private static DeliveryChangeReceipt BuildWithProfile(
+        EditFixture edit,
+        DeliveryReceiptPrivacyProfile profile)
+    {
+        var builder = Builder(edit, profile);
+        AddTransactionWithSemantic(builder, edit);
+        return builder.Build();
+    }
+
+    private static DeliveryChangeReceiptBuilder Builder(
+        EditFixture edit,
+        DeliveryReceiptPrivacyProfile profile = DeliveryReceiptPrivacyProfile.HashAndSummary)
+    {
+        var builder = new DeliveryChangeReceiptBuilder(
+            edit.BeforeManifest, edit.Result.BaseVersion, profile)
+            .SetDeliveredDocument(edit.AfterManifest, edit.Result.ResultVersion);
+        AddCleanDocx(builder, edit.AfterBytes, edit.AfterManifest, edit.Result.ResultVersion);
+        builder.AddSemanticChangeSet(DeliverySemanticChangeSetInput.ForSourceToDelivered(
+            SemanticChanges(edit.BeforeBytes, edit.AfterBytes)));
+        return builder;
+    }
+
+    private static string AddTransactionWithSemantic(
+        DeliveryChangeReceiptBuilder builder,
+        EditFixture edit)
+    {
+        var entryId = builder.AddTransaction(edit.Contribution);
+        AddTransactionSemantic(
+            builder, entryId, edit.BeforeBytes, edit.AfterBytes,
+            "semantic-source-to-delivered");
+        return entryId;
+    }
+
+    private static void AddTransactionSemantic(
+        DeliveryChangeReceiptBuilder builder,
+        string entryId,
+        byte[] beforeBytes,
+        byte[] afterBytes,
+        string artifactId)
+    {
+        builder.AddSemanticChangeSet(DeliverySemanticChangeSetInput.ForTransaction(
+            entryId, SemanticChanges(beforeBytes, afterBytes), artifactId));
+    }
+
+    private static void AddCleanDocx(
+        DeliveryChangeReceiptBuilder builder,
+        byte[] deliveredBytes,
+        PackageManifest deliveredManifest,
+        long deliveredVersion)
+    {
+        builder.AddArtifact(DeliveryArtifactInput.Available(
+            "clean-docx",
+            DeliveryArtifactRole.CleanDocx,
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            deliveredBytes) with
+        {
+            Document = DeliveryDocumentIdentity.FromManifest(
+                deliveredManifest, deliveredVersion),
+            RelativePath = "delivery/clean.docx",
+        });
+    }
+
+    private static void AddPaginatedCitation(
+        DeliveryChangeReceiptBuilder builder,
+        DeliveryDocumentIdentity identity,
+        PageCitation citation,
+        byte[] pdfBytes,
+        byte[] pageMapBytes)
+    {
+        var pageMapDigest = Digest(pageMapBytes);
+        builder.AddArtifact(DeliveryArtifactInput.Available(
+            "pdf", DeliveryArtifactRole.Pdf, "application/pdf", pdfBytes) with
+        {
+            Document = identity,
+            RendererFingerprint = citation.RendererFingerprint,
+            PageMapDigest = pageMapDigest,
+        });
+        builder.AddArtifact(DeliveryArtifactInput.Available(
+            "page-map", DeliveryArtifactRole.PageMap, "application/json", pageMapBytes) with
+        {
+            Document = identity,
+            RendererFingerprint = citation.RendererFingerprint,
+        });
+        builder.AddPageCitation(new DeliveryPageCitationInput
+        {
+            Citation = citation,
+            Scope = "body",
+            Document = identity,
+            PageMapDigest = pageMapDigest,
+            PageMapArtifactId = "page-map",
+            RenderArtifactId = "pdf",
+        });
+    }
+
+    private static DeliveryChangeReceipt Rehash(DeliveryChangeReceiptPayload payload) => new()
+    {
+        Payload = payload,
+        ReceiptDigest = Digest(DeliveryChangeReceiptSerializer.SerializePayload(payload)),
+    };
+
+    private static SemanticChangeSet SemanticChanges(byte[] before, byte[] after) =>
+        SemanticDiff.Compare(
+            new WmlDocument("before.docx", before),
+            new WmlDocument("after.docx", after));
+
+    private static SemanticChangeSet SemanticSet(SemanticValue before) => new(new[]
+    {
+        new SemanticChange
+        {
+            Id = "ignored",
+            Operation = SemanticChangeOperation.Modify,
+            Family = SemanticChangeFamily.Text,
+            PartUri = "/word/document.xml",
+            Path = "body/paragraph[1]",
+            Before = before,
+            After = SemanticValue.Absent,
+        },
+    });
+
+    private static Dictionary<string, byte[]> RequiredArtifactBytes(EditFixture edit) => new()
+    {
+        ["clean-docx"] = edit.AfterBytes,
+        ["semantic-source-to-delivered"] =
+            SemanticChanges(edit.BeforeBytes, edit.AfterBytes).ToCanonicalUtf8Bytes(),
+    };
+
+    private static EditFixture SingleEdit(
+        string replacement,
+        bool tracked = false,
+        DeliveryTransactionIdentity? identity = null)
+    {
+        var source = DocxSessionTests.BuildDS001_SimpleTwoParagraphs();
+        using var session = new DocxSession(source, new DocxSessionSettings
+        {
+            PersistAnchorIds = true,
+            TrackedChanges = tracked ? TrackedChangeMode.RenderInline : TrackedChangeMode.Accept,
+            RevisionAuthor = "Receipt Author",
+        });
+        var anchor = BodyParagraphs(session)[0];
+        var beforeBytes = session.Save();
+        var beforeManifest = Manifest(beforeBytes);
+        var operation = DeliveryNormalizedOperation.Create("docx_edit", "replace_text",
+            JsonSerializer.Serialize(new { anchorId = anchor, markdown = replacement }));
+        var result = session.ExecuteBatch(new[]
+        {
+            new MutationBatchStep("docx_edit", "replace_text",
+                s => s.ReplaceText(anchor, replacement)),
+        });
+        Assert.True(result.Success,
+            result.Failure is null ? "batch failed" : result.Failure.Error.Message);
+        var afterBytes = session.Save();
+        var afterManifest = Manifest(afterBytes);
+        var contribution = DeliveryTransactionContribution.FromMutationBatchResult(
+            result, beforeManifest, afterManifest, new[] { operation }, identity);
+        return new EditFixture(
+            anchor, beforeBytes, afterBytes, beforeManifest, afterManifest, result, contribution);
+    }
+
+    private static PageCitation Citation(string anchorId, long version, string renderer) => new()
+    {
+        AnchorId = anchorId,
+        Availability = PageMapAvailability.Available,
+        DocumentVersion = version,
+        RendererFingerprint = renderer,
+        Pages = new[]
+        {
+            new PageMapPage
+            {
+                PageNumber = 1,
+                PageInSection = 1,
+                Width = 612,
+                Height = 792,
+                SectionIndex = 0,
+                PageName = "page-1",
+            },
+        },
+        Fragments = new[]
+        {
+            new PageMapFragment
+            {
+                FragmentId = "page-1-fragment-0",
+                AnchorId = anchorId,
+                FragmentIndex = 0,
+                PageNumber = 1,
+                Geometry = new PageMapRect(72, 72, 300, 24),
+                Story = PageMapStory.Body,
+            },
+        },
+    };
+
+    private static byte[] PageMapBytes(string anchorId, long version, string renderer)
+    {
+        var citation = Citation(anchorId, version, renderer);
+        return JsonSerializer.SerializeToUtf8Bytes(new PageMap
+        {
+            Mode = PageMapMode.Paginated,
+            Availability = PageMapAvailability.Available,
+            DocumentVersion = version,
+            RendererFingerprint = renderer,
+            Pages = citation.Pages,
+            Fragments = citation.Fragments,
+        }, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters =
+            {
+                new System.Text.Json.Serialization.JsonStringEnumConverter(
+                    JsonNamingPolicy.CamelCase, allowIntegerValues: false),
+            },
+        });
+    }
+
+    private static DocxSession Open(byte[] bytes) => new(bytes, new DocxSessionSettings
+    {
+        PersistAnchorIds = true,
+    });
+
+    private static string[] BodyParagraphs(DocxSession session) =>
+        session.Project().AnchorIndex.Keys
+            .Where(id => id.StartsWith("p:body:", StringComparison.Ordinal))
+            .ToArray();
+
+    private static PackageManifest Manifest(byte[] bytes) =>
+        PackageManifestGenerator.Generate(bytes);
+
+    private static VerificationDigest Digest(byte[] bytes) => new()
+    {
+        Algorithm = "SHA-256",
+        Value = Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant(),
+    };
+
+    private static string Fingerprint(string value) => "sha256:" + Digest(
+        Encoding.UTF8.GetBytes(value)).Value;
+
+    private sealed record EditFixture(
+        string AnchorId,
+        byte[] BeforeBytes,
+        byte[] AfterBytes,
+        PackageManifest BeforeManifest,
+        PackageManifest AfterManifest,
+        MutationBatchResult Result,
+        DeliveryTransactionContribution Contribution);
+}

--- a/Docxodus.Tests/DeliveryChangeReceiptTests.cs
+++ b/Docxodus.Tests/DeliveryChangeReceiptTests.cs
@@ -496,6 +496,7 @@ public class DeliveryChangeReceiptTests
         Assert.Equal(DeliveryArtifactVerificationStatus.DigestMismatch,
             Assert.Single(artifactResult.Artifacts,
                 artifact => artifact.ArtifactId == "pdf").Status);
+        Assert.Contains("artifact_digest_mismatch:pdf", artifactResult.Findings);
 
         var missing = DeliveryChangeReceiptVerifier.Verify(receipt,
             new Dictionary<string, byte[]>());
@@ -503,6 +504,7 @@ public class DeliveryChangeReceiptTests
         Assert.Equal(DeliveryArtifactVerificationStatus.Missing,
             Assert.Single(missing.Artifacts,
                 artifact => artifact.ArtifactId == "pdf").Status);
+        Assert.Contains("artifact_missing:pdf", missing.Findings);
 
         var tamperedReceipt = receipt.ToJson().Replace(
             "hashAndSummary", "fullEvidence", StringComparison.Ordinal);
@@ -2449,6 +2451,73 @@ public class DeliveryChangeReceiptTests
                     Schema = "https://example.invalid/not-the-owner-schema",
                     Digest = Digest(canonical),
                 })).Code);
+    }
+
+    [Fact]
+    public void DCR042_UndefinedIntegerEnumValues_AreRejectedAsEvidenceAndPayload()
+    {
+        var edit = SingleEdit("Reject undefined integer enums.");
+        var validation = DeliverableVerifier.VerifyDeliverable(
+            edit.BeforeBytes, edit.AfterBytes);
+        var canonical = validation.ToCanonicalUtf8Bytes();
+        Assert.True(DeliverableVerificationResult.IsExactCanonical(canonical));
+
+        var json = Encoding.UTF8.GetString(canonical);
+        Assert.Contains("\"mode\":\"standard\"", json);
+        var forged = Encoding.UTF8.GetBytes(json.Replace(
+            "\"mode\":\"standard\"", "\"mode\":9999"));
+        Assert.False(DeliverableVerificationResult.IsExactCanonical(forged));
+
+        var builder = Builder(edit);
+        AddTransactionWithSemantic(builder, edit);
+        var receipt = builder.Build();
+        var payload = JsonNode.Parse(receipt.ToJson())!["payload"]!.AsObject();
+        payload["privacyProfile"] = 9999;
+        var result = DeliveryChangeReceiptVerifier.VerifyJson(
+            RehashPayloadJson(payload), RequiredArtifactBytes(edit));
+        Assert.False(result.IsValid);
+    }
+
+    [Fact]
+    public void DCR043_VerifierRejectsNonNormalizedArtifactPaths()
+    {
+        var edit = SingleEdit("Portable path enforcement.");
+        var builder = Builder(edit);
+        AddTransactionWithSemantic(builder, edit);
+        var receipt = builder.Build();
+        var payload = JsonNode.Parse(receipt.ToJson())!["payload"]!.AsObject();
+        var artifact = payload["artifacts"]!.AsArray()
+            .Single(item => item!["relativePath"] is not null)!.AsObject();
+        Assert.Equal("delivery/clean.docx", artifact["relativePath"]!.GetValue<string>());
+        artifact["relativePath"] = "delivery\\clean.docx";
+
+        var result = DeliveryChangeReceiptVerifier.VerifyJson(
+            RehashPayloadJson(payload), RequiredArtifactBytes(edit));
+
+        Assert.False(result.IsValid);
+        Assert.Contains("unsafe_artifact_path", result.Findings);
+    }
+
+    [Fact]
+    public void DCR044_DeepOperationArguments_WithinLimitsSurviveTheFullPipeline()
+    {
+        var deepArguments =
+            string.Concat(Enumerable.Repeat("{\"a\":", 100)) + "1" + new string('}', 100);
+        var operation = DeliveryNormalizedOperation.Create(
+            "docx_edit", "replace_text", deepArguments);
+
+        var edit = SingleEdit("Deep argument payload.");
+        var contribution = DeliveryTransactionContribution.FromMutationBatchResult(
+            edit.Result, edit.BeforeManifest, edit.AfterManifest, new[] { operation });
+        var builder = Builder(edit);
+        var entryId = builder.AddTransaction(contribution);
+        AddTransactionSemantic(builder, entryId, edit.BeforeBytes, edit.AfterBytes,
+            "semantic-source-to-delivered");
+        var receipt = builder.Build();
+
+        var result = DeliveryChangeReceiptVerifier.VerifyJson(
+            receipt.ToJson(), RequiredArtifactBytes(edit));
+        Assert.True(result.IsValid, string.Join("; ", result.Findings));
     }
 
     private static DeliveryChangeReceipt BuildWithProfile(

--- a/Docxodus.Tests/DeliveryChangeReceiptTests.cs
+++ b/Docxodus.Tests/DeliveryChangeReceiptTests.cs
@@ -350,8 +350,12 @@ public class DeliveryChangeReceiptTests
             edit.AfterManifest, edit.Result.ResultVersion);
         var htmlBytes = Encoding.UTF8.GetBytes("<main>Changed for delivery.</main>");
         var pdfBytes = Encoding.ASCII.GetBytes("%PDF-1.7\nreceipt pagination fixture\n%%EOF");
-        var validationBytes = Encoding.UTF8.GetBytes("{\"valid\":true}");
-        var reversibilityBytes = Encoding.UTF8.GetBytes("{\"roundTrip\":\"verified\"}");
+        var validation = DeliverableVerifier.VerifyDeliverable(
+            edit.BeforeBytes, edit.AfterBytes);
+        var validationBytes = validation.ToCanonicalUtf8Bytes();
+        var reversibility = RedlineReversibilityVerifier.Prove(
+            edit.BeforeBytes, edit.AfterBytes, redlineBytes).Proof;
+        var reversibilityBytes = Encoding.UTF8.GetBytes(reversibility.ToCanonicalJson());
         const string renderer = "chromium-140|fonts-v3|pagination-v1";
         var semanticBytes = SemanticChanges(
             edit.BeforeBytes, edit.AfterBytes).ToCanonicalUtf8Bytes();
@@ -395,18 +399,18 @@ public class DeliveryChangeReceiptTests
         builder.AddEvidence(new DeliveryEvidenceReference
         {
             Kind = DeliveryEvidenceKind.ValidationResult,
-            Schema = "https://docxodus.dev/schemas/verification/validation-result/v1",
+            Schema = DeliverableVerificationResult.SchemaId,
             Digest = Digest(validationBytes),
             ArtifactId = "validation",
-            Summary = "Package validation passed.",
+            Summary = $"Deliverable verification decision: {validation.Decision}.",
         });
         builder.AddEvidence(new DeliveryEvidenceReference
         {
             Kind = DeliveryEvidenceKind.RedlineReversibility,
-            Schema = "https://docxodus.dev/schemas/verification/redline-proof/v1",
+            Schema = RedlineReversibilityProof.SchemaId,
             Digest = Digest(reversibilityBytes),
             ArtifactId = "reversibility",
-            Summary = "Redline reversibility verified.",
+            Summary = $"Redline reversibility success: {reversibility.Success}.",
         });
         builder.AddPageCitation(new DeliveryPageCitationInput
         {
@@ -443,6 +447,13 @@ public class DeliveryChangeReceiptTests
                 && evidence.Schema == SemanticChangeSet.CurrentSchema);
         Assert.Contains(receipt.Payload.Artifacts,
             artifact => artifact.Role == DeliveryArtifactRole.ReviewDocx);
+        Assert.Contains(receipt.Payload.Evidence,
+            evidence => evidence.Schema == DeliverableVerificationResult.SchemaId
+                && evidence.Digest == Digest(validation.ToCanonicalUtf8Bytes()));
+        Assert.Contains(receipt.Payload.Evidence,
+            evidence => evidence.Schema == RedlineReversibilityProof.SchemaId
+                && evidence.Digest == Digest(Encoding.UTF8.GetBytes(
+                    reversibility.ToCanonicalJson())));
     }
 
     [Fact]
@@ -1795,6 +1806,234 @@ public class DeliveryChangeReceiptTests
             Assert.Throws<DeliveryReceiptValidationException>(() =>
                 DeliverySemanticChangeSetAdapter.InspectExact(
                     semanticBytes, semanticLimits)).Code);
+    }
+
+    [Fact]
+    public void DCR030_PackageChanges_ProjectTheSharedPackageDeltaExactly()
+    {
+        var edit = SingleEdit("Shared package delta projection.");
+        var shared = PackageDelta.Compare(edit.BeforeManifest, edit.AfterManifest);
+        var projected = DeliveryPackageManifestAdapter.Compare(
+            edit.BeforeManifest, edit.AfterManifest);
+
+        Assert.Equal(shared.Count, projected.Count);
+        for (int index = 0; index < shared.Count; index++)
+        {
+            var expected = shared[index];
+            var actual = projected[index];
+            Assert.Equal(expected.Kind switch
+            {
+                PackageDeltaChangeKind.EntryAdded => DeliveryPackageChangeKind.PartAdded,
+                PackageDeltaChangeKind.EntryRemoved => DeliveryPackageChangeKind.PartRemoved,
+                PackageDeltaChangeKind.EntryModified => DeliveryPackageChangeKind.PartModified,
+                PackageDeltaChangeKind.RelationshipAdded =>
+                    DeliveryPackageChangeKind.RelationshipAdded,
+                PackageDeltaChangeKind.RelationshipRemoved =>
+                    DeliveryPackageChangeKind.RelationshipRemoved,
+                PackageDeltaChangeKind.RelationshipModified =>
+                    DeliveryPackageChangeKind.RelationshipModified,
+                _ => throw new ArgumentOutOfRangeException(),
+            }, actual.Kind);
+            Assert.Equal(expected.Location, actual.Location);
+            Assert.Equal(expected.BeforeValue, actual.Before);
+            Assert.Equal(expected.AfterValue, actual.After);
+        }
+    }
+
+    [Fact]
+    public void DCR031_PackageChangeVerification_UsesSharedTargetAwareOrdering()
+    {
+        var edit = SingleEdit("Target-aware package change order.");
+        var duplicateRelationships = new[]
+        {
+            new PackageRelationship
+            {
+                OwnerUri = "/word/document.xml",
+                Id = "rDuplicate",
+                Type = "a-type",
+                Target = "z.xml",
+                TargetMode = "Internal",
+                ResolvedTargetUri = "/word/z.xml",
+                IsTargetPresent = false,
+            },
+            new PackageRelationship
+            {
+                OwnerUri = "/word/document.xml",
+                Id = "rDuplicate",
+                Type = "z-type",
+                Target = "a.xml",
+                TargetMode = "Internal",
+                ResolvedTargetUri = "/word/a.xml",
+                IsTargetPresent = false,
+            },
+        };
+        var sourceManifest = edit.BeforeManifest with
+        {
+            Relationships = edit.BeforeManifest.Relationships
+                .Concat(duplicateRelationships).ToArray(),
+        };
+        var builder = new DeliveryChangeReceiptBuilder(
+            sourceManifest, edit.Result.BaseVersion)
+            .SetDeliveredDocument(edit.AfterManifest, edit.Result.ResultVersion);
+        AddCleanDocx(builder, edit.AfterBytes, edit.AfterManifest, edit.Result.ResultVersion);
+        builder.AddSemanticChangeSet(DeliverySemanticChangeSetInput.ForSourceToDelivered(
+            SemanticChanges(edit.BeforeBytes, edit.AfterBytes)));
+        var entryId = builder.AddTransaction(edit.Contribution);
+        AddTransactionSemantic(
+            builder, entryId, edit.BeforeBytes, edit.AfterBytes,
+            "semantic-source-to-delivered");
+
+        var receipt = builder.Build();
+        var duplicateChanges = receipt.Payload.PackageChanges.Where(change =>
+            change.Location.RelationshipId == "rDuplicate").ToArray();
+
+        Assert.Equal(
+            new[] { "/word/a.xml", "/word/z.xml" },
+            duplicateChanges.Select(change => change.Location.TargetUri));
+        Assert.True(DeliveryChangeReceiptVerifier.Verify(
+            receipt, RequiredArtifactBytes(edit)).IsValid);
+    }
+
+    [Fact]
+    public void DCR032_RetryIdentity_RejectsDifferentResultEvidence()
+    {
+        var sourceBytes = DocxSessionTests.BuildDS001_SimpleTwoParagraphs();
+        var manifest = Manifest(sourceBytes);
+        var operation = DeliveryNormalizedOperation.Create("docx_edit", "replace_text");
+        var identity = new DeliveryTransactionIdentity
+        {
+            TransactionId = "delivery-conflicting-result",
+            RequestFingerprint = Fingerprint("same retry request"),
+        };
+        MutationBatchResult FailedResult(string message)
+        {
+            var error = new EditError(EditErrorCode.PreconditionFailed, message);
+            return new MutationBatchResult
+            {
+                Mode = MutationBatchMode.Atomic,
+                Success = false,
+                RolledBack = true,
+                BaseVersion = 7,
+                ResultVersion = 7,
+                Steps = new[]
+                {
+                    new MutationBatchStepResult(0, operation.Tool, operation.Action,
+                        new[] { new EditResult { Success = false, Error = error } }, true),
+                },
+                Failure = new MutationBatchFailure(
+                    0, operation.Tool, operation.Action, error, true),
+            };
+        }
+        DeliveryTransactionContribution Contribution(string message) =>
+            DeliveryTransactionContribution.FromMutationBatchResult(
+                FailedResult(message), manifest, manifest, new[] { operation }, identity);
+        var builder = new DeliveryChangeReceiptBuilder(manifest, 7);
+
+        builder.AddTransaction(Contribution("first failure evidence"));
+        var error = Assert.Throws<DeliveryReceiptValidationException>(() =>
+            builder.AddTransaction(Contribution("different failure evidence")));
+
+        Assert.Equal("retry_result_conflict", error.Code);
+    }
+
+    [Fact]
+    public void DCR033_AuthoredChanges_DisambiguateDuplicateRevisionIdsAcrossParts()
+    {
+        var edit = SingleEdit("Duplicate revision identity.", tracked: true);
+        var revision = edit.Result.RevisionChanges.Added.First();
+        var duplicate = revision with
+        {
+            PartUri = "/word/header1.xml",
+            Scope = "hdr1",
+        };
+        var result = edit.Result with
+        {
+            RevisionChanges = new MutationBatchChangeSet<RevisionListEntry>(
+                new[] { revision, duplicate },
+                Array.Empty<RevisionListEntry>(),
+                Array.Empty<RevisionListEntry>()),
+        };
+        var operation = DeliveryNormalizedOperation.Create(
+            "docx_edit", "replace_text",
+            JsonSerializer.Serialize(new
+            {
+                anchorId = edit.AnchorId,
+                markdown = "Duplicate revision identity.",
+            }));
+        var contribution = DeliveryTransactionContribution.FromMutationBatchResult(
+            result, edit.BeforeManifest, edit.AfterManifest, new[] { operation });
+        var builder = Builder(edit);
+        var entryId = builder.AddTransaction(contribution);
+        AddTransactionSemantic(
+            builder, entryId, edit.BeforeBytes, edit.AfterBytes,
+            "semantic-source-to-delivered");
+
+        var receipt = builder.Build();
+        var duplicateIds = Assert.Single(receipt.Payload.Transactions).AuthoredChanges
+            .Where(change => change.EntityKind == DeliveryAuthoredEntityKind.Revision
+                && change.EntityId == revision.Id)
+            .ToArray();
+
+        Assert.Equal(2, duplicateIds.Length);
+        Assert.Equal(
+            new[] { revision.PartUri, duplicate.PartUri }.OrderBy(value => value),
+            duplicateIds.Select(change => change.PartUri));
+        Assert.True(DeliveryChangeReceiptVerifier.Verify(
+            receipt, RequiredArtifactBytes(edit)).IsValid);
+    }
+
+    [Fact]
+    public void DCR034_DistinctNoOpTransactions_HaveDistinctEntryIdentities()
+    {
+        var documentBytes = DocxSessionTests.BuildDS001_SimpleTwoParagraphs();
+        var manifest = Manifest(documentBytes);
+        var operation = DeliveryNormalizedOperation.Create("docx_edit", "no_op");
+        var result = new MutationBatchResult
+        {
+            Mode = MutationBatchMode.Atomic,
+            Success = true,
+            RolledBack = false,
+            BaseVersion = 7,
+            ResultVersion = 7,
+            Steps = new[]
+            {
+                new MutationBatchStepResult(
+                    0, operation.Tool, operation.Action, Array.Empty<EditResult>(), false),
+            },
+        };
+        DeliveryTransactionContribution Contribution(string? transactionId) =>
+            DeliveryTransactionContribution.FromMutationBatchResult(
+                result, manifest, manifest, new[] { operation },
+                transactionId is null
+                    ? null
+                    : new DeliveryTransactionIdentity
+                    {
+                        TransactionId = transactionId,
+                        RequestFingerprint = Fingerprint("shared no-op request"),
+                    });
+        var builder = new DeliveryChangeReceiptBuilder(manifest, 7)
+            .SetDeliveredDocument(manifest, 7);
+        AddCleanDocx(builder, documentBytes, manifest, 7);
+        var emptySemantic = new SemanticChangeSet(Array.Empty<SemanticChange>());
+        builder.AddSemanticChangeSet(
+            DeliverySemanticChangeSetInput.ForSourceToDelivered(emptySemantic));
+
+        var entryIds = new[]
+        {
+            builder.AddTransaction(Contribution("delivery-no-op-a")),
+            builder.AddTransaction(Contribution("delivery-no-op-b")),
+            builder.AddTransaction(Contribution(null)),
+            builder.AddTransaction(Contribution(null)),
+        };
+        var receipt = builder.Build();
+
+        Assert.Equal(entryIds.Length, entryIds.Distinct(StringComparer.Ordinal).Count());
+        Assert.Equal(entryIds, receipt.Payload.Transactions.Select(entry => entry.EntryId));
+        Assert.True(DeliveryChangeReceiptVerifier.Verify(receipt, new Dictionary<string, byte[]>
+        {
+            ["clean-docx"] = documentBytes,
+            ["semantic-source-to-delivered"] = emptySemantic.ToCanonicalUtf8Bytes(),
+        }).IsValid);
     }
 
     private static DeliveryChangeReceipt BuildWithProfile(

--- a/Docxodus.Tests/DeliveryChangeReceiptTests.cs
+++ b/Docxodus.Tests/DeliveryChangeReceiptTests.cs
@@ -6,6 +6,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Docxodus.Verification;
 using Xunit;
 
@@ -244,6 +245,20 @@ public class DeliveryChangeReceiptTests
                 ["semantic-transaction-2"] =
                     SemanticChanges(undoBytes, deliveredBytes).ToCanonicalUtf8Bytes(),
             }).IsValid);
+
+        var observed = receipt.Payload.PackageChanges.First();
+        builder.AddAttributionRule(new DeliveryChangeAttributionRule
+        {
+            Kind = observed.Kind,
+            EntryUri = observed.Location.EntryUri,
+            OwnerUri = observed.Location.OwnerUri,
+            RelationshipId = observed.Location.RelationshipId,
+            Disposition = DeliveryChangeDisposition.UserRequested,
+            TransactionEntryId = firstEntryId,
+            RequestedOperationIndex = 0,
+        });
+        Assert.Equal("unapplied_attribution_transaction",
+            Assert.Throws<DeliveryReceiptValidationException>(() => builder.Build()).Code);
     }
 
     [Fact]
@@ -1480,14 +1495,14 @@ public class DeliveryChangeReceiptTests
         builder.AddEvidence(new DeliveryEvidenceReference
         {
             Kind = DeliveryEvidenceKind.ValidationResult,
-            Schema = "https://example.test/validation/v1",
+            Schema = DeliverableVerificationResult.SchemaId,
             Digest = Digest(Encoding.UTF8.GetBytes("validation")),
             Summary = "validation evidence",
         });
         builder.AddEvidence(new DeliveryEvidenceReference
         {
             Kind = DeliveryEvidenceKind.RedlineReversibility,
-            Schema = "https://example.test/reversibility/v1",
+            Schema = RedlineReversibilityProof.SchemaId,
             Digest = Digest(Encoding.UTF8.GetBytes("reversibility")),
             Summary = "reversibility evidence",
         });
@@ -1617,9 +1632,11 @@ public class DeliveryChangeReceiptTests
             });
         Assert.Contains("receipt_resource_limit", objectLimit.Findings);
 
+        using var oversizedJson = JsonDocument.Parse(
+            JsonSerializer.Serialize(new { Value = new string('x', 4_096) }));
         var bounded = Assert.Throws<DeliveryReceiptValidationException>(() =>
             DeliveryReceiptCanonicalJson.SerializeCanonicalBounded(
-                new { Value = new string('x', 4_096) },
+                oversizedJson.RootElement,
                 new DeliveryReceiptLimits { MaxReceiptJsonBytes = 128 },
                 128,
                 "receipt_resource_limit"));
@@ -1812,14 +1829,16 @@ public class DeliveryChangeReceiptTests
     public void DCR030_PackageChanges_ProjectTheSharedPackageDeltaExactly()
     {
         var edit = SingleEdit("Shared package delta projection.");
-        var shared = PackageDelta.Compare(edit.BeforeManifest, edit.AfterManifest);
+        var shared = PackageDelta.Compare(
+            edit.BeforeManifest, edit.AfterManifest, int.MaxValue);
         var projected = DeliveryPackageManifestAdapter.Compare(
-            edit.BeforeManifest, edit.AfterManifest);
+            edit.BeforeManifest, edit.AfterManifest, int.MaxValue);
 
-        Assert.Equal(shared.Count, projected.Count);
-        for (int index = 0; index < shared.Count; index++)
+        Assert.True(shared.Complete);
+        Assert.Equal(shared.Changes.Count, projected.Count);
+        for (int index = 0; index < shared.Changes.Count; index++)
         {
-            var expected = shared[index];
+            var expected = shared.Changes[index];
             var actual = projected[index];
             Assert.Equal(expected.Kind switch
             {
@@ -1978,6 +1997,13 @@ public class DeliveryChangeReceiptTests
         Assert.Equal(
             new[] { revision.PartUri, duplicate.PartUri }.OrderBy(value => value),
             duplicateIds.Select(change => change.PartUri));
+        Assert.All(duplicateIds, change =>
+        {
+            Assert.NotNull(change.Family);
+            Assert.NotNull(change.ResolutionStatus);
+            Assert.NotEmpty(change.ConstituentIds);
+            Assert.NotEmpty(change.ConstituentKeys);
+        });
         Assert.True(DeliveryChangeReceiptVerifier.Verify(
             receipt, RequiredArtifactBytes(edit)).IsValid);
     }
@@ -2034,6 +2060,395 @@ public class DeliveryChangeReceiptTests
             ["clean-docx"] = documentBytes,
             ["semantic-source-to-delivered"] = emptySemantic.ToCanonicalUtf8Bytes(),
         }).IsValid);
+    }
+
+    [Fact]
+    public void DCR035_JsonReader_RequiresExactKnownFieldsAndProtectsRedactedExtensions()
+    {
+        const string secret = "DO-NOT-LEAK-UNKNOWN-EXTENSION-458";
+        var edit = SingleEdit("Strict portable JSON.");
+        var builder = Builder(edit);
+        AddTransactionWithSemantic(builder, edit);
+        var receipt = builder.Build();
+        var artifacts = RequiredArtifactBytes(edit);
+
+        JsonObject Payload(DeliveryChangeReceipt value) =>
+            JsonNode.Parse(value.ToJson())!["payload"]!.AsObject();
+
+        var missingSchema = Payload(receipt);
+        Assert.True(missingSchema.Remove("schema"));
+        var missingResult = DeliveryChangeReceiptVerifier.VerifyJson(
+            RehashPayloadJson(missingSchema), artifacts);
+        Assert.Contains("noncanonical_known_payload", missingResult.Findings);
+
+        var enumCase = Payload(receipt);
+        enumCase["privacyProfile"] = "HashAndSummary";
+        var enumResult = DeliveryChangeReceiptVerifier.VerifyJson(
+            RehashPayloadJson(enumCase), artifacts);
+        Assert.Contains("noncanonical_known_payload", enumResult.Findings);
+
+        var redactedExtension = Payload(receipt);
+        redactedExtension["secret"] = secret;
+        var redactedResult = DeliveryChangeReceiptVerifier.VerifyJson(
+            RehashPayloadJson(redactedExtension), artifacts);
+        Assert.Contains("unknown_fields_violate_privacy_profile", redactedResult.Findings);
+
+        var fullBuilder = Builder(edit, DeliveryReceiptPrivacyProfile.FullEvidence);
+        AddTransactionWithSemantic(fullBuilder, edit);
+        var full = fullBuilder.Build();
+        var fullExtension = Payload(full);
+        fullExtension["futureEvidence"] = new JsonObject { ["value"] = secret };
+        var fullResult = DeliveryChangeReceiptVerifier.VerifyJson(
+            RehashPayloadJson(fullExtension), artifacts);
+        Assert.True(fullResult.IsValid, string.Join(",", fullResult.Findings));
+
+        foreach (var profile in new[]
+                 {
+                     DeliveryReceiptPrivacyProfile.HashOnly,
+                     DeliveryReceiptPrivacyProfile.HashAndSummary,
+                 })
+        {
+            var privacyBuilder = Builder(edit, profile);
+            AddTransactionWithSemantic(privacyBuilder, edit);
+            privacyBuilder.AddArtifact(DeliveryArtifactInput.Unavailable(
+                "private-render", DeliveryArtifactRole.Pdf, "application/pdf", secret));
+            privacyBuilder.AddEvidence(new DeliveryEvidenceReference
+            {
+                Kind = DeliveryEvidenceKind.ValidationResult,
+                Schema = DeliverableVerificationResult.SchemaId,
+                Digest = Digest(Encoding.UTF8.GetBytes("detached evidence")),
+                Summary = secret,
+            });
+            Assert.DoesNotContain(
+                secret, privacyBuilder.Build().ToJson(), StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void DCR036_FullEvidence_RejectsContradictoryProjectionsAndLogicalDuplicates()
+    {
+        var edit = SingleEdit("Full evidence projection.", tracked: true);
+        var builder = Builder(edit, DeliveryReceiptPrivacyProfile.FullEvidence);
+        AddTransactionWithSemantic(builder, edit);
+        var receipt = builder.Build();
+        var artifacts = RequiredArtifactBytes(edit);
+        var transaction = Assert.Single(receipt.Payload.Transactions);
+        var authored = transaction.AuthoredChanges.First();
+        var operation = Assert.Single(transaction.Operations);
+        var operationResult = Assert.Single(operation.Results);
+        var objectChange = Assert.Single(operationResult.ObjectChanges);
+
+        var forgedAuthor = Rehash(receipt.Payload with
+        {
+            Transactions = new[]
+            {
+                transaction with
+                {
+                    AuthoredChanges = new[] { authored with { Author = "Mallory" } },
+                },
+            },
+        });
+        var authorResult = DeliveryChangeReceiptVerifier.Verify(forgedAuthor, artifacts);
+        Assert.Contains("authored_evidence_projection_mismatch", authorResult.Findings);
+
+        var forgedObject = objectChange with
+        {
+            Scope = "header1",
+            AnchorId = $"{objectChange.Kind}:header1:{objectChange.Unid}",
+        };
+        var forgedResult = Rehash(receipt.Payload with
+        {
+            Transactions = new[]
+            {
+                transaction with
+                {
+                    Operations = new[]
+                    {
+                        operation with
+                        {
+                            Results = new[]
+                            {
+                                operationResult with
+                                {
+                                    ObjectChanges = new[] { forgedObject },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        });
+        var objectResult = DeliveryChangeReceiptVerifier.Verify(forgedResult, artifacts);
+        Assert.Contains("operation_result_projection_mismatch", objectResult.Findings);
+
+        var contradictory = authored with
+        {
+            ChangeKind = authored.ChangeKind == DeliveryObjectChangeKind.Added
+                ? DeliveryObjectChangeKind.Removed
+                : DeliveryObjectChangeKind.Added,
+            SourceDigest = Digest(Encoding.UTF8.GetBytes("contradictory owner bytes")),
+        };
+        var duplicate = Rehash(receipt.Payload with
+        {
+            Transactions = new[]
+            {
+                transaction with
+                {
+                    AuthoredChanges = new[] { authored, contradictory }
+                        .OrderBy(change => change.ChangeKind)
+                        .ToArray(),
+                },
+            },
+        });
+        var duplicateResult = DeliveryChangeReceiptVerifier.Verify(duplicate, artifacts);
+        Assert.Contains("duplicate_authored_change", duplicateResult.Findings);
+    }
+
+    [Fact]
+    public void DCR037_Prediction_ProvesOutputWithoutAdvancingLineage()
+    {
+        var edit = SingleEdit("Predicted output.");
+        var predictedResult = edit.Result with { Preview = true };
+        var operation = DeliveryNormalizedOperation.Create(
+            "docx_edit", "replace_text",
+            JsonSerializer.Serialize(new
+            {
+                anchorId = edit.AnchorId,
+                markdown = "Predicted output.",
+            }));
+        var contribution = DeliveryTransactionContribution.FromMutationBatchResult(
+            predictedResult,
+            edit.BeforeManifest,
+            edit.AfterManifest,
+            new[] { operation });
+        var builder = new DeliveryChangeReceiptBuilder(
+            edit.BeforeManifest, predictedResult.BaseVersion)
+            .SetDeliveredDocument(edit.BeforeManifest, predictedResult.BaseVersion);
+        AddCleanDocx(
+            builder, edit.BeforeBytes, edit.BeforeManifest, predictedResult.BaseVersion);
+        var noDeliveryChange = new SemanticChangeSet(Array.Empty<SemanticChange>());
+        builder.AddSemanticChangeSet(
+            DeliverySemanticChangeSetInput.ForSourceToDelivered(noDeliveryChange));
+        builder.AddTransaction(contribution);
+
+        var receipt = builder.Build();
+        var transaction = Assert.Single(receipt.Payload.Transactions);
+        Assert.Equal(DeliveryTransactionStatus.Prediction, transaction.Status);
+        Assert.Equal(predictedResult.PackageHash,
+            transaction.ReportedPackageContentDigest?.Value);
+        var artifacts = new Dictionary<string, byte[]>
+        {
+            ["clean-docx"] = edit.BeforeBytes,
+            ["semantic-source-to-delivered"] = noDeliveryChange.ToCanonicalUtf8Bytes(),
+        };
+        Assert.True(DeliveryChangeReceiptVerifier.Verify(receipt, artifacts).IsValid);
+
+        var versionOnly = transaction with
+        {
+            ResultVersion = transaction.BaseVersion + 1,
+            AfterDocument = transaction.BeforeDocument with
+            {
+                DocumentVersion = transaction.BaseVersion + 1,
+            },
+        };
+        var forged = Rehash(receipt.Payload with { Transactions = new[] { versionOnly } });
+        var forgedResult = DeliveryChangeReceiptVerifier.Verify(forged, artifacts);
+        Assert.Contains("invalid_prediction_transition", forgedResult.Findings);
+    }
+
+    [Fact]
+    public void DCR038_PortableIntegersFactoriesAndOutputSerialization_AreBounded()
+    {
+        var edit = SingleEdit("Portable integer bounds.");
+        const long firstUnsafeInteger = 9_007_199_254_740_992;
+        var versionError = Assert.Throws<DeliveryReceiptValidationException>(() =>
+            DeliveryDocumentIdentity.FromManifest(edit.BeforeManifest, firstUnsafeInteger));
+        Assert.Equal("invalid_document_version", versionError.Code);
+
+        var builder = Builder(edit);
+        AddTransactionWithSemantic(builder, edit);
+        var receipt = builder.Build();
+        var unsafePayload = receipt.Payload with
+        {
+            SourceDocument = receipt.Payload.SourceDocument with
+            {
+                DocumentVersion = firstUnsafeInteger,
+            },
+        };
+        var unsafeReceipt = Rehash(unsafePayload);
+        var unsafeResult = DeliveryChangeReceiptVerifier.Verify(
+            unsafeReceipt, RequiredArtifactBytes(edit));
+        Assert.Contains("invalid_document_version", unsafeResult.Findings);
+        Assert.Empty(unsafeResult.Artifacts);
+
+        int yielded = 0;
+        var operation = DeliveryNormalizedOperation.Create("docx_edit", "no_op");
+        IEnumerable<DeliveryNormalizedOperation> InfiniteOperations()
+        {
+            while (true)
+            {
+                yielded++;
+                yield return operation;
+            }
+        }
+        var emptyResult = new MutationBatchResult
+        {
+            Mode = MutationBatchMode.Atomic,
+            Success = true,
+            RolledBack = false,
+            BaseVersion = 0,
+            ResultVersion = 0,
+        };
+        var enumerableError = Assert.Throws<DeliveryReceiptValidationException>(() =>
+            DeliveryTransactionContribution.FromMutationBatchResult(
+                emptyResult,
+                edit.BeforeManifest,
+                edit.BeforeManifest,
+                InfiniteOperations(),
+                limits: new DeliveryReceiptLimits { MaxOperationsPerTransaction = 3 }));
+        Assert.Equal("receipt_resource_limit", enumerableError.Code);
+        Assert.Equal(4, yielded);
+
+        var compact = receipt.ToJsonBytes();
+        var indented = receipt.ToJsonBytes(indented: true);
+        Assert.True(indented.Length > compact.Length);
+        var outputLimits = new DeliveryReceiptLimits
+        {
+            MaxReceiptJsonBytes = compact.Length + ((indented.Length - compact.Length) / 2),
+        };
+        Assert.Equal(compact, receipt.ToJsonBytes(outputLimits));
+        Assert.Equal("receipt_resource_limit",
+            Assert.Throws<DeliveryReceiptValidationException>(() =>
+                receipt.ToJsonBytes(outputLimits, indented: true)).Code);
+    }
+
+    [Fact]
+    public void DCR039_CanonicalJson_HasPortableEscapingOrderingAndTextCounts()
+    {
+        var escaped = DeliveryReceiptCanonicalJson.Canonicalize(Encoding.UTF8.GetBytes(
+            "{\"\uE000\":\"é\",\"😀\":\"<&>\"}"));
+        Assert.Equal(
+            "{\"\\uD83D\\uDE00\":\"\\u003C\\u0026\\u003E\"," +
+            "\"\\uE000\":\"\\u00E9\"}",
+            Encoding.UTF8.GetString(escaped));
+
+        var exactNumbers = DeliveryReceiptCanonicalJson.Canonicalize(Encoding.UTF8.GetBytes(
+            "{\"y\":1e+02,\"x\":9007199254740993.123456789}"));
+        Assert.Equal(
+            "{\"x\":9007199254740993.123456789,\"y\":1e+02}",
+            Encoding.UTF8.GetString(exactNumbers));
+
+        var dense = Encoding.UTF8.GetBytes(
+            "[" + string.Join(',', Enumerable.Repeat("0", 10_000)) + "]");
+        var denseLimits = new DeliveryReceiptLimits
+        {
+            MaxCollectionItems = 8,
+            MaxReceiptJsonBytes = dense.Length + 1,
+        };
+        Assert.Equal("receipt_resource_limit",
+            Assert.Throws<DeliveryReceiptValidationException>(() =>
+                DeliveryReceiptCanonicalJson.CanonicalizeBounded(
+                    dense,
+                    denseLimits,
+                    denseLimits.MaxReceiptJsonBytes,
+                    "receipt_resource_limit")).Code);
+
+        var edit = SingleEdit("UTF-16 evidence count.");
+        var builder = Builder(edit);
+        AddTransactionWithSemantic(builder, edit);
+        builder.AddWarning("😀");
+        var warning = Assert.Single(builder.Build().Payload.Warnings);
+        Assert.Equal(2, warning.CharacterCount);
+    }
+
+    [Fact]
+    public void DCR040_SourceInventoryIsSnapshottedAndMustIdentifyWordprocessingOpc()
+    {
+        var edit = SingleEdit("Immutable source inventory.");
+        var expectedBuilder = Builder(edit);
+        AddTransactionWithSemantic(expectedBuilder, edit);
+        var expected = expectedBuilder.Build();
+
+        var mutableEntries = edit.BeforeManifest.Entries.ToArray();
+        var mutableManifest = edit.BeforeManifest with { Entries = mutableEntries };
+        var snapshotBuilder = new DeliveryChangeReceiptBuilder(
+            mutableManifest, edit.Result.BaseVersion)
+            .SetDeliveredDocument(edit.AfterManifest, edit.Result.ResultVersion);
+        mutableEntries[0] = mutableEntries[0] with { Uri = "/tampered-after-construction.xml" };
+        AddCleanDocx(
+            snapshotBuilder, edit.AfterBytes, edit.AfterManifest, edit.Result.ResultVersion);
+        snapshotBuilder.AddSemanticChangeSet(
+            DeliverySemanticChangeSetInput.ForSourceToDelivered(
+                SemanticChanges(edit.BeforeBytes, edit.AfterBytes)));
+        var entryId = snapshotBuilder.AddTransaction(edit.Contribution);
+        AddTransactionSemantic(
+            snapshotBuilder,
+            entryId,
+            edit.BeforeBytes,
+            edit.AfterBytes,
+            "semantic-source-to-delivered");
+        var snapshot = snapshotBuilder.Build();
+        Assert.Equal(expected.Payload.PackageChanges, snapshot.Payload.PackageChanges);
+
+        Assert.Equal("not_wordprocessing_package",
+            Assert.Throws<DeliveryReceiptValidationException>(() =>
+                DeliveryDocumentIdentity.FromManifest(
+                    edit.BeforeManifest with { PackageKind = "zip" },
+                    edit.Result.BaseVersion)).Code);
+        Assert.Equal("not_wordprocessing_package",
+            Assert.Throws<DeliveryReceiptValidationException>(() =>
+                DeliveryDocumentIdentity.FromManifest(
+                    edit.BeforeManifest with
+                    {
+                        Facts = edit.BeforeManifest.Facts with { MainDocumentUri = null },
+                    },
+                    edit.Result.BaseVersion)).Code);
+        Assert.Equal("not_wordprocessing_package",
+            Assert.Throws<DeliveryReceiptValidationException>(() =>
+                DeliveryDocumentIdentity.FromManifest(
+                    edit.BeforeManifest with
+                    {
+                        Facts = edit.BeforeManifest.Facts with
+                        {
+                            MainDocumentUri = "word/document.xml",
+                        },
+                    },
+                    edit.Result.BaseVersion)).Code);
+    }
+
+    [Fact]
+    public void DCR041_ExternalEvidenceRequiresOwnerSchemaAndExactCanonicalBytes()
+    {
+        var edit = SingleEdit("Exact owner evidence.");
+        var validation = DeliverableVerifier.VerifyDeliverable(
+            edit.BeforeBytes, edit.AfterBytes);
+        var canonical = validation.ToCanonicalUtf8Bytes();
+        var noncanonical = Encoding.UTF8.GetBytes(
+            Encoding.UTF8.GetString(canonical).Insert(1, "\n"));
+        var builder = Builder(edit);
+        AddTransactionWithSemantic(builder, edit);
+        builder.AddArtifact(DeliveryArtifactInput.Available(
+            "validation", DeliveryArtifactRole.ValidationReport,
+            "application/json", noncanonical));
+        builder.AddEvidence(new DeliveryEvidenceReference
+        {
+            Kind = DeliveryEvidenceKind.ValidationResult,
+            Schema = DeliverableVerificationResult.SchemaId,
+            Digest = Digest(noncanonical),
+            ArtifactId = "validation",
+        });
+        Assert.Equal("invalid_evidence_artifact",
+            Assert.Throws<DeliveryReceiptValidationException>(() => builder.Build()).Code);
+
+        var schemaBuilder = Builder(edit);
+        Assert.Equal("evidence_schema_mismatch",
+            Assert.Throws<DeliveryReceiptValidationException>(() =>
+                schemaBuilder.AddEvidence(new DeliveryEvidenceReference
+                {
+                    Kind = DeliveryEvidenceKind.ValidationResult,
+                    Schema = "https://example.invalid/not-the-owner-schema",
+                    Digest = Digest(canonical),
+                })).Code);
     }
 
     private static DeliveryChangeReceipt BuildWithProfile(
@@ -2135,6 +2550,18 @@ public class DeliveryChangeReceiptTests
         Payload = payload,
         ReceiptDigest = Digest(DeliveryChangeReceiptSerializer.SerializePayload(payload)),
     };
+
+    private static byte[] RehashPayloadJson(JsonObject payload)
+    {
+        var canonicalPayload = DeliveryReceiptCanonicalJson.Canonicalize(
+            Encoding.UTF8.GetBytes(payload.ToJsonString()));
+        var digest = Digest(canonicalPayload);
+        var envelope = Encoding.UTF8.GetBytes(
+            $"{{\"payload\":{Encoding.UTF8.GetString(canonicalPayload)}," +
+            $"\"receiptDigest\":{{\"algorithm\":\"{digest.Algorithm}\"," +
+            $"\"value\":\"{digest.Value}\"}}}}");
+        return DeliveryReceiptCanonicalJson.Canonicalize(envelope);
+    }
 
     private static SemanticChangeSet SemanticChanges(byte[] before, byte[] after) =>
         SemanticDiff.Compare(

--- a/Docxodus.Tests/DeliveryChangeReceiptTests.cs
+++ b/Docxodus.Tests/DeliveryChangeReceiptTests.cs
@@ -2779,6 +2779,134 @@ public class DeliveryChangeReceiptTests
                 () => rogueBuilder.Build()).Code);
     }
 
+    [Fact]
+    public void DCR049_IdempotentPreview_BuildsAValidNoOpPrediction()
+    {
+        var source = DocxSessionTests.BuildDS001_SimpleTwoParagraphs();
+        using var session = Open(source);
+        var anchor = BodyParagraphs(session)[0];
+        MutationBatchStep[] Steps() => new[]
+        {
+            new MutationBatchStep("docx_edit", "replace_text",
+                s => s.ReplaceText(anchor, "Idempotent clause.")),
+        };
+        var commit = session.ExecuteBatch(Steps());
+        Assert.True(commit.Success, "commit failed");
+        var committedBytes = session.Save();
+        var committedManifest = Manifest(committedBytes);
+
+        var preview = session.PreviewBatch(Steps());
+        Assert.True(preview.Success, "preview failed");
+        Assert.True(preview.Preview);
+        Assert.Equal(commit.ResultVersion, preview.BaseVersion);
+        Assert.Equal(preview.BaseVersion + 1, preview.ResultVersion);
+
+        var operation = DeliveryNormalizedOperation.Create("docx_edit", "replace_text",
+            JsonSerializer.Serialize(new
+            {
+                anchorId = anchor,
+                markdown = "Idempotent clause.",
+            }));
+        var contribution = DeliveryTransactionContribution.FromMutationBatchResult(
+            preview, committedManifest, committedManifest, new[] { operation });
+
+        var builder = new DeliveryChangeReceiptBuilder(committedManifest, preview.BaseVersion)
+            .SetDeliveredDocument(committedManifest, preview.BaseVersion);
+        AddCleanDocx(builder, committedBytes, committedManifest, preview.BaseVersion);
+        var noChange = new SemanticChangeSet(Array.Empty<SemanticChange>());
+        builder.AddSemanticChangeSet(
+            DeliverySemanticChangeSetInput.ForSourceToDelivered(noChange));
+        builder.AddTransaction(contribution);
+        var receipt = builder.Build();
+
+        var transaction = Assert.Single(receipt.Payload.Transactions);
+        Assert.Equal(DeliveryTransactionStatus.Prediction, transaction.Status);
+        Assert.Equal(transaction.BeforeDocument, transaction.AfterDocument);
+        var artifacts = new Dictionary<string, byte[]>
+        {
+            ["clean-docx"] = committedBytes,
+            ["semantic-source-to-delivered"] = noChange.ToCanonicalUtf8Bytes(),
+        };
+        var result = DeliveryChangeReceiptVerifier.Verify(receipt, artifacts);
+        Assert.True(result.IsValid, string.Join("; ", result.Findings));
+    }
+
+    [Fact]
+    public void DCR050_EveryFailedStepResult_RequiresAStructuredEditError()
+    {
+        var source = DocxSessionTests.BuildDS001_SimpleTwoParagraphs();
+        using var session = Open(source);
+        var beforeBytes = session.Save();
+        var beforeManifest = Manifest(beforeBytes);
+        var result = session.ExecuteBatch(new[]
+        {
+            new MutationBatchStep("docx_edit", "replace_text",
+                s => s.ReplaceText("p:body:missing00", "never lands")),
+            new MutationBatchStep("docx_edit", "custom",
+                s => new EditResult { Success = false }),
+        }, MutationBatchMode.BestEffort);
+        Assert.False(result.Success);
+        var afterBytes = session.Save();
+        var afterManifest = Manifest(afterBytes);
+        var operations = new[]
+        {
+            DeliveryNormalizedOperation.Create("docx_edit", "replace_text",
+                "{\"anchorId\":\"p:body:missing00\"}"),
+            DeliveryNormalizedOperation.Create("docx_edit", "custom", "{}"),
+        };
+
+        Assert.Equal("invalid_operation_result",
+            Assert.Throws<DeliveryReceiptValidationException>(() =>
+                DeliveryTransactionContribution.FromMutationBatchResult(
+                    result, beforeManifest, afterManifest, operations)).Code);
+    }
+
+    [Fact]
+    public void DCR051_LineageEventDocumentIdentities_AreValidatedAtBuildTime()
+    {
+        var edit = SingleEdit("Lineage identity validation.");
+        var builder = Builder(edit);
+        var entryId = AddTransactionWithSemantic(builder, edit);
+        var valid = DeliveryLineageEventInput.FromManifests(
+            DeliveryLineageAction.Undo, entryId,
+            edit.AfterManifest, edit.Result.ResultVersion,
+            edit.BeforeManifest, edit.Result.BaseVersion);
+
+        var malformed = valid with
+        {
+            BeforeDocument = valid.BeforeDocument with
+            {
+                NormalizedSemanticDigest = new VerificationDigest
+                {
+                    Algorithm = "SHA-256",
+                    Value = "NOT-A-DIGEST",
+                },
+            },
+        };
+
+        Assert.Equal("invalid_digest",
+            Assert.Throws<DeliveryReceiptValidationException>(
+                () => builder.AddLineageEvent(malformed)).Code);
+    }
+
+    [Fact]
+    public void DCR052_IdenticalSemanticEvidenceRetry_IsIdempotent()
+    {
+        var edit = SingleEdit("Idempotent semantic evidence.");
+        var builder = Builder(edit);
+        AddTransactionWithSemantic(builder, edit);
+        builder.AddSemanticChangeSet(DeliverySemanticChangeSetInput.ForSourceToDelivered(
+            SemanticChanges(edit.BeforeBytes, edit.AfterBytes)));
+
+        var receipt = builder.Build();
+
+        Assert.Single(receipt.Payload.SemanticChangeSets,
+            binding => binding.Scope == DeliverySemanticComparisonScope.SourceToDelivered);
+        var result = DeliveryChangeReceiptVerifier.Verify(
+            receipt, RequiredArtifactBytes(edit));
+        Assert.True(result.IsValid, string.Join("; ", result.Findings));
+    }
+
     private static DeliveryChangeReceipt BuildWithProfile(
         EditFixture edit,
         DeliveryReceiptPrivacyProfile profile)

--- a/Docxodus.Tests/DeliveryChangeReceiptTests.cs
+++ b/Docxodus.Tests/DeliveryChangeReceiptTests.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -2518,6 +2519,163 @@ public class DeliveryChangeReceiptTests
         var result = DeliveryChangeReceiptVerifier.VerifyJson(
             receipt.ToJson(), RequiredArtifactBytes(edit));
         Assert.True(result.IsValid, string.Join("; ", result.Findings));
+    }
+
+    [Fact]
+    public void DCR045_StaleCitation_DoesNotPoisonPageMapVerdictForLaterCitations()
+    {
+        var edit = SingleEdit("Citation cache isolation.");
+        using var reopened = Open(edit.AfterBytes);
+        var anchors = BodyParagraphs(reopened);
+        Assert.True(anchors.Length >= 2);
+        var identity = DeliveryDocumentIdentity.FromManifest(
+            edit.AfterManifest, edit.Result.ResultVersion);
+        var version = edit.Result.ResultVersion;
+        const string renderer = "renderer-A";
+
+        PageCitation CitationFor(string anchorId, int index) =>
+            Citation(anchorId, version, renderer) with
+            {
+                Fragments = new[]
+                {
+                    new PageMapFragment
+                    {
+                        FragmentId = $"page-1-fragment-{index}",
+                        AnchorId = anchorId,
+                        FragmentIndex = 0,
+                        PageNumber = 1,
+                        Geometry = new PageMapRect(72, 72 + (index * 30), 300, 24),
+                        Story = PageMapStory.Body,
+                    },
+                },
+            };
+        var citations = new[] { CitationFor(anchors[0], 0), CitationFor(anchors[1], 1) };
+        var pageMapBytes = JsonSerializer.SerializeToUtf8Bytes(new PageMap
+        {
+            Mode = PageMapMode.Paginated,
+            Availability = PageMapAvailability.Available,
+            DocumentVersion = version,
+            RendererFingerprint = renderer,
+            Pages = citations[0].Pages,
+            Fragments = citations.SelectMany(citation => citation.Fragments).ToArray(),
+        }, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters =
+            {
+                new System.Text.Json.Serialization.JsonStringEnumConverter(
+                    JsonNamingPolicy.CamelCase, allowIntegerValues: false),
+            },
+        });
+        var pageMapDigest = Digest(pageMapBytes);
+        var pdf = Encoding.ASCII.GetBytes("%PDF-1.7\ncitation-cache\n%%EOF");
+
+        var builder = Builder(edit);
+        AddTransactionWithSemantic(builder, edit);
+        builder.AddArtifact(DeliveryArtifactInput.Available(
+            "pdf", DeliveryArtifactRole.Pdf, "application/pdf", pdf) with
+        {
+            Document = identity,
+            RendererFingerprint = renderer,
+            PageMapDigest = pageMapDigest,
+        });
+        builder.AddArtifact(DeliveryArtifactInput.Available(
+            "page-map", DeliveryArtifactRole.PageMap, "application/json", pageMapBytes) with
+        {
+            Document = identity,
+            RendererFingerprint = renderer,
+        });
+        foreach (var citation in citations)
+        {
+            builder.AddPageCitation(new DeliveryPageCitationInput
+            {
+                Citation = citation,
+                Scope = "body",
+                Document = identity,
+                PageMapDigest = pageMapDigest,
+                PageMapArtifactId = "page-map",
+                RenderArtifactId = "pdf",
+            });
+        }
+        var receipt = builder.Build();
+        var artifactBytes = RequiredArtifactBytes(edit);
+        artifactBytes["pdf"] = pdf;
+        artifactBytes["page-map"] = pageMapBytes;
+        Assert.True(DeliveryChangeReceiptVerifier.Verify(receipt, artifactBytes).IsValid);
+
+        var payload = JsonNode.Parse(receipt.ToJson())!["payload"]!.AsObject();
+        var ordered = payload["pageCitations"]!.AsArray();
+        Assert.Equal(2, ordered.Count);
+        var staleAnchor = ordered[0]!["anchorId"]!.GetValue<string>();
+        var healthyAnchor = ordered[1]!["anchorId"]!.GetValue<string>();
+        ordered[0]!["documentVersion"] = edit.Result.BaseVersion;
+
+        var result = DeliveryChangeReceiptVerifier.VerifyJson(
+            RehashPayloadJson(payload), artifactBytes);
+
+        Assert.False(result.IsValid);
+        Assert.Contains($"invalid_page_map_artifact:{staleAnchor}", result.Findings);
+        Assert.DoesNotContain(
+            $"invalid_page_map_artifact:{healthyAnchor}", result.Findings);
+        Assert.DoesNotContain(result.Findings,
+            finding => finding.EndsWith($":{healthyAnchor}", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void DCR046_AnnotationTimestamps_AreUtcNormalizedInTheHashedPayload()
+    {
+        var source = DocxSessionTests.BuildDS001_SimpleTwoParagraphs();
+        using var session = Open(source);
+        var anchor = BodyParagraphs(session)[0];
+        var beforeBytes = session.Save();
+        var beforeManifest = Manifest(beforeBytes);
+        var createdUtc = new DateTime(2026, 8, 19, 17, 30, 0, DateTimeKind.Utc);
+        var operation = DeliveryNormalizedOperation.Create("docx_edit", "add_annotation",
+            JsonSerializer.Serialize(new { anchorId = anchor, labelId = "CLAUSE" }));
+        var result = session.ExecuteBatch(new[]
+        {
+            new MutationBatchStep("docx_edit", "add_annotation",
+                s => s.AddAnnotation(anchor, null, new DocumentAnnotation
+                {
+                    Id = "ann-1",
+                    LabelId = "CLAUSE",
+                    Label = "Clause",
+                    Color = "#FFEB3B",
+                    Author = "Annotator",
+                    Created = createdUtc.ToLocalTime(),
+                })),
+        });
+        Assert.True(result.Success,
+            result.Failure is null ? "batch failed" : result.Failure.Error.Message);
+        var afterBytes = session.Save();
+        var afterManifest = Manifest(afterBytes);
+        var contribution = DeliveryTransactionContribution.FromMutationBatchResult(
+            result, beforeManifest, afterManifest, new[] { operation });
+
+        var builder = new DeliveryChangeReceiptBuilder(
+            beforeManifest, result.BaseVersion, DeliveryReceiptPrivacyProfile.FullEvidence)
+            .SetDeliveredDocument(afterManifest, result.ResultVersion);
+        AddCleanDocx(builder, afterBytes, afterManifest, result.ResultVersion);
+        builder.AddSemanticChangeSet(DeliverySemanticChangeSetInput.ForSourceToDelivered(
+            SemanticChanges(beforeBytes, afterBytes)));
+        var entryId = builder.AddTransaction(contribution);
+        AddTransactionSemantic(
+            builder, entryId, beforeBytes, afterBytes, "semantic-source-to-delivered");
+        var receipt = builder.Build();
+
+        var change = Assert.Single(
+            Assert.Single(receipt.Payload.Transactions).AuthoredChanges,
+            item => item.EntityKind == DeliveryAuthoredEntityKind.Annotation);
+        Assert.NotNull(change.Date);
+        Assert.EndsWith("Z", change.Date, StringComparison.Ordinal);
+        Assert.Equal(createdUtc, DateTime.Parse(
+            change.Date, CultureInfo.InvariantCulture,
+            DateTimeStyles.RoundtripKind).ToUniversalTime());
+        Assert.NotNull(change.FullEvidence);
+        var evidenceCreated = change.FullEvidence.Value
+            .GetProperty("created").GetString();
+        Assert.NotNull(evidenceCreated);
+        Assert.EndsWith("Z", evidenceCreated, StringComparison.Ordinal);
     }
 
     private static DeliveryChangeReceipt BuildWithProfile(

--- a/Docxodus.Tests/RedlineReversibilityProofTests.cs
+++ b/Docxodus.Tests/RedlineReversibilityProofTests.cs
@@ -1285,6 +1285,26 @@ public class RedlineReversibilityProofTests
             finding.Code == "revision_evidence_limit_exceeded");
     }
 
+    [Fact]
+    public void RP051_IsExactCanonical_RejectsUndefinedIntegerEnumValues()
+    {
+        var baseline = Document("The original clause.");
+        var intendedFinal = Document("The revised clause.");
+        var redline = DocxDiff.Compare(
+            new WmlDocument("baseline.docx", baseline),
+            new WmlDocument("final.docx", intendedFinal),
+            new DocxDiffSettings { AuthorForRevisions = "Comparison Engine" }).DocumentByteArray;
+        var proof = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline).Proof;
+        var canonical = proof.ToCanonicalUtf8Bytes();
+        Assert.True(RedlineReversibilityProof.IsExactCanonical(canonical));
+
+        var json = Encoding.UTF8.GetString(canonical);
+        Assert.Contains("\"disposition\":\"generated\"", json);
+        var forged = Encoding.UTF8.GetBytes(json.Replace(
+            "\"disposition\":\"generated\"", "\"disposition\":9999"));
+        Assert.False(RedlineReversibilityProof.IsExactCanonical(forged));
+    }
+
     private static void AssertResolutionClosure(RedlineProofPathResult path)
     {
         var accountedFor = path.ResolvedRevisionIds

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -1418,8 +1418,9 @@ public enum MutationBatchMode
 /// <summary>
 /// One core batch step. <see cref="Preflight"/> performs any read-only validation that can be
 /// decided before mutation begins (all steps up front for atomic mode, or immediately before each
-/// step for best-effort mode); <see cref="Mutation"/> returns one or more edit envelopes so
-/// multi-match replacement can remain one step without losing its individual results.
+/// step for best-effort mode); <see cref="Mutation"/> returns zero or more edit envelopes. An
+/// empty collection is a successful no-op, while multiple results let multi-match replacement
+/// remain one step without losing its individual outcomes.
 /// </summary>
 public sealed class MutationBatchStep
 {

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -4112,11 +4112,11 @@ public sealed partial class DocxSession : IDisposable
         try
         {
             var results = step.Mutation(this);
-            if (results is not { Count: > 0 } || results.Any(result => result is null))
+            if (results is null || results.Any(result => result is null))
                 return new[]
                 {
                     EditResult.Fail(EditErrorCode.InternalError,
-                        "batch mutation returned no valid edit results"),
+                        "batch mutation returned invalid edit results"),
                 };
             return results;
         }

--- a/Docxodus/Internal/AnnotationsCustomXml.cs
+++ b/Docxodus/Internal/AnnotationsCustomXml.cs
@@ -149,7 +149,14 @@ internal static class AnnotationsCustomXml
         };
 
         var createdStr = (string?)element.Attribute("created");
-        if (DateTime.TryParse(createdStr, out var created)) a.Created = created;
+        if (DateTime.TryParse(
+                createdStr, System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.AdjustToUniversal
+                | System.Globalization.DateTimeStyles.AssumeUniversal,
+                out var created))
+        {
+            a.Created = created;
+        }
 
         var range = element.Element(Ann + "range");
         if (range is not null) a.BookmarkName = (string?)range.Attribute("bookmarkName");

--- a/Docxodus/Internal/DocxSessionJson.cs
+++ b/Docxodus/Internal/DocxSessionJson.cs
@@ -1923,6 +1923,16 @@ internal static class DocxSessionJson
         return sb.ToString();
     }
 
+    /// <summary>UTC-normalized round-trip timestamp: the wire format never carries a
+    /// machine-local offset, so hash-covered payloads are timezone-independent.
+    /// Unspecified kinds are treated as UTC deterministically.</summary>
+    public static string UtcRoundtrip(System.DateTime value) => (value.Kind switch
+    {
+        System.DateTimeKind.Utc => value,
+        System.DateTimeKind.Local => value.ToUniversalTime(),
+        _ => System.DateTime.SpecifyKind(value, System.DateTimeKind.Utc),
+    }).ToString("O", System.Globalization.CultureInfo.InvariantCulture);
+
     public static string EnumToSnake(System.Enum code)
     {
         var s = code.ToString();
@@ -2626,7 +2636,7 @@ internal static class DocxSessionJson
             if (a.Author is not null)
                 sb.Append(",\"author\":").Append(JsonString(a.Author));
             if (a.Created.HasValue)
-                sb.Append(",\"created\":").Append(JsonString(a.Created.Value.ToString("o")));
+                sb.Append(",\"created\":").Append(JsonString(UtcRoundtrip(a.Created.Value)));
             if (a.AnnotatedText is not null)
                 sb.Append(",\"annotatedText\":").Append(JsonString(a.AnnotatedText));
             if (a.Metadata is { Count: > 0 })

--- a/Docxodus/Internal/PageMapContract.cs
+++ b/Docxodus/Internal/PageMapContract.cs
@@ -185,7 +185,8 @@ internal static class PageMapContract
     };
 
     private static bool ValidRect(PageMapRect rect) =>
-        double.IsFinite(rect.X) && rect.X >= 0
+        rect is not null
+        && double.IsFinite(rect.X) && rect.X >= 0
         && double.IsFinite(rect.Y) && rect.Y >= 0
         && double.IsFinite(rect.Width) && rect.Width > 0
         && double.IsFinite(rect.Height) && rect.Height > 0;

--- a/Docxodus/Verification/DeliverableVerificationModels.cs
+++ b/Docxodus/Verification/DeliverableVerificationModels.cs
@@ -473,6 +473,23 @@ public sealed record DeliverableVerificationResult
         this, (indented ? JsonOptions.Indented : JsonOptions.Canonical)
             .DeliverableVerificationResult);
 
+    internal static bool IsExactCanonical(ReadOnlySpan<byte> bytes)
+    {
+        try
+        {
+            var result = JsonSerializer.Deserialize(
+                bytes, JsonOptions.Canonical.DeliverableVerificationResult);
+            return result is not null
+                && string.Equals(result.Schema, SchemaId, StringComparison.Ordinal)
+                && result.SchemaVersion == 1
+                && bytes.SequenceEqual(result.ToCanonicalUtf8Bytes());
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
     private static class JsonOptions
     {
         internal static readonly DeliverableVerificationJsonContext Canonical =

--- a/Docxodus/Verification/DeliverableVerificationModels.cs
+++ b/Docxodus/Verification/DeliverableVerificationModels.cs
@@ -508,27 +508,27 @@ public sealed record DeliverableVerificationResult
             // source-generation switch emits enum member names verbatim, while schema v1's
             // durable wire vocabulary is camelCase.
             options.Converters.Add(new JsonStringEnumConverter<DeliverableVerificationMode>(
-                JsonNamingPolicy.CamelCase));
+                JsonNamingPolicy.CamelCase, allowIntegerValues: false));
             options.Converters.Add(new JsonStringEnumConverter<DeliverableVerificationDecision>(
-                JsonNamingPolicy.CamelCase));
+                JsonNamingPolicy.CamelCase, allowIntegerValues: false));
             options.Converters.Add(new JsonStringEnumConverter<DeliverableCheckStatus>(
-                JsonNamingPolicy.CamelCase));
+                JsonNamingPolicy.CamelCase, allowIntegerValues: false));
             options.Converters.Add(new JsonStringEnumConverter<DeliverableFindingCategory>(
-                JsonNamingPolicy.CamelCase));
+                JsonNamingPolicy.CamelCase, allowIntegerValues: false));
             options.Converters.Add(new JsonStringEnumConverter<VerificationFindingSeverity>(
-                JsonNamingPolicy.CamelCase));
+                JsonNamingPolicy.CamelCase, allowIntegerValues: false));
             options.Converters.Add(new JsonStringEnumConverter<DeliverableFindingDisposition>(
-                JsonNamingPolicy.CamelCase));
+                JsonNamingPolicy.CamelCase, allowIntegerValues: false));
             options.Converters.Add(new JsonStringEnumConverter<DeliverablePackageChangeKind>(
-                JsonNamingPolicy.CamelCase));
+                JsonNamingPolicy.CamelCase, allowIntegerValues: false));
             options.Converters.Add(new JsonStringEnumConverter<SemanticChangeOperation>(
-                JsonNamingPolicy.CamelCase));
+                JsonNamingPolicy.CamelCase, allowIntegerValues: false));
             options.Converters.Add(new JsonStringEnumConverter<SemanticChangeFamily>(
-                JsonNamingPolicy.CamelCase));
+                JsonNamingPolicy.CamelCase, allowIntegerValues: false));
             options.Converters.Add(new JsonStringEnumConverter<DeliverableArtifactRole>(
-                JsonNamingPolicy.CamelCase));
+                JsonNamingPolicy.CamelCase, allowIntegerValues: false));
             options.Converters.Add(new JsonStringEnumConverter<DeliverableArtifactAvailability>(
-                JsonNamingPolicy.CamelCase));
+                JsonNamingPolicy.CamelCase, allowIntegerValues: false));
             return new DeliverableVerificationJsonContext(options);
         }
     }

--- a/Docxodus/Verification/DeliveryChangeReceiptBuilder.cs
+++ b/Docxodus/Verification/DeliveryChangeReceiptBuilder.cs
@@ -1994,7 +1994,10 @@ public sealed class DeliveryChangeReceiptBuilder
 
     private static JsonElement ParseCanonical(byte[] canonical)
     {
-        using var document = JsonDocument.Parse(canonical);
+        using var document = JsonDocument.Parse(canonical, new JsonDocumentOptions
+        {
+            MaxDepth = DeliveryReceiptLimits.MaxAllowedJsonDepth,
+        });
         return document.RootElement.Clone();
     }
 
@@ -2008,7 +2011,10 @@ public sealed class DeliveryChangeReceiptBuilder
         var canonicalArray = DeliveryReceiptCanonicalJson.CanonicalizeBounded(
             Encoding.UTF8.GetBytes(json), _limits, _limits.MaxReceiptJsonBytes,
             "receipt_resource_limit");
-        using var document = JsonDocument.Parse(canonicalArray);
+        using var document = JsonDocument.Parse(canonicalArray, new JsonDocumentOptions
+        {
+            MaxDepth = DeliveryReceiptLimits.MaxAllowedJsonDepth,
+        });
         if (document.RootElement.ValueKind != JsonValueKind.Array
             || document.RootElement.GetArrayLength() != 1)
         {

--- a/Docxodus/Verification/DeliveryChangeReceiptBuilder.cs
+++ b/Docxodus/Verification/DeliveryChangeReceiptBuilder.cs
@@ -30,11 +30,15 @@ public sealed class DeliveryChangeReceiptBuilder
     private readonly List<(long Sequence, DeliveryLineageEventInput Input)> _lineage = new();
     private readonly Dictionary<string, DeliveryArtifact> _artifacts = new(StringComparer.Ordinal);
     private readonly Dictionary<string, byte[]> _artifactBytes = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, PageMap> _validatedPageMaps = new(StringComparer.Ordinal);
+    private readonly Dictionary<(string ArtifactId, string AnchorId), PageCitation>
+        _pageMapProjections = new();
     private readonly List<DeliveryPageCitationInput> _citations = new();
     private readonly List<DeliveryEvidenceReference> _evidence = new();
     private readonly List<(DeliverySemanticChangeSetInput Input,
         DeliverySemanticChangeSetProjection Projection)> _semanticChangeSets = new();
-    private readonly List<DeliveryChangeAttributionRule> _attributionRules = new();
+    private readonly Dictionary<DeliveryAttributionKey, DeliveryChangeAttributionRule>
+        _attributionRules = new();
     private readonly List<string> _warnings = new();
     private long _nextSequence;
     private DeliveryDocumentIdentity? _deliveredDocument;
@@ -52,7 +56,7 @@ public sealed class DeliveryChangeReceiptBuilder
             throw new ArgumentOutOfRangeException(nameof(privacyProfile));
         _limits = (limits ?? new DeliveryReceiptLimits()).ValidateAndClone();
         ValidateManifestResources(sourceManifest);
-        _sourceManifest = sourceManifest;
+        _sourceManifest = CloneManifest(sourceManifest);
         _sourceDocument = DeliveryDocumentIdentity.FromManifest(
             sourceManifest, sourceDocumentVersion);
         _privacyProfile = privacyProfile;
@@ -166,7 +170,8 @@ public sealed class DeliveryChangeReceiptBuilder
             input.ArtifactId,
             DeliveryArtifactRole.SemanticDiff,
             "application/json",
-            projection.CanonicalBytes) with
+            projection.CanonicalBytes,
+            _limits) with
         {
             RelativePath = input.RelativePath,
         };
@@ -211,15 +216,23 @@ public sealed class DeliveryChangeReceiptBuilder
                 "Semantic evidence must be registered from a SemanticChangeSet instance.");
         }
         DeliveryReceiptValidation.RequireNonBlank(evidence.Schema, "evidence schema", 2048);
+        var expectedSchema = ExpectedEvidenceSchema(evidence.Kind);
+        if (!string.Equals(evidence.Schema, expectedSchema, StringComparison.Ordinal))
+        {
+            throw new DeliveryReceiptValidationException(
+                "evidence_schema_mismatch",
+                $"Evidence kind '{evidence.Kind}' requires schema '{expectedSchema}'.");
+        }
         DeliveryReceiptValidation.ValidateDigest(evidence.Digest, "evidence digest");
         if (evidence.ArtifactId is not null)
             DeliveryReceiptValidation.RequireNonBlank(evidence.ArtifactId, "evidence artifact id", 256);
         _evidence.Add(evidence with
         {
             Digest = DeliveryReceiptValidation.CloneDigest(evidence.Digest),
-            Summary = _privacyProfile == DeliveryReceiptPrivacyProfile.HashOnly
+            Summary = evidence.Summary is null
+                || _privacyProfile == DeliveryReceiptPrivacyProfile.HashOnly
                 ? null
-                : evidence.Summary,
+                : ProfiledFreeText(evidence.Summary, "evidence summary"),
         });
         return this;
     }
@@ -229,7 +242,12 @@ public sealed class DeliveryChangeReceiptBuilder
         ArgumentNullException.ThrowIfNull(rule);
         EnsureCollectionCapacity(_attributionRules.Count, "attribution rules");
         ValidateAttributionRule(rule);
-        _attributionRules.Add(rule);
+        if (!_attributionRules.TryAdd(AttributionKey(rule), rule))
+        {
+            throw new DeliveryReceiptValidationException(
+                "ambiguous_attribution",
+                "More than one attribution rule identifies the same package change.");
+        }
         return this;
     }
 
@@ -260,7 +278,8 @@ public sealed class DeliveryChangeReceiptBuilder
         }
         var deliveredManifest = ValidateRequiredCleanDocx(_deliveredDocument);
         var semanticChangeSets = BuildSemanticChangeSetBindings(lineageValidation);
-        var packageChanges = BuildPackageChanges(_sourceManifest, deliveredManifest);
+        var packageChanges = BuildPackageChanges(
+            _sourceManifest, deliveredManifest, lineageValidation);
         if (FailOnUnexpectedChanges
             && packageChanges.Any(change =>
                 change.Disposition == DeliveryChangeDisposition.Unexpected))
@@ -353,11 +372,9 @@ public sealed class DeliveryChangeReceiptBuilder
         if (authoredChanges.GroupBy(value => new
             {
                 value.EntityKind,
-                value.ChangeKind,
                 value.EntityId,
                 value.PartUri,
                 value.Scope,
-                SourceDigest = value.SourceDigest.Value,
             }).Any(group => group.Count() != 1))
         {
             throw new DeliveryReceiptValidationException(
@@ -381,6 +398,13 @@ public sealed class DeliveryChangeReceiptBuilder
             ResultVersion = result.ResultVersion,
             BeforeDocument = contribution.BeforeDocument,
             AfterDocument = contribution.AfterDocument,
+            ReportedPackageContentDigest = result.PackageHash is null
+                ? null
+                : new VerificationDigest
+                {
+                    Algorithm = DeliveryReceiptValidation.Sha256Algorithm,
+                    Value = result.PackageHash,
+                },
             Operations = operations,
             AuthoredChanges = authoredChanges,
             Warnings = warnings,
@@ -403,7 +427,6 @@ public sealed class DeliveryChangeReceiptBuilder
             }
             propertyNames.Add(property.Name);
         }
-        propertyNames.Sort(StringComparer.Ordinal);
         return new DeliveryOperationEvidence
         {
             Index = index,
@@ -414,7 +437,7 @@ public sealed class DeliveryChangeReceiptBuilder
                 ? null
                 : propertyNames.Count == 0
                     ? "no argument properties"
-                    : $"{propertyNames.Count} argument properties: {string.Join(", ", propertyNames)}",
+                    : $"{propertyNames.Count} argument properties",
             Arguments = _privacyProfile == DeliveryReceiptPrivacyProfile.FullEvidence
                 ? operation.Arguments.Clone()
                 : null,
@@ -463,7 +486,9 @@ public sealed class DeliveryChangeReceiptBuilder
         {
             ResultDigest = DeliveryReceiptCanonicalJson.Digest(canonical),
             Success = result.Success,
-            ErrorCode = result.Error?.Code.ToString(),
+            ErrorCode = result.Error is null
+                ? null
+                : DocxSessionJson.EnumToSnake(result.Error.Code),
             ErrorMessage = result.Error is null
                 ? null
                 : TextEvidence(result.Error.Message, "structured edit error"),
@@ -695,8 +720,7 @@ public sealed class DeliveryChangeReceiptBuilder
             .ThenBy(change => change.ChangeKind)
             .ThenBy(change => change.EntityId, StringComparer.Ordinal)
             .ThenBy(change => change.PartUri, StringComparer.Ordinal)
-            .ThenBy(change => change.Scope, StringComparer.Ordinal)
-            .ThenBy(change => change.SourceDigest.Value, StringComparer.Ordinal);
+            .ThenBy(change => change.Scope, StringComparer.Ordinal);
     }
 
     private static void AddAuthoredChanges<T>(
@@ -726,9 +750,30 @@ public sealed class DeliveryChangeReceiptBuilder
             SourceDigest = DeliveryReceiptCanonicalJson.Digest(canonical.Bytes),
             Author = revision.Author,
             Date = revision.Date,
+            DateUtc = revision.DateUtc,
             Type = revision.Type,
+            Family = revision.Family,
             PartUri = revision.PartUri,
             Scope = revision.Scope,
+            AnchorId = revision.AnchorId,
+            ResolutionStatus = revision.ResolutionStatus,
+            Diagnostic = revision.Diagnostic is null
+                ? null
+                : new DeliveryAuthoredDiagnostic
+                {
+                    Code = DeliveryReceiptValidation.RequireNonBlank(
+                        revision.Diagnostic.Code, "revision diagnostic code", 1024),
+                    Message = TextEvidence(
+                        revision.Diagnostic.Message, "revision diagnostic message"),
+                },
+            ConstituentIds = revision.ConstituentIds
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(value => value, StringComparer.Ordinal)
+                .ToArray(),
+            ConstituentKeys = revision.ConstituentKeys
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(value => value, StringComparer.Ordinal)
+                .ToArray(),
             AffectedAnchorIds = revision.AffectedAnchors.Select(anchor => anchor.Id)
                 .Distinct(StringComparer.Ordinal)
                 .OrderBy(value => value, StringComparer.Ordinal)
@@ -861,6 +906,7 @@ public sealed class DeliveryChangeReceiptBuilder
             input.MediaType, "artifact media type", 512);
         var path = DeliveryReceiptValidation.NormalizeRelativePath(input.RelativePath);
         DeliveryReceiptValidation.ValidateOptionalDigest(input.PageMapDigest, "artifact page-map digest");
+        ValidateInputDocument(input.Document);
         if (input.RendererFingerprint is not null)
             DeliveryReceiptValidation.RequireNonBlank(
                 input.RendererFingerprint, "renderer fingerprint", 4096);
@@ -946,8 +992,10 @@ public sealed class DeliveryChangeReceiptBuilder
             Role = input.Role,
             MediaType = mediaType,
             Availability = input.Availability,
-            UnavailableReason = DeliveryReceiptValidation.RequireNonBlank(
-                input.UnavailableReason, "artifact unavailable reason", 4096),
+            UnavailableReason = ProfiledFreeText(
+                DeliveryReceiptValidation.RequireNonBlank(
+                    input.UnavailableReason, "artifact unavailable reason", 4096),
+                "artifact unavailable reason"),
             RelativePath = path,
             DocumentVersion = input.Document?.DocumentVersion,
             PackageDigest = DeliveryReceiptValidation.CloneOptionalDigest(
@@ -956,6 +1004,61 @@ public sealed class DeliveryChangeReceiptBuilder
             PageMapDigest = DeliveryReceiptValidation.CloneOptionalDigest(input.PageMapDigest),
         };
     }
+
+    private static void ValidateInputDocument(DeliveryDocumentIdentity? document)
+    {
+        if (document is null)
+            return;
+        DeliveryReceiptValidation.ValidatePortableNonNegativeInteger(
+            document.DocumentVersion, "invalid_document_version", "Artifact document version");
+        DeliveryReceiptValidation.RequireNonBlank(
+            document.PackageKind, "artifact package kind", 256);
+        if (!string.Equals(document.PackageKind, "opc", StringComparison.Ordinal))
+        {
+            throw new DeliveryReceiptValidationException(
+                "not_wordprocessing_package", "Artifact document must be an OPC package.");
+        }
+        DeliveryReceiptValidation.RequireOpcMainDocumentUri(
+            document.MainDocumentUri, "artifact main document URI");
+        if (!DeliveryPackageManifestAdapter.IsSupportedSchema(document.PackageManifestSchema))
+        {
+            throw new DeliveryReceiptValidationException(
+                "unsupported_package_manifest", "Artifact package-manifest schema is unsupported.");
+        }
+        DeliveryReceiptValidation.ValidateDigest(
+            document.RawPackageBytesDigest, "artifact package digest");
+        DeliveryReceiptValidation.ValidateOptionalDigest(
+            document.OrderedOpcContentDigest, "artifact content digest");
+        DeliveryReceiptValidation.ValidateOptionalDigest(
+            document.NormalizedSemanticDigest, "artifact semantic digest");
+    }
+
+    private static PackageManifest CloneManifest(PackageManifest manifest) => manifest with
+    {
+        RawPackageBytesDigest = DeliveryReceiptValidation.CloneDigest(
+            manifest.RawPackageBytesDigest),
+        OrderedOpcContentDigest = DeliveryReceiptValidation.CloneOptionalDigest(
+            manifest.OrderedOpcContentDigest),
+        NormalizedSemanticDigest = DeliveryReceiptValidation.CloneOptionalDigest(
+            manifest.NormalizedSemanticDigest),
+        Entries = manifest.Entries.Select(entry => entry with
+        {
+            RawBytesDigest = DeliveryReceiptValidation.CloneOptionalDigest(entry.RawBytesDigest),
+            NormalizedXmlDigest = DeliveryReceiptValidation.CloneOptionalDigest(
+                entry.NormalizedXmlDigest),
+        }).ToArray(),
+        ContentTypes = manifest.ContentTypes.Select(value => value with { }).ToArray(),
+        Relationships = manifest.Relationships.Select(value => value with { }).ToArray(),
+        Facts = manifest.Facts with
+        {
+            Revisions = manifest.Facts.Revisions with { },
+            Annotations = manifest.Facts.Annotations with { },
+        },
+        Findings = manifest.Findings.Select(finding => finding with
+        {
+            Location = finding.Location is null ? null : finding.Location with { },
+        }).ToArray(),
+    };
 
     private IReadOnlyList<DeliveryLineageEvent> MaterializeLineage()
     {
@@ -1097,23 +1200,20 @@ public sealed class DeliveryChangeReceiptBuilder
 
     private IReadOnlyList<DeliveryPackageChange> BuildPackageChanges(
         PackageManifest before,
-        PackageManifest after)
+        PackageManifest after,
+        DeliveryLineageValidationResult lineageValidation)
     {
-        return DeliveryPackageManifestAdapter.Compare(before, after)
-            .Select(candidate => BuildPackageChange(candidate))
+        return DeliveryPackageManifestAdapter.Compare(
+                before, after, _limits.MaxCollectionItems)
+            .Select(candidate => BuildPackageChange(candidate, lineageValidation))
             .ToArray();
     }
 
-    private DeliveryPackageChange BuildPackageChange(DeliveryPackageChangeObservation candidate)
+    private DeliveryPackageChange BuildPackageChange(
+        DeliveryPackageChangeObservation candidate,
+        DeliveryLineageValidationResult lineageValidation)
     {
-        var matching = _attributionRules.Where(rule => Matches(rule, candidate)).ToArray();
-        if (matching.Length > 1)
-        {
-            throw new DeliveryReceiptValidationException(
-                "ambiguous_attribution",
-                "More than one attribution rule matches the same package change.");
-        }
-        var rule = matching.SingleOrDefault();
+        _attributionRules.TryGetValue(AttributionKey(candidate), out var rule);
         if (rule is not null && rule.TransactionEntryId is not null)
         {
             if (!_entriesById.TryGetValue(rule.TransactionEntryId, out var entry))
@@ -1128,6 +1228,12 @@ public sealed class DeliveryChangeReceiptBuilder
                 throw new DeliveryReceiptValidationException(
                     "invalid_attribution_transaction",
                     "Package-change attribution must reference a committed transaction.");
+            }
+            if (!lineageValidation.AppliedTransactionEntryIds.Contains(entry.EntryId))
+            {
+                throw new DeliveryReceiptValidationException(
+                    "unapplied_attribution_transaction",
+                    "Package-change attribution must reference a transaction applied in the delivered state.");
             }
             if (rule.RequestedOperationIndex is { } index
                 && (index < 0 || index >= entry.Operations.Count))
@@ -1152,17 +1258,13 @@ public sealed class DeliveryChangeReceiptBuilder
         var afterEvidence = candidate.After is null
             ? null
             : TextEvidence(candidate.After, "result package record");
-        var identity = new
-        {
-            after = afterEvidence?.Digest,
-            before = beforeEvidence?.Digest,
-            kind = candidate.Kind.ToString(),
-            location = candidate.Location,
-        };
         return new DeliveryPackageChange
         {
-            ChangeId = DeliveryReceiptCanonicalJson.DigestToken(
-                DeliveryReceiptCanonicalJson.SerializeCanonical(identity)),
+            ChangeId = DeliveryReceiptIdentity.PackageChangeId(
+                candidate.Kind,
+                candidate.Location,
+                beforeEvidence?.Digest,
+                afterEvidence?.Digest),
             Kind = candidate.Kind,
             Location = candidate.Location,
             Before = beforeEvidence,
@@ -1170,7 +1272,9 @@ public sealed class DeliveryChangeReceiptBuilder
             Disposition = rule?.Disposition ?? DeliveryChangeDisposition.Unexpected,
             TransactionEntryId = rule?.TransactionEntryId,
             RequestedOperationIndex = rule?.RequestedOperationIndex,
-            Derivation = rule?.Derivation,
+            Derivation = rule?.Derivation is null
+                ? null
+                : ProfiledFreeText(rule.Derivation, "derivation"),
         };
     }
 
@@ -1214,10 +1318,39 @@ public sealed class DeliveryChangeReceiptBuilder
                         "evidence_artifact_role_mismatch",
                         $"Evidence '{reference.Kind}' requires artifact role '{expectedRole}'.");
                 }
+                if (!_artifactBytes.TryGetValue(artifactId, out var evidenceBytes)
+                    || !IsExactEvidence(reference.Kind, evidenceBytes))
+                {
+                    throw new DeliveryReceiptValidationException(
+                        "invalid_evidence_artifact",
+                        $"Evidence artifact '{artifactId}' is not the exact canonical owner contract.");
+                }
             }
             yield return reference;
         }
     }
+
+    private static string ExpectedEvidenceSchema(DeliveryEvidenceKind kind) => kind switch
+    {
+        DeliveryEvidenceKind.ValidationResult => DeliverableVerificationResult.SchemaId,
+        DeliveryEvidenceKind.RedlineReversibility => RedlineReversibilityProof.SchemaId,
+        DeliveryEvidenceKind.SemanticChangeSet =>
+            throw new DeliveryReceiptValidationException(
+                "semantic_evidence_requires_typed_factory",
+                "Semantic evidence must use the typed #457 binding."),
+        _ => throw new DeliveryReceiptValidationException(
+            "unknown_evidence_kind", "Unknown evidence kind."),
+    };
+
+    private static bool IsExactEvidence(DeliveryEvidenceKind kind, ReadOnlySpan<byte> bytes) =>
+        kind switch
+        {
+            DeliveryEvidenceKind.ValidationResult =>
+                DeliverableVerificationResult.IsExactCanonical(bytes),
+            DeliveryEvidenceKind.RedlineReversibility =>
+                RedlineReversibilityProof.IsExactCanonical(bytes),
+            _ => false,
+        };
 
     private DeliveryPageCitation BuildPageCitation(
         DeliveryPageCitationInput input,
@@ -1225,8 +1358,10 @@ public sealed class DeliveryChangeReceiptBuilder
     {
         ArgumentNullException.ThrowIfNull(input.Citation);
         ArgumentNullException.ThrowIfNull(input.Document);
-        if (!lineageValidation.ReachableDocuments.Any(document =>
-                DeliveryReceiptLineageValidator.DocumentEquals(document, input.Document)))
+        if (!lineageValidation.ReachableDocumentsByVersion.TryGetValue(
+                input.Document.DocumentVersion, out var reachableDocument)
+            || !DeliveryReceiptLineageValidator.DocumentEquals(
+                reachableDocument, input.Document))
         {
             throw new DeliveryReceiptValidationException(
                 "unreachable_citation_document",
@@ -1245,12 +1380,11 @@ public sealed class DeliveryChangeReceiptBuilder
                 "missing_citation_artifact", $"Citation artifact '{artifactId}' is unavailable.");
         }
         if (artifact.Role is not (DeliveryArtifactRole.Pdf
-            or DeliveryArtifactRole.PageImage
             or DeliveryArtifactRole.RenderReport))
         {
             throw new DeliveryReceiptValidationException(
                 "non_paginated_citation_artifact",
-                "Page citations require PDF, page-image, or paginated render-report evidence.");
+                "Page citations require PDF or paginated render-report evidence.");
         }
         if (!_artifacts.TryGetValue(pageMapArtifactId, out var pageMapArtifact)
             || pageMapArtifact.Availability != DeliveryArtifactAvailability.Available
@@ -1315,34 +1449,42 @@ public sealed class DeliveryChangeReceiptBuilder
                 "citation_page_map_binding_mismatch",
                 "Page-map artifact does not match the citation document and renderer.");
         }
-        PageMap pageMap;
-        try
+        if (!_validatedPageMaps.TryGetValue(pageMapArtifactId, out var pageMap))
         {
-            // Canonicalization is only a strict UTF-8/JSON/duplicate-property gate. The artifact
-            // digest above remains over the renderer's original bytes.
-            _ = DeliveryReceiptCanonicalJson.CanonicalizeBounded(
-                pageMapBytes, _limits, _limits.MaxPageMapBytes,
-                "page_map_resource_limit");
-            pageMap = DocxSessionJson.ParsePageMap(Encoding.UTF8.GetString(pageMapBytes));
+            try
+            {
+                // Canonicalization is only a strict UTF-8/JSON/duplicate-property gate. The
+                // artifact digest above remains over the renderer's original bytes.
+                _ = DeliveryReceiptCanonicalJson.CanonicalizeBounded(
+                    pageMapBytes, _limits, _limits.MaxPageMapBytes,
+                    "page_map_resource_limit");
+                pageMap = DocxSessionJson.ParsePageMap(Encoding.UTF8.GetString(pageMapBytes));
+            }
+            catch (Exception ex) when (ex is JsonException or FormatException)
+            {
+                throw new DeliveryReceiptValidationException(
+                    "invalid_page_map_artifact",
+                    $"Page-map artifact '{pageMapArtifactId}' is not a valid PageMap: {ex.Message}");
+            }
+            var mapValidation = PageMapContract.ValidatePortable(
+                pageMap, input.Document.DocumentVersion, rendererFingerprint);
+            if (!mapValidation.Success)
+            {
+                throw new DeliveryReceiptValidationException(
+                    "invalid_page_map_artifact",
+                    mapValidation.Message ?? "Page-map artifact is invalid.");
+            }
+            _validatedPageMaps.Add(pageMapArtifactId, pageMap);
         }
-        catch (Exception ex) when (ex is JsonException or FormatException)
+        var projectionKey = (pageMapArtifactId, citation.AnchorId);
+        if (!_pageMapProjections.TryGetValue(projectionKey, out var projected))
         {
-            throw new DeliveryReceiptValidationException(
-                "invalid_page_map_artifact",
-                $"Page-map artifact '{pageMapArtifactId}' is not a valid PageMap: {ex.Message}");
+            projected = PageMapContract.ProjectCitation(
+                pageMap,
+                citation.AnchorId,
+                new PageCitationRequest(citation.DocumentVersion, rendererFingerprint));
+            _pageMapProjections.Add(projectionKey, projected);
         }
-        var mapValidation = PageMapContract.ValidatePortable(
-            pageMap, input.Document.DocumentVersion, rendererFingerprint);
-        if (!mapValidation.Success)
-        {
-            throw new DeliveryReceiptValidationException(
-                "invalid_page_map_artifact",
-                mapValidation.Message ?? "Page-map artifact is invalid.");
-        }
-        var projected = PageMapContract.ProjectCitation(
-            pageMap,
-            citation.AnchorId,
-            new PageCitationRequest(citation.DocumentVersion, rendererFingerprint));
         if (projected.Availability != PageMapAvailability.Available
             || !CitationCoordinatesEqual(citation, projected))
         {
@@ -1398,16 +1540,40 @@ public sealed class DeliveryChangeReceiptBuilder
         };
     }
 
+    private string ProfiledFreeText(string value, string label)
+    {
+        var digest = DeliveryReceiptCanonicalJson.DigestToken(Encoding.UTF8.GetBytes(value));
+        return _privacyProfile switch
+        {
+            DeliveryReceiptPrivacyProfile.HashOnly => digest,
+            DeliveryReceiptPrivacyProfile.HashAndSummary =>
+                $"{label}; {value.Length.ToString(CultureInfo.InvariantCulture)} characters; {digest}",
+            _ => value,
+        };
+    }
+
     private static DeliveryObjectChange ObjectChange(
         DeliveryObjectChangeKind changeKind,
-        Anchor anchor) => new()
+        Anchor anchor)
     {
-        ChangeKind = changeKind,
-        AnchorId = anchor.Id,
-        Kind = anchor.Kind,
-        Scope = anchor.Scope,
-        Unid = anchor.Unid,
-    };
+        var id = DeliveryReceiptValidation.RequireNonBlank(anchor.Id, "anchor id", 4096);
+        var kind = DeliveryReceiptValidation.RequireNonBlank(anchor.Kind, "anchor kind", 256);
+        var scope = DeliveryReceiptValidation.RequireNonBlank(anchor.Scope, "anchor scope", 1024);
+        var unid = DeliveryReceiptValidation.RequireNonBlank(anchor.Unid, "anchor unid", 2048);
+        if (!string.Equals(id, $"{kind}:{scope}:{unid}", StringComparison.Ordinal))
+        {
+            throw new DeliveryReceiptValidationException(
+                "invalid_anchor_id", "Changed anchor identity is inconsistent.");
+        }
+        return new DeliveryObjectChange
+        {
+            ChangeKind = changeKind,
+            AnchorId = id,
+            Kind = kind,
+            Scope = scope,
+            Unid = unid,
+        };
+    }
 
     private static DeliveryTransactionStatus TransactionStatus(MutationBatchResult result)
     {
@@ -1428,20 +1594,7 @@ public sealed class DeliveryChangeReceiptBuilder
         MutationBatchMode mode,
         IReadOnlyList<DeliveryNormalizedOperation> operations)
     {
-        var shape = new
-        {
-            mode = mode == MutationBatchMode.Atomic ? "atomic" : "bestEffort",
-            operations = operations.Select(operation => new
-            {
-                action = operation.Action,
-                arguments = operation.Arguments,
-                tool = operation.Tool,
-            }).ToArray(),
-        };
-        return DeliveryReceiptCanonicalJson.DigestToken(
-            DeliveryReceiptCanonicalJson.SerializeCanonicalBounded(
-                shape, _limits, _limits.MaxReceiptJsonBytes,
-                "receipt_resource_limit"));
+        return DeliveryReceiptIdentity.RequestFingerprint(mode, operations, _limits);
     }
 
     private static string DeriveEntryId(
@@ -1453,30 +1606,22 @@ public sealed class DeliveryChangeReceiptBuilder
         string? transactionId,
         long sequence)
     {
-        var identity = new
-        {
-            afterPackage = after.RawPackageBytesDigest,
-            baseVersion,
-            beforePackage = before.RawPackageBytesDigest,
+        return DeliveryReceiptIdentity.TransactionEntryId(
             requestFingerprint,
+            before,
+            after,
+            baseVersion,
             resultVersion,
             transactionId,
-            transactionSequence = transactionId is null ? sequence : (long?)null,
-        };
-        return DeliveryReceiptCanonicalJson.DigestToken(
-            DeliveryReceiptCanonicalJson.SerializeCanonical(identity));
+            sequence);
     }
 
     private bool TransactionEvidenceEquals(
         DeliveryTransactionEntry left,
         DeliveryTransactionEntry right)
     {
-        var leftBytes = DeliveryReceiptCanonicalJson.SerializeCanonicalBounded(
-            left with { Sequence = 0 }, _limits, _limits.MaxReceiptJsonBytes,
-            "receipt_resource_limit");
-        var rightBytes = DeliveryReceiptCanonicalJson.SerializeCanonicalBounded(
-            right with { Sequence = 0 }, _limits, _limits.MaxReceiptJsonBytes,
-            "receipt_resource_limit");
+        var leftBytes = DeliveryReceiptIdentity.TransactionEvidence(left, _limits);
+        var rightBytes = DeliveryReceiptIdentity.TransactionEvidence(right, _limits);
         return leftBytes.AsSpan().SequenceEqual(rightBytes);
     }
 
@@ -1572,6 +1717,7 @@ public sealed class DeliveryChangeReceiptBuilder
             budget.String(revision.Type, "revision type");
             budget.String(revision.Author, "revision author");
             budget.String(revision.Date, "revision date");
+            budget.String(revision.DateUtc, "revision UTC date");
             budget.String(revision.Text, "revision text");
             budget.String(revision.PartUri, "revision part URI");
             budget.String(revision.Scope, "revision scope");
@@ -1579,6 +1725,9 @@ public sealed class DeliveryChangeReceiptBuilder
             budget.AddItems(revision.ConstituentIds.Count, "revision constituent ids");
             foreach (var id in revision.ConstituentIds)
                 budget.String(id, "revision constituent id");
+            budget.AddItems(revision.ConstituentKeys.Count, "revision constituent keys");
+            foreach (var key in revision.ConstituentKeys)
+                budget.String(key, "revision constituent key");
             budget.AddItems(revision.AffectedAnchors.Count, "revision affected anchors");
             foreach (var anchor in revision.AffectedAnchors)
                 AccountAnchor(anchor, budget);
@@ -1872,16 +2021,19 @@ public sealed class DeliveryChangeReceiptBuilder
             "receipt_resource_limit"), element);
     }
 
-    private static bool Matches(
-        DeliveryChangeAttributionRule rule,
-        DeliveryPackageChangeObservation candidate) =>
-        rule.Kind == candidate.Kind
-        && (rule.EntryUri is null || string.Equals(
-            rule.EntryUri, candidate.Location.EntryUri, StringComparison.Ordinal))
-        && (rule.OwnerUri is null || string.Equals(
-            rule.OwnerUri, candidate.Location.OwnerUri, StringComparison.Ordinal))
-        && (rule.RelationshipId is null || string.Equals(
-            rule.RelationshipId, candidate.Location.RelationshipId, StringComparison.Ordinal));
+    private static DeliveryAttributionKey AttributionKey(
+        DeliveryChangeAttributionRule rule) => new(
+            rule.Kind,
+            rule.EntryUri ?? string.Empty,
+            rule.OwnerUri ?? string.Empty,
+            rule.RelationshipId ?? string.Empty);
+
+    private static DeliveryAttributionKey AttributionKey(
+        DeliveryPackageChangeObservation candidate) => new(
+            candidate.Kind,
+            candidate.Location.EntryUri ?? string.Empty,
+            candidate.Location.OwnerUri ?? string.Empty,
+            candidate.Location.RelationshipId ?? string.Empty);
 
     private static void ValidateAttributionRule(DeliveryChangeAttributionRule rule)
     {
@@ -1922,4 +2074,10 @@ public sealed class DeliveryChangeReceiptBuilder
         if (rule.Disposition == DeliveryChangeDisposition.Derived)
             DeliveryReceiptValidation.RequireNonBlank(rule.Derivation, "derivation", 4096);
     }
+
+    private readonly record struct DeliveryAttributionKey(
+        DeliveryPackageChangeKind Kind,
+        string EntryUri,
+        string OwnerUri,
+        string RelationshipId);
 }

--- a/Docxodus/Verification/DeliveryChangeReceiptBuilder.cs
+++ b/Docxodus/Verification/DeliveryChangeReceiptBuilder.cs
@@ -828,7 +828,9 @@ public sealed class DeliveryChangeReceiptBuilder
                 annotation.Id, "annotation id", 2048),
             SourceDigest = DeliveryReceiptCanonicalJson.Digest(canonical.Bytes),
             Author = annotation.Author,
-            Date = annotation.Created?.ToString("O", CultureInfo.InvariantCulture),
+            Date = annotation.Created is { } created
+                ? DocxSessionJson.UtcRoundtrip(created)
+                : null,
             Type = annotation.LabelId,
             AffectedAnchorIds = Array.Empty<string>(),
             Text = TextEvidence(annotation.AnnotatedText ?? string.Empty, "annotation text"),

--- a/Docxodus/Verification/DeliveryChangeReceiptBuilder.cs
+++ b/Docxodus/Verification/DeliveryChangeReceiptBuilder.cs
@@ -141,6 +141,8 @@ public sealed class DeliveryChangeReceiptBuilder
             throw new ArgumentOutOfRangeException(nameof(lineageEvent));
         DeliveryReceiptValidation.RequireNonBlank(
             lineageEvent.AffectedEntryId, "affected entry id", 256);
+        DeliveryReceiptValidation.ValidateDocument(lineageEvent.BeforeDocument);
+        DeliveryReceiptValidation.ValidateDocument(lineageEvent.AfterDocument);
         EnsureCollectionCapacity(_lineage.Count, "lineage events");
         _lineage.Add((_nextSequence++, lineageEvent));
         return this;
@@ -191,7 +193,18 @@ public sealed class DeliveryChangeReceiptBuilder
         {
             RegisterArtifact(artifactInput);
         }
-        _semanticChangeSets.Add((input, projection));
+        // An exact re-registration is an idempotent transport retry, mirroring the
+        // AddTransaction retry contract; the artifact-conflict check above has already
+        // rejected same-id registrations that differ in bytes or metadata.
+        bool duplicate = _semanticChangeSets.Any(entry =>
+            entry.Input.Scope == input.Scope
+            && string.Equals(entry.Input.ArtifactId, input.ArtifactId, StringComparison.Ordinal)
+            && string.Equals(entry.Input.TransactionEntryId, input.TransactionEntryId,
+                StringComparison.Ordinal)
+            && entry.Projection.CanonicalBytes.AsSpan().SequenceEqual(
+                projection.CanonicalBytes));
+        if (!duplicate)
+            _semanticChangeSets.Add((input, projection));
         return this;
     }
 
@@ -390,8 +403,8 @@ public sealed class DeliveryChangeReceiptBuilder
             requestFingerprint,
             contribution.BeforeDocument,
             contribution.AfterDocument,
-            result.BaseVersion,
-            result.ResultVersion,
+            contribution.BeforeDocument.DocumentVersion,
+            contribution.AfterDocument.DocumentVersion,
             contribution.Identity?.TransactionId,
             sequence);
 
@@ -427,8 +440,8 @@ public sealed class DeliveryChangeReceiptBuilder
             RequestFingerprint = requestFingerprint,
             Mode = result.Mode,
             Status = TransactionStatus(result),
-            BaseVersion = result.BaseVersion,
-            ResultVersion = result.ResultVersion,
+            BaseVersion = contribution.BeforeDocument.DocumentVersion,
+            ResultVersion = contribution.AfterDocument.DocumentVersion,
             BeforeDocument = contribution.BeforeDocument,
             AfterDocument = contribution.AfterDocument,
             ReportedPackageContentDigest = result.PackageHash is null

--- a/Docxodus/Verification/DeliveryChangeReceiptBuilder.cs
+++ b/Docxodus/Verification/DeliveryChangeReceiptBuilder.cs
@@ -1,0 +1,1886 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Globalization;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using Docxodus.Internal;
+
+namespace Docxodus.Verification;
+
+/// <summary>
+/// Composes immutable transaction, package, render, and artifact evidence into one receipt. This
+/// type performs no mutation or rendering. It does independently re-inspect the exact clean-DOCX
+/// bytes and strictly reconstruct typed semantic evidence before binding either artifact.
+/// </summary>
+public sealed class DeliveryChangeReceiptBuilder
+{
+    private readonly PackageManifest _sourceManifest;
+    private readonly DeliveryDocumentIdentity _sourceDocument;
+    private readonly DeliveryReceiptPrivacyProfile _privacyProfile;
+    private readonly DeliveryReceiptLimits _limits;
+    private readonly List<DeliveryTransactionEntry> _transactions = new();
+    private readonly Dictionary<string, DeliveryTransactionEntry> _entriesById =
+        new(StringComparer.Ordinal);
+    private readonly Dictionary<string, DeliveryTransactionEntry> _entriesByTransactionId =
+        new(StringComparer.Ordinal);
+    private readonly List<(long Sequence, DeliveryLineageEventInput Input)> _lineage = new();
+    private readonly Dictionary<string, DeliveryArtifact> _artifacts = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, byte[]> _artifactBytes = new(StringComparer.Ordinal);
+    private readonly List<DeliveryPageCitationInput> _citations = new();
+    private readonly List<DeliveryEvidenceReference> _evidence = new();
+    private readonly List<(DeliverySemanticChangeSetInput Input,
+        DeliverySemanticChangeSetProjection Projection)> _semanticChangeSets = new();
+    private readonly List<DeliveryChangeAttributionRule> _attributionRules = new();
+    private readonly List<string> _warnings = new();
+    private long _nextSequence;
+    private DeliveryDocumentIdentity? _deliveredDocument;
+    private long _totalArtifactBytes;
+
+    public DeliveryChangeReceiptBuilder(
+        PackageManifest sourceManifest,
+        long sourceDocumentVersion,
+        DeliveryReceiptPrivacyProfile privacyProfile =
+            DeliveryReceiptPrivacyProfile.HashAndSummary,
+        DeliveryReceiptLimits? limits = null)
+    {
+        ArgumentNullException.ThrowIfNull(sourceManifest);
+        if (!Enum.IsDefined(privacyProfile))
+            throw new ArgumentOutOfRangeException(nameof(privacyProfile));
+        _limits = (limits ?? new DeliveryReceiptLimits()).ValidateAndClone();
+        ValidateManifestResources(sourceManifest);
+        _sourceManifest = sourceManifest;
+        _sourceDocument = DeliveryDocumentIdentity.FromManifest(
+            sourceManifest, sourceDocumentVersion);
+        _privacyProfile = privacyProfile;
+    }
+
+    /// <summary>When true, Build rejects rather than merely reporting unexpected package changes.</summary>
+    public bool FailOnUnexpectedChanges { get; set; }
+
+    public DeliveryChangeReceiptBuilder SetDeliveredDocument(
+        PackageManifest manifest,
+        long documentVersion)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+        _deliveredDocument = DeliveryDocumentIdentity.FromManifest(manifest, documentVersion);
+        return this;
+    }
+
+    /// <summary>
+    /// Add one batch result. An identical idempotent retry returns the original entry id and does
+    /// not append a second edit. Conflicting transaction reuse fails closed.
+    /// </summary>
+    public string AddTransaction(DeliveryTransactionContribution contribution)
+    {
+        ArgumentNullException.ThrowIfNull(contribution);
+        ValidateContributionResources(contribution);
+        var entry = BuildTransactionEntry(contribution, _nextSequence);
+
+        if (contribution.Identity is { } identity
+            && _entriesByTransactionId.TryGetValue(identity.TransactionId, out var prior))
+        {
+            if (!string.Equals(prior.RequestFingerprint, entry.RequestFingerprint,
+                    StringComparison.Ordinal))
+            {
+                throw new DeliveryReceiptValidationException(
+                    "transaction_conflict",
+                    $"Transaction id '{identity.TransactionId}' has a different request fingerprint.");
+            }
+            if (!string.Equals(prior.EntryId, entry.EntryId, StringComparison.Ordinal))
+            {
+                throw new DeliveryReceiptValidationException(
+                    "retry_result_conflict",
+                    $"Transaction id '{identity.TransactionId}' no longer identifies the original result.");
+            }
+            return prior.EntryId;
+        }
+
+        if (_entriesById.TryGetValue(entry.EntryId, out var duplicate))
+            return duplicate.EntryId;
+
+        if (_transactions.Count >= _limits.MaxTransactions)
+        {
+            throw new DeliveryReceiptValidationException(
+                "receipt_resource_limit", "Receipt transaction limit exceeded.");
+        }
+
+        _transactions.Add(entry);
+        _entriesById.Add(entry.EntryId, entry);
+        if (entry.TransactionId is not null)
+            _entriesByTransactionId.Add(entry.TransactionId, entry);
+        _nextSequence++;
+        return entry.EntryId;
+    }
+
+    public DeliveryChangeReceiptBuilder AddLineageEvent(DeliveryLineageEventInput lineageEvent)
+    {
+        ArgumentNullException.ThrowIfNull(lineageEvent);
+        if (!Enum.IsDefined(lineageEvent.Action))
+            throw new ArgumentOutOfRangeException(nameof(lineageEvent));
+        DeliveryReceiptValidation.RequireNonBlank(
+            lineageEvent.AffectedEntryId, "affected entry id", 256);
+        EnsureCollectionCapacity(_lineage.Count, "lineage events");
+        _lineage.Add((_nextSequence++, lineageEvent));
+        return this;
+    }
+
+    public DeliveryChangeReceiptBuilder AddArtifact(DeliveryArtifactInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        RegisterArtifact(input);
+        return this;
+    }
+
+    /// <summary>
+    /// Add exact canonical #457 evidence. One source-to-delivered binding and one binding for every
+    /// state-changing transaction are required at Build time.
+    /// </summary>
+    public DeliveryChangeReceiptBuilder AddSemanticChangeSet(
+        DeliverySemanticChangeSetInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        if (!Enum.IsDefined(input.Scope))
+            throw new ArgumentOutOfRangeException(nameof(input));
+
+        EnsureCollectionCapacity(_semanticChangeSets.Count, "semantic change sets");
+        var projection = DeliverySemanticChangeSetAdapter.Project(input.ChangeSet, _limits);
+        var artifactInput = DeliveryArtifactInput.Available(
+            input.ArtifactId,
+            DeliveryArtifactRole.SemanticDiff,
+            "application/json",
+            projection.CanonicalBytes) with
+        {
+            RelativePath = input.RelativePath,
+        };
+        var artifact = BuildArtifact(artifactInput);
+        if (_artifacts.TryGetValue(artifact.ArtifactId, out var existing))
+        {
+            if (!ArtifactEquals(existing, artifact)
+                || !_artifactBytes.TryGetValue(artifact.ArtifactId, out var existingBytes)
+                || !existingBytes.AsSpan().SequenceEqual(projection.CanonicalBytes))
+            {
+                throw new DeliveryReceiptValidationException(
+                    "semantic_artifact_conflict",
+                    $"Semantic artifact id '{artifact.ArtifactId}' identifies different bytes or metadata.");
+            }
+        }
+        else
+        {
+            RegisterArtifact(artifactInput);
+        }
+        _semanticChangeSets.Add((input, projection));
+        return this;
+    }
+
+    public DeliveryChangeReceiptBuilder AddPageCitation(DeliveryPageCitationInput citation)
+    {
+        ArgumentNullException.ThrowIfNull(citation);
+        EnsureCollectionCapacity(_citations.Count, "page citations");
+        _citations.Add(citation);
+        return this;
+    }
+
+    public DeliveryChangeReceiptBuilder AddEvidence(DeliveryEvidenceReference evidence)
+    {
+        ArgumentNullException.ThrowIfNull(evidence);
+        EnsureCollectionCapacity(_evidence.Count, "evidence references");
+        if (!Enum.IsDefined(evidence.Kind))
+            throw new ArgumentOutOfRangeException(nameof(evidence));
+        if (evidence.Kind == DeliveryEvidenceKind.SemanticChangeSet)
+        {
+            throw new DeliveryReceiptValidationException(
+                "semantic_evidence_requires_typed_factory",
+                "Semantic evidence must be registered from a SemanticChangeSet instance.");
+        }
+        DeliveryReceiptValidation.RequireNonBlank(evidence.Schema, "evidence schema", 2048);
+        DeliveryReceiptValidation.ValidateDigest(evidence.Digest, "evidence digest");
+        if (evidence.ArtifactId is not null)
+            DeliveryReceiptValidation.RequireNonBlank(evidence.ArtifactId, "evidence artifact id", 256);
+        _evidence.Add(evidence with
+        {
+            Digest = DeliveryReceiptValidation.CloneDigest(evidence.Digest),
+            Summary = _privacyProfile == DeliveryReceiptPrivacyProfile.HashOnly
+                ? null
+                : evidence.Summary,
+        });
+        return this;
+    }
+
+    public DeliveryChangeReceiptBuilder AddAttributionRule(DeliveryChangeAttributionRule rule)
+    {
+        ArgumentNullException.ThrowIfNull(rule);
+        EnsureCollectionCapacity(_attributionRules.Count, "attribution rules");
+        ValidateAttributionRule(rule);
+        _attributionRules.Add(rule);
+        return this;
+    }
+
+    public DeliveryChangeReceiptBuilder AddWarning(string warning)
+    {
+        EnsureCollectionCapacity(_warnings.Count, "warnings");
+        _warnings.Add(DeliveryReceiptValidation.RequireNonBlank(
+            warning, "warning", Math.Min(16_384, _limits.MaxStringLength)));
+        return this;
+    }
+
+    public DeliveryChangeReceipt Build()
+    {
+        if (_deliveredDocument is null)
+        {
+            throw new DeliveryReceiptValidationException(
+                "missing_delivered_document", "SetDeliveredDocument must be called before Build.");
+        }
+
+        var lineage = MaterializeLineage();
+        var lineageValidation = DeliveryReceiptLineageValidator.Validate(
+            _sourceDocument, _deliveredDocument, _transactions, lineage);
+        if (!lineageValidation.IsValid)
+        {
+            throw new DeliveryReceiptValidationException(
+                lineageValidation.Findings[0],
+                "Transaction and undo/redo history is not a valid delivery lineage.");
+        }
+        var deliveredManifest = ValidateRequiredCleanDocx(_deliveredDocument);
+        var semanticChangeSets = BuildSemanticChangeSetBindings(lineageValidation);
+        var packageChanges = BuildPackageChanges(_sourceManifest, deliveredManifest);
+        if (FailOnUnexpectedChanges
+            && packageChanges.Any(change =>
+                change.Disposition == DeliveryChangeDisposition.Unexpected))
+        {
+            throw new DeliveryReceiptValidationException(
+                "unexpected_package_change",
+                "At least one package change was not covered by an attribution rule.");
+        }
+
+        var artifacts = _artifacts.Values
+            .OrderBy(artifact => artifact.ArtifactId, StringComparer.Ordinal)
+            .ToArray();
+        var evidence = ValidateEvidence().ToArray();
+        if (evidence.GroupBy(value => new
+            {
+                value.Kind,
+                value.Schema,
+                Digest = value.Digest.Value,
+            }).Any(group => group.Count() != 1))
+        {
+            throw new DeliveryReceiptValidationException(
+                "duplicate_evidence", "Receipt evidence identities must be unique.");
+        }
+        var citations = _citations
+            .Select(citation => BuildPageCitation(citation, lineageValidation))
+            .OrderBy(citation => citation.AnchorId, StringComparer.Ordinal)
+            .ThenBy(citation => citation.RenderArtifactId, StringComparer.Ordinal)
+            .ThenBy(citation => citation.PageMapArtifactId, StringComparer.Ordinal)
+            .ToArray();
+        if (citations.GroupBy(value => new
+            {
+                value.AnchorId,
+                value.RenderArtifactId,
+                value.PageMapArtifactId,
+            }).Any(group => group.Count() != 1))
+        {
+            throw new DeliveryReceiptValidationException(
+                "duplicate_page_citation", "Page-citation identities must be unique.");
+        }
+        var warnings = _warnings
+            .Distinct(StringComparer.Ordinal)
+            .Select(value => TextEvidence(value, "warning"))
+            .OrderBy(value => value.Digest.Value, StringComparer.Ordinal)
+            .ToArray();
+
+        var payload = new DeliveryChangeReceiptPayload
+        {
+            PrivacyProfile = _privacyProfile,
+            SourceDocument = _sourceDocument,
+            DeliveredDocument = _deliveredDocument,
+            Transactions = _transactions.ToArray(),
+            Lineage = lineage,
+            PackageChanges = packageChanges,
+            HasUnexpectedChanges = packageChanges.Any(change =>
+                change.Disposition == DeliveryChangeDisposition.Unexpected),
+            Evidence = evidence,
+            SemanticChangeSets = semanticChangeSets,
+            Artifacts = artifacts,
+            PageCitations = citations,
+            Warnings = warnings,
+        };
+        DeliveryReceiptResourceValidator.ValidatePayload(payload, _limits);
+        return DeliveryChangeReceiptSerializer.Create(payload, _limits);
+    }
+
+    private DeliveryTransactionEntry BuildTransactionEntry(
+        DeliveryTransactionContribution contribution,
+        long sequence)
+    {
+        var result = contribution.Result;
+        var requestFingerprint = contribution.Identity?.RequestFingerprint
+            ?? DeriveRequestFingerprint(result.Mode, contribution.Operations);
+        DeliveryTransactionContribution.ValidateFingerprint(requestFingerprint);
+        var entryId = DeriveEntryId(
+            requestFingerprint,
+            contribution.BeforeDocument,
+            contribution.AfterDocument,
+            result.BaseVersion,
+            result.ResultVersion);
+
+        var stepsByIndex = result.Steps.ToDictionary(step => step.Index);
+        var operations = contribution.Operations.Select((operation, index) =>
+            BuildOperationEvidence(
+                index,
+                operation,
+                stepsByIndex.TryGetValue(index, out var step) ? step : null)).ToArray();
+        var authoredChanges = BuildAuthoredChanges(result).ToArray();
+        if (authoredChanges.GroupBy(value => new
+            {
+                value.EntityKind,
+                value.ChangeKind,
+                value.EntityId,
+            }).Any(group => group.Count() != 1))
+        {
+            throw new DeliveryReceiptValidationException(
+                "duplicate_authored_change", "Authored-change identities must be unique.");
+        }
+        var warnings = result.Warnings
+            .Distinct(StringComparer.Ordinal)
+            .Select(value => TextEvidence(value, "transaction warning"))
+            .OrderBy(value => value.Digest.Value, StringComparer.Ordinal)
+            .ToArray();
+
+        return new DeliveryTransactionEntry
+        {
+            Sequence = sequence,
+            EntryId = entryId,
+            TransactionId = contribution.Identity?.TransactionId,
+            RequestFingerprint = requestFingerprint,
+            Mode = result.Mode,
+            Status = TransactionStatus(result),
+            BaseVersion = result.BaseVersion,
+            ResultVersion = result.ResultVersion,
+            BeforeDocument = contribution.BeforeDocument,
+            AfterDocument = contribution.AfterDocument,
+            Operations = operations,
+            AuthoredChanges = authoredChanges,
+            Warnings = warnings,
+        };
+    }
+
+    private DeliveryOperationEvidence BuildOperationEvidence(
+        int index,
+        DeliveryNormalizedOperation operation,
+        MutationBatchStepResult? step)
+    {
+        var propertyNames = new List<string>();
+        foreach (var property in operation.Arguments.EnumerateObject())
+        {
+            if (propertyNames.Count >= _limits.MaxCollectionItems)
+            {
+                throw new DeliveryReceiptValidationException(
+                    "receipt_resource_limit",
+                    "Operation argument properties exceed the item limit.");
+            }
+            propertyNames.Add(property.Name);
+        }
+        propertyNames.Sort(StringComparer.Ordinal);
+        return new DeliveryOperationEvidence
+        {
+            Index = index,
+            Tool = operation.Tool,
+            Action = operation.Action,
+            ArgumentsDigest = DeliveryReceiptValidation.CloneDigest(operation.ArgumentsDigest),
+            ArgumentsSummary = _privacyProfile == DeliveryReceiptPrivacyProfile.HashOnly
+                ? null
+                : propertyNames.Count == 0
+                    ? "no argument properties"
+                    : $"{propertyNames.Count} argument properties: {string.Join(", ", propertyNames)}",
+            Arguments = _privacyProfile == DeliveryReceiptPrivacyProfile.FullEvidence
+                ? operation.Arguments.Clone()
+                : null,
+            ExecutionStatus = OperationExecutionStatus(step),
+            Success = step?.Success ?? false,
+            RolledBack = step?.RolledBack ?? false,
+            Results = step?.Results.Select(BuildOperationResult).ToArray()
+                ?? Array.Empty<DeliveryOperationResultEvidence>(),
+        };
+    }
+
+    private static DeliveryOperationExecutionStatus OperationExecutionStatus(
+        MutationBatchStepResult? step) => step switch
+        {
+            null => DeliveryOperationExecutionStatus.NotExecuted,
+            { Success: true, RolledBack: false } =>
+                DeliveryOperationExecutionStatus.Succeeded,
+            { Success: false, RolledBack: false } =>
+                DeliveryOperationExecutionStatus.Failed,
+            { Success: true, RolledBack: true } =>
+                DeliveryOperationExecutionStatus.SucceededRolledBack,
+            _ => DeliveryOperationExecutionStatus.FailedRolledBack,
+        };
+
+    private DeliveryOperationResultEvidence BuildOperationResult(EditResult result)
+    {
+        var serialized = SerializeEditResultBounded(result);
+        var canonical = DeliveryReceiptCanonicalJson.CanonicalizeBounded(
+            serialized, _limits, _limits.MaxReceiptJsonBytes,
+            "receipt_resource_limit");
+        var changes = new List<DeliveryObjectChange>();
+        changes.AddRange(result.Created.Select(anchor => ObjectChange(
+            DeliveryObjectChangeKind.Added, anchor)));
+        changes.AddRange(result.Removed.Select(anchor => ObjectChange(
+            DeliveryObjectChangeKind.Removed, anchor)));
+        changes.AddRange(result.Modified.Select(anchor => ObjectChange(
+            DeliveryObjectChangeKind.Modified, anchor)));
+        if (changes.GroupBy(value => new { value.ChangeKind, value.AnchorId })
+            .Any(group => group.Count() != 1))
+        {
+            throw new DeliveryReceiptValidationException(
+                "duplicate_object_change", "Object-change identities must be unique.");
+        }
+
+        return new DeliveryOperationResultEvidence
+        {
+            ResultDigest = DeliveryReceiptCanonicalJson.Digest(canonical),
+            Success = result.Success,
+            ErrorCode = result.Error?.Code.ToString(),
+            ErrorMessage = result.Error is null
+                ? null
+                : TextEvidence(result.Error.Message, "structured edit error"),
+            ObjectChanges = changes
+                .OrderBy(change => change.ChangeKind)
+                .ThenBy(change => change.AnchorId, StringComparer.Ordinal)
+                .ToArray(),
+            FullResult = _privacyProfile == DeliveryReceiptPrivacyProfile.FullEvidence
+                ? ParseCanonical(canonical)
+                : null,
+        };
+    }
+
+    private byte[] SerializeEditResultBounded(EditResult result)
+    {
+        using var stream = new DeliveryReceiptBoundedMemoryStream(
+            _limits.MaxReceiptJsonBytes,
+            "receipt_resource_limit",
+            "Operation result JSON");
+        using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
+        {
+            Encoder = JavaScriptEncoder.Default,
+            Indented = false,
+            MaxDepth = _limits.MaxJsonDepth,
+        }))
+        {
+            WriteEditResult(writer, result);
+        }
+        return stream.ToArray();
+    }
+
+    private static void WriteEditResult(Utf8JsonWriter writer, EditResult result)
+    {
+        writer.WriteStartObject();
+        writer.WriteBoolean("success", result.Success);
+        if (result.Error is { } error)
+        {
+            writer.WriteStartObject("error");
+            writer.WriteString("code", DocxSessionJson.EnumToSnake(error.Code));
+            writer.WriteString("message", error.Message);
+            if (error.AnchorId is not null)
+                writer.WriteString("anchorId", error.AnchorId);
+            if (error.Precondition is { } precondition)
+            {
+                writer.WriteStartObject("precondition");
+                writer.WriteString("condition", precondition.Condition);
+                writer.WritePropertyName("expected");
+                WritePreconditionValue(writer, precondition.Expected);
+                writer.WritePropertyName("actual");
+                WritePreconditionValue(writer, precondition.Actual);
+                writer.WriteNumber("currentVersion", precondition.CurrentVersion);
+                if (precondition.CurrentTarget is { } target)
+                {
+                    writer.WriteStartObject("currentTarget");
+                    writer.WriteBoolean("exists", target.Exists);
+                    WriteOptionalString(writer, "anchorId", target.AnchorId);
+                    WriteOptionalString(writer, "kind", target.Kind);
+                    WriteOptionalString(writer, "scope", target.Scope);
+                    WriteOptionalString(writer, "contentHash", target.ContentHash);
+                    WriteOptionalString(writer, "visibleText", target.VisibleText);
+                    writer.WriteEndObject();
+                }
+                writer.WriteEndObject();
+            }
+            writer.WriteEndObject();
+        }
+        WriteAnchors(writer, "created", result.Created);
+        WriteAnchors(writer, "removed", result.Removed);
+        WriteAnchors(writer, "modified", result.Modified);
+        if (result.TableAnchors is { } tableAnchors)
+            WriteTableAnchorMapping(writer, tableAnchors);
+        WriteOptionalString(writer, "annotationId", result.AnnotationId);
+        WriteOptionalString(writer, "hyperlinkId", result.HyperlinkId);
+        WriteOptionalString(writer, "bookmarkName", result.BookmarkName);
+        WriteOptionalString(writer, "imageId", result.ImageId);
+        if (result.Patch is { } patch)
+        {
+            writer.WriteStartObject("patch");
+            writer.WriteString("scopeAnchorId", patch.ScopeAnchorId);
+            writer.WriteString("markdown", patch.Markdown);
+            writer.WriteEndObject();
+        }
+        writer.WriteEndObject();
+    }
+
+    private static void WritePreconditionValue(Utf8JsonWriter writer, object? value)
+    {
+        switch (value)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case string text:
+                writer.WriteStringValue(text);
+                break;
+            case bool boolean:
+                writer.WriteBooleanValue(boolean);
+                break;
+            case byte number:
+                writer.WriteNumberValue(number);
+                break;
+            case sbyte number:
+                writer.WriteNumberValue(number);
+                break;
+            case short number:
+                writer.WriteNumberValue(number);
+                break;
+            case ushort number:
+                writer.WriteNumberValue(number);
+                break;
+            case int number:
+                writer.WriteNumberValue(number);
+                break;
+            case uint number:
+                writer.WriteNumberValue(number);
+                break;
+            case long number:
+                writer.WriteNumberValue(number);
+                break;
+            case ulong number:
+                writer.WriteNumberValue(number);
+                break;
+            case float number:
+                writer.WriteNumberValue(number);
+                break;
+            case double number:
+                writer.WriteNumberValue(number);
+                break;
+            case decimal number:
+                writer.WriteNumberValue(number);
+                break;
+            case JsonElement json:
+                json.WriteTo(writer);
+                break;
+            default:
+                throw new DeliveryReceiptValidationException(
+                    "invalid_batch_evidence",
+                    "Precondition evidence must be a JSON scalar or JsonElement.");
+        }
+    }
+
+    private static void WriteAnchors(
+        Utf8JsonWriter writer,
+        string propertyName,
+        IReadOnlyList<Anchor> anchors)
+    {
+        writer.WriteStartArray(propertyName);
+        foreach (var anchor in anchors)
+            WriteAnchor(writer, anchor);
+        writer.WriteEndArray();
+    }
+
+    private static void WriteAnchor(Utf8JsonWriter writer, Anchor anchor)
+    {
+        writer.WriteStartObject();
+        writer.WriteString("id", anchor.Id);
+        writer.WriteString("kind", anchor.Kind);
+        writer.WriteString("scope", anchor.Scope);
+        writer.WriteString("unid", anchor.Unid);
+        writer.WriteEndObject();
+    }
+
+    private static void WriteTableAnchorMapping(
+        Utf8JsonWriter writer,
+        TableAnchorMapping mapping)
+    {
+        writer.WriteStartObject("tableAnchors");
+        writer.WriteStartArray("retained");
+        foreach (var retained in mapping.Retained)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("before");
+            WriteTableAnchorLocation(writer, retained.Before);
+            writer.WritePropertyName("after");
+            WriteTableAnchorLocation(writer, retained.After);
+            writer.WriteEndObject();
+        }
+        writer.WriteEndArray();
+        writer.WriteStartArray("added");
+        foreach (var added in mapping.Added)
+            WriteTableAnchorLocation(writer, added);
+        writer.WriteEndArray();
+        writer.WriteStartArray("invalidated");
+        foreach (var invalidated in mapping.Invalidated)
+            WriteTableAnchorLocation(writer, invalidated);
+        writer.WriteEndArray();
+        writer.WriteEndObject();
+    }
+
+    private static void WriteTableAnchorLocation(
+        Utf8JsonWriter writer,
+        TableAnchorLocation location)
+    {
+        writer.WriteStartObject();
+        writer.WritePropertyName("anchor");
+        WriteAnchor(writer, location.Anchor);
+        writer.WriteString(
+            "entityKind", location.EntityKind.ToString().ToLowerInvariant());
+        if (location.RowIndex is { } rowIndex)
+            writer.WriteNumber("rowIndex", rowIndex);
+        if (location.ColumnIndex is { } columnIndex)
+            writer.WriteNumber("columnIndex", columnIndex);
+        if (location.RowSpan is { } rowSpan)
+            writer.WriteNumber("rowSpan", rowSpan);
+        if (location.ColumnSpan is { } columnSpan)
+            writer.WriteNumber("columnSpan", columnSpan);
+        if (location.IsVirtual)
+            writer.WriteBoolean("isVirtual", true);
+        writer.WriteEndObject();
+    }
+
+    private static void WriteOptionalString(
+        Utf8JsonWriter writer,
+        string propertyName,
+        string? value)
+    {
+        if (value is not null)
+            writer.WriteString(propertyName, value);
+    }
+
+    private IEnumerable<DeliveryAuthoredChange> BuildAuthoredChanges(MutationBatchResult result)
+    {
+        var changes = new List<DeliveryAuthoredChange>();
+        AddAuthoredChanges(changes, result.RevisionChanges, BuildRevisionChange);
+        AddAuthoredChanges(changes, result.CommentChanges, BuildCommentChange);
+        AddAuthoredChanges(changes, result.AnnotationChanges, BuildAnnotationChange);
+        return changes
+            .OrderBy(change => change.EntityKind)
+            .ThenBy(change => change.ChangeKind)
+            .ThenBy(change => change.EntityId, StringComparer.Ordinal);
+    }
+
+    private static void AddAuthoredChanges<T>(
+        ICollection<DeliveryAuthoredChange> destination,
+        MutationBatchChangeSet<T> source,
+        Func<T, DeliveryObjectChangeKind, DeliveryAuthoredChange> map)
+    {
+        foreach (var item in source.Added)
+            destination.Add(map(item, DeliveryObjectChangeKind.Added));
+        foreach (var item in source.Removed)
+            destination.Add(map(item, DeliveryObjectChangeKind.Removed));
+        foreach (var item in source.Modified)
+            destination.Add(map(item, DeliveryObjectChangeKind.Modified));
+    }
+
+    private DeliveryAuthoredChange BuildRevisionChange(
+        RevisionListEntry revision,
+        DeliveryObjectChangeKind changeKind)
+    {
+        var canonical = CanonicalListItem(DocxSessionJson.SerializeRevisionList(new[] { revision }));
+        return new DeliveryAuthoredChange
+        {
+            EntityKind = DeliveryAuthoredEntityKind.Revision,
+            ChangeKind = changeKind,
+            EntityId = DeliveryReceiptValidation.RequireNonBlank(
+                revision.Id, "revision id", 2048),
+            SourceDigest = DeliveryReceiptCanonicalJson.Digest(canonical.Bytes),
+            Author = revision.Author,
+            Date = revision.Date,
+            Type = revision.Type,
+            PartUri = revision.PartUri,
+            Scope = revision.Scope,
+            AffectedAnchorIds = revision.AffectedAnchors.Select(anchor => anchor.Id)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(value => value, StringComparer.Ordinal)
+                .ToArray(),
+            Text = TextEvidence(revision.Text ?? string.Empty, "revision text"),
+            FullEvidence = _privacyProfile == DeliveryReceiptPrivacyProfile.FullEvidence
+                ? canonical.Element
+                : null,
+        };
+    }
+
+    private DeliveryAuthoredChange BuildCommentChange(
+        CommentListEntry comment,
+        DeliveryObjectChangeKind changeKind)
+    {
+        var canonical = CanonicalListItem(DocxSessionJson.SerializeCommentList(new[] { comment }));
+        return new DeliveryAuthoredChange
+        {
+            EntityKind = DeliveryAuthoredEntityKind.Comment,
+            ChangeKind = changeKind,
+            EntityId = DeliveryReceiptValidation.RequireNonBlank(
+                comment.DefAnchorId, "comment anchor id", 2048),
+            SourceDigest = DeliveryReceiptCanonicalJson.Digest(canonical.Bytes),
+            Author = comment.Author,
+            Date = comment.Date,
+            Type = comment.ParentAnchorId is null ? "comment" : "commentReply",
+            Scope = ScopeFromAnchor(comment.DefAnchorId),
+            AffectedAnchorIds = new[] { comment.DefAnchorId }
+                .Concat(comment.ParentAnchorId is null
+                    ? Array.Empty<string>()
+                    : new[] { comment.ParentAnchorId })
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(value => value, StringComparer.Ordinal)
+                .ToArray(),
+            Text = TextEvidence(comment.Text ?? string.Empty, "comment text"),
+            FullEvidence = _privacyProfile == DeliveryReceiptPrivacyProfile.FullEvidence
+                ? canonical.Element
+                : null,
+        };
+    }
+
+    private DeliveryAuthoredChange BuildAnnotationChange(
+        DocumentAnnotation annotation,
+        DeliveryObjectChangeKind changeKind)
+    {
+        var canonical = CanonicalListItem(DocxSessionJson.SerializeAnnotations(new[] { annotation }));
+        return new DeliveryAuthoredChange
+        {
+            EntityKind = DeliveryAuthoredEntityKind.Annotation,
+            ChangeKind = changeKind,
+            EntityId = DeliveryReceiptValidation.RequireNonBlank(
+                annotation.Id, "annotation id", 2048),
+            SourceDigest = DeliveryReceiptCanonicalJson.Digest(canonical.Bytes),
+            Author = annotation.Author,
+            Date = annotation.Created?.ToString("O", CultureInfo.InvariantCulture),
+            Type = annotation.LabelId,
+            AffectedAnchorIds = Array.Empty<string>(),
+            Text = TextEvidence(annotation.AnnotatedText ?? string.Empty, "annotation text"),
+            FullEvidence = _privacyProfile == DeliveryReceiptPrivacyProfile.FullEvidence
+                ? canonical.Element
+                : null,
+        };
+    }
+
+    private void RegisterArtifact(DeliveryArtifactInput input)
+    {
+        if (_artifacts.Count >= _limits.MaxArtifacts)
+        {
+            throw new DeliveryReceiptValidationException(
+                "artifact_resource_limit", "Receipt artifact count limit exceeded.");
+        }
+        ValidateArtifactResourceLimits(input);
+        var artifact = BuildArtifact(input);
+        if (!_artifacts.TryAdd(artifact.ArtifactId, artifact))
+        {
+            throw new DeliveryReceiptValidationException(
+                "duplicate_artifact_id", $"Artifact id '{artifact.ArtifactId}' is duplicated.");
+        }
+        if (input.Bytes is not null)
+        {
+            _totalArtifactBytes = checked(_totalArtifactBytes + input.Bytes.LongLength);
+            _artifactBytes.Add(artifact.ArtifactId, input.Bytes.ToArray());
+        }
+    }
+
+    private void ValidateArtifactResourceLimits(DeliveryArtifactInput input)
+    {
+        CheckString(input.ArtifactId, "artifact id");
+        CheckString(input.MediaType, "artifact media type");
+        CheckString(input.RelativePath, "artifact path");
+        CheckString(input.UnavailableReason, "artifact unavailable reason");
+        CheckString(input.RendererFingerprint, "renderer fingerprint");
+        if (input.Bytes is null)
+            return;
+        DeliveryReceiptResourceBudget.Bytes(
+            input.Bytes.LongLength,
+            _limits.MaxArtifactBytes,
+            "artifact_resource_limit",
+            "Artifact");
+        if (input.Role == DeliveryArtifactRole.SemanticDiff)
+        {
+            DeliveryReceiptResourceBudget.Bytes(
+                input.Bytes.LongLength,
+                _limits.MaxSemanticEvidenceBytes,
+                "semantic_resource_limit",
+                "Semantic artifact");
+        }
+        if (input.Role == DeliveryArtifactRole.PageMap)
+        {
+            DeliveryReceiptResourceBudget.Bytes(
+                input.Bytes.LongLength,
+                _limits.MaxPageMapBytes,
+                "page_map_resource_limit",
+                "PageMap artifact");
+        }
+        if (input.Bytes.LongLength > _limits.MaxTotalArtifactBytes - _totalArtifactBytes)
+        {
+            throw new DeliveryReceiptValidationException(
+                "artifact_resource_limit", "Total receipt artifact byte limit exceeded.");
+        }
+    }
+
+    private DeliveryArtifact BuildArtifact(DeliveryArtifactInput input)
+    {
+        if (!Enum.IsDefined(input.Role) || !Enum.IsDefined(input.Availability))
+            throw new DeliveryReceiptValidationException("invalid_artifact_enum", "Unknown artifact value.");
+        var artifactId = DeliveryReceiptValidation.RequireNonBlank(
+            input.ArtifactId, "artifact id", 256);
+        var mediaType = DeliveryReceiptValidation.RequireNonBlank(
+            input.MediaType, "artifact media type", 512);
+        var path = DeliveryReceiptValidation.NormalizeRelativePath(input.RelativePath);
+        DeliveryReceiptValidation.ValidateOptionalDigest(input.PageMapDigest, "artifact page-map digest");
+        if (input.RendererFingerprint is not null)
+            DeliveryReceiptValidation.RequireNonBlank(
+                input.RendererFingerprint, "renderer fingerprint", 4096);
+
+        if (input.Availability == DeliveryArtifactAvailability.Available)
+        {
+            if (input.Bytes is null)
+            {
+                throw new DeliveryReceiptValidationException(
+                    "missing_artifact_bytes", $"Available artifact '{artifactId}' has no bytes.");
+            }
+            if (input.UnavailableReason is not null)
+            {
+                throw new DeliveryReceiptValidationException(
+                    "inconsistent_artifact_availability",
+                    $"Available artifact '{artifactId}' cannot have an unavailable reason.");
+            }
+            var digest = DeliveryReceiptCanonicalJson.Digest(input.Bytes);
+            var document = input.Document;
+            if (input.Role == DeliveryArtifactRole.CleanDocx)
+            {
+                if (document is null)
+                {
+                    throw new DeliveryReceiptValidationException(
+                        "clean_docx_delivery_mismatch",
+                        "The clean DOCX requires a document identity and exact bytes.");
+                }
+                var manifest = PackageManifestGenerator.Generate(
+                    input.Bytes, _limits.CleanDocxManifestOptions);
+                if (!manifest.IsValid
+                    || !string.Equals(manifest.PackageKind, "opc", StringComparison.Ordinal)
+                    || string.IsNullOrWhiteSpace(manifest.Facts.MainDocumentUri))
+                {
+                    throw new DeliveryReceiptValidationException(
+                        "invalid_clean_docx",
+                        "Clean DOCX bytes must be a valid bounded WordprocessingML OPC package.");
+                }
+                var actual = DeliveryDocumentIdentity.FromManifest(
+                    manifest, document.DocumentVersion);
+                if (!DeliveryReceiptLineageValidator.DocumentEquals(actual, document))
+                {
+                    throw new DeliveryReceiptValidationException(
+                        "clean_docx_delivery_mismatch",
+                        "Caller-supplied clean DOCX identity does not match recomputed bytes.");
+                }
+                document = actual;
+            }
+            if (document is not null
+                && input.Role is DeliveryArtifactRole.CleanDocx or DeliveryArtifactRole.ReviewDocx
+                && !DeliveryReceiptValidation.DigestEquals(
+                    digest, document.RawPackageBytesDigest))
+            {
+                throw new DeliveryReceiptValidationException(
+                    "docx_artifact_identity_mismatch",
+                    $"DOCX artifact '{artifactId}' does not match its package identity.");
+            }
+            return new DeliveryArtifact
+            {
+                ArtifactId = artifactId,
+                Role = input.Role,
+                MediaType = mediaType,
+                Availability = input.Availability,
+                ByteLength = input.Bytes.LongLength,
+                Digest = digest,
+                RelativePath = path,
+                DocumentVersion = document?.DocumentVersion,
+                PackageDigest = DeliveryReceiptValidation.CloneOptionalDigest(
+                    document?.RawPackageBytesDigest),
+                RendererFingerprint = input.RendererFingerprint,
+                PageMapDigest = DeliveryReceiptValidation.CloneOptionalDigest(input.PageMapDigest),
+            };
+        }
+
+        if (input.Bytes is not null)
+        {
+            throw new DeliveryReceiptValidationException(
+                "inconsistent_artifact_availability",
+                $"Unavailable artifact '{artifactId}' cannot carry bytes.");
+        }
+        return new DeliveryArtifact
+        {
+            ArtifactId = artifactId,
+            Role = input.Role,
+            MediaType = mediaType,
+            Availability = input.Availability,
+            UnavailableReason = DeliveryReceiptValidation.RequireNonBlank(
+                input.UnavailableReason, "artifact unavailable reason", 4096),
+            RelativePath = path,
+            DocumentVersion = input.Document?.DocumentVersion,
+            PackageDigest = DeliveryReceiptValidation.CloneOptionalDigest(
+                input.Document?.RawPackageBytesDigest),
+            RendererFingerprint = input.RendererFingerprint,
+            PageMapDigest = DeliveryReceiptValidation.CloneOptionalDigest(input.PageMapDigest),
+        };
+    }
+
+    private IReadOnlyList<DeliveryLineageEvent> MaterializeLineage()
+    {
+        return _lineage.Select(value =>
+            new DeliveryLineageEvent
+            {
+                Sequence = value.Sequence,
+                Action = value.Input.Action,
+                AffectedEntryId = value.Input.AffectedEntryId,
+                BeforeDocument = value.Input.BeforeDocument,
+                AfterDocument = value.Input.AfterDocument,
+            })
+            .OrderBy(value => value.Sequence)
+            .ToArray();
+    }
+
+    private PackageManifest ValidateRequiredCleanDocx(
+        DeliveryDocumentIdentity deliveredDocument)
+    {
+        var cleanArtifacts = _artifacts.Values
+            .Where(artifact => artifact.Role == DeliveryArtifactRole.CleanDocx)
+            .ToArray();
+        if (cleanArtifacts.Length != 1)
+        {
+            throw new DeliveryReceiptValidationException(
+                cleanArtifacts.Length == 0 ? "missing_clean_docx" : "multiple_clean_docx_artifacts",
+                "A delivery receipt requires exactly one clean DOCX artifact.");
+        }
+
+        var clean = cleanArtifacts[0];
+        if (clean.Availability != DeliveryArtifactAvailability.Available
+            || clean.Digest is null
+            || !_artifactBytes.TryGetValue(clean.ArtifactId, out var cleanBytes)
+            || clean.DocumentVersion != deliveredDocument.DocumentVersion
+            || !DeliveryReceiptValidation.DigestEquals(
+                clean.PackageDigest, deliveredDocument.RawPackageBytesDigest)
+            || !DeliveryReceiptValidation.DigestEquals(
+                clean.Digest, deliveredDocument.RawPackageBytesDigest))
+        {
+            throw new DeliveryReceiptValidationException(
+                "clean_docx_delivery_mismatch",
+                "The clean DOCX artifact must be available and exactly match DeliveredDocument.");
+        }
+        var actualManifest = PackageManifestGenerator.Generate(
+            cleanBytes, _limits.CleanDocxManifestOptions);
+        if (!actualManifest.IsValid
+            || !string.Equals(actualManifest.PackageKind, "opc", StringComparison.Ordinal)
+            || string.IsNullOrWhiteSpace(actualManifest.Facts.MainDocumentUri)
+            || !DeliveryReceiptLineageValidator.DocumentEquals(
+                DeliveryDocumentIdentity.FromManifest(
+                    actualManifest, deliveredDocument.DocumentVersion),
+                deliveredDocument))
+        {
+            throw new DeliveryReceiptValidationException(
+                "clean_docx_delivery_mismatch",
+                "Recomputed clean DOCX package identity does not match DeliveredDocument.");
+        }
+        ValidateManifestResources(actualManifest);
+        return actualManifest;
+    }
+
+    private IReadOnlyList<DeliverySemanticChangeSetBinding> BuildSemanticChangeSetBindings(
+        DeliveryLineageValidationResult lineageValidation)
+    {
+        var aggregate = _semanticChangeSets
+            .Where(entry => entry.Input.Scope
+                == DeliverySemanticComparisonScope.SourceToDelivered)
+            .ToArray();
+        if (aggregate.Length != 1)
+        {
+            throw new DeliveryReceiptValidationException(
+                "missing_source_to_delivered_semantic_evidence",
+                "Exactly one source-to-delivered SemanticChangeSet is required.");
+        }
+
+        var transactionInputs = _semanticChangeSets
+            .Where(entry => entry.Input.Scope == DeliverySemanticComparisonScope.Transaction)
+            .GroupBy(entry => entry.Input.TransactionEntryId!, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.ToArray(), StringComparer.Ordinal);
+        var expectedTransactions = lineageValidation.StateChangingTransactions
+            .ToDictionary(transaction => transaction.EntryId, StringComparer.Ordinal);
+        if (transactionInputs.Any(pair => pair.Value.Length != 1
+                || !expectedTransactions.ContainsKey(pair.Key))
+            || expectedTransactions.Keys.Any(entryId => !transactionInputs.ContainsKey(entryId)))
+        {
+            throw new DeliveryReceiptValidationException(
+                "semantic_transaction_coverage_mismatch",
+                "Every state-changing transaction requires exactly one typed semantic binding.");
+        }
+
+        var output = new List<DeliverySemanticChangeSetBinding>
+        {
+            BuildSemanticBinding(aggregate[0], _sourceDocument, _deliveredDocument!, null),
+        };
+        output.AddRange(lineageValidation.StateChangingTransactions.Select(transaction =>
+            BuildSemanticBinding(
+                transactionInputs[transaction.EntryId][0],
+                transaction.BeforeDocument,
+                transaction.AfterDocument,
+                transaction.EntryId)));
+        return output;
+    }
+
+    private DeliverySemanticChangeSetBinding BuildSemanticBinding(
+        (DeliverySemanticChangeSetInput Input,
+            DeliverySemanticChangeSetProjection Projection) entry,
+        DeliveryDocumentIdentity before,
+        DeliveryDocumentIdentity after,
+        string? transactionEntryId)
+    {
+        var input = entry.Input;
+        var projection = entry.Projection;
+        if (!_artifacts.TryGetValue(input.ArtifactId, out var artifact)
+            || artifact.Role != DeliveryArtifactRole.SemanticDiff
+            || artifact.Availability != DeliveryArtifactAvailability.Available
+            || artifact.Digest is null
+            || !DeliveryReceiptValidation.DigestEquals(artifact.Digest, projection.Digest)
+            || !_artifactBytes.TryGetValue(input.ArtifactId, out var bytes)
+            || !bytes.AsSpan().SequenceEqual(projection.CanonicalBytes))
+        {
+            throw new DeliveryReceiptValidationException(
+                "semantic_artifact_binding_mismatch",
+                $"Semantic artifact '{input.ArtifactId}' does not contain the exact #457 canonical bytes.");
+        }
+
+        return new DeliverySemanticChangeSetBinding
+        {
+            Scope = input.Scope,
+            TransactionEntryId = transactionEntryId,
+            BeforeDocument = before,
+            AfterDocument = after,
+            Schema = projection.Schema,
+            SchemaVersion = projection.SchemaVersion,
+            ChangeCount = projection.ChangeCount,
+            Digest = DeliveryReceiptValidation.CloneDigest(projection.Digest),
+            ArtifactId = input.ArtifactId,
+        };
+    }
+
+    private IReadOnlyList<DeliveryPackageChange> BuildPackageChanges(
+        PackageManifest before,
+        PackageManifest after)
+    {
+        return DeliveryPackageManifestAdapter.Compare(before, after)
+            .Select(candidate => BuildPackageChange(candidate))
+            .ToArray();
+    }
+
+    private DeliveryPackageChange BuildPackageChange(DeliveryPackageChangeObservation candidate)
+    {
+        var matching = _attributionRules.Where(rule => Matches(rule, candidate)).ToArray();
+        if (matching.Length > 1)
+        {
+            throw new DeliveryReceiptValidationException(
+                "ambiguous_attribution",
+                "More than one attribution rule matches the same package change.");
+        }
+        var rule = matching.SingleOrDefault();
+        if (rule is not null && rule.TransactionEntryId is not null)
+        {
+            if (!_entriesById.TryGetValue(rule.TransactionEntryId, out var entry))
+            {
+                throw new DeliveryReceiptValidationException(
+                    "unknown_attribution_transaction",
+                    $"Attribution references unknown entry '{rule.TransactionEntryId}'.");
+            }
+            if (entry.Status is not (DeliveryTransactionStatus.Committed
+                or DeliveryTransactionStatus.PartiallyCommitted))
+            {
+                throw new DeliveryReceiptValidationException(
+                    "invalid_attribution_transaction",
+                    "Package-change attribution must reference a committed transaction.");
+            }
+            if (rule.RequestedOperationIndex is { } index
+                && (index < 0 || index >= entry.Operations.Count))
+            {
+                throw new DeliveryReceiptValidationException(
+                    "invalid_attribution_operation",
+                    "Attribution operation index is outside the referenced transaction.");
+            }
+            if (rule.RequestedOperationIndex is { } requestedIndex
+                && entry.Operations[requestedIndex].ExecutionStatus
+                    != DeliveryOperationExecutionStatus.Succeeded)
+            {
+                throw new DeliveryReceiptValidationException(
+                    "invalid_attribution_operation",
+                    "Attribution may reference only a successful, retained operation.");
+            }
+        }
+
+        var beforeEvidence = candidate.Before is null
+            ? null
+            : TextEvidence(candidate.Before, "prior package record");
+        var afterEvidence = candidate.After is null
+            ? null
+            : TextEvidence(candidate.After, "result package record");
+        var identity = new
+        {
+            after = afterEvidence?.Digest,
+            before = beforeEvidence?.Digest,
+            kind = candidate.Kind.ToString(),
+            location = candidate.Location,
+        };
+        return new DeliveryPackageChange
+        {
+            ChangeId = DeliveryReceiptCanonicalJson.DigestToken(
+                DeliveryReceiptCanonicalJson.SerializeCanonical(identity)),
+            Kind = candidate.Kind,
+            Location = candidate.Location,
+            Before = beforeEvidence,
+            After = afterEvidence,
+            Disposition = rule?.Disposition ?? DeliveryChangeDisposition.Unexpected,
+            TransactionEntryId = rule?.TransactionEntryId,
+            RequestedOperationIndex = rule?.RequestedOperationIndex,
+            Derivation = rule?.Derivation,
+        };
+    }
+
+    private IEnumerable<DeliveryEvidenceReference> ValidateEvidence()
+    {
+        foreach (var reference in _evidence
+                     .OrderBy(value => value.Kind)
+                     .ThenBy(value => value.Schema, StringComparer.Ordinal)
+                     .ThenBy(value => value.Digest.Value, StringComparer.Ordinal))
+        {
+            if (reference.ArtifactId is { } artifactId)
+            {
+                if (!_artifacts.TryGetValue(artifactId, out var artifact)
+                    || artifact.Availability != DeliveryArtifactAvailability.Available
+                    || artifact.Digest is null)
+                {
+                    throw new DeliveryReceiptValidationException(
+                        "missing_evidence_artifact",
+                        $"Evidence artifact '{artifactId}' is not available.");
+                }
+                if (!DeliveryReceiptValidation.DigestEquals(reference.Digest, artifact.Digest))
+                {
+                    throw new DeliveryReceiptValidationException(
+                        "evidence_artifact_digest_mismatch",
+                        $"Evidence digest does not match artifact '{artifactId}'.");
+                }
+                var expectedRole = reference.Kind switch
+                {
+                    DeliveryEvidenceKind.ValidationResult => DeliveryArtifactRole.ValidationReport,
+                    DeliveryEvidenceKind.RedlineReversibility => DeliveryArtifactRole.ReversibilityProof,
+                    DeliveryEvidenceKind.SemanticChangeSet =>
+                        throw new DeliveryReceiptValidationException(
+                            "semantic_evidence_requires_typed_factory",
+                            "Semantic evidence must use the typed #457 binding."),
+                    _ => throw new DeliveryReceiptValidationException(
+                        "unknown_evidence_kind", "Unknown evidence kind."),
+                };
+                if (artifact.Role != expectedRole)
+                {
+                    throw new DeliveryReceiptValidationException(
+                        "evidence_artifact_role_mismatch",
+                        $"Evidence '{reference.Kind}' requires artifact role '{expectedRole}'.");
+                }
+            }
+            yield return reference;
+        }
+    }
+
+    private DeliveryPageCitation BuildPageCitation(
+        DeliveryPageCitationInput input,
+        DeliveryLineageValidationResult lineageValidation)
+    {
+        ArgumentNullException.ThrowIfNull(input.Citation);
+        ArgumentNullException.ThrowIfNull(input.Document);
+        if (!lineageValidation.ReachableDocuments.Any(document =>
+                DeliveryReceiptLineageValidator.DocumentEquals(document, input.Document)))
+        {
+            throw new DeliveryReceiptValidationException(
+                "unreachable_citation_document",
+                "Citation document identity is not a reachable receipt-owned state.");
+        }
+        DeliveryReceiptValidation.ValidateDigest(input.PageMapDigest, "page-map digest");
+        var pageMapArtifactId = DeliveryReceiptValidation.RequireNonBlank(
+            input.PageMapArtifactId, "page-map artifact id", 256);
+        var artifactId = DeliveryReceiptValidation.RequireNonBlank(
+            input.RenderArtifactId, "render artifact id", 256);
+        if (!_artifacts.TryGetValue(artifactId, out var artifact)
+            || artifact.Availability != DeliveryArtifactAvailability.Available
+            || artifact.Digest is null)
+        {
+            throw new DeliveryReceiptValidationException(
+                "missing_citation_artifact", $"Citation artifact '{artifactId}' is unavailable.");
+        }
+        if (artifact.Role is not (DeliveryArtifactRole.Pdf
+            or DeliveryArtifactRole.PageImage
+            or DeliveryArtifactRole.RenderReport))
+        {
+            throw new DeliveryReceiptValidationException(
+                "non_paginated_citation_artifact",
+                "Page citations require PDF, page-image, or paginated render-report evidence.");
+        }
+        if (!_artifacts.TryGetValue(pageMapArtifactId, out var pageMapArtifact)
+            || pageMapArtifact.Availability != DeliveryArtifactAvailability.Available
+            || pageMapArtifact.Role != DeliveryArtifactRole.PageMap
+            || pageMapArtifact.Digest is null
+            || !DeliveryReceiptValidation.DigestEquals(
+                pageMapArtifact.Digest, input.PageMapDigest))
+        {
+            throw new DeliveryReceiptValidationException(
+                "missing_page_map_artifact",
+                $"Page-map artifact '{pageMapArtifactId}' is unavailable or has the wrong digest.");
+        }
+        if (!_artifactBytes.TryGetValue(pageMapArtifactId, out var pageMapBytes))
+        {
+            throw new DeliveryReceiptValidationException(
+                "missing_page_map_artifact_bytes",
+                $"Page-map artifact '{pageMapArtifactId}' has no verifiable bytes.");
+        }
+        var citation = input.Citation;
+        if (citation.Availability != PageMapAvailability.Available
+            || citation.UnavailableReason is not null
+            || citation.Pages.Count == 0
+            || citation.Fragments.Count == 0)
+        {
+            throw new DeliveryReceiptValidationException(
+                "unavailable_page_citation",
+                "Only available citations from a paginated page map can enter a receipt.");
+        }
+        var scope = DeliveryReceiptValidation.RequireNonBlank(input.Scope, "citation scope", 1024);
+        if (!string.Equals(ScopeFromAnchor(citation.AnchorId), scope, StringComparison.Ordinal))
+        {
+            throw new DeliveryReceiptValidationException(
+                "citation_scope_mismatch", "Citation scope does not match its canonical anchor.");
+        }
+        if (citation.DocumentVersion != input.Document.DocumentVersion)
+        {
+            throw new DeliveryReceiptValidationException(
+                "citation_document_version_mismatch", "Citation document version is stale.");
+        }
+        var rendererFingerprint = DeliveryReceiptValidation.RequireNonBlank(
+            citation.RendererFingerprint, "citation renderer fingerprint", 4096);
+
+        if (artifact.DocumentVersion != input.Document.DocumentVersion
+            || !DeliveryReceiptValidation.DigestEquals(
+                artifact.PackageDigest, input.Document.RawPackageBytesDigest)
+            || !string.Equals(artifact.RendererFingerprint, rendererFingerprint,
+                StringComparison.Ordinal)
+            || !DeliveryReceiptValidation.DigestEquals(
+                artifact.PageMapDigest, input.PageMapDigest))
+        {
+            throw new DeliveryReceiptValidationException(
+                "citation_render_binding_mismatch",
+                "Citation package, renderer, or page-map identity does not match its artifact.");
+        }
+        if (pageMapArtifact.DocumentVersion != input.Document.DocumentVersion
+            || !DeliveryReceiptValidation.DigestEquals(
+                pageMapArtifact.PackageDigest, input.Document.RawPackageBytesDigest)
+            || !string.Equals(pageMapArtifact.RendererFingerprint, rendererFingerprint,
+                StringComparison.Ordinal))
+        {
+            throw new DeliveryReceiptValidationException(
+                "citation_page_map_binding_mismatch",
+                "Page-map artifact does not match the citation document and renderer.");
+        }
+        PageMap pageMap;
+        try
+        {
+            // Canonicalization is only a strict UTF-8/JSON/duplicate-property gate. The artifact
+            // digest above remains over the renderer's original bytes.
+            _ = DeliveryReceiptCanonicalJson.CanonicalizeBounded(
+                pageMapBytes, _limits, _limits.MaxPageMapBytes,
+                "page_map_resource_limit");
+            pageMap = DocxSessionJson.ParsePageMap(Encoding.UTF8.GetString(pageMapBytes));
+        }
+        catch (Exception ex) when (ex is JsonException or FormatException)
+        {
+            throw new DeliveryReceiptValidationException(
+                "invalid_page_map_artifact",
+                $"Page-map artifact '{pageMapArtifactId}' is not a valid PageMap: {ex.Message}");
+        }
+        var mapValidation = PageMapContract.ValidatePortable(
+            pageMap, input.Document.DocumentVersion, rendererFingerprint);
+        if (!mapValidation.Success)
+        {
+            throw new DeliveryReceiptValidationException(
+                "invalid_page_map_artifact",
+                mapValidation.Message ?? "Page-map artifact is invalid.");
+        }
+        var projected = PageMapContract.ProjectCitation(
+            pageMap,
+            citation.AnchorId,
+            new PageCitationRequest(citation.DocumentVersion, rendererFingerprint));
+        if (projected.Availability != PageMapAvailability.Available
+            || !CitationCoordinatesEqual(citation, projected))
+        {
+            throw new DeliveryReceiptValidationException(
+                "citation_page_map_projection_mismatch",
+                "Citation pages and fragments are not the exact projection of its PageMap bytes.");
+        }
+        if (projected.Fragments.Any(fragment =>
+                !PageMapContract.StoryMatchesScope(fragment.Story, scope)))
+        {
+            throw new DeliveryReceiptValidationException(
+                "citation_scope_mismatch",
+                "Citation fragment story does not match its canonical anchor scope.");
+        }
+        return new DeliveryPageCitation
+        {
+            AnchorId = citation.AnchorId,
+            Scope = scope,
+            DocumentVersion = citation.DocumentVersion,
+            PackageDigest = DeliveryReceiptValidation.CloneDigest(
+                input.Document.RawPackageBytesDigest),
+            RendererFingerprint = rendererFingerprint,
+            PageMapDigest = DeliveryReceiptValidation.CloneDigest(input.PageMapDigest),
+            PageMapArtifactId = pageMapArtifactId,
+            RenderArtifactId = artifactId,
+            RenderArtifactDigest = DeliveryReceiptValidation.CloneDigest(artifact.Digest),
+            Pages = projected.Pages.ToArray(),
+            Fragments = projected.Fragments.ToArray(),
+        };
+    }
+
+    private static bool CitationCoordinatesEqual(PageCitation left, PageCitation right) =>
+        string.Equals(left.AnchorId, right.AnchorId, StringComparison.Ordinal)
+        && left.Availability == right.Availability
+        && left.UnavailableReason == right.UnavailableReason
+        && left.DocumentVersion == right.DocumentVersion
+        && string.Equals(left.RendererFingerprint, right.RendererFingerprint,
+            StringComparison.Ordinal)
+        && left.Pages.SequenceEqual(right.Pages)
+        && left.Fragments.SequenceEqual(right.Fragments);
+
+    private DeliveryTextEvidence TextEvidence(string value, string structuralSummary)
+    {
+        value ??= string.Empty;
+        return new DeliveryTextEvidence
+        {
+            Digest = DeliveryReceiptCanonicalJson.DigestText(value),
+            CharacterCount = value.Length,
+            Summary = _privacyProfile == DeliveryReceiptPrivacyProfile.HashOnly
+                ? null
+                : $"{structuralSummary}; {value.Length.ToString(CultureInfo.InvariantCulture)} characters",
+            Value = _privacyProfile == DeliveryReceiptPrivacyProfile.FullEvidence ? value : null,
+        };
+    }
+
+    private static DeliveryObjectChange ObjectChange(
+        DeliveryObjectChangeKind changeKind,
+        Anchor anchor) => new()
+    {
+        ChangeKind = changeKind,
+        AnchorId = anchor.Id,
+        Kind = anchor.Kind,
+        Scope = anchor.Scope,
+        Unid = anchor.Unid,
+    };
+
+    private static DeliveryTransactionStatus TransactionStatus(MutationBatchResult result)
+    {
+        if (result.Preview)
+            return DeliveryTransactionStatus.Prediction;
+        if (result.Mode == MutationBatchMode.Atomic)
+            return result.Success && !result.RolledBack
+                ? DeliveryTransactionStatus.Committed
+                : DeliveryTransactionStatus.Failed;
+        if (result.Success)
+            return DeliveryTransactionStatus.Committed;
+        return !result.RolledBack && result.Steps.Any(step => step.Success)
+            ? DeliveryTransactionStatus.PartiallyCommitted
+            : DeliveryTransactionStatus.Failed;
+    }
+
+    private string DeriveRequestFingerprint(
+        MutationBatchMode mode,
+        IReadOnlyList<DeliveryNormalizedOperation> operations)
+    {
+        var shape = new
+        {
+            mode = mode == MutationBatchMode.Atomic ? "atomic" : "bestEffort",
+            operations = operations.Select(operation => new
+            {
+                action = operation.Action,
+                arguments = operation.Arguments,
+                tool = operation.Tool,
+            }).ToArray(),
+        };
+        return DeliveryReceiptCanonicalJson.DigestToken(
+            DeliveryReceiptCanonicalJson.SerializeCanonicalBounded(
+                shape, _limits, _limits.MaxReceiptJsonBytes,
+                "receipt_resource_limit"));
+    }
+
+    private static string DeriveEntryId(
+        string requestFingerprint,
+        DeliveryDocumentIdentity before,
+        DeliveryDocumentIdentity after,
+        long baseVersion,
+        long resultVersion)
+    {
+        var identity = new
+        {
+            afterPackage = after.RawPackageBytesDigest,
+            baseVersion,
+            beforePackage = before.RawPackageBytesDigest,
+            requestFingerprint,
+            resultVersion,
+        };
+        return DeliveryReceiptCanonicalJson.DigestToken(
+            DeliveryReceiptCanonicalJson.SerializeCanonical(identity));
+    }
+
+    private void ValidateContributionResources(DeliveryTransactionContribution contribution)
+    {
+        if (contribution.Operations.Count > _limits.MaxOperationsPerTransaction)
+        {
+            throw new DeliveryReceiptValidationException(
+                "receipt_resource_limit", "Transaction operation limit exceeded.");
+        }
+        var budget = new DeliveryReceiptResourceBudget(_limits);
+        budget.AddItems(contribution.Operations.Count, "transaction operations");
+        foreach (var operation in contribution.Operations)
+        {
+            budget.String(operation.Tool, "operation tool");
+            budget.String(operation.Action, "operation action");
+            DeliveryReceiptResourceBudget.Bytes(
+                operation.CanonicalArguments.LongLength,
+                _limits.MaxStringLength,
+                "receipt_resource_limit",
+                "Canonical operation arguments");
+            budget.AddSerializedBytes(
+                operation.CanonicalArguments.LongLength,
+                "Canonical operation arguments");
+            AccountJsonElement(
+                operation.Arguments, budget, depth: 1, "operation arguments");
+        }
+        budget.AddItems(contribution.Result.Steps.Count, "batch step results");
+        foreach (var step in contribution.Result.Steps)
+        {
+            budget.String(step.Tool, "batch step tool");
+            budget.String(step.Action, "batch step action");
+            budget.AddItems(step.Results.Count, "operation results");
+            foreach (var result in step.Results)
+            {
+                budget.AddSerializedBytes(256, "operation result structure");
+                budget.AddItems(result.Created.Count, "created anchors");
+                budget.AddItems(result.Removed.Count, "removed anchors");
+                budget.AddItems(result.Modified.Count, "modified anchors");
+                foreach (var anchor in result.Created
+                    .Concat(result.Removed)
+                    .Concat(result.Modified))
+                {
+                    AccountAnchor(anchor, budget);
+                }
+                budget.String(result.Error?.Message, "edit error message");
+                budget.String(result.Error?.AnchorId, "edit error anchor");
+                if (result.Error?.Precondition is { } precondition)
+                {
+                    budget.AddSerializedBytes(128, "precondition evidence structure");
+                    budget.String(precondition.Condition, "precondition condition");
+                    AccountPreconditionValue(
+                        precondition.Expected, budget, "precondition expected value");
+                    AccountPreconditionValue(
+                        precondition.Actual, budget, "precondition actual value");
+                    if (precondition.CurrentTarget is { } target)
+                    {
+                        budget.String(target.AnchorId, "precondition target anchor");
+                        budget.String(target.Kind, "precondition target kind");
+                        budget.String(target.Scope, "precondition target scope");
+                        budget.String(target.ContentHash, "precondition target content hash");
+                        budget.String(target.VisibleText, "precondition target text");
+                    }
+                }
+                budget.String(result.AnnotationId, "annotation id");
+                budget.String(result.HyperlinkId, "hyperlink id");
+                budget.String(result.BookmarkName, "bookmark name");
+                budget.String(result.ImageId, "image id");
+                if (result.Patch is { } patch)
+                {
+                    budget.String(patch.ScopeAnchorId, "patch scope anchor");
+                    budget.String(patch.Markdown, "patch markdown");
+                }
+                if (result.TableAnchors is { } tableAnchors)
+                    AccountTableAnchors(tableAnchors, budget);
+            }
+        }
+        budget.AddItems(contribution.Result.RevisionChanges.Added.Count, "revision changes");
+        budget.AddItems(contribution.Result.RevisionChanges.Removed.Count, "revision changes");
+        budget.AddItems(contribution.Result.RevisionChanges.Modified.Count, "revision changes");
+        budget.AddItems(contribution.Result.CommentChanges.Added.Count, "comment changes");
+        budget.AddItems(contribution.Result.CommentChanges.Removed.Count, "comment changes");
+        budget.AddItems(contribution.Result.CommentChanges.Modified.Count, "comment changes");
+        budget.AddItems(contribution.Result.AnnotationChanges.Added.Count, "annotation changes");
+        budget.AddItems(contribution.Result.AnnotationChanges.Removed.Count, "annotation changes");
+        budget.AddItems(contribution.Result.AnnotationChanges.Modified.Count, "annotation changes");
+        foreach (var revision in contribution.Result.RevisionChanges.Added
+            .Concat(contribution.Result.RevisionChanges.Removed)
+            .Concat(contribution.Result.RevisionChanges.Modified))
+        {
+            budget.AddSerializedBytes(512, "revision evidence structure");
+            budget.String(revision.Id, "revision id");
+            budget.String(revision.Type, "revision type");
+            budget.String(revision.Author, "revision author");
+            budget.String(revision.Date, "revision date");
+            budget.String(revision.Text, "revision text");
+            budget.String(revision.PartUri, "revision part URI");
+            budget.String(revision.Scope, "revision scope");
+            budget.String(revision.AnchorId, "revision anchor");
+            budget.AddItems(revision.ConstituentIds.Count, "revision constituent ids");
+            foreach (var id in revision.ConstituentIds)
+                budget.String(id, "revision constituent id");
+            budget.AddItems(revision.AffectedAnchors.Count, "revision affected anchors");
+            foreach (var anchor in revision.AffectedAnchors)
+                AccountAnchor(anchor, budget);
+            budget.String(revision.Diagnostic?.Code, "revision diagnostic code");
+            budget.String(revision.Diagnostic?.Message, "revision diagnostic message");
+        }
+        foreach (var comment in contribution.Result.CommentChanges.Added
+            .Concat(contribution.Result.CommentChanges.Removed)
+            .Concat(contribution.Result.CommentChanges.Modified))
+        {
+            budget.AddSerializedBytes(256, "comment evidence structure");
+            budget.String(comment.DefAnchorId, "comment anchor");
+            budget.String(comment.Author, "comment author");
+            budget.String(comment.Initials, "comment initials");
+            budget.String(comment.Date, "comment date");
+            budget.String(comment.Text, "comment text");
+            budget.String(comment.ParentAnchorId, "comment parent anchor");
+        }
+        foreach (var annotation in contribution.Result.AnnotationChanges.Added
+            .Concat(contribution.Result.AnnotationChanges.Removed)
+            .Concat(contribution.Result.AnnotationChanges.Modified))
+        {
+            budget.AddSerializedBytes(384, "annotation evidence structure");
+            budget.String(annotation.Id, "annotation id");
+            budget.String(annotation.LabelId, "annotation label id");
+            budget.String(annotation.Label, "annotation label");
+            budget.String(annotation.Color, "annotation color");
+            budget.String(annotation.Author, "annotation author");
+            budget.String(annotation.BookmarkName, "annotation bookmark");
+            budget.String(annotation.AnnotatedText, "annotation text");
+            budget.AddItems(annotation.Metadata.Count, "annotation metadata");
+            foreach (var pair in annotation.Metadata)
+            {
+                budget.String(pair.Key, "annotation metadata key");
+                budget.String(pair.Value, "annotation metadata value");
+            }
+        }
+        budget.AddItems(contribution.Result.Warnings.Count, "transaction warnings");
+        foreach (var warning in contribution.Result.Warnings)
+            budget.String(warning, "transaction warning");
+    }
+
+    private static void AccountAnchor(
+        Anchor anchor,
+        DeliveryReceiptResourceBudget budget)
+    {
+        budget.AddSerializedBytes(48, "anchor structure");
+        budget.String(anchor.Id, "anchor id");
+        budget.String(anchor.Kind, "anchor kind");
+        budget.String(anchor.Scope, "anchor scope");
+        budget.String(anchor.Unid, "anchor unid");
+    }
+
+    private static void AccountTableAnchors(
+        TableAnchorMapping mapping,
+        DeliveryReceiptResourceBudget budget)
+    {
+        budget.AddSerializedBytes(96, "table-anchor mapping structure");
+        budget.AddItems(mapping.Retained.Count, "retained table anchors");
+        budget.AddItems(mapping.Added.Count, "added table anchors");
+        budget.AddItems(mapping.Invalidated.Count, "invalidated table anchors");
+        foreach (var retained in mapping.Retained)
+        {
+            AccountTableAnchorLocation(retained.Before, budget);
+            AccountTableAnchorLocation(retained.After, budget);
+        }
+        foreach (var location in mapping.Added.Concat(mapping.Invalidated))
+            AccountTableAnchorLocation(location, budget);
+    }
+
+    private static void AccountTableAnchorLocation(
+        TableAnchorLocation location,
+        DeliveryReceiptResourceBudget budget)
+    {
+        budget.AddSerializedBytes(128, "table-anchor location structure");
+        AccountAnchor(location.Anchor, budget);
+    }
+
+    private static void AccountPreconditionValue(
+        object? value,
+        DeliveryReceiptResourceBudget budget,
+        string name)
+    {
+        switch (value)
+        {
+            case null:
+            case bool:
+            case byte:
+            case sbyte:
+            case short:
+            case ushort:
+            case int:
+            case uint:
+            case long:
+            case ulong:
+            case float:
+            case double:
+            case decimal:
+                budget.AddSerializedBytes(32, name);
+                break;
+            case string text:
+                budget.String(text, name);
+                break;
+            case JsonElement json:
+                AccountJsonElement(json, budget, depth: 1, name);
+                break;
+            default:
+                throw new DeliveryReceiptValidationException(
+                    "invalid_batch_evidence",
+                    "Precondition evidence must be a JSON scalar or JsonElement.");
+        }
+    }
+
+    private static void AccountJsonElement(
+        JsonElement value,
+        DeliveryReceiptResourceBudget budget,
+        int depth,
+        string name)
+    {
+        budget.Depth(depth, name);
+        budget.AddSerializedBytes(8, name);
+        switch (value.ValueKind)
+        {
+            case JsonValueKind.Object:
+            {
+                foreach (var property in value.EnumerateObject())
+                {
+                    budget.AddItems(1, name);
+                    budget.String(property.Name, $"{name} property");
+                    AccountJsonElement(property.Value, budget, depth + 1, name);
+                }
+                break;
+            }
+            case JsonValueKind.Array:
+            {
+                foreach (var item in value.EnumerateArray())
+                {
+                    budget.AddItems(1, name);
+                    AccountJsonElement(item, budget, depth + 1, name);
+                }
+                break;
+            }
+            case JsonValueKind.String:
+                budget.String(value.GetString(), name);
+                break;
+            case JsonValueKind.Number:
+                budget.AddSerializedBytes(value.GetRawText().Length, name);
+                break;
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+            case JsonValueKind.Null:
+                break;
+            default:
+                throw new DeliveryReceiptValidationException(
+                    "invalid_batch_evidence", "Precondition JSON is incomplete.");
+        }
+    }
+
+    private void ValidateManifestResources(PackageManifest manifest)
+    {
+        if (manifest.Entries.Count > _limits.CleanDocxManifestOptions.MaxEntryCount)
+        {
+            throw new DeliveryReceiptValidationException(
+                "receipt_resource_limit", "Source manifest exceeds the package entry limit.");
+        }
+        var budget = new DeliveryReceiptResourceBudget(_limits);
+        budget.String(manifest.Schema, "manifest schema");
+        budget.String(manifest.PackageKind, "manifest package kind");
+        AccountDigest(manifest.RawPackageBytesDigest, budget, "manifest raw digest");
+        AccountDigest(manifest.OrderedOpcContentDigest, budget, "manifest content digest");
+        AccountDigest(manifest.NormalizedSemanticDigest, budget, "manifest semantic digest");
+        budget.AddItems(manifest.Entries.Count, "source manifest entries");
+        budget.AddSerializedBytes(
+            checked(manifest.Entries.Count * 256L), "source manifest entry structure");
+        foreach (var entry in manifest.Entries)
+        {
+            budget.String(entry.Uri, "source entry URI");
+            budget.String(entry.ContentType, "source entry content type");
+            budget.String(entry.ContentTypeSource, "source content-type source");
+            AccountDigest(entry.RawBytesDigest, budget, "source entry raw digest");
+            AccountDigest(entry.NormalizedXmlDigest, budget, "source entry XML digest");
+        }
+        budget.AddItems(manifest.Relationships.Count, "source relationships");
+        budget.AddSerializedBytes(
+            checked(manifest.Relationships.Count * 192L), "source relationship structure");
+        foreach (var relationship in manifest.Relationships)
+        {
+            budget.String(relationship.OwnerUri, "source relationship owner");
+            budget.String(relationship.Id, "source relationship id");
+            budget.String(relationship.Type, "source relationship type");
+            budget.String(relationship.Target, "source relationship target");
+            budget.String(relationship.TargetMode, "source relationship target mode");
+            budget.String(relationship.ResolvedTargetUri, "source relationship target URI");
+        }
+        budget.AddItems(manifest.ContentTypes.Count, "source content types");
+        budget.AddSerializedBytes(
+            checked(manifest.ContentTypes.Count * 96L), "source content-type structure");
+        foreach (var contentType in manifest.ContentTypes)
+        {
+            budget.String(contentType.Kind, "source content-type kind");
+            budget.String(contentType.Key, "source content-type key");
+            budget.String(contentType.ContentType, "source content type");
+        }
+        budget.AddItems(manifest.Findings.Count, "source manifest findings");
+        budget.AddSerializedBytes(
+            checked(manifest.Findings.Count * 192L), "source finding structure");
+        foreach (var finding in manifest.Findings)
+        {
+            budget.String(finding.Code, "source manifest finding code");
+            budget.String(finding.Message, "source manifest finding message");
+            budget.String(finding.Location?.EntryUri, "source finding entry URI");
+            budget.String(finding.Location?.OwnerUri, "source finding owner URI");
+            budget.String(finding.Location?.RelationshipId, "source finding relationship id");
+            budget.String(finding.Location?.TargetUri, "source finding target URI");
+            budget.String(finding.Location?.PropertyPath, "source finding property path");
+        }
+        budget.String(manifest.Facts.MainDocumentUri, "source main-document URI");
+    }
+
+    private static void AccountDigest(
+        VerificationDigest? digest,
+        DeliveryReceiptResourceBudget budget,
+        string name)
+    {
+        if (digest is null)
+            return;
+        budget.String(digest.Algorithm, $"{name} algorithm");
+        budget.String(digest.Value, $"{name} value");
+    }
+
+    private void EnsureCollectionCapacity(int currentCount, string name)
+    {
+        if (currentCount >= _limits.MaxCollectionItems)
+        {
+            throw new DeliveryReceiptValidationException(
+                "receipt_resource_limit", $"Receipt {name} limit exceeded.");
+        }
+    }
+
+    private void CheckString(string? value, string name)
+    {
+        if (value is not null && value.Length > _limits.MaxStringLength)
+        {
+            throw new DeliveryReceiptValidationException(
+                "receipt_resource_limit", $"{name} exceeds the string-length limit.");
+        }
+    }
+
+    private static bool ArtifactEquals(DeliveryArtifact left, DeliveryArtifact right) =>
+        left == right;
+
+    private static string ScopeFromAnchor(string anchorId)
+    {
+        DeliveryReceiptValidation.RequireNonBlank(anchorId, "anchor id", 4096);
+        var first = anchorId.IndexOf(':');
+        var second = first < 0 ? -1 : anchorId.IndexOf(':', first + 1);
+        if (first <= 0 || second <= first + 1 || second == anchorId.Length - 1)
+        {
+            throw new DeliveryReceiptValidationException(
+                "invalid_anchor_id", $"'{anchorId}' is not a canonical kind:scope:unid anchor.");
+        }
+        return anchorId[(first + 1)..second];
+    }
+
+    private static JsonElement ParseCanonical(byte[] canonical)
+    {
+        using var document = JsonDocument.Parse(canonical);
+        return document.RootElement.Clone();
+    }
+
+    private (byte[] Bytes, JsonElement Element) CanonicalListItem(string json)
+    {
+        DeliveryReceiptResourceBudget.Bytes(
+            Encoding.UTF8.GetByteCount(json),
+            _limits.MaxReceiptJsonBytes,
+            "receipt_resource_limit",
+            "Authorship evidence JSON");
+        var canonicalArray = DeliveryReceiptCanonicalJson.CanonicalizeBounded(
+            Encoding.UTF8.GetBytes(json), _limits, _limits.MaxReceiptJsonBytes,
+            "receipt_resource_limit");
+        using var document = JsonDocument.Parse(canonicalArray);
+        if (document.RootElement.ValueKind != JsonValueKind.Array
+            || document.RootElement.GetArrayLength() != 1)
+        {
+            throw new DeliveryReceiptValidationException(
+                "invalid_batch_evidence", "Expected one serialized batch evidence item.");
+        }
+        var element = document.RootElement[0].Clone();
+        return (DeliveryReceiptCanonicalJson.SerializeCanonicalBounded(
+            element, _limits, _limits.MaxReceiptJsonBytes,
+            "receipt_resource_limit"), element);
+    }
+
+    private static bool Matches(
+        DeliveryChangeAttributionRule rule,
+        DeliveryPackageChangeObservation candidate) =>
+        rule.Kind == candidate.Kind
+        && (rule.EntryUri is null || string.Equals(
+            rule.EntryUri, candidate.Location.EntryUri, StringComparison.Ordinal))
+        && (rule.OwnerUri is null || string.Equals(
+            rule.OwnerUri, candidate.Location.OwnerUri, StringComparison.Ordinal))
+        && (rule.RelationshipId is null || string.Equals(
+            rule.RelationshipId, candidate.Location.RelationshipId, StringComparison.Ordinal));
+
+    private static void ValidateAttributionRule(DeliveryChangeAttributionRule rule)
+    {
+        if (!Enum.IsDefined(rule.Kind) || !Enum.IsDefined(rule.Disposition))
+            throw new DeliveryReceiptValidationException("invalid_attribution", "Unknown attribution value.");
+        if (rule.Kind is DeliveryPackageChangeKind.PartAdded
+            or DeliveryPackageChangeKind.PartRemoved
+            or DeliveryPackageChangeKind.PartModified)
+        {
+            DeliveryReceiptValidation.RequireNonBlank(rule.EntryUri, "attribution entry URI", 4096);
+            if (rule.OwnerUri is not null || rule.RelationshipId is not null)
+                throw new DeliveryReceiptValidationException(
+                    "invalid_attribution", "Part attribution cannot contain relationship fields.");
+        }
+        else
+        {
+            DeliveryReceiptValidation.RequireNonBlank(rule.OwnerUri, "attribution owner URI", 4096);
+            DeliveryReceiptValidation.RequireNonBlank(
+                rule.RelationshipId, "attribution relationship id", 2048);
+            if (rule.EntryUri is not null)
+                throw new DeliveryReceiptValidationException(
+                    "invalid_attribution", "Relationship attribution cannot contain an entry URI.");
+        }
+        if (rule.Disposition == DeliveryChangeDisposition.UserRequested)
+        {
+            DeliveryReceiptValidation.RequireNonBlank(
+                rule.TransactionEntryId, "attribution transaction entry id", 256);
+            if (rule.RequestedOperationIndex is null or < 0)
+                throw new DeliveryReceiptValidationException(
+                    "invalid_attribution", "User-requested attribution requires an operation index.");
+        }
+        if (rule.TransactionEntryId is null && rule.RequestedOperationIndex is not null)
+        {
+            throw new DeliveryReceiptValidationException(
+                "invalid_attribution",
+                "An attribution operation index requires a transaction entry id.");
+        }
+        if (rule.Disposition == DeliveryChangeDisposition.Derived)
+            DeliveryReceiptValidation.RequireNonBlank(rule.Derivation, "derivation", 4096);
+    }
+}

--- a/Docxodus/Verification/DeliveryChangeReceiptBuilder.cs
+++ b/Docxodus/Verification/DeliveryChangeReceiptBuilder.cs
@@ -31,6 +31,8 @@ public sealed class DeliveryChangeReceiptBuilder
     private readonly Dictionary<string, DeliveryArtifact> _artifacts = new(StringComparer.Ordinal);
     private readonly Dictionary<string, byte[]> _artifactBytes = new(StringComparer.Ordinal);
     private readonly Dictionary<string, PageMap> _validatedPageMaps = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, PackageManifest> _cleanDocxManifests =
+        new(StringComparer.Ordinal);
     private readonly Dictionary<(string ArtifactId, string AnchorId), PageCitation>
         _pageMapProjections = new();
     private readonly List<DeliveryPageCitationInput> _citations = new();
@@ -689,6 +691,8 @@ public sealed class DeliveryChangeReceiptBuilder
 
     private static void WriteAnchor(Utf8JsonWriter writer, Anchor anchor)
     {
+        // Exactly DeliveryReceiptContract.EditResultAnchorPropertyCount properties;
+        // the verifier re-reads anchors with that arity.
         writer.WriteStartObject();
         writer.WriteString("id", anchor.Id);
         writer.WriteString("kind", anchor.Kind);
@@ -894,12 +898,14 @@ public sealed class DeliveryChangeReceiptBuilder
                 "artifact_resource_limit", "Receipt artifact count limit exceeded.");
         }
         ValidateArtifactResourceLimits(input);
-        var artifact = BuildArtifact(input);
+        var artifact = BuildArtifact(input, out var cleanDocxManifest);
         if (!_artifacts.TryAdd(artifact.ArtifactId, artifact))
         {
             throw new DeliveryReceiptValidationException(
                 "duplicate_artifact_id", $"Artifact id '{artifact.ArtifactId}' is duplicated.");
         }
+        if (cleanDocxManifest is not null)
+            _cleanDocxManifests[artifact.ArtifactId] = cleanDocxManifest;
         if (input.Bytes is not null)
         {
             _totalArtifactBytes = checked(_totalArtifactBytes + input.Bytes.LongLength);
@@ -944,8 +950,14 @@ public sealed class DeliveryChangeReceiptBuilder
         }
     }
 
-    private DeliveryArtifact BuildArtifact(DeliveryArtifactInput input)
+    private DeliveryArtifact BuildArtifact(DeliveryArtifactInput input) =>
+        BuildArtifact(input, out _);
+
+    private DeliveryArtifact BuildArtifact(
+        DeliveryArtifactInput input,
+        out PackageManifest? cleanDocxManifest)
     {
+        cleanDocxManifest = null;
         if (!Enum.IsDefined(input.Role) || !Enum.IsDefined(input.Availability))
             throw new DeliveryReceiptValidationException("invalid_artifact_enum", "Unknown artifact value.");
         var artifactId = DeliveryReceiptValidation.RequireNonBlank(
@@ -1001,6 +1013,7 @@ public sealed class DeliveryChangeReceiptBuilder
                         "Caller-supplied clean DOCX identity does not match recomputed bytes.");
                 }
                 document = actual;
+                cleanDocxManifest = manifest;
             }
             if (document is not null
                 && input.Role is DeliveryArtifactRole.CleanDocx or DeliveryArtifactRole.ReviewDocx
@@ -1150,8 +1163,10 @@ public sealed class DeliveryChangeReceiptBuilder
                 "clean_docx_delivery_mismatch",
                 "The clean DOCX artifact must be available and exactly match DeliveredDocument.");
         }
-        var actualManifest = PackageManifestGenerator.Generate(
-            cleanBytes, _limits.CleanDocxManifestOptions);
+        var actualManifest = _cleanDocxManifests.TryGetValue(
+                clean.ArtifactId, out var cachedManifest)
+            ? cachedManifest
+            : PackageManifestGenerator.Generate(cleanBytes, _limits.CleanDocxManifestOptions);
         if (!actualManifest.IsValid
             || !string.Equals(actualManifest.PackageKind, "opc", StringComparison.Ordinal)
             || string.IsNullOrWhiteSpace(actualManifest.Facts.MainDocumentUri)
@@ -1378,17 +1393,14 @@ public sealed class DeliveryChangeReceiptBuilder
         }
     }
 
-    private static string ExpectedEvidenceSchema(DeliveryEvidenceKind kind) => kind switch
-    {
-        DeliveryEvidenceKind.ValidationResult => DeliverableVerificationResult.SchemaId,
-        DeliveryEvidenceKind.RedlineReversibility => RedlineReversibilityProof.SchemaId,
-        DeliveryEvidenceKind.SemanticChangeSet =>
-            throw new DeliveryReceiptValidationException(
+    private static string ExpectedEvidenceSchema(DeliveryEvidenceKind kind) =>
+        DeliveryReceiptContract.EvidenceSchemaFor(kind)
+        ?? throw (kind == DeliveryEvidenceKind.SemanticChangeSet
+            ? new DeliveryReceiptValidationException(
                 "semantic_evidence_requires_typed_factory",
-                "Semantic evidence must use the typed #457 binding."),
-        _ => throw new DeliveryReceiptValidationException(
-            "unknown_evidence_kind", "Unknown evidence kind."),
-    };
+                "Semantic evidence must use the typed #457 binding.")
+            : new DeliveryReceiptValidationException(
+                "unknown_evidence_kind", "Unknown evidence kind."));
 
     private static bool IsExactEvidence(DeliveryEvidenceKind kind, ReadOnlySpan<byte> bytes) =>
         kind switch
@@ -1565,14 +1577,11 @@ public sealed class DeliveryChangeReceiptBuilder
     }
 
     private static bool CitationCoordinatesEqual(PageCitation left, PageCitation right) =>
-        string.Equals(left.AnchorId, right.AnchorId, StringComparison.Ordinal)
+        DeliveryReceiptContract.CitationCoordinatesEqual(
+            right, left.AnchorId, left.DocumentVersion, left.RendererFingerprint,
+            left.Pages, left.Fragments)
         && left.Availability == right.Availability
-        && left.UnavailableReason == right.UnavailableReason
-        && left.DocumentVersion == right.DocumentVersion
-        && string.Equals(left.RendererFingerprint, right.RendererFingerprint,
-            StringComparison.Ordinal)
-        && left.Pages.SequenceEqual(right.Pages)
-        && left.Fragments.SequenceEqual(right.Fragments);
+        && left.UnavailableReason == right.UnavailableReason;
 
     private DeliveryTextEvidence TextEvidence(string value, string structuralSummary)
     {
@@ -1595,7 +1604,7 @@ public sealed class DeliveryChangeReceiptBuilder
         {
             DeliveryReceiptPrivacyProfile.HashOnly => digest,
             DeliveryReceiptPrivacyProfile.HashAndSummary =>
-                $"{label}; {value.Length.ToString(CultureInfo.InvariantCulture)} characters; {digest}",
+                DeliveryReceiptContract.RedactedFreeText(label, value.Length, digest),
             _ => value,
         };
     }
@@ -2030,14 +2039,7 @@ public sealed class DeliveryChangeReceiptBuilder
     private static string ScopeFromAnchor(string anchorId)
     {
         DeliveryReceiptValidation.RequireNonBlank(anchorId, "anchor id", 4096);
-        var first = anchorId.IndexOf(':');
-        var second = first < 0 ? -1 : anchorId.IndexOf(':', first + 1);
-        if (first <= 0 || second <= first + 1 || second == anchorId.Length - 1)
-        {
-            throw new DeliveryReceiptValidationException(
-                "invalid_anchor_id", $"'{anchorId}' is not a canonical kind:scope:unid anchor.");
-        }
-        return anchorId[(first + 1)..second];
+        return DeliveryReceiptContract.ScopeFromAnchor(anchorId);
     }
 
     private static JsonElement ParseCanonical(byte[] canonical)

--- a/Docxodus/Verification/DeliveryChangeReceiptBuilder.cs
+++ b/Docxodus/Verification/DeliveryChangeReceiptBuilder.cs
@@ -303,6 +303,39 @@ public sealed class DeliveryChangeReceiptBuilder
             throw new DeliveryReceiptValidationException(
                 "duplicate_evidence", "Receipt evidence identities must be unique.");
         }
+        foreach (var artifact in artifacts)
+        {
+            if (artifact.Role != DeliveryArtifactRole.ReviewDocx
+                && artifact.DocumentVersion is { } artifactVersion
+                && artifact.PackageDigest is { } artifactPackageDigest
+                && !DeliveryReceiptLineageValidator.IsArtifactDocumentReachable(
+                    lineageValidation, artifactVersion, artifactPackageDigest, artifacts))
+            {
+                throw new DeliveryReceiptValidationException(
+                    "unreachable_artifact_document",
+                    $"Artifact '{artifact.ArtifactId}' is bound to a document identity that "
+                    + "is neither a lineage state nor an in-receipt review copy.");
+            }
+        }
+        var boundEvidenceArtifacts = semanticChangeSets
+            .Select(binding => binding.ArtifactId)
+            .Concat(evidence.Select(item => item.ArtifactId)
+                .Where(artifactId => artifactId is not null)
+                .Select(artifactId => artifactId!))
+            .ToHashSet(StringComparer.Ordinal);
+        foreach (var artifact in artifacts)
+        {
+            if (artifact.Role is DeliveryArtifactRole.SemanticDiff
+                    or DeliveryArtifactRole.ValidationReport
+                    or DeliveryArtifactRole.ReversibilityProof
+                && !boundEvidenceArtifacts.Contains(artifact.ArtifactId))
+            {
+                throw new DeliveryReceiptValidationException(
+                    "unbound_evidence_artifact",
+                    $"Artifact '{artifact.ArtifactId}' claims a typed-evidence role but no "
+                    + "semantic binding or evidence reference attests it.");
+            }
+        }
         var citations = _citations
             .Select(citation => BuildPageCitation(citation, lineageValidation))
             .OrderBy(citation => citation.AnchorId, StringComparer.Ordinal)

--- a/Docxodus/Verification/DeliveryChangeReceiptBuilder.cs
+++ b/Docxodus/Verification/DeliveryChangeReceiptBuilder.cs
@@ -96,11 +96,25 @@ public sealed class DeliveryChangeReceiptBuilder
                     "retry_result_conflict",
                     $"Transaction id '{identity.TransactionId}' no longer identifies the original result.");
             }
+            if (!TransactionEvidenceEquals(prior, entry))
+            {
+                throw new DeliveryReceiptValidationException(
+                    "retry_result_conflict",
+                    $"Transaction id '{identity.TransactionId}' returned different result evidence.");
+            }
             return prior.EntryId;
         }
 
         if (_entriesById.TryGetValue(entry.EntryId, out var duplicate))
+        {
+            if (!TransactionEvidenceEquals(duplicate, entry))
+            {
+                throw new DeliveryReceiptValidationException(
+                    "retry_result_conflict",
+                    $"Transaction entry '{entry.EntryId}' has conflicting result evidence.");
+            }
             return duplicate.EntryId;
+        }
 
         if (_transactions.Count >= _limits.MaxTransactions)
         {
@@ -325,7 +339,9 @@ public sealed class DeliveryChangeReceiptBuilder
             contribution.BeforeDocument,
             contribution.AfterDocument,
             result.BaseVersion,
-            result.ResultVersion);
+            result.ResultVersion,
+            contribution.Identity?.TransactionId,
+            sequence);
 
         var stepsByIndex = result.Steps.ToDictionary(step => step.Index);
         var operations = contribution.Operations.Select((operation, index) =>
@@ -339,6 +355,9 @@ public sealed class DeliveryChangeReceiptBuilder
                 value.EntityKind,
                 value.ChangeKind,
                 value.EntityId,
+                value.PartUri,
+                value.Scope,
+                SourceDigest = value.SourceDigest.Value,
             }).Any(group => group.Count() != 1))
         {
             throw new DeliveryReceiptValidationException(
@@ -674,7 +693,10 @@ public sealed class DeliveryChangeReceiptBuilder
         return changes
             .OrderBy(change => change.EntityKind)
             .ThenBy(change => change.ChangeKind)
-            .ThenBy(change => change.EntityId, StringComparer.Ordinal);
+            .ThenBy(change => change.EntityId, StringComparer.Ordinal)
+            .ThenBy(change => change.PartUri, StringComparer.Ordinal)
+            .ThenBy(change => change.Scope, StringComparer.Ordinal)
+            .ThenBy(change => change.SourceDigest.Value, StringComparer.Ordinal);
     }
 
     private static void AddAuthoredChanges<T>(
@@ -1427,7 +1449,9 @@ public sealed class DeliveryChangeReceiptBuilder
         DeliveryDocumentIdentity before,
         DeliveryDocumentIdentity after,
         long baseVersion,
-        long resultVersion)
+        long resultVersion,
+        string? transactionId,
+        long sequence)
     {
         var identity = new
         {
@@ -1436,9 +1460,24 @@ public sealed class DeliveryChangeReceiptBuilder
             beforePackage = before.RawPackageBytesDigest,
             requestFingerprint,
             resultVersion,
+            transactionId,
+            transactionSequence = transactionId is null ? sequence : (long?)null,
         };
         return DeliveryReceiptCanonicalJson.DigestToken(
             DeliveryReceiptCanonicalJson.SerializeCanonical(identity));
+    }
+
+    private bool TransactionEvidenceEquals(
+        DeliveryTransactionEntry left,
+        DeliveryTransactionEntry right)
+    {
+        var leftBytes = DeliveryReceiptCanonicalJson.SerializeCanonicalBounded(
+            left with { Sequence = 0 }, _limits, _limits.MaxReceiptJsonBytes,
+            "receipt_resource_limit");
+        var rightBytes = DeliveryReceiptCanonicalJson.SerializeCanonicalBounded(
+            right with { Sequence = 0 }, _limits, _limits.MaxReceiptJsonBytes,
+            "receipt_resource_limit");
+        return leftBytes.AsSpan().SequenceEqual(rightBytes);
     }
 
     private void ValidateContributionResources(DeliveryTransactionContribution contribution)

--- a/Docxodus/Verification/DeliveryPackageManifestAdapter.cs
+++ b/Docxodus/Verification/DeliveryPackageManifestAdapter.cs
@@ -22,8 +22,8 @@ internal static class DeliveryPackageManifestAdapter
         long documentVersion)
     {
         ArgumentNullException.ThrowIfNull(manifest);
-        if (documentVersion < 0)
-            throw new ArgumentOutOfRangeException(nameof(documentVersion));
+        DeliveryReceiptValidation.ValidatePortableNonNegativeInteger(
+            documentVersion, "invalid_document_version", "Document version");
         if (!IsSupportedSchema(manifest.Schema) || manifest.SchemaVersion != 1)
         {
             throw new DeliveryReceiptValidationException(
@@ -43,11 +43,20 @@ internal static class DeliveryPackageManifestAdapter
             manifest.NormalizedSemanticDigest, "normalized semantic digest");
         var packageKind = DeliveryReceiptValidation.RequireNonBlank(
             manifest.PackageKind, "package kind", 256);
+        if (!string.Equals(packageKind, "opc", StringComparison.Ordinal))
+        {
+            throw new DeliveryReceiptValidationException(
+                "not_wordprocessing_package",
+                "Delivery document identities require an OPC Word main-document part.");
+        }
+        var mainDocumentUri = DeliveryReceiptValidation.RequireOpcMainDocumentUri(
+            manifest.Facts.MainDocumentUri, "main document URI");
         return new DeliveryDocumentIdentity
         {
             DocumentVersion = documentVersion,
             PackageKind = packageKind,
             PackageManifestSchema = manifest.Schema,
+            MainDocumentUri = mainDocumentUri,
             RawPackageBytesDigest = DeliveryReceiptValidation.CloneDigest(
                 manifest.RawPackageBytesDigest),
             OrderedOpcContentDigest = DeliveryReceiptValidation.CloneOptionalDigest(
@@ -59,11 +68,19 @@ internal static class DeliveryPackageManifestAdapter
 
     public static IReadOnlyList<DeliveryPackageChangeObservation> Compare(
         PackageManifest before,
-        PackageManifest after)
+        PackageManifest after,
+        int maximumChanges)
     {
         ArgumentNullException.ThrowIfNull(before);
         ArgumentNullException.ThrowIfNull(after);
-        return PackageDelta.Compare(before, after).Select(ProjectChange).ToArray();
+        var delta = PackageDelta.Compare(before, after, maximumChanges);
+        if (!delta.Complete)
+        {
+            throw new DeliveryReceiptValidationException(
+                "receipt_resource_limit",
+                "Package comparison exceeds the receipt change-record limit.");
+        }
+        return delta.Changes.Select(ProjectChange).ToArray();
     }
 
     private static DeliveryPackageChangeObservation ProjectChange(PackageDeltaChange change) =>

--- a/Docxodus/Verification/DeliveryPackageManifestAdapter.cs
+++ b/Docxodus/Verification/DeliveryPackageManifestAdapter.cs
@@ -1,0 +1,187 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Globalization;
+using System.Text;
+
+namespace Docxodus.Verification;
+
+/// <summary>
+/// The single #456 integration point for delivery receipts. Package parsing remains owned by
+/// PackageManifestGenerator; this adapter only projects the public manifest into immutable receipt
+/// identities and compares already-materialized records. Corrected #493 availability semantics for
+/// optional content/semantic digests remain isolated here rather than being reinterpreted by receipts.
+/// </summary>
+internal static class DeliveryPackageManifestAdapter
+{
+    public static bool IsSupportedSchema(string schema) =>
+        string.Equals(schema, PackageManifest.SchemaId, StringComparison.Ordinal);
+
+    public static DeliveryDocumentIdentity CreateIdentity(
+        PackageManifest manifest,
+        long documentVersion)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+        if (documentVersion < 0)
+            throw new ArgumentOutOfRangeException(nameof(documentVersion));
+        if (!IsSupportedSchema(manifest.Schema) || manifest.SchemaVersion != 1)
+        {
+            throw new DeliveryReceiptValidationException(
+                "unsupported_package_manifest",
+                $"Expected {PackageManifest.SchemaId} version 1.");
+        }
+        if (!manifest.IsValid)
+        {
+            throw new DeliveryReceiptValidationException(
+                "invalid_package_manifest",
+                "Delivery document identities require a manifest with no error findings.");
+        }
+        DeliveryReceiptValidation.ValidateDigest(manifest.RawPackageBytesDigest, "raw package digest");
+        DeliveryReceiptValidation.ValidateOptionalDigest(
+            manifest.OrderedOpcContentDigest, "ordered OPC content digest");
+        DeliveryReceiptValidation.ValidateOptionalDigest(
+            manifest.NormalizedSemanticDigest, "normalized semantic digest");
+        var packageKind = DeliveryReceiptValidation.RequireNonBlank(
+            manifest.PackageKind, "package kind", 256);
+        return new DeliveryDocumentIdentity
+        {
+            DocumentVersion = documentVersion,
+            PackageKind = packageKind,
+            PackageManifestSchema = manifest.Schema,
+            RawPackageBytesDigest = DeliveryReceiptValidation.CloneDigest(
+                manifest.RawPackageBytesDigest),
+            OrderedOpcContentDigest = DeliveryReceiptValidation.CloneOptionalDigest(
+                manifest.OrderedOpcContentDigest),
+            NormalizedSemanticDigest = DeliveryReceiptValidation.CloneOptionalDigest(
+                manifest.NormalizedSemanticDigest),
+        };
+    }
+
+    public static IReadOnlyList<DeliveryPackageChangeObservation> Compare(
+        PackageManifest before,
+        PackageManifest after)
+    {
+        ArgumentNullException.ThrowIfNull(before);
+        ArgumentNullException.ThrowIfNull(after);
+        var changes = new List<DeliveryPackageChangeObservation>();
+        AddEntryChanges(changes, before.Entries, after.Entries);
+        AddRelationshipChanges(changes, before.Relationships, after.Relationships);
+        return changes
+            .OrderBy(change => change.Kind)
+            .ThenBy(change => change.Location.EntryUri, StringComparer.Ordinal)
+            .ThenBy(change => change.Location.OwnerUri, StringComparer.Ordinal)
+            .ThenBy(change => change.Location.RelationshipId, StringComparer.Ordinal)
+            .ThenBy(change => change.Location.PropertyPath, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static void AddEntryChanges(
+        ICollection<DeliveryPackageChangeObservation> changes,
+        IReadOnlyList<PackageManifestEntry> before,
+        IReadOnlyList<PackageManifestEntry> after)
+    {
+        var left = before.ToDictionary(
+            entry => (entry.Uri, entry.Occurrence), EntryValue);
+        var right = after.ToDictionary(
+            entry => (entry.Uri, entry.Occurrence), EntryValue);
+        foreach (var key in left.Keys.Union(right.Keys)
+                     .OrderBy(key => key.Uri, StringComparer.Ordinal)
+                     .ThenBy(key => key.Occurrence))
+        {
+            left.TryGetValue(key, out var oldValue);
+            right.TryGetValue(key, out var newValue);
+            if (string.Equals(oldValue, newValue, StringComparison.Ordinal))
+                continue;
+            changes.Add(new DeliveryPackageChangeObservation(
+                oldValue is null ? DeliveryPackageChangeKind.PartAdded
+                    : newValue is null ? DeliveryPackageChangeKind.PartRemoved
+                    : DeliveryPackageChangeKind.PartModified,
+                new ChangeLocation
+                {
+                    EntryUri = key.Uri,
+                    PropertyPath = $"occurrence:{key.Occurrence.ToString(CultureInfo.InvariantCulture)}",
+                },
+                oldValue,
+                newValue));
+        }
+    }
+
+    private static void AddRelationshipChanges(
+        ICollection<DeliveryPackageChangeObservation> changes,
+        IReadOnlyList<PackageRelationship> before,
+        IReadOnlyList<PackageRelationship> after)
+    {
+        var left = IndexedRelationships(before);
+        var right = IndexedRelationships(after);
+        foreach (var key in left.Keys.Union(right.Keys)
+                     .OrderBy(key => key.OwnerUri, StringComparer.Ordinal)
+                     .ThenBy(key => key.Id, StringComparer.Ordinal)
+                     .ThenBy(key => key.Occurrence))
+        {
+            left.TryGetValue(key, out var oldRelationship);
+            right.TryGetValue(key, out var newRelationship);
+            var oldValue = oldRelationship is null ? null : RelationshipValue(oldRelationship);
+            var newValue = newRelationship is null ? null : RelationshipValue(newRelationship);
+            if (string.Equals(oldValue, newValue, StringComparison.Ordinal))
+                continue;
+            changes.Add(new DeliveryPackageChangeObservation(
+                oldRelationship is null ? DeliveryPackageChangeKind.RelationshipAdded
+                    : newRelationship is null ? DeliveryPackageChangeKind.RelationshipRemoved
+                    : DeliveryPackageChangeKind.RelationshipModified,
+                new ChangeLocation
+                {
+                    OwnerUri = key.OwnerUri,
+                    RelationshipId = key.Id,
+                    TargetUri = newRelationship?.ResolvedTargetUri ?? newRelationship?.Target
+                        ?? oldRelationship?.ResolvedTargetUri ?? oldRelationship?.Target,
+                    PropertyPath = $"occurrence:{key.Occurrence.ToString(CultureInfo.InvariantCulture)}",
+                },
+                oldValue,
+                newValue));
+        }
+    }
+
+    private static string EntryValue(PackageManifestEntry entry) =>
+        Encoding.UTF8.GetString(DeliveryReceiptCanonicalJson.SerializeCanonical(new
+        {
+            contentType = entry.ContentType,
+            contentTypeSource = entry.ContentTypeSource,
+            isEncrypted = entry.IsEncrypted,
+            isXml = entry.IsXml,
+            normalizedXmlDigest = entry.NormalizedXmlDigest,
+            rawBytesDigest = entry.RawBytesDigest,
+            size = entry.Size,
+        }));
+
+    private static string RelationshipValue(PackageRelationship relationship) =>
+        Encoding.UTF8.GetString(DeliveryReceiptCanonicalJson.SerializeCanonical(new
+        {
+            isTargetPresent = relationship.IsTargetPresent,
+            resolvedTargetUri = relationship.ResolvedTargetUri,
+            target = relationship.Target,
+            targetMode = relationship.TargetMode,
+            type = relationship.Type,
+        }));
+
+    private static Dictionary<(string OwnerUri, string Id, int Occurrence), PackageRelationship>
+        IndexedRelationships(IReadOnlyList<PackageRelationship> relationships)
+    {
+        var result = new Dictionary<(string, string, int), PackageRelationship>();
+        foreach (var group in relationships
+                     .GroupBy(relationship => (relationship.OwnerUri, relationship.Id)))
+        {
+            var occurrence = 0;
+            foreach (var relationship in group.OrderBy(RelationshipValue, StringComparer.Ordinal))
+                result.Add((group.Key.OwnerUri, group.Key.Id, occurrence++), relationship);
+        }
+        return result;
+    }
+}
+
+internal sealed record DeliveryPackageChangeObservation(
+    DeliveryPackageChangeKind Kind,
+    ChangeLocation Location,
+    string? Before,
+    string? After);

--- a/Docxodus/Verification/DeliveryPackageManifestAdapter.cs
+++ b/Docxodus/Verification/DeliveryPackageManifestAdapter.cs
@@ -3,16 +3,14 @@
 
 #nullable enable
 
-using System.Globalization;
-using System.Text;
-
 namespace Docxodus.Verification;
 
 /// <summary>
 /// The single #456 integration point for delivery receipts. Package parsing remains owned by
 /// PackageManifestGenerator; this adapter only projects the public manifest into immutable receipt
-/// identities and compares already-materialized records. Corrected #493 availability semantics for
-/// optional content/semantic digests remain isolated here rather than being reinterpreted by receipts.
+/// identities and adapts #463's policy-neutral package delta into receipt evidence. Corrected #493
+/// availability semantics for optional content/semantic digests remain isolated here rather than
+/// being reinterpreted by receipts.
 /// </summary>
 internal static class DeliveryPackageManifestAdapter
 {
@@ -65,119 +63,27 @@ internal static class DeliveryPackageManifestAdapter
     {
         ArgumentNullException.ThrowIfNull(before);
         ArgumentNullException.ThrowIfNull(after);
-        var changes = new List<DeliveryPackageChangeObservation>();
-        AddEntryChanges(changes, before.Entries, after.Entries);
-        AddRelationshipChanges(changes, before.Relationships, after.Relationships);
-        return changes
-            .OrderBy(change => change.Kind)
-            .ThenBy(change => change.Location.EntryUri, StringComparer.Ordinal)
-            .ThenBy(change => change.Location.OwnerUri, StringComparer.Ordinal)
-            .ThenBy(change => change.Location.RelationshipId, StringComparer.Ordinal)
-            .ThenBy(change => change.Location.PropertyPath, StringComparer.Ordinal)
-            .ToArray();
+        return PackageDelta.Compare(before, after).Select(ProjectChange).ToArray();
     }
 
-    private static void AddEntryChanges(
-        ICollection<DeliveryPackageChangeObservation> changes,
-        IReadOnlyList<PackageManifestEntry> before,
-        IReadOnlyList<PackageManifestEntry> after)
-    {
-        var left = before.ToDictionary(
-            entry => (entry.Uri, entry.Occurrence), EntryValue);
-        var right = after.ToDictionary(
-            entry => (entry.Uri, entry.Occurrence), EntryValue);
-        foreach (var key in left.Keys.Union(right.Keys)
-                     .OrderBy(key => key.Uri, StringComparer.Ordinal)
-                     .ThenBy(key => key.Occurrence))
-        {
-            left.TryGetValue(key, out var oldValue);
-            right.TryGetValue(key, out var newValue);
-            if (string.Equals(oldValue, newValue, StringComparison.Ordinal))
-                continue;
-            changes.Add(new DeliveryPackageChangeObservation(
-                oldValue is null ? DeliveryPackageChangeKind.PartAdded
-                    : newValue is null ? DeliveryPackageChangeKind.PartRemoved
-                    : DeliveryPackageChangeKind.PartModified,
-                new ChangeLocation
-                {
-                    EntryUri = key.Uri,
-                    PropertyPath = $"occurrence:{key.Occurrence.ToString(CultureInfo.InvariantCulture)}",
-                },
-                oldValue,
-                newValue));
-        }
-    }
-
-    private static void AddRelationshipChanges(
-        ICollection<DeliveryPackageChangeObservation> changes,
-        IReadOnlyList<PackageRelationship> before,
-        IReadOnlyList<PackageRelationship> after)
-    {
-        var left = IndexedRelationships(before);
-        var right = IndexedRelationships(after);
-        foreach (var key in left.Keys.Union(right.Keys)
-                     .OrderBy(key => key.OwnerUri, StringComparer.Ordinal)
-                     .ThenBy(key => key.Id, StringComparer.Ordinal)
-                     .ThenBy(key => key.Occurrence))
-        {
-            left.TryGetValue(key, out var oldRelationship);
-            right.TryGetValue(key, out var newRelationship);
-            var oldValue = oldRelationship is null ? null : RelationshipValue(oldRelationship);
-            var newValue = newRelationship is null ? null : RelationshipValue(newRelationship);
-            if (string.Equals(oldValue, newValue, StringComparison.Ordinal))
-                continue;
-            changes.Add(new DeliveryPackageChangeObservation(
-                oldRelationship is null ? DeliveryPackageChangeKind.RelationshipAdded
-                    : newRelationship is null ? DeliveryPackageChangeKind.RelationshipRemoved
-                    : DeliveryPackageChangeKind.RelationshipModified,
-                new ChangeLocation
-                {
-                    OwnerUri = key.OwnerUri,
-                    RelationshipId = key.Id,
-                    TargetUri = newRelationship?.ResolvedTargetUri ?? newRelationship?.Target
-                        ?? oldRelationship?.ResolvedTargetUri ?? oldRelationship?.Target,
-                    PropertyPath = $"occurrence:{key.Occurrence.ToString(CultureInfo.InvariantCulture)}",
-                },
-                oldValue,
-                newValue));
-        }
-    }
-
-    private static string EntryValue(PackageManifestEntry entry) =>
-        Encoding.UTF8.GetString(DeliveryReceiptCanonicalJson.SerializeCanonical(new
-        {
-            contentType = entry.ContentType,
-            contentTypeSource = entry.ContentTypeSource,
-            isEncrypted = entry.IsEncrypted,
-            isXml = entry.IsXml,
-            normalizedXmlDigest = entry.NormalizedXmlDigest,
-            rawBytesDigest = entry.RawBytesDigest,
-            size = entry.Size,
-        }));
-
-    private static string RelationshipValue(PackageRelationship relationship) =>
-        Encoding.UTF8.GetString(DeliveryReceiptCanonicalJson.SerializeCanonical(new
-        {
-            isTargetPresent = relationship.IsTargetPresent,
-            resolvedTargetUri = relationship.ResolvedTargetUri,
-            target = relationship.Target,
-            targetMode = relationship.TargetMode,
-            type = relationship.Type,
-        }));
-
-    private static Dictionary<(string OwnerUri, string Id, int Occurrence), PackageRelationship>
-        IndexedRelationships(IReadOnlyList<PackageRelationship> relationships)
-    {
-        var result = new Dictionary<(string, string, int), PackageRelationship>();
-        foreach (var group in relationships
-                     .GroupBy(relationship => (relationship.OwnerUri, relationship.Id)))
-        {
-            var occurrence = 0;
-            foreach (var relationship in group.OrderBy(RelationshipValue, StringComparer.Ordinal))
-                result.Add((group.Key.OwnerUri, group.Key.Id, occurrence++), relationship);
-        }
-        return result;
-    }
+    private static DeliveryPackageChangeObservation ProjectChange(PackageDeltaChange change) =>
+        new(
+            change.Kind switch
+            {
+                PackageDeltaChangeKind.EntryAdded => DeliveryPackageChangeKind.PartAdded,
+                PackageDeltaChangeKind.EntryRemoved => DeliveryPackageChangeKind.PartRemoved,
+                PackageDeltaChangeKind.EntryModified => DeliveryPackageChangeKind.PartModified,
+                PackageDeltaChangeKind.RelationshipAdded =>
+                    DeliveryPackageChangeKind.RelationshipAdded,
+                PackageDeltaChangeKind.RelationshipRemoved =>
+                    DeliveryPackageChangeKind.RelationshipRemoved,
+                PackageDeltaChangeKind.RelationshipModified =>
+                    DeliveryPackageChangeKind.RelationshipModified,
+                _ => throw new ArgumentOutOfRangeException(nameof(change), change.Kind, null),
+            },
+            change.Location,
+            change.BeforeValue,
+            change.AfterValue);
 }
 
 internal sealed record DeliveryPackageChangeObservation(

--- a/Docxodus/Verification/DeliveryReceiptCanonicalJson.cs
+++ b/Docxodus/Verification/DeliveryReceiptCanonicalJson.cs
@@ -632,6 +632,11 @@ internal static class DeliveryReceiptValidation
         && string.Equals(left.Algorithm, right.Algorithm, StringComparison.Ordinal)
         && string.Equals(left.Value, right.Value, StringComparison.Ordinal);
 
+    /// <summary>Digest equality where mutual absence counts as equal — for optional
+    /// identity components whose absence is itself part of the identity.</summary>
+    public static bool OptionalDigestEquals(VerificationDigest? left, VerificationDigest? right) =>
+        (left is null && right is null) || DigestEquals(left, right);
+
     public static string Invariant(long value) => value.ToString(CultureInfo.InvariantCulture);
 }
 
@@ -726,18 +731,23 @@ public static class DeliveryChangeReceiptSerializer
         DeliveryReceiptLimits limits)
     {
         var canonicalPayload = SerializePayload(payload, limits);
+        var receiptDigest = DeliveryReceiptCanonicalJson.Digest(canonicalPayload);
         var receipt = new DeliveryChangeReceipt
         {
             Payload = payload,
-            ReceiptDigest = DeliveryReceiptCanonicalJson.Digest(canonicalPayload),
+            ReceiptDigest = receiptDigest,
         };
+        // The canonical envelope is exactly {"payload":<canonicalPayload>,
+        // "receiptDigest":{"algorithm":…,"value":…}} with ASCII digest fields, so its
+        // length is arithmetic; re-serializing the whole envelope only to measure it
+        // doubled the largest allocation of a Build.
+        long envelopeLength = "{\"payload\":".Length
+            + canonicalPayload.LongLength
+            + ",\"receiptDigest\":{\"algorithm\":\"\",\"value\":\"\"}}".Length
+            + receiptDigest.Algorithm.Length
+            + receiptDigest.Value.Length;
         DeliveryReceiptResourceBudget.Bytes(
-            DeliveryReceiptCanonicalJson.SerializeCanonicalBounded(
-                receipt,
-                DeliveryReceiptCanonicalJson.JsonContext.DeliveryChangeReceipt,
-                limits,
-                limits.MaxReceiptJsonBytes,
-                "receipt_resource_limit").LongLength,
+            envelopeLength,
             limits.MaxReceiptJsonBytes,
             "receipt_resource_limit",
             "Receipt JSON");

--- a/Docxodus/Verification/DeliveryReceiptCanonicalJson.cs
+++ b/Docxodus/Verification/DeliveryReceiptCanonicalJson.cs
@@ -602,6 +602,31 @@ internal static class DeliveryReceiptValidation
         return string.Join('/', segments);
     }
 
+    /// <summary>The one validation of a document identity's shape; the builder applies it
+    /// at intake and the verifier re-applies it to untrusted payloads.</summary>
+    public static void ValidateDocument(DeliveryDocumentIdentity document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ValidatePortableNonNegativeInteger(
+            document.DocumentVersion, "invalid_document_version", "Document version");
+        if (!DeliveryPackageManifestAdapter.IsSupportedSchema(
+                document.PackageManifestSchema))
+        {
+            throw new DeliveryReceiptValidationException(
+                "unsupported_package_manifest", "Unsupported package-manifest schema.");
+        }
+        RequireNonBlank(document.PackageKind, "document package kind", 256);
+        if (!string.Equals(document.PackageKind, "opc", StringComparison.Ordinal))
+        {
+            throw new DeliveryReceiptValidationException(
+                "not_wordprocessing_package", "Document identity must be an OPC package.");
+        }
+        RequireOpcMainDocumentUri(document.MainDocumentUri, "main document URI");
+        ValidateDigest(document.RawPackageBytesDigest, "document package digest");
+        ValidateOptionalDigest(document.OrderedOpcContentDigest, "document content digest");
+        ValidateOptionalDigest(document.NormalizedSemanticDigest, "document semantic digest");
+    }
+
     public static bool DigestEquals(VerificationDigest? left, VerificationDigest? right) =>
         left is not null && right is not null
         && string.Equals(left.Algorithm, right.Algorithm, StringComparison.Ordinal)

--- a/Docxodus/Verification/DeliveryReceiptCanonicalJson.cs
+++ b/Docxodus/Verification/DeliveryReceiptCanonicalJson.cs
@@ -226,7 +226,10 @@ internal static class DeliveryReceiptCanonicalJson
                 "invalid_operation_arguments", $"{parameterName} is not valid JSON: {ex.Message}");
         }
 
-        using var document = JsonDocument.Parse(canonical);
+        using var document = JsonDocument.Parse(canonical, new JsonDocumentOptions
+        {
+            MaxDepth = DeliveryReceiptLimits.MaxAllowedJsonDepth,
+        });
         if (document.RootElement.ValueKind != JsonValueKind.Object)
         {
             throw new DeliveryReceiptValidationException(
@@ -645,7 +648,10 @@ public static class DeliveryChangeReceiptSerializer
         var payload = SerializePayload(receipt.Payload, validatedLimits);
         DeliveryReceiptValidation.ValidateDigest(receipt.ReceiptDigest, "receipt digest");
 
-        using var payloadDocument = JsonDocument.Parse(payload);
+        using var payloadDocument = JsonDocument.Parse(payload, new JsonDocumentOptions
+        {
+            MaxDepth = DeliveryReceiptLimits.MaxAllowedJsonDepth,
+        });
         using var stream = new DeliveryReceiptBoundedMemoryStream(
             validatedLimits.MaxReceiptJsonBytes,
             "receipt_resource_limit",
@@ -670,7 +676,10 @@ public static class DeliveryChangeReceiptSerializer
         if (!indented)
             return canonical;
 
-        using var canonicalDocument = JsonDocument.Parse(canonical);
+        using var canonicalDocument = JsonDocument.Parse(canonical, new JsonDocumentOptions
+        {
+            MaxDepth = DeliveryReceiptLimits.MaxAllowedJsonDepth,
+        });
         using var indentedStream = new DeliveryReceiptBoundedMemoryStream(
             validatedLimits.MaxReceiptJsonBytes,
             "receipt_resource_limit",

--- a/Docxodus/Verification/DeliveryReceiptCanonicalJson.cs
+++ b/Docxodus/Verification/DeliveryReceiptCanonicalJson.cs
@@ -1,0 +1,411 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Docxodus.Verification;
+
+internal static class DeliveryReceiptCanonicalJson
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+        Encoder = JavaScriptEncoder.Default,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        MaxDepth = 128,
+        WriteIndented = false,
+        Converters =
+        {
+            new JsonStringEnumConverter(JsonNamingPolicy.CamelCase, allowIntegerValues: false),
+        },
+    };
+
+    public static JsonSerializerOptions JsonOptions => SerializerOptions;
+
+    public static byte[] SerializeCanonical<T>(T value)
+    {
+        var json = JsonSerializer.SerializeToUtf8Bytes(value, SerializerOptions);
+        return Canonicalize(json);
+    }
+
+    public static byte[] SerializeCanonicalBounded<T>(
+        T value,
+        DeliveryReceiptLimits limits,
+        int maximumBytes,
+        string limitCode)
+    {
+        ArgumentNullException.ThrowIfNull(limits);
+        using var stream = new DeliveryReceiptBoundedMemoryStream(
+            maximumBytes, limitCode, "Serialized JSON");
+        using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
+        {
+            Encoder = JavaScriptEncoder.Default,
+            Indented = false,
+            MaxDepth = limits.MaxJsonDepth,
+        }))
+        {
+            var options = new JsonSerializerOptions(SerializerOptions)
+            {
+                MaxDepth = limits.MaxJsonDepth,
+            };
+            JsonSerializer.Serialize(writer, value, options);
+        }
+        var json = stream.ToArray();
+        return CanonicalizeBounded(json, limits, maximumBytes, limitCode);
+    }
+
+    public static byte[] Canonicalize(ReadOnlySpan<byte> json)
+        => CanonicalizeCore(json, null, int.MaxValue, "receipt_resource_limit");
+
+    public static byte[] CanonicalizeBounded(
+        ReadOnlySpan<byte> json,
+        DeliveryReceiptLimits limits,
+        int maximumBytes,
+        string limitCode)
+    {
+        ArgumentNullException.ThrowIfNull(limits);
+        DeliveryReceiptResourceBudget.Bytes(json.Length, maximumBytes, limitCode, "JSON input");
+        return CanonicalizeCore(json, limits, maximumBytes, limitCode);
+    }
+
+    private static byte[] CanonicalizeCore(
+        ReadOnlySpan<byte> json,
+        DeliveryReceiptLimits? limits,
+        int maximumBytes,
+        string limitCode)
+    {
+        if (limits is not null)
+            DeliveryReceiptResourceBudget.Bytes(json.Length, maximumBytes, limitCode, "JSON input");
+        using var document = JsonDocument.Parse(json.ToArray(), new JsonDocumentOptions
+        {
+            AllowTrailingCommas = false,
+            CommentHandling = JsonCommentHandling.Disallow,
+            MaxDepth = limits?.MaxJsonDepth ?? 128,
+        });
+        using MemoryStream stream = limits is null
+            ? new MemoryStream()
+            : new DeliveryReceiptBoundedMemoryStream(
+                maximumBytes, limitCode, "Canonical JSON");
+        long collectionItems = 0;
+        using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
+        {
+            Encoder = JavaScriptEncoder.Default,
+            Indented = false,
+            MaxDepth = limits?.MaxJsonDepth ?? 128,
+        }))
+        {
+            WriteCanonical(
+                writer, document.RootElement, limits, ref collectionItems, limitCode);
+        }
+        var canonical = stream.ToArray();
+        if (limits is not null)
+        {
+            DeliveryReceiptResourceBudget.Bytes(
+                canonical.LongLength, maximumBytes, limitCode, "Canonical JSON");
+        }
+        return canonical;
+    }
+
+    public static JsonElement ParseCanonicalObject(string json, string parameterName)
+    {
+        if (json is null)
+            throw new ArgumentNullException(parameterName);
+        byte[] canonical;
+        try
+        {
+            canonical = Canonicalize(Encoding.UTF8.GetBytes(json));
+        }
+        catch (JsonException ex)
+        {
+            throw new DeliveryReceiptValidationException(
+                "invalid_operation_arguments", $"{parameterName} is not valid JSON: {ex.Message}");
+        }
+
+        using var document = JsonDocument.Parse(canonical);
+        if (document.RootElement.ValueKind != JsonValueKind.Object)
+        {
+            throw new DeliveryReceiptValidationException(
+                "invalid_operation_arguments", $"{parameterName} must be a JSON object.");
+        }
+        return document.RootElement.Clone();
+    }
+
+    public static VerificationDigest Digest(ReadOnlySpan<byte> bytes) => new()
+    {
+        Algorithm = DeliveryReceiptValidation.Sha256Algorithm,
+        Value = Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant(),
+    };
+
+    public static VerificationDigest DigestText(string value) =>
+        Digest(Encoding.UTF8.GetBytes(value));
+
+    public static bool FixedTimeEquals(VerificationDigest expected, ReadOnlySpan<byte> bytes)
+    {
+        DeliveryReceiptValidation.ValidateDigest(expected, "expected digest");
+        byte[] expectedBytes;
+        try { expectedBytes = Convert.FromHexString(expected.Value); }
+        catch (FormatException) { return false; }
+        var actual = SHA256.HashData(bytes);
+        return CryptographicOperations.FixedTimeEquals(expectedBytes, actual);
+    }
+
+    public static string DigestToken(ReadOnlySpan<byte> bytes) =>
+        "sha256:" + Digest(bytes).Value;
+
+    private static void WriteCanonical(
+        Utf8JsonWriter writer,
+        JsonElement value,
+        DeliveryReceiptLimits? limits,
+        ref long collectionItems,
+        string limitCode)
+    {
+        switch (value.ValueKind)
+        {
+            case JsonValueKind.Object:
+            {
+                writer.WriteStartObject();
+                var properties = new List<JsonProperty>();
+                foreach (var property in value.EnumerateObject())
+                {
+                    AddJsonItems(limits, 1, ref collectionItems, limitCode);
+                    CheckJsonString(
+                        limits, property.Name, "JSON property name", limitCode);
+                    properties.Add(property);
+                }
+                properties.Sort(static (left, right) =>
+                    string.CompareOrdinal(left.Name, right.Name));
+                for (int i = 1; i < properties.Count; i++)
+                {
+                    if (string.Equals(properties[i - 1].Name, properties[i].Name,
+                            StringComparison.Ordinal))
+                    {
+                        throw new JsonException(
+                            $"Duplicate JSON property '{properties[i].Name}' is not canonical.");
+                    }
+                }
+                foreach (var property in properties)
+                {
+                    writer.WritePropertyName(property.Name);
+                    WriteCanonical(
+                        writer, property.Value, limits, ref collectionItems, limitCode);
+                }
+                writer.WriteEndObject();
+                break;
+            }
+            case JsonValueKind.Array:
+                writer.WriteStartArray();
+                foreach (var item in value.EnumerateArray())
+                {
+                    AddJsonItems(limits, 1, ref collectionItems, limitCode);
+                    WriteCanonical(writer, item, limits, ref collectionItems, limitCode);
+                }
+                writer.WriteEndArray();
+                break;
+            case JsonValueKind.String:
+                var stringValue = value.GetString();
+                CheckJsonString(limits, stringValue, "JSON string", limitCode);
+                writer.WriteStringValue(stringValue);
+                break;
+            case JsonValueKind.Number:
+                // Numeric spelling is part of v1 for arbitrary operation/evidence extensions.
+                // Core receipt numbers are emitted by System.Text.Json using invariant formatting.
+                writer.WriteRawValue(value.GetRawText(), skipInputValidation: false);
+                break;
+            case JsonValueKind.True:
+                writer.WriteBooleanValue(true);
+                break;
+            case JsonValueKind.False:
+                writer.WriteBooleanValue(false);
+                break;
+            case JsonValueKind.Null:
+                writer.WriteNullValue();
+                break;
+            default:
+                throw new JsonException($"Unsupported JSON token {value.ValueKind}.");
+        }
+
+    }
+
+    private static void AddJsonItems(
+        DeliveryReceiptLimits? limits,
+        int count,
+        ref long collectionItems,
+        string limitCode)
+    {
+        if (limits is null)
+            return;
+        if (count > limits.MaxCollectionItems)
+            throw new DeliveryReceiptValidationException(
+                limitCode, "JSON collection exceeds the per-collection item limit.");
+        collectionItems = checked(collectionItems + count);
+        if (collectionItems > limits.MaxCollectionItems)
+            throw new DeliveryReceiptValidationException(
+                limitCode, "JSON collections exceed the aggregate item limit.");
+    }
+
+    private static void CheckJsonString(
+        DeliveryReceiptLimits? limits,
+        string? text,
+        string name,
+        string limitCode)
+    {
+        if (limits is not null && text is not null
+            && text.Length > limits.MaxStringLength)
+        {
+            throw new DeliveryReceiptValidationException(
+                limitCode, $"{name} exceeds the string-length limit.");
+        }
+    }
+}
+
+internal static class DeliveryReceiptValidation
+{
+    public const string Sha256Algorithm = "SHA-256";
+
+    public static void ValidateDigest(VerificationDigest? digest, string name)
+    {
+        if (digest is null)
+            throw new DeliveryReceiptValidationException("missing_digest", $"{name} is required.");
+        if (!string.Equals(digest.Algorithm, Sha256Algorithm, StringComparison.Ordinal))
+        {
+            throw new DeliveryReceiptValidationException(
+                "unsupported_digest_algorithm", $"{name} must use {Sha256Algorithm}.");
+        }
+        if (digest.Value is null || digest.Value.Length != 64
+            || digest.Value.Any(c => !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))))
+        {
+            throw new DeliveryReceiptValidationException(
+                "invalid_digest", $"{name} must be 64 lower-case hexadecimal characters.");
+        }
+    }
+
+    public static void ValidateOptionalDigest(VerificationDigest? digest, string name)
+    {
+        if (digest is not null)
+            ValidateDigest(digest, name);
+    }
+
+    public static VerificationDigest CloneDigest(VerificationDigest digest)
+    {
+        ValidateDigest(digest, "digest");
+        return new VerificationDigest { Algorithm = digest.Algorithm, Value = digest.Value };
+    }
+
+    public static VerificationDigest? CloneOptionalDigest(VerificationDigest? digest) =>
+        digest is null ? null : CloneDigest(digest);
+
+    public static string RequireNonBlank(string? value, string name, int maxLength = 2048)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new DeliveryReceiptValidationException("missing_value", $"{name} is required.");
+        if (value.Length > maxLength)
+            throw new DeliveryReceiptValidationException("value_too_long", $"{name} is too long.");
+        return value;
+    }
+
+    public static string? NormalizeRelativePath(string? path)
+    {
+        if (path is null)
+            return null;
+        RequireNonBlank(path, "artifact relative path", 4096);
+        if (path[0] is '/' or '\\'
+            || (path.Length >= 2
+                && ((path[0] >= 'A' && path[0] <= 'Z')
+                    || (path[0] >= 'a' && path[0] <= 'z'))
+                && path[1] == ':'))
+        {
+            throw new DeliveryReceiptValidationException(
+                "unsafe_artifact_path", "Artifact display paths must be portable relative paths.");
+        }
+        var normalized = path.Replace('\\', '/');
+        var segments = normalized.Split('/');
+        if (segments.Any(segment => segment is "" or "." or ".."))
+        {
+            throw new DeliveryReceiptValidationException(
+                "unsafe_artifact_path", "Artifact display paths cannot contain empty, dot, or parent segments.");
+        }
+        return string.Join('/', segments);
+    }
+
+    public static bool DigestEquals(VerificationDigest? left, VerificationDigest? right) =>
+        left is not null && right is not null
+        && string.Equals(left.Algorithm, right.Algorithm, StringComparison.Ordinal)
+        && string.Equals(left.Value, right.Value, StringComparison.Ordinal);
+
+    public static string Invariant(long value) => value.ToString(CultureInfo.InvariantCulture);
+}
+
+/// <summary>Canonical serializer for the delivery-receipt v1 envelope.</summary>
+public static class DeliveryChangeReceiptSerializer
+{
+    public static byte[] SerializePayload(DeliveryChangeReceiptPayload payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        return DeliveryReceiptCanonicalJson.SerializeCanonical(payload);
+    }
+
+    internal static byte[] SerializePayload(
+        DeliveryChangeReceiptPayload payload,
+        DeliveryReceiptLimits limits)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        return DeliveryReceiptCanonicalJson.SerializeCanonicalBounded(
+            payload,
+            limits,
+            limits.MaxReceiptJsonBytes,
+            "receipt_resource_limit");
+    }
+
+    public static byte[] Serialize(DeliveryChangeReceipt receipt, bool indented = false)
+    {
+        ArgumentNullException.ThrowIfNull(receipt);
+        var payload = SerializePayload(receipt.Payload);
+        DeliveryReceiptValidation.ValidateDigest(receipt.ReceiptDigest, "receipt digest");
+
+        using var payloadDocument = JsonDocument.Parse(payload);
+        var envelope = new Dictionary<string, object?>
+        {
+            ["payload"] = payloadDocument.RootElement.Clone(),
+            ["receiptDigest"] = receipt.ReceiptDigest,
+        };
+        var canonical = DeliveryReceiptCanonicalJson.SerializeCanonical(envelope);
+        if (!indented)
+            return canonical;
+
+        using var canonicalDocument = JsonDocument.Parse(canonical);
+        return JsonSerializer.SerializeToUtf8Bytes(canonicalDocument.RootElement,
+            new JsonSerializerOptions(DeliveryReceiptCanonicalJson.JsonOptions)
+            {
+                WriteIndented = true,
+            });
+    }
+
+    internal static DeliveryChangeReceipt Create(
+        DeliveryChangeReceiptPayload payload,
+        DeliveryReceiptLimits limits)
+    {
+        var canonicalPayload = SerializePayload(payload, limits);
+        var receipt = new DeliveryChangeReceipt
+        {
+            Payload = payload,
+            ReceiptDigest = DeliveryReceiptCanonicalJson.Digest(canonicalPayload),
+        };
+        DeliveryReceiptResourceBudget.Bytes(
+            DeliveryReceiptCanonicalJson.SerializeCanonicalBounded(
+                receipt,
+                limits,
+                limits.MaxReceiptJsonBytes,
+                "receipt_resource_limit").LongLength,
+            limits.MaxReceiptJsonBytes,
+            "receipt_resource_limit",
+            "Receipt JSON");
+        return receipt;
+    }
+}

--- a/Docxodus/Verification/DeliveryReceiptCanonicalJson.cs
+++ b/Docxodus/Verification/DeliveryReceiptCanonicalJson.cs
@@ -14,29 +14,25 @@ namespace Docxodus.Verification;
 
 internal static class DeliveryReceiptCanonicalJson
 {
-    private static readonly JsonSerializerOptions SerializerOptions = new()
-    {
-        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
-        Encoder = JavaScriptEncoder.Default,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        MaxDepth = 128,
-        WriteIndented = false,
-        Converters =
-        {
-            new JsonStringEnumConverter(JsonNamingPolicy.CamelCase, allowIntegerValues: false),
-        },
-    };
+    private static readonly DeliveryReceiptJsonContext SerializerContext =
+        CreateSerializerContext();
 
-    public static JsonSerializerOptions JsonOptions => SerializerOptions;
+    internal static DeliveryReceiptJsonContext JsonContext => SerializerContext;
 
-    public static byte[] SerializeCanonical<T>(T value)
-    {
-        var json = JsonSerializer.SerializeToUtf8Bytes(value, SerializerOptions);
-        return Canonicalize(json);
-    }
+    public static byte[] SerializeCanonical(JsonElement value) =>
+        Canonicalize(Encoding.UTF8.GetBytes(value.GetRawText()));
 
-    public static byte[] SerializeCanonicalBounded<T>(
+    public static byte[] SerializeCanonicalBounded(
+        JsonElement value,
+        DeliveryReceiptLimits limits,
+        int maximumBytes,
+        string limitCode)
+        => CanonicalizeBounded(
+            Encoding.UTF8.GetBytes(value.GetRawText()), limits, maximumBytes, limitCode);
+
+    internal static byte[] SerializeCanonicalBounded<T>(
         T value,
+        System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> typeInfo,
         DeliveryReceiptLimits limits,
         int maximumBytes,
         string limitCode)
@@ -51,11 +47,7 @@ internal static class DeliveryReceiptCanonicalJson
             MaxDepth = limits.MaxJsonDepth,
         }))
         {
-            var options = new JsonSerializerOptions(SerializerOptions)
-            {
-                MaxDepth = limits.MaxJsonDepth,
-            };
-            JsonSerializer.Serialize(writer, value, options);
+            JsonSerializer.Serialize(writer, value, typeInfo);
         }
         var json = stream.ToArray();
         return CanonicalizeBounded(json, limits, maximumBytes, limitCode);
@@ -82,7 +74,10 @@ internal static class DeliveryReceiptCanonicalJson
         string limitCode)
     {
         if (limits is not null)
+        {
             DeliveryReceiptResourceBudget.Bytes(json.Length, maximumBytes, limitCode, "JSON input");
+            ScanBoundedJson(json, limits, limitCode);
+        }
         using var document = JsonDocument.Parse(json.ToArray(), new JsonDocumentOptions
         {
             AllowTrailingCommas = false,
@@ -111,6 +106,109 @@ internal static class DeliveryReceiptCanonicalJson
                 canonical.LongLength, maximumBytes, limitCode, "Canonical JSON");
         }
         return canonical;
+    }
+
+    private static void ScanBoundedJson(
+        ReadOnlySpan<byte> json,
+        DeliveryReceiptLimits limits,
+        string limitCode)
+    {
+        var reader = new Utf8JsonReader(json, new JsonReaderOptions
+        {
+            AllowTrailingCommas = false,
+            CommentHandling = JsonCommentHandling.Disallow,
+            MaxDepth = limits.MaxJsonDepth,
+        });
+        var containers = new List<JsonScanContainer>();
+        long aggregateItems = 0;
+
+        void CountArrayValue()
+        {
+            if (containers.Count == 0 || containers[^1].IsObject)
+                return;
+            CountItem(containers[^1]);
+        }
+
+        void CountItem(JsonScanContainer container)
+        {
+            container.ItemCount++;
+            if (container.ItemCount > limits.MaxCollectionItems)
+            {
+                throw new DeliveryReceiptValidationException(
+                    limitCode, "JSON collection exceeds the per-collection item limit.");
+            }
+            aggregateItems = checked(aggregateItems + 1);
+            if (aggregateItems > limits.MaxCollectionItems)
+            {
+                throw new DeliveryReceiptValidationException(
+                    limitCode, "JSON collections exceed the aggregate item limit.");
+            }
+        }
+
+        while (reader.Read())
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.StartObject:
+                    CountArrayValue();
+                    containers.Add(new JsonScanContainer(isObject: true));
+                    break;
+                case JsonTokenType.StartArray:
+                    CountArrayValue();
+                    containers.Add(new JsonScanContainer(isObject: false));
+                    break;
+                case JsonTokenType.EndObject:
+                case JsonTokenType.EndArray:
+                    if (containers.Count == 0)
+                        throw new JsonException("JSON container is unbalanced.");
+                    containers.RemoveAt(containers.Count - 1);
+                    break;
+                case JsonTokenType.PropertyName:
+                {
+                    if (containers.Count == 0 || !containers[^1].IsObject)
+                        throw new JsonException("JSON property is outside an object.");
+                    var container = containers[^1];
+                    CountItem(container);
+                    var name = ReadBoundedJsonString(
+                        ref reader, limits, "JSON property name", limitCode);
+                    if (!container.PropertyNames!.Add(name))
+                        throw new JsonException($"Duplicate JSON property '{name}' is not canonical.");
+                    break;
+                }
+                case JsonTokenType.String:
+                    CountArrayValue();
+                    _ = ReadBoundedJsonString(
+                        ref reader, limits, "JSON string", limitCode);
+                    break;
+                case JsonTokenType.Number:
+                case JsonTokenType.True:
+                case JsonTokenType.False:
+                case JsonTokenType.Null:
+                    CountArrayValue();
+                    break;
+                default:
+                    throw new JsonException($"Unsupported JSON token {reader.TokenType}.");
+            }
+        }
+        if (containers.Count != 0)
+            throw new JsonException("JSON container is unbalanced.");
+    }
+
+    private static string ReadBoundedJsonString(
+        ref Utf8JsonReader reader,
+        DeliveryReceiptLimits limits,
+        string name,
+        string limitCode)
+    {
+        long maximumEncodedLength = checked((long)limits.MaxStringLength * 6);
+        if (reader.ValueSpan.Length > maximumEncodedLength)
+        {
+            throw new DeliveryReceiptValidationException(
+                limitCode, $"{name} exceeds the string-length limit.");
+        }
+        var value = reader.GetString()!;
+        CheckJsonString(limits, value, name, limitCode);
+        return value;
     }
 
     public static JsonElement ParseCanonicalObject(string json, string parameterName)
@@ -214,9 +312,7 @@ internal static class DeliveryReceiptCanonicalJson
                 writer.WriteStringValue(stringValue);
                 break;
             case JsonValueKind.Number:
-                // Numeric spelling is part of v1 for arbitrary operation/evidence extensions.
-                // Core receipt numbers are emitted by System.Text.Json using invariant formatting.
-                writer.WriteRawValue(value.GetRawText(), skipInputValidation: false);
+                WriteCanonicalNumber(writer, value);
                 break;
             case JsonValueKind.True:
                 writer.WriteBooleanValue(true);
@@ -231,6 +327,131 @@ internal static class DeliveryReceiptCanonicalJson
                 throw new JsonException($"Unsupported JSON token {value.ValueKind}.");
         }
 
+    }
+
+    /// <summary>
+    /// Require every known field emitted by the typed v1 model to be present with its canonical
+    /// value while allowing digest-covered future optional object properties.
+    /// </summary>
+    public static bool ContainsCanonicalKnownProjection(
+        JsonElement supplied,
+        JsonElement known)
+    {
+        if (supplied.ValueKind != known.ValueKind)
+            return false;
+        switch (known.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (var property in known.EnumerateObject())
+                {
+                    if (!supplied.TryGetProperty(property.Name, out var suppliedValue)
+                        || !ContainsCanonicalKnownProjection(suppliedValue, property.Value))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            case JsonValueKind.Array:
+            {
+                var suppliedItems = supplied.EnumerateArray().ToArray();
+                var knownItems = known.EnumerateArray().ToArray();
+                return suppliedItems.Length == knownItems.Length
+                    && suppliedItems.Zip(knownItems).All(pair =>
+                        ContainsCanonicalKnownProjection(pair.First, pair.Second));
+            }
+            case JsonValueKind.String:
+                return string.Equals(
+                    supplied.GetString(), known.GetString(), StringComparison.Ordinal);
+            case JsonValueKind.Number:
+                return string.Equals(
+                    supplied.GetRawText(), known.GetRawText(), StringComparison.Ordinal);
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+            case JsonValueKind.Null:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public static bool HasOnlyKnownProperties(JsonElement supplied, JsonElement known)
+    {
+        if (supplied.ValueKind != known.ValueKind)
+            return false;
+        if (known.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in supplied.EnumerateObject())
+            {
+                if (!known.TryGetProperty(property.Name, out var knownValue)
+                    || !HasOnlyKnownProperties(property.Value, knownValue))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+        if (known.ValueKind == JsonValueKind.Array)
+        {
+            var suppliedItems = supplied.EnumerateArray().ToArray();
+            var knownItems = known.EnumerateArray().ToArray();
+            return suppliedItems.Length == knownItems.Length
+                && suppliedItems.Zip(knownItems).All(pair =>
+                    HasOnlyKnownProperties(pair.First, pair.Second));
+        }
+        return true;
+    }
+
+    private static DeliveryReceiptJsonContext CreateSerializerContext()
+    {
+        var options = new JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+            Encoder = JavaScriptEncoder.Default,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            MaxDepth = 128,
+            WriteIndented = false,
+        };
+        options.Converters.Add(new JsonStringEnumConverter<DeliveryReceiptPrivacyProfile>(
+            JsonNamingPolicy.CamelCase, allowIntegerValues: false));
+        options.Converters.Add(new JsonStringEnumConverter<DeliveryTransactionStatus>(
+            JsonNamingPolicy.CamelCase, allowIntegerValues: false));
+        options.Converters.Add(new JsonStringEnumConverter<DeliveryOperationExecutionStatus>(
+            JsonNamingPolicy.CamelCase, allowIntegerValues: false));
+        options.Converters.Add(new JsonStringEnumConverter<DeliveryLineageAction>(
+            JsonNamingPolicy.CamelCase, allowIntegerValues: false));
+        options.Converters.Add(new JsonStringEnumConverter<DeliveryChangeDisposition>(
+            JsonNamingPolicy.CamelCase, allowIntegerValues: false));
+        options.Converters.Add(new JsonStringEnumConverter<DeliveryPackageChangeKind>(
+            JsonNamingPolicy.CamelCase, allowIntegerValues: false));
+        options.Converters.Add(new JsonStringEnumConverter<DeliveryArtifactRole>(
+            JsonNamingPolicy.CamelCase, allowIntegerValues: false));
+        options.Converters.Add(new JsonStringEnumConverter<DeliveryArtifactAvailability>(
+            JsonNamingPolicy.CamelCase, allowIntegerValues: false));
+        options.Converters.Add(new JsonStringEnumConverter<DeliveryEvidenceKind>(
+            JsonNamingPolicy.CamelCase, allowIntegerValues: false));
+        options.Converters.Add(new JsonStringEnumConverter<DeliverySemanticComparisonScope>(
+            JsonNamingPolicy.CamelCase, allowIntegerValues: false));
+        options.Converters.Add(new JsonStringEnumConverter<DeliveryAuthoredEntityKind>(
+            JsonNamingPolicy.CamelCase, allowIntegerValues: false));
+        options.Converters.Add(new JsonStringEnumConverter<DeliveryObjectChangeKind>(
+            JsonNamingPolicy.CamelCase, allowIntegerValues: false));
+        options.Converters.Add(new JsonStringEnumConverter<RevisionFamily>(
+            JsonNamingPolicy.CamelCase, allowIntegerValues: false));
+        options.Converters.Add(new JsonStringEnumConverter<RevisionResolutionStatus>(
+            JsonNamingPolicy.CamelCase, allowIntegerValues: false));
+        options.Converters.Add(new JsonStringEnumConverter<MutationBatchMode>(
+            JsonNamingPolicy.CamelCase, allowIntegerValues: false));
+        options.Converters.Add(new JsonStringEnumConverter<PageMapStory>(
+            JsonNamingPolicy.CamelCase, allowIntegerValues: false));
+        return new DeliveryReceiptJsonContext(options);
+    }
+
+    private static void WriteCanonicalNumber(Utf8JsonWriter writer, JsonElement value)
+    {
+        // V1 deliberately preserves the exact valid JSON numeric token. This avoids lossy
+        // double round-tripping for arbitrary future extension fields and is part of the
+        // hash-addressed wire contract.
+        writer.WriteRawValue(value.GetRawText(), skipInputValidation: false);
     }
 
     private static void AddJsonItems(
@@ -257,17 +478,47 @@ internal static class DeliveryReceiptCanonicalJson
         string limitCode)
     {
         if (limits is not null && text is not null
-            && text.Length > limits.MaxStringLength)
+            && (text.Length > limits.MaxStringLength
+                || Encoding.UTF8.GetByteCount(text) > limits.MaxStringLength))
         {
             throw new DeliveryReceiptValidationException(
                 limitCode, $"{name} exceeds the string-length limit.");
         }
+    }
+
+    private sealed class JsonScanContainer
+    {
+        public JsonScanContainer(bool isObject)
+        {
+            IsObject = isObject;
+            PropertyNames = isObject ? new HashSet<string>(StringComparer.Ordinal) : null;
+        }
+
+        public bool IsObject { get; }
+
+        public HashSet<string>? PropertyNames { get; }
+
+        public int ItemCount { get; set; }
     }
 }
 
 internal static class DeliveryReceiptValidation
 {
     public const string Sha256Algorithm = "SHA-256";
+    public const long MaxPortableInteger = 9_007_199_254_740_991;
+
+    public static void ValidatePortableNonNegativeInteger(
+        long value,
+        string code,
+        string name)
+    {
+        if (value < 0 || value > MaxPortableInteger)
+        {
+            throw new DeliveryReceiptValidationException(
+                code,
+                $"{name} must be between 0 and {Invariant(MaxPortableInteger)} inclusive.");
+        }
+    }
 
     public static void ValidateDigest(VerificationDigest? digest, string name)
     {
@@ -310,6 +561,20 @@ internal static class DeliveryReceiptValidation
         return value;
     }
 
+    public static string RequireOpcMainDocumentUri(string? value, string name)
+    {
+        if (string.IsNullOrWhiteSpace(value)
+            || value.Length > 4096
+            || value[0] != '/'
+            || value.Contains('\\'))
+        {
+            throw new DeliveryReceiptValidationException(
+                "not_wordprocessing_package",
+                $"{name} must be an absolute OPC part URI.");
+        }
+        return value;
+    }
+
     public static string? NormalizeRelativePath(string? path)
     {
         if (path is null)
@@ -347,8 +612,9 @@ public static class DeliveryChangeReceiptSerializer
 {
     public static byte[] SerializePayload(DeliveryChangeReceiptPayload payload)
     {
-        ArgumentNullException.ThrowIfNull(payload);
-        return DeliveryReceiptCanonicalJson.SerializeCanonical(payload);
+        var limits = new DeliveryReceiptLimits().ValidateAndClone();
+        DeliveryReceiptResourceValidator.ValidatePayload(payload, limits);
+        return SerializePayload(payload, limits);
     }
 
     internal static byte[] SerializePayload(
@@ -358,33 +624,67 @@ public static class DeliveryChangeReceiptSerializer
         ArgumentNullException.ThrowIfNull(payload);
         return DeliveryReceiptCanonicalJson.SerializeCanonicalBounded(
             payload,
+            DeliveryReceiptCanonicalJson.JsonContext.DeliveryChangeReceiptPayload,
             limits,
             limits.MaxReceiptJsonBytes,
             "receipt_resource_limit");
     }
 
     public static byte[] Serialize(DeliveryChangeReceipt receipt, bool indented = false)
+        => Serialize(receipt, new DeliveryReceiptLimits(), indented);
+
+    public static byte[] Serialize(
+        DeliveryChangeReceipt receipt,
+        DeliveryReceiptLimits limits,
+        bool indented = false)
     {
         ArgumentNullException.ThrowIfNull(receipt);
-        var payload = SerializePayload(receipt.Payload);
+        ArgumentNullException.ThrowIfNull(limits);
+        var validatedLimits = limits.ValidateAndClone();
+        DeliveryReceiptResourceValidator.ValidatePayload(receipt.Payload, validatedLimits);
+        var payload = SerializePayload(receipt.Payload, validatedLimits);
         DeliveryReceiptValidation.ValidateDigest(receipt.ReceiptDigest, "receipt digest");
 
         using var payloadDocument = JsonDocument.Parse(payload);
-        var envelope = new Dictionary<string, object?>
+        using var stream = new DeliveryReceiptBoundedMemoryStream(
+            validatedLimits.MaxReceiptJsonBytes,
+            "receipt_resource_limit",
+            "Receipt JSON");
+        using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
         {
-            ["payload"] = payloadDocument.RootElement.Clone(),
-            ["receiptDigest"] = receipt.ReceiptDigest,
-        };
-        var canonical = DeliveryReceiptCanonicalJson.SerializeCanonical(envelope);
+            Encoder = JavaScriptEncoder.Default,
+            Indented = false,
+            MaxDepth = 128,
+        }))
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("payload");
+            payloadDocument.RootElement.WriteTo(writer);
+            writer.WriteStartObject("receiptDigest");
+            writer.WriteString("algorithm", receipt.ReceiptDigest.Algorithm);
+            writer.WriteString("value", receipt.ReceiptDigest.Value);
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+        }
+        var canonical = stream.ToArray();
         if (!indented)
             return canonical;
 
         using var canonicalDocument = JsonDocument.Parse(canonical);
-        return JsonSerializer.SerializeToUtf8Bytes(canonicalDocument.RootElement,
-            new JsonSerializerOptions(DeliveryReceiptCanonicalJson.JsonOptions)
-            {
-                WriteIndented = true,
-            });
+        using var indentedStream = new DeliveryReceiptBoundedMemoryStream(
+            validatedLimits.MaxReceiptJsonBytes,
+            "receipt_resource_limit",
+            "Indented receipt JSON");
+        using (var writer = new Utf8JsonWriter(indentedStream, new JsonWriterOptions
+        {
+            Encoder = JavaScriptEncoder.Default,
+            Indented = true,
+            MaxDepth = 128,
+        }))
+        {
+            canonicalDocument.RootElement.WriteTo(writer);
+        }
+        return indentedStream.ToArray();
     }
 
     internal static DeliveryChangeReceipt Create(
@@ -400,6 +700,7 @@ public static class DeliveryChangeReceiptSerializer
         DeliveryReceiptResourceBudget.Bytes(
             DeliveryReceiptCanonicalJson.SerializeCanonicalBounded(
                 receipt,
+                DeliveryReceiptCanonicalJson.JsonContext.DeliveryChangeReceipt,
                 limits,
                 limits.MaxReceiptJsonBytes,
                 "receipt_resource_limit").LongLength,

--- a/Docxodus/Verification/DeliveryReceiptContract.cs
+++ b/Docxodus/Verification/DeliveryReceiptContract.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Globalization;
+
+namespace Docxodus.Verification;
+
+/// <summary>
+/// Constants and pure functions of the receipt wire contract that the producer
+/// (<see cref="DeliveryChangeReceiptBuilder"/>) and the adversarial verifier
+/// (<see cref="DeliveryChangeReceiptVerifier"/>) must agree on. The two sides
+/// deliberately share no serialization or parsing code — a verifier that trusts
+/// producer code cannot catch producer bugs — so everything they must not drift
+/// on lives here instead.
+/// </summary>
+internal static class DeliveryReceiptContract
+{
+    /// <summary>
+    /// Owner schema for a generic evidence kind, or null when the kind has no
+    /// generic owner schema (typed semantic evidence uses the #457 binding).
+    /// </summary>
+    public static string? EvidenceSchemaFor(DeliveryEvidenceKind kind) => kind switch
+    {
+        DeliveryEvidenceKind.ValidationResult => DeliverableVerificationResult.SchemaId,
+        DeliveryEvidenceKind.RedlineReversibility => RedlineReversibilityProof.SchemaId,
+        _ => null,
+    };
+
+    /// <summary>
+    /// Property count of one serialized EditResult anchor. The producer is
+    /// <c>DeliveryChangeReceiptBuilder.WriteAnchor</c>; the verifier re-reads the
+    /// object with exactly this arity.
+    /// </summary>
+    public const int EditResultAnchorPropertyCount = 4;
+
+    /// <summary>The scope segment of a canonical <c>kind:scope:unid</c> anchor.</summary>
+    public static string ScopeFromAnchor(string anchorId)
+    {
+        var first = anchorId.IndexOf(':');
+        var second = first < 0 ? -1 : anchorId.IndexOf(':', first + 1);
+        if (first <= 0 || second <= first + 1 || second == anchorId.Length - 1)
+        {
+            throw new DeliveryReceiptValidationException(
+                "invalid_anchor_id", $"'{anchorId}' is not a canonical kind:scope:unid anchor.");
+        }
+        return anchorId[(first + 1)..second];
+    }
+
+    /// <summary>
+    /// The digest-token grammar — <c>sha256:</c> followed by 64 lower-case hex
+    /// characters — shared by transaction entry ids, request fingerprints, and
+    /// redaction tokens.
+    /// </summary>
+    public static bool IsSha256DigestToken(string? value)
+    {
+        if (value is null
+            || value.Length != 71
+            || !value.StartsWith("sha256:", StringComparison.Ordinal))
+        {
+            return false;
+        }
+        foreach (var character in value.AsSpan(7))
+        {
+            if (character is not (>= '0' and <= '9') and not (>= 'a' and <= 'f'))
+                return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// The redacted free-text shape: <c>{label}; {count} characters; {digestToken}</c>.
+    /// The producer formats with it and the verifier re-parses the identical shape.
+    /// </summary>
+    public static string RedactedFreeText(string label, int characterCount, string digestToken) =>
+        $"{label}; {characterCount.ToString(CultureInfo.InvariantCulture)}"
+        + $" characters; {digestToken}";
+
+    /// <summary>True when <paramref name="value"/> matches the
+    /// <see cref="RedactedFreeText"/> shape for <paramref name="label"/>.</summary>
+    public static bool IsRedactedFreeText(string value, string label)
+    {
+        var prefix = $"{label}; ";
+        const string separator = " characters; ";
+        if (!value.StartsWith(prefix, StringComparison.Ordinal))
+            return false;
+        int separatorIndex = value.IndexOf(separator, prefix.Length, StringComparison.Ordinal);
+        return separatorIndex > prefix.Length
+            && int.TryParse(
+                value.AsSpan(prefix.Length, separatorIndex - prefix.Length),
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out var count)
+            && count >= 0
+            && IsSha256DigestToken(value[(separatorIndex + separator.Length)..]);
+    }
+
+    /// <summary>
+    /// Coordinate equality between a projected citation and claimed coordinates.
+    /// Availability metadata is compared by the producer only; the wire citation
+    /// carries no availability, so this is the largest shape both sides check.
+    /// </summary>
+    public static bool CitationCoordinatesEqual(
+        PageCitation projected,
+        string? anchorId,
+        long documentVersion,
+        string? rendererFingerprint,
+        IReadOnlyList<PageMapPage> pages,
+        IReadOnlyList<PageMapFragment> fragments) =>
+        string.Equals(anchorId, projected.AnchorId, StringComparison.Ordinal)
+        && documentVersion == projected.DocumentVersion
+        && string.Equals(rendererFingerprint, projected.RendererFingerprint,
+            StringComparison.Ordinal)
+        && pages.SequenceEqual(projected.Pages)
+        && fragments.SequenceEqual(projected.Fragments);
+}

--- a/Docxodus/Verification/DeliveryReceiptIdentity.cs
+++ b/Docxodus/Verification/DeliveryReceiptIdentity.cs
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Text.Encodings.Web;
+using System.Text.Json;
+
+namespace Docxodus.Verification;
+
+/// <summary>
+/// Trim/AOT-safe writers for the small canonical projections used as receipt identities.
+/// Keeping construction and portable verification on these shared writers prevents drift.
+/// </summary>
+internal static class DeliveryReceiptIdentity
+{
+    public static string PackageChangeId(
+        DeliveryPackageChangeKind kind,
+        ChangeLocation location,
+        VerificationDigest? before,
+        VerificationDigest? after)
+    {
+        ArgumentNullException.ThrowIfNull(location);
+        return DeliveryReceiptCanonicalJson.DigestToken(Write(writer =>
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("after");
+            WriteDigest(writer, after);
+            writer.WritePropertyName("before");
+            WriteDigest(writer, before);
+            writer.WriteString("kind", kind.ToString());
+            writer.WriteStartObject("location");
+            WriteNullableString(writer, "entryUri", location.EntryUri);
+            WriteNullableString(writer, "ownerUri", location.OwnerUri);
+            WriteNullableString(writer, "propertyPath", location.PropertyPath);
+            WriteNullableString(writer, "relationshipId", location.RelationshipId);
+            WriteNullableString(writer, "targetUri", location.TargetUri);
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+        }));
+    }
+
+    public static string TransactionEntryId(
+        string requestFingerprint,
+        DeliveryDocumentIdentity before,
+        DeliveryDocumentIdentity after,
+        long baseVersion,
+        long resultVersion,
+        string? transactionId,
+        long sequence)
+    {
+        ArgumentNullException.ThrowIfNull(before);
+        ArgumentNullException.ThrowIfNull(after);
+        return DeliveryReceiptCanonicalJson.DigestToken(Write(writer =>
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("afterPackage");
+            WriteDigest(writer, after.RawPackageBytesDigest);
+            writer.WriteNumber("baseVersion", baseVersion);
+            writer.WritePropertyName("beforePackage");
+            WriteDigest(writer, before.RawPackageBytesDigest);
+            writer.WriteString("requestFingerprint", requestFingerprint);
+            writer.WriteNumber("resultVersion", resultVersion);
+            WriteNullableString(writer, "transactionId", transactionId);
+            if (transactionId is null)
+                writer.WriteNumber("transactionSequence", sequence);
+            else
+                writer.WriteNull("transactionSequence");
+            writer.WriteEndObject();
+        }));
+    }
+
+    public static string RequestFingerprint(
+        MutationBatchMode mode,
+        IReadOnlyList<DeliveryNormalizedOperation> operations,
+        DeliveryReceiptLimits limits)
+    {
+        ArgumentNullException.ThrowIfNull(operations);
+        ArgumentNullException.ThrowIfNull(limits);
+        var bytes = WriteBounded(writer =>
+        {
+            writer.WriteStartObject();
+            writer.WriteString(
+                "mode", mode == MutationBatchMode.Atomic ? "atomic" : "bestEffort");
+            writer.WriteStartArray("operations");
+            foreach (var operation in operations)
+            {
+                writer.WriteStartObject();
+                writer.WriteString("action", operation.Action);
+                writer.WritePropertyName("arguments");
+                operation.Arguments.WriteTo(writer);
+                writer.WriteString("tool", operation.Tool);
+                writer.WriteEndObject();
+            }
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }, limits);
+        return DeliveryReceiptCanonicalJson.DigestToken(bytes);
+    }
+
+    public static byte[] TransactionEvidence(
+        DeliveryTransactionEntry entry,
+        DeliveryReceiptLimits limits) =>
+        DeliveryReceiptCanonicalJson.SerializeCanonicalBounded(
+            entry with { Sequence = 0 },
+            DeliveryReceiptCanonicalJson.JsonContext.DeliveryTransactionEntry,
+            limits,
+            limits.MaxReceiptJsonBytes,
+            "receipt_resource_limit");
+
+    private static byte[] Write(Action<Utf8JsonWriter> write)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = NewWriter(stream, 128))
+            write(writer);
+        return DeliveryReceiptCanonicalJson.Canonicalize(stream.ToArray());
+    }
+
+    private static byte[] WriteBounded(
+        Action<Utf8JsonWriter> write,
+        DeliveryReceiptLimits limits)
+    {
+        using var stream = new DeliveryReceiptBoundedMemoryStream(
+            limits.MaxReceiptJsonBytes,
+            "receipt_resource_limit",
+            "Receipt identity JSON");
+        using (var writer = NewWriter(stream, limits.MaxJsonDepth))
+            write(writer);
+        return DeliveryReceiptCanonicalJson.CanonicalizeBounded(
+            stream.ToArray(),
+            limits,
+            limits.MaxReceiptJsonBytes,
+            "receipt_resource_limit");
+    }
+
+    private static Utf8JsonWriter NewWriter(Stream stream, int maxDepth) => new(
+        stream,
+        new JsonWriterOptions
+        {
+            Encoder = JavaScriptEncoder.Default,
+            Indented = false,
+            MaxDepth = maxDepth,
+        });
+
+    private static void WriteDigest(Utf8JsonWriter writer, VerificationDigest? digest)
+    {
+        if (digest is null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+        writer.WriteStartObject();
+        writer.WriteString("algorithm", digest.Algorithm);
+        writer.WriteString("value", digest.Value);
+        writer.WriteEndObject();
+    }
+
+    private static void WriteNullableString(
+        Utf8JsonWriter writer,
+        string propertyName,
+        string? value)
+    {
+        if (value is null)
+            writer.WriteNull(propertyName);
+        else
+            writer.WriteString(propertyName, value);
+    }
+}

--- a/Docxodus/Verification/DeliveryReceiptInputs.cs
+++ b/Docxodus/Verification/DeliveryReceiptInputs.cs
@@ -59,7 +59,10 @@ public sealed class DeliveryNormalizedOperation
             throw new DeliveryReceiptValidationException(
                 "invalid_operation_arguments", $"argumentsJson is not valid JSON: {ex.Message}");
         }
-        using var document = JsonDocument.Parse(canonical);
+        using var document = JsonDocument.Parse(canonical, new JsonDocumentOptions
+        {
+            MaxDepth = DeliveryReceiptLimits.MaxAllowedJsonDepth,
+        });
         if (document.RootElement.ValueKind != JsonValueKind.Object)
         {
             throw new DeliveryReceiptValidationException(

--- a/Docxodus/Verification/DeliveryReceiptInputs.cs
+++ b/Docxodus/Verification/DeliveryReceiptInputs.cs
@@ -11,12 +11,16 @@ namespace Docxodus.Verification;
 /// <summary>A caller-normalized document operation paired with one batch step.</summary>
 public sealed class DeliveryNormalizedOperation
 {
-    private DeliveryNormalizedOperation(string tool, string action, JsonElement arguments)
+    private DeliveryNormalizedOperation(
+        string tool,
+        string action,
+        JsonElement arguments,
+        byte[] canonicalArguments)
     {
         Tool = tool;
         Action = action;
         Arguments = arguments;
-        CanonicalArguments = DeliveryReceiptCanonicalJson.SerializeCanonical(arguments);
+        CanonicalArguments = canonicalArguments;
         ArgumentsDigest = DeliveryReceiptCanonicalJson.Digest(CanonicalArguments);
     }
 
@@ -29,18 +33,43 @@ public sealed class DeliveryNormalizedOperation
     public static DeliveryNormalizedOperation Create(
         string tool,
         string action,
-        string argumentsJson = "{}")
+        string argumentsJson = "{}",
+        DeliveryReceiptLimits? limits = null)
     {
         ArgumentNullException.ThrowIfNull(argumentsJson);
-        if (argumentsJson.Length > new DeliveryReceiptLimits().MaxStringLength)
+        var validatedLimits = (limits ?? new DeliveryReceiptLimits()).ValidateAndClone();
+        int utf8Length = Encoding.UTF8.GetByteCount(argumentsJson);
+        if (argumentsJson.Length > validatedLimits.MaxStringLength
+            || utf8Length > validatedLimits.MaxReceiptJsonBytes)
         {
             throw new DeliveryReceiptValidationException(
                 "receipt_resource_limit", "Operation arguments exceed the string-length limit.");
         }
+        byte[] canonical;
+        try
+        {
+            canonical = DeliveryReceiptCanonicalJson.CanonicalizeBounded(
+                Encoding.UTF8.GetBytes(argumentsJson),
+                validatedLimits,
+                validatedLimits.MaxReceiptJsonBytes,
+                "receipt_resource_limit");
+        }
+        catch (JsonException ex)
+        {
+            throw new DeliveryReceiptValidationException(
+                "invalid_operation_arguments", $"argumentsJson is not valid JSON: {ex.Message}");
+        }
+        using var document = JsonDocument.Parse(canonical);
+        if (document.RootElement.ValueKind != JsonValueKind.Object)
+        {
+            throw new DeliveryReceiptValidationException(
+                "invalid_operation_arguments", "argumentsJson must be a JSON object.");
+        }
         return new DeliveryNormalizedOperation(
             DeliveryReceiptValidation.RequireNonBlank(tool, nameof(tool), 256),
             DeliveryReceiptValidation.RequireNonBlank(action, nameof(action), 256),
-            DeliveryReceiptCanonicalJson.ParseCanonicalObject(argumentsJson, nameof(argumentsJson)));
+            document.RootElement.Clone(),
+            canonical);
     }
 }
 
@@ -84,7 +113,8 @@ public sealed class DeliveryTransactionContribution
         PackageManifest beforeManifest,
         PackageManifest afterManifest,
         IEnumerable<DeliveryNormalizedOperation> operations,
-        DeliveryTransactionIdentity? identity = null)
+        DeliveryTransactionIdentity? identity = null,
+        DeliveryReceiptLimits? limits = null)
     {
         ArgumentNullException.ThrowIfNull(result);
         ArgumentNullException.ThrowIfNull(beforeManifest);
@@ -92,22 +122,39 @@ public sealed class DeliveryTransactionContribution
         ArgumentNullException.ThrowIfNull(operations);
         if (!Enum.IsDefined(result.Mode))
             throw new DeliveryReceiptValidationException("invalid_batch_mode", "Unknown batch mode.");
-        if (result.BaseVersion < 0 || result.ResultVersion < 0)
-            throw new DeliveryReceiptValidationException(
-                "invalid_document_version", "Batch versions cannot be negative.");
+        DeliveryReceiptValidation.ValidatePortableNonNegativeInteger(
+            result.BaseVersion, "invalid_document_version", "Batch base version");
+        DeliveryReceiptValidation.ValidatePortableNonNegativeInteger(
+            result.ResultVersion, "invalid_document_version", "Batch result version");
+        if (result.PackageHash is not null)
+        {
+            DeliveryReceiptValidation.ValidateDigest(
+                new VerificationDigest
+                {
+                    Algorithm = DeliveryReceiptValidation.Sha256Algorithm,
+                    Value = result.PackageHash,
+                },
+                "batch package-content digest");
+        }
 
-        var materialized = operations.ToArray();
-        if (materialized.Any(operation => operation is null))
+        var validatedLimits = (limits ?? new DeliveryReceiptLimits()).ValidateAndClone();
+        var materializedList = new List<DeliveryNormalizedOperation>();
+        foreach (var operation in operations)
         {
-            throw new DeliveryReceiptValidationException(
-                "null_operation", "Normalized operations cannot contain null.");
+            if (materializedList.Count >= validatedLimits.MaxOperationsPerTransaction)
+            {
+                throw new DeliveryReceiptValidationException(
+                    "receipt_resource_limit",
+                    "Normalized operations exceed the per-transaction limit.");
+            }
+            if (operation is null)
+            {
+                throw new DeliveryReceiptValidationException(
+                    "null_operation", "Normalized operations cannot contain null.");
+            }
+            materializedList.Add(operation);
         }
-        if (materialized.Length > new DeliveryReceiptLimits().MaxOperationsPerTransaction)
-        {
-            throw new DeliveryReceiptValidationException(
-                "receipt_resource_limit",
-                "Normalized operations exceed the default per-transaction limit.");
-        }
+        var materialized = materializedList.ToArray();
         var stepsByIndex = new Dictionary<int, MutationBatchStepResult>();
         foreach (var step in result.Steps)
         {
@@ -265,14 +312,15 @@ public sealed record DeliveryArtifactInput
         string artifactId,
         DeliveryArtifactRole role,
         string mediaType,
-        ReadOnlySpan<byte> bytes)
+        ReadOnlySpan<byte> bytes,
+        DeliveryReceiptLimits? limits = null)
     {
-        var defaults = new DeliveryReceiptLimits();
+        var validatedLimits = (limits ?? new DeliveryReceiptLimits()).ValidateAndClone();
         var maximum = role switch
         {
-            DeliveryArtifactRole.SemanticDiff => defaults.MaxSemanticEvidenceBytes,
-            DeliveryArtifactRole.PageMap => defaults.MaxPageMapBytes,
-            _ => defaults.MaxArtifactBytes,
+            DeliveryArtifactRole.SemanticDiff => validatedLimits.MaxSemanticEvidenceBytes,
+            DeliveryArtifactRole.PageMap => validatedLimits.MaxPageMapBytes,
+            _ => validatedLimits.MaxArtifactBytes,
         };
         var code = role switch
         {

--- a/Docxodus/Verification/DeliveryReceiptInputs.cs
+++ b/Docxodus/Verification/DeliveryReceiptInputs.cs
@@ -1,0 +1,402 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Text;
+using System.Text.Json;
+
+namespace Docxodus.Verification;
+
+/// <summary>A caller-normalized document operation paired with one batch step.</summary>
+public sealed class DeliveryNormalizedOperation
+{
+    private DeliveryNormalizedOperation(string tool, string action, JsonElement arguments)
+    {
+        Tool = tool;
+        Action = action;
+        Arguments = arguments;
+        CanonicalArguments = DeliveryReceiptCanonicalJson.SerializeCanonical(arguments);
+        ArgumentsDigest = DeliveryReceiptCanonicalJson.Digest(CanonicalArguments);
+    }
+
+    public string Tool { get; }
+    public string Action { get; }
+    public JsonElement Arguments { get; }
+    public VerificationDigest ArgumentsDigest { get; }
+    internal byte[] CanonicalArguments { get; }
+
+    public static DeliveryNormalizedOperation Create(
+        string tool,
+        string action,
+        string argumentsJson = "{}")
+    {
+        ArgumentNullException.ThrowIfNull(argumentsJson);
+        if (argumentsJson.Length > new DeliveryReceiptLimits().MaxStringLength)
+        {
+            throw new DeliveryReceiptValidationException(
+                "receipt_resource_limit", "Operation arguments exceed the string-length limit.");
+        }
+        return new DeliveryNormalizedOperation(
+            DeliveryReceiptValidation.RequireNonBlank(tool, nameof(tool), 256),
+            DeliveryReceiptValidation.RequireNonBlank(action, nameof(action), 256),
+            DeliveryReceiptCanonicalJson.ParseCanonicalObject(argumentsJson, nameof(argumentsJson)));
+    }
+}
+
+/// <summary>Optional transport identity supplied alongside a core MutationBatchResult.</summary>
+public sealed record DeliveryTransactionIdentity
+{
+    public int SchemaVersion { get; init; } = 1;
+    required public string TransactionId { get; init; }
+    required public string RequestFingerprint { get; init; }
+}
+
+/// <summary>
+/// The immutable inputs needed to turn one MutationBatchResult into receipt evidence. Operation
+/// arguments and transport identity are explicit because the core result intentionally does not
+/// retain either one.
+/// </summary>
+public sealed class DeliveryTransactionContribution
+{
+    private DeliveryTransactionContribution(
+        MutationBatchResult result,
+        DeliveryDocumentIdentity beforeDocument,
+        DeliveryDocumentIdentity afterDocument,
+        IReadOnlyList<DeliveryNormalizedOperation> operations,
+        DeliveryTransactionIdentity? identity)
+    {
+        Result = result;
+        BeforeDocument = beforeDocument;
+        AfterDocument = afterDocument;
+        Operations = operations;
+        Identity = identity;
+    }
+
+    public MutationBatchResult Result { get; }
+    public DeliveryDocumentIdentity BeforeDocument { get; }
+    public DeliveryDocumentIdentity AfterDocument { get; }
+    public IReadOnlyList<DeliveryNormalizedOperation> Operations { get; }
+    public DeliveryTransactionIdentity? Identity { get; }
+
+    public static DeliveryTransactionContribution FromMutationBatchResult(
+        MutationBatchResult result,
+        PackageManifest beforeManifest,
+        PackageManifest afterManifest,
+        IEnumerable<DeliveryNormalizedOperation> operations,
+        DeliveryTransactionIdentity? identity = null)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentNullException.ThrowIfNull(beforeManifest);
+        ArgumentNullException.ThrowIfNull(afterManifest);
+        ArgumentNullException.ThrowIfNull(operations);
+        if (!Enum.IsDefined(result.Mode))
+            throw new DeliveryReceiptValidationException("invalid_batch_mode", "Unknown batch mode.");
+        if (result.BaseVersion < 0 || result.ResultVersion < 0)
+            throw new DeliveryReceiptValidationException(
+                "invalid_document_version", "Batch versions cannot be negative.");
+
+        var materialized = operations.ToArray();
+        if (materialized.Any(operation => operation is null))
+        {
+            throw new DeliveryReceiptValidationException(
+                "null_operation", "Normalized operations cannot contain null.");
+        }
+        if (materialized.Length > new DeliveryReceiptLimits().MaxOperationsPerTransaction)
+        {
+            throw new DeliveryReceiptValidationException(
+                "receipt_resource_limit",
+                "Normalized operations exceed the default per-transaction limit.");
+        }
+        var stepsByIndex = new Dictionary<int, MutationBatchStepResult>();
+        foreach (var step in result.Steps)
+        {
+            if (step is null || step.Index < 0 || step.Index >= materialized.Length
+                || !stepsByIndex.TryAdd(step.Index, step)
+                || !string.Equals(step.Tool, materialized[step.Index].Tool,
+                    StringComparison.Ordinal)
+                || !string.Equals(step.Action, materialized[step.Index].Action,
+                    StringComparison.Ordinal)
+                || step.Results is null
+                || step.Results.Any(stepResult => stepResult is null))
+            {
+                throw new DeliveryReceiptValidationException(
+                    "operation_step_mismatch",
+                    "Sparse batch results must have unique in-range indices and match requested operations.");
+            }
+        }
+        if ((result.Mode == MutationBatchMode.BestEffort || result.Success)
+            && stepsByIndex.Count != materialized.Length)
+        {
+            throw new DeliveryReceiptValidationException(
+                "operation_step_mismatch",
+                "Successful and best-effort batches require one result for every requested operation.");
+        }
+        if (!result.Success && result.Mode == MutationBatchMode.Atomic
+            && stepsByIndex.Count == 0)
+        {
+            throw new DeliveryReceiptValidationException(
+                "operation_step_mismatch", "A failed atomic batch requires failure evidence.");
+        }
+        ValidateBatchOutcome(
+            result, stepsByIndex.Values.OrderBy(step => step.Index).ToArray());
+
+        if (identity is not null)
+        {
+            if (result.Preview)
+            {
+                throw new DeliveryReceiptValidationException(
+                    "preview_transaction_identity",
+                    "Predictions cannot carry applying transaction identities.");
+            }
+            if (identity.SchemaVersion != 1)
+            {
+                throw new DeliveryReceiptValidationException(
+                    "unsupported_transaction_identity", "Only transaction identity v1 is supported.");
+            }
+            DeliveryReceiptValidation.RequireNonBlank(
+                identity.TransactionId, "transaction id", 1024);
+            ValidateFingerprint(identity.RequestFingerprint);
+        }
+
+        return new DeliveryTransactionContribution(
+            result,
+            DeliveryDocumentIdentity.FromManifest(beforeManifest, result.BaseVersion),
+            DeliveryDocumentIdentity.FromManifest(afterManifest, result.ResultVersion),
+            materialized,
+            identity);
+    }
+
+    internal static void ValidateFingerprint(string fingerprint)
+    {
+        if (fingerprint is null || fingerprint.Length != 71
+            || !fingerprint.StartsWith("sha256:", StringComparison.Ordinal)
+            || fingerprint.AsSpan(7).ToString().Any(
+                c => !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))))
+        {
+            throw new DeliveryReceiptValidationException(
+                "invalid_request_fingerprint",
+                "Request fingerprints must be 'sha256:' followed by 64 lower-case hex characters.");
+        }
+    }
+
+    private static void ValidateBatchOutcome(
+        MutationBatchResult result,
+        IReadOnlyList<MutationBatchStepResult> steps)
+    {
+        bool derivedSuccess = steps.All(step => step.Success);
+        if (result.Success != derivedSuccess
+            || (result.Mode == MutationBatchMode.BestEffort && result.RolledBack)
+            || (result.Mode == MutationBatchMode.Atomic
+                && result.RolledBack == result.Success))
+        {
+            throw new DeliveryReceiptValidationException(
+                "invalid_batch_result", "Batch success and rollback flags are inconsistent.");
+        }
+
+        if (result.Mode == MutationBatchMode.BestEffort
+            && steps.Any(step => step.RolledBack))
+        {
+            throw new DeliveryReceiptValidationException(
+                "invalid_batch_result", "Best-effort steps cannot be rolled back.");
+        }
+        if (result.Mode == MutationBatchMode.Atomic && result.Success
+            && steps.Any(step => !step.Success || step.RolledBack))
+        {
+            throw new DeliveryReceiptValidationException(
+                "invalid_batch_result", "A committed atomic batch requires retained successful steps.");
+        }
+        if (result.Mode == MutationBatchMode.Atomic && !result.Success)
+        {
+            var failedSteps = steps.Where(step => !step.Success).ToArray();
+            if (failedSteps.Length != 1 || steps.Any(step => !step.RolledBack))
+            {
+                throw new DeliveryReceiptValidationException(
+                    "invalid_batch_result", "A failed atomic batch requires one rolled-back failure.");
+            }
+            int failedIndex = failedSteps[0].Index;
+            bool preflightShape = steps.Count == 1;
+            bool executionShape = steps.Count == failedIndex + 1
+                && steps.Select(step => step.Index).SequenceEqual(
+                    Enumerable.Range(0, failedIndex + 1))
+                && steps.Take(failedIndex).All(step => step.Success);
+            if (!preflightShape && !executionShape)
+            {
+                throw new DeliveryReceiptValidationException(
+                    "invalid_batch_result",
+                    "Failed atomic steps must be one preflight failure or an executed prefix.");
+            }
+        }
+
+        var firstFailure = steps.FirstOrDefault(step => !step.Success);
+        var firstFailureResult = firstFailure?.Results.FirstOrDefault(value => !value.Success);
+        if (result.Success != (result.Failure is null)
+            || (!result.Success && (firstFailure is null
+                || firstFailureResult?.Error is null
+                || result.Failure!.Index != firstFailure.Index
+                || !string.Equals(result.Failure.Tool, firstFailure.Tool,
+                    StringComparison.Ordinal)
+                || !string.Equals(result.Failure.Action, firstFailure.Action,
+                    StringComparison.Ordinal)
+                || result.Failure.RolledBack != firstFailure.RolledBack
+                || result.Failure.Error != firstFailureResult.Error)))
+        {
+            throw new DeliveryReceiptValidationException(
+                "invalid_batch_result", "Batch failure metadata is inconsistent.");
+        }
+    }
+}
+
+/// <summary>Bytes and optional render/document binding for one output artifact.</summary>
+public sealed record DeliveryArtifactInput
+{
+    required public string ArtifactId { get; init; }
+    required public DeliveryArtifactRole Role { get; init; }
+    required public string MediaType { get; init; }
+    required public DeliveryArtifactAvailability Availability { get; init; }
+    public byte[]? Bytes { get; init; }
+    public string? RelativePath { get; init; }
+    public string? UnavailableReason { get; init; }
+    public DeliveryDocumentIdentity? Document { get; init; }
+    public string? RendererFingerprint { get; init; }
+    public VerificationDigest? PageMapDigest { get; init; }
+
+    public static DeliveryArtifactInput Available(
+        string artifactId,
+        DeliveryArtifactRole role,
+        string mediaType,
+        ReadOnlySpan<byte> bytes)
+    {
+        var defaults = new DeliveryReceiptLimits();
+        var maximum = role switch
+        {
+            DeliveryArtifactRole.SemanticDiff => defaults.MaxSemanticEvidenceBytes,
+            DeliveryArtifactRole.PageMap => defaults.MaxPageMapBytes,
+            _ => defaults.MaxArtifactBytes,
+        };
+        var code = role switch
+        {
+            DeliveryArtifactRole.SemanticDiff => "semantic_resource_limit",
+            DeliveryArtifactRole.PageMap => "page_map_resource_limit",
+            _ => "artifact_resource_limit",
+        };
+        DeliveryReceiptResourceBudget.Bytes(
+            bytes.Length,
+            maximum,
+            code,
+            "Artifact");
+        return new DeliveryArtifactInput
+        {
+            ArtifactId = artifactId,
+            Role = role,
+            MediaType = mediaType,
+            Availability = DeliveryArtifactAvailability.Available,
+            Bytes = bytes.ToArray(),
+        };
+    }
+
+    public static DeliveryArtifactInput Unavailable(
+        string artifactId,
+        DeliveryArtifactRole role,
+        string mediaType,
+        string reason) => new()
+    {
+        ArtifactId = artifactId,
+        Role = role,
+        MediaType = mediaType,
+        Availability = DeliveryArtifactAvailability.Unavailable,
+        UnavailableReason = reason,
+    };
+}
+
+/// <summary>
+/// Typed registration of exact <see cref="SemanticChangeSet.ToCanonicalUtf8Bytes"/> output for
+/// either the complete delivery or one state-changing transaction.
+/// </summary>
+public sealed class DeliverySemanticChangeSetInput
+{
+    private DeliverySemanticChangeSetInput(
+        DeliverySemanticComparisonScope scope,
+        string? transactionEntryId,
+        SemanticChangeSet changeSet,
+        string artifactId,
+        string? relativePath)
+    {
+        Scope = scope;
+        TransactionEntryId = transactionEntryId;
+        ArtifactId = DeliveryReceiptValidation.RequireNonBlank(
+            artifactId, "semantic artifact id", 256);
+        RelativePath = DeliveryReceiptValidation.NormalizeRelativePath(relativePath);
+        ChangeSet = changeSet ?? throw new ArgumentNullException(nameof(changeSet));
+    }
+
+    public DeliverySemanticComparisonScope Scope { get; }
+    public string? TransactionEntryId { get; }
+    public string ArtifactId { get; }
+    public string? RelativePath { get; }
+    internal SemanticChangeSet ChangeSet { get; }
+
+    public static DeliverySemanticChangeSetInput ForSourceToDelivered(
+        SemanticChangeSet changeSet,
+        string artifactId = "semantic-source-to-delivered",
+        string? relativePath = null) =>
+        new(DeliverySemanticComparisonScope.SourceToDelivered, null,
+            changeSet, artifactId, relativePath);
+
+    public static DeliverySemanticChangeSetInput ForTransaction(
+        string transactionEntryId,
+        SemanticChangeSet changeSet,
+        string artifactId,
+        string? relativePath = null) =>
+        new(DeliverySemanticComparisonScope.Transaction,
+            DeliveryReceiptValidation.RequireNonBlank(
+                transactionEntryId, "semantic transaction entry id", 256),
+            changeSet, artifactId, relativePath);
+}
+
+/// <summary>Existing PageCitation plus the package, page map, and artifact that made it true.</summary>
+public sealed record DeliveryPageCitationInput
+{
+    required public PageCitation Citation { get; init; }
+    required public string Scope { get; init; }
+    required public DeliveryDocumentIdentity Document { get; init; }
+    required public VerificationDigest PageMapDigest { get; init; }
+    required public string PageMapArtifactId { get; init; }
+    required public string RenderArtifactId { get; init; }
+}
+
+/// <summary>One explicit undo/redo contribution.</summary>
+public sealed record DeliveryLineageEventInput
+{
+    required public DeliveryLineageAction Action { get; init; }
+    required public string AffectedEntryId { get; init; }
+    required public DeliveryDocumentIdentity BeforeDocument { get; init; }
+    required public DeliveryDocumentIdentity AfterDocument { get; init; }
+
+    public static DeliveryLineageEventInput FromManifests(
+        DeliveryLineageAction action,
+        string affectedEntryId,
+        PackageManifest beforeManifest,
+        long beforeVersion,
+        PackageManifest afterManifest,
+        long afterVersion) => new()
+    {
+        Action = action,
+        AffectedEntryId = affectedEntryId,
+        BeforeDocument = DeliveryDocumentIdentity.FromManifest(beforeManifest, beforeVersion),
+        AfterDocument = DeliveryDocumentIdentity.FromManifest(afterManifest, afterVersion),
+    };
+}
+
+/// <summary>An exact attribution rule for one class of observed manifest changes.</summary>
+public sealed record DeliveryChangeAttributionRule
+{
+    required public DeliveryPackageChangeKind Kind { get; init; }
+    public string? EntryUri { get; init; }
+    public string? OwnerUri { get; init; }
+    public string? RelationshipId { get; init; }
+    required public DeliveryChangeDisposition Disposition { get; init; }
+    public string? TransactionEntryId { get; init; }
+    public int? RequestedOperationIndex { get; init; }
+    public string? Derivation { get; init; }
+}

--- a/Docxodus/Verification/DeliveryReceiptInputs.cs
+++ b/Docxodus/Verification/DeliveryReceiptInputs.cs
@@ -232,10 +232,7 @@ public sealed class DeliveryTransactionContribution
 
     internal static void ValidateFingerprint(string fingerprint)
     {
-        if (fingerprint is null || fingerprint.Length != 71
-            || !fingerprint.StartsWith("sha256:", StringComparison.Ordinal)
-            || fingerprint.AsSpan(7).ToString().Any(
-                c => !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))))
+        if (!DeliveryReceiptContract.IsSha256DigestToken(fingerprint))
         {
             throw new DeliveryReceiptValidationException(
                 "invalid_request_fingerprint",

--- a/Docxodus/Verification/DeliveryReceiptInputs.cs
+++ b/Docxodus/Verification/DeliveryReceiptInputs.cs
@@ -209,10 +209,23 @@ public sealed class DeliveryTransactionContribution
             ValidateFingerprint(identity.RequestFingerprint);
         }
 
+        var beforeDocument = DeliveryDocumentIdentity.FromManifest(
+            beforeManifest, result.BaseVersion);
+        var afterDocument = DeliveryDocumentIdentity.FromManifest(
+            afterManifest, result.ResultVersion);
+        if (result.Preview
+            && DeliveryReceiptLineageValidator.SameIdentityExceptVersion(
+                beforeDocument, afterDocument))
+        {
+            // The engine consumes a version for any recorded mutation even when the net
+            // package is unchanged. A prediction never advances lineage, so an idempotent
+            // preview collapses to the canonical no-op shape the validator accepts.
+            afterDocument = beforeDocument;
+        }
         return new DeliveryTransactionContribution(
             result,
-            DeliveryDocumentIdentity.FromManifest(beforeManifest, result.BaseVersion),
-            DeliveryDocumentIdentity.FromManifest(afterManifest, result.ResultVersion),
+            beforeDocument,
+            afterDocument,
             materialized,
             identity);
     }
@@ -275,6 +288,28 @@ public sealed class DeliveryTransactionContribution
                 throw new DeliveryReceiptValidationException(
                     "invalid_batch_result",
                     "Failed atomic steps must be one preflight failure or an executed prefix.");
+            }
+        }
+
+        foreach (var step in steps)
+        {
+            foreach (var value in step.Results)
+            {
+                if (!value.Success
+                    && (value.Error is null
+                        || !Enum.IsDefined(value.Error.Code)
+                        || string.IsNullOrEmpty(value.Error.Message)))
+                {
+                    throw new DeliveryReceiptValidationException(
+                        "invalid_operation_result",
+                        "Every failed step result must carry a structured edit error.");
+                }
+                if (value.Success && value.Error is not null)
+                {
+                    throw new DeliveryReceiptValidationException(
+                        "invalid_operation_result",
+                        "Successful step results cannot carry an edit error.");
+                }
             }
         }
 

--- a/Docxodus/Verification/DeliveryReceiptLimits.cs
+++ b/Docxodus/Verification/DeliveryReceiptLimits.cs
@@ -17,7 +17,11 @@ public sealed record DeliveryReceiptLimits
     public int MaxPageMapBytes { get; init; } = 64 * 1024 * 1024;
     public int MaxArtifactBytes { get; init; } = 256 * 1024 * 1024;
     public long MaxTotalArtifactBytes { get; init; } = 512L * 1024 * 1024;
-    public int MaxJsonDepth { get; init; } = 128;
+    /// <summary>Hard ceiling for <see cref="MaxJsonDepth"/>; every secondary parse of
+    /// already-bounded canonical JSON must allow at least this depth.</summary>
+    internal const int MaxAllowedJsonDepth = 128;
+
+    public int MaxJsonDepth { get; init; } = MaxAllowedJsonDepth;
     public int MaxCollectionItems { get; init; } = 100_000;
     public int MaxTransactions { get; init; } = 10_000;
     public int MaxOperationsPerTransaction { get; init; } = 10_000;
@@ -38,7 +42,7 @@ public sealed record DeliveryReceiptLimits
         Positive(MaxArtifactBytes, nameof(MaxArtifactBytes));
         if (MaxTotalArtifactBytes <= 0)
             throw new ArgumentOutOfRangeException(nameof(MaxTotalArtifactBytes));
-        if (MaxJsonDepth is < 1 or > 128)
+        if (MaxJsonDepth is < 1 or > MaxAllowedJsonDepth)
             throw new ArgumentOutOfRangeException(nameof(MaxJsonDepth));
         Positive(MaxCollectionItems, nameof(MaxCollectionItems));
         Positive(MaxTransactions, nameof(MaxTransactions));

--- a/Docxodus/Verification/DeliveryReceiptLimits.cs
+++ b/Docxodus/Verification/DeliveryReceiptLimits.cs
@@ -63,15 +63,8 @@ public sealed record DeliveryReceiptLimits
             throw new ArgumentOutOfRangeException(name);
     }
 
-    private static PackageManifestOptions CloneManifestOptions(PackageManifestOptions value) => new()
-    {
-        MaxEntryCount = value.MaxEntryCount,
-        MaxEntryUncompressedBytes = value.MaxEntryUncompressedBytes,
-        MaxTotalUncompressedBytes = value.MaxTotalUncompressedBytes,
-        MaxXmlPartBytes = value.MaxXmlPartBytes,
-        MaxCompressionRatio = value.MaxCompressionRatio,
-        MaxUriLength = value.MaxUriLength,
-    };
+    private static PackageManifestOptions CloneManifestOptions(PackageManifestOptions value) =>
+        value with { };
 }
 
 /// <summary>Options for portable receipt verification.</summary>

--- a/Docxodus/Verification/DeliveryReceiptLimits.cs
+++ b/Docxodus/Verification/DeliveryReceiptLimits.cs
@@ -1,0 +1,217 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+
+namespace Docxodus.Verification;
+
+/// <summary>Bounded resource policy shared by receipt construction and verification.</summary>
+public sealed record DeliveryReceiptLimits
+{
+    public int MaxReceiptJsonBytes { get; init; } = 16 * 1024 * 1024;
+    public int MaxSemanticEvidenceBytes { get; init; } = 64 * 1024 * 1024;
+    public int MaxPageMapBytes { get; init; } = 64 * 1024 * 1024;
+    public int MaxArtifactBytes { get; init; } = 256 * 1024 * 1024;
+    public long MaxTotalArtifactBytes { get; init; } = 512L * 1024 * 1024;
+    public int MaxJsonDepth { get; init; } = 128;
+    public int MaxCollectionItems { get; init; } = 100_000;
+    public int MaxTransactions { get; init; } = 10_000;
+    public int MaxOperationsPerTransaction { get; init; } = 10_000;
+    public int MaxArtifacts { get; init; } = 1_024;
+    public int MaxStringLength { get; init; } = 1024 * 1024;
+
+    /// <summary>
+    /// Corrected #493 inspection policy used when clean-DOCX bytes are independently reparsed.
+    /// Package expansion, entry, XML, ratio, and URI limits remain owned by that contract.
+    /// </summary>
+    public PackageManifestOptions CleanDocxManifestOptions { get; init; } = new();
+
+    internal DeliveryReceiptLimits ValidateAndClone()
+    {
+        Positive(MaxReceiptJsonBytes, nameof(MaxReceiptJsonBytes));
+        Positive(MaxSemanticEvidenceBytes, nameof(MaxSemanticEvidenceBytes));
+        Positive(MaxPageMapBytes, nameof(MaxPageMapBytes));
+        Positive(MaxArtifactBytes, nameof(MaxArtifactBytes));
+        if (MaxTotalArtifactBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(MaxTotalArtifactBytes));
+        if (MaxJsonDepth is < 1 or > 128)
+            throw new ArgumentOutOfRangeException(nameof(MaxJsonDepth));
+        Positive(MaxCollectionItems, nameof(MaxCollectionItems));
+        Positive(MaxTransactions, nameof(MaxTransactions));
+        Positive(MaxOperationsPerTransaction, nameof(MaxOperationsPerTransaction));
+        Positive(MaxArtifacts, nameof(MaxArtifacts));
+        Positive(MaxStringLength, nameof(MaxStringLength));
+        ArgumentNullException.ThrowIfNull(CleanDocxManifestOptions);
+        CleanDocxManifestOptions.Validate();
+        return this with
+        {
+            CleanDocxManifestOptions = CloneManifestOptions(CleanDocxManifestOptions),
+        };
+    }
+
+    private static void Positive(int value, string name)
+    {
+        if (value <= 0)
+            throw new ArgumentOutOfRangeException(name);
+    }
+
+    private static PackageManifestOptions CloneManifestOptions(PackageManifestOptions value) => new()
+    {
+        MaxEntryCount = value.MaxEntryCount,
+        MaxEntryUncompressedBytes = value.MaxEntryUncompressedBytes,
+        MaxTotalUncompressedBytes = value.MaxTotalUncompressedBytes,
+        MaxXmlPartBytes = value.MaxXmlPartBytes,
+        MaxCompressionRatio = value.MaxCompressionRatio,
+        MaxUriLength = value.MaxUriLength,
+    };
+}
+
+/// <summary>Options for portable receipt verification.</summary>
+public sealed record DeliveryReceiptVerificationOptions
+{
+    public DeliveryReceiptLimits Limits { get; init; } = new();
+
+    internal DeliveryReceiptVerificationOptions ValidateAndClone()
+    {
+        ArgumentNullException.ThrowIfNull(Limits);
+        return this with { Limits = Limits.ValidateAndClone() };
+    }
+}
+
+internal sealed class DeliveryReceiptResourceBudget
+{
+    private readonly DeliveryReceiptLimits _limits;
+    private readonly long _maximumSerializedBytes;
+    private readonly string _limitCode;
+    private long _collectionItems;
+    private long _serializedBytes;
+
+    public DeliveryReceiptResourceBudget(
+        DeliveryReceiptLimits limits,
+        long? maximumSerializedBytes = null,
+        string limitCode = "receipt_resource_limit")
+    {
+        _limits = limits;
+        _maximumSerializedBytes = maximumSerializedBytes ?? limits.MaxReceiptJsonBytes;
+        _limitCode = limitCode;
+    }
+
+    public void AddItems(int count, string name)
+    {
+        if (count < 0 || count > _limits.MaxCollectionItems)
+            Fail($"{name} exceeds the per-collection item limit.", _limitCode);
+        _collectionItems = checked(_collectionItems + count);
+        if (_collectionItems > _limits.MaxCollectionItems)
+            Fail("Receipt collections exceed the aggregate item limit.", _limitCode);
+    }
+
+    public void String(string? value, string name)
+    {
+        if (value is null)
+            return;
+        if (value.Length > _limits.MaxStringLength)
+            Fail($"{name} exceeds the string-length limit.", _limitCode);
+        int utf8Length = Encoding.UTF8.GetByteCount(value);
+        if (utf8Length > _limits.MaxStringLength)
+            Fail($"{name} exceeds the string-length limit.", _limitCode);
+        var encoded = JsonEncodedText.Encode(value, JavaScriptEncoder.Default);
+        AddSerializedBytes(encoded.EncodedUtf8Bytes.Length + 2L, name);
+    }
+
+    public void AddSerializedBytes(long count, string name)
+    {
+        if (count < 0 || count > _maximumSerializedBytes - _serializedBytes)
+            Fail($"{name} exceeds the aggregate serialized-byte limit.", _limitCode);
+        _serializedBytes += count;
+    }
+
+    public void Depth(int depth, string name)
+    {
+        if (depth > _limits.MaxJsonDepth)
+            Fail($"{name} exceeds the JSON-depth limit.", _limitCode);
+    }
+
+    public static void Bytes(long length, long maximum, string code, string name)
+    {
+        if (length < 0 || length > maximum)
+            throw new DeliveryReceiptValidationException(code, $"{name} exceeds its byte limit.");
+    }
+
+    private static void Fail(string message, string code = "receipt_resource_limit") =>
+        throw new DeliveryReceiptValidationException(code, message);
+}
+
+/// <summary>A MemoryStream that fails before accepting bytes past a configured ceiling.</summary>
+internal sealed class DeliveryReceiptBoundedMemoryStream : MemoryStream
+{
+    private readonly long _maximumBytes;
+    private readonly string _limitCode;
+    private readonly string _name;
+
+    public DeliveryReceiptBoundedMemoryStream(
+        long maximumBytes,
+        string limitCode,
+        string name)
+        : base(capacity: (int)Math.Min(maximumBytes, 16 * 1024))
+    {
+        _maximumBytes = maximumBytes;
+        _limitCode = limitCode;
+        _name = name;
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        EnsureCapacityFor(count);
+        base.Write(buffer, offset, count);
+    }
+
+    public override void Write(ReadOnlySpan<byte> buffer)
+    {
+        EnsureCapacityFor(buffer.Length);
+        base.Write(buffer);
+    }
+
+    public override void WriteByte(byte value)
+    {
+        EnsureCapacityFor(1);
+        base.WriteByte(value);
+    }
+
+    public override Task WriteAsync(
+        byte[] buffer,
+        int offset,
+        int count,
+        CancellationToken cancellationToken)
+    {
+        EnsureCapacityFor(count);
+        return base.WriteAsync(buffer, offset, count, cancellationToken);
+    }
+
+    public override ValueTask WriteAsync(
+        ReadOnlyMemory<byte> buffer,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureCapacityFor(buffer.Length);
+        return base.WriteAsync(buffer, cancellationToken);
+    }
+
+    public override void SetLength(long value)
+    {
+        if (value > _maximumBytes)
+            Fail();
+        base.SetLength(value);
+    }
+
+    private void EnsureCapacityFor(int count)
+    {
+        if (count < 0 || Position > _maximumBytes - count)
+            Fail();
+    }
+
+    private void Fail() => throw new DeliveryReceiptValidationException(
+        _limitCode, $"{_name} exceeds its byte limit.");
+}

--- a/Docxodus/Verification/DeliveryReceiptLineageValidator.cs
+++ b/Docxodus/Verification/DeliveryReceiptLineageValidator.cs
@@ -208,6 +208,21 @@ internal static class DeliveryReceiptLineageValidator
         && DeliveryReceiptValidation.DigestEquals(
             document.RawPackageBytesDigest, packageDigest);
 
+    /// <summary>An artifact document identity is valid when it is a lineage-reachable
+    /// edit state, or when it matches the identity of a ReviewDocx artifact in the same
+    /// receipt (a render of the review copy is attested by the review copy itself).</summary>
+    public static bool IsArtifactDocumentReachable(
+        DeliveryLineageValidationResult validation,
+        long documentVersion,
+        VerificationDigest packageDigest,
+        IReadOnlyCollection<DeliveryArtifact> artifacts) =>
+        IsReachable(validation, documentVersion, packageDigest)
+        || artifacts.Any(artifact =>
+            artifact.Role == DeliveryArtifactRole.ReviewDocx
+            && artifact.DocumentVersion == documentVersion
+            && DeliveryReceiptValidation.DigestEquals(
+                artifact.PackageDigest, packageDigest));
+
     public static bool DocumentEquals(
         DeliveryDocumentIdentity left,
         DeliveryDocumentIdentity right) =>

--- a/Docxodus/Verification/DeliveryReceiptLineageValidator.cs
+++ b/Docxodus/Verification/DeliveryReceiptLineageValidator.cs
@@ -236,7 +236,7 @@ internal static class DeliveryReceiptLineageValidator
         && OptionalDigestEquals(left.OrderedOpcContentDigest, right.OrderedOpcContentDigest)
         && OptionalDigestEquals(left.NormalizedSemanticDigest, right.NormalizedSemanticDigest);
 
-    private static bool SameIdentityExceptVersion(
+    internal static bool SameIdentityExceptVersion(
         DeliveryDocumentIdentity left,
         DeliveryDocumentIdentity right) =>
         string.Equals(left.PackageKind, right.PackageKind, StringComparison.Ordinal)

--- a/Docxodus/Verification/DeliveryReceiptLineageValidator.cs
+++ b/Docxodus/Verification/DeliveryReceiptLineageValidator.cs
@@ -11,8 +11,12 @@ internal sealed record DeliveryLineageValidationResult
     public IReadOnlyList<string> Findings { get; init; } = Array.Empty<string>();
     public IReadOnlyList<DeliveryDocumentIdentity> ReachableDocuments { get; init; } =
         Array.Empty<DeliveryDocumentIdentity>();
+    public IReadOnlyDictionary<long, DeliveryDocumentIdentity> ReachableDocumentsByVersion
+        { get; init; } = new Dictionary<long, DeliveryDocumentIdentity>();
     public IReadOnlyList<DeliveryTransactionEntry> StateChangingTransactions { get; init; } =
         Array.Empty<DeliveryTransactionEntry>();
+    public IReadOnlySet<string> AppliedTransactionEntryIds { get; init; } =
+        new HashSet<string>(StringComparer.Ordinal);
 }
 
 /// <summary>
@@ -28,7 +32,7 @@ internal static class DeliveryReceiptLineageValidator
         IReadOnlyList<DeliveryLineageEvent> lineage)
     {
         var reachable = new List<DeliveryDocumentIdentity>();
-        var digestByVersion = new Dictionary<long, string>();
+        var identityByVersion = new Dictionary<long, DeliveryDocumentIdentity>();
         var stateChanging = new List<DeliveryTransactionEntry>();
         var applied = new List<DeliveryTransactionEntry>();
         var redo = new List<DeliveryTransactionEntry>();
@@ -38,20 +42,22 @@ internal static class DeliveryReceiptLineageValidator
             IsValid = false,
             Findings = new[] { finding },
             ReachableDocuments = reachable.ToArray(),
+            ReachableDocumentsByVersion = new Dictionary<long, DeliveryDocumentIdentity>(
+                identityByVersion),
             StateChangingTransactions = stateChanging.ToArray(),
+            AppliedTransactionEntryIds = applied
+                .Select(entry => entry.EntryId)
+                .ToHashSet(StringComparer.Ordinal),
         };
 
         bool RegisterReachable(DeliveryDocumentIdentity document)
         {
-            if (digestByVersion.TryGetValue(document.DocumentVersion, out var digest)
-                && !string.Equals(digest, document.RawPackageBytesDigest.Value,
-                    StringComparison.Ordinal))
+            if (identityByVersion.TryGetValue(document.DocumentVersion, out var existing))
             {
-                return false;
+                return DocumentEquals(existing, document);
             }
-            digestByVersion[document.DocumentVersion] = document.RawPackageBytesDigest.Value;
-            if (!reachable.Any(existing => DocumentEquals(existing, document)))
-                reachable.Add(document);
+            identityByVersion.Add(document.DocumentVersion, document);
+            reachable.Add(document);
             return true;
         }
 
@@ -107,6 +113,17 @@ internal static class DeliveryReceiptLineageValidator
                             return Fail("failed_transaction_changed_document");
                         break;
                     case DeliveryTransactionStatus.Prediction:
+                        if (!DocumentEquals(transaction.BeforeDocument, transaction.AfterDocument)
+                            && (SameIdentityExceptVersion(
+                                    transaction.BeforeDocument, transaction.AfterDocument)
+                                || transaction.AfterDocument.DocumentVersion
+                                != transaction.BeforeDocument.DocumentVersion + 1
+                                || !transaction.Operations.Any(operation =>
+                                    operation.ExecutionStatus
+                                        == DeliveryOperationExecutionStatus.Succeeded)))
+                        {
+                            return Fail("invalid_prediction_transition");
+                        }
                         break;
                     default:
                         return Fail("invalid_transaction_status");
@@ -173,7 +190,12 @@ internal static class DeliveryReceiptLineageValidator
         {
             IsValid = true,
             ReachableDocuments = reachable.ToArray(),
+            ReachableDocumentsByVersion = new Dictionary<long, DeliveryDocumentIdentity>(
+                identityByVersion),
             StateChangingTransactions = stateChanging.ToArray(),
+            AppliedTransactionEntryIds = applied
+                .Select(entry => entry.EntryId)
+                .ToHashSet(StringComparer.Ordinal),
         };
     }
 
@@ -181,10 +203,10 @@ internal static class DeliveryReceiptLineageValidator
         DeliveryLineageValidationResult validation,
         long documentVersion,
         VerificationDigest packageDigest) =>
-        validation.ReachableDocuments.Any(document =>
-            document.DocumentVersion == documentVersion
-            && DeliveryReceiptValidation.DigestEquals(
-                document.RawPackageBytesDigest, packageDigest));
+        validation.ReachableDocumentsByVersion.TryGetValue(
+            documentVersion, out var document)
+        && DeliveryReceiptValidation.DigestEquals(
+            document.RawPackageBytesDigest, packageDigest);
 
     public static bool DocumentEquals(
         DeliveryDocumentIdentity left,
@@ -193,6 +215,19 @@ internal static class DeliveryReceiptLineageValidator
         && string.Equals(left.PackageKind, right.PackageKind, StringComparison.Ordinal)
         && string.Equals(left.PackageManifestSchema, right.PackageManifestSchema,
             StringComparison.Ordinal)
+        && string.Equals(left.MainDocumentUri, right.MainDocumentUri, StringComparison.Ordinal)
+        && DeliveryReceiptValidation.DigestEquals(
+            left.RawPackageBytesDigest, right.RawPackageBytesDigest)
+        && OptionalDigestEquals(left.OrderedOpcContentDigest, right.OrderedOpcContentDigest)
+        && OptionalDigestEquals(left.NormalizedSemanticDigest, right.NormalizedSemanticDigest);
+
+    private static bool SameIdentityExceptVersion(
+        DeliveryDocumentIdentity left,
+        DeliveryDocumentIdentity right) =>
+        string.Equals(left.PackageKind, right.PackageKind, StringComparison.Ordinal)
+        && string.Equals(left.PackageManifestSchema, right.PackageManifestSchema,
+            StringComparison.Ordinal)
+        && string.Equals(left.MainDocumentUri, right.MainDocumentUri, StringComparison.Ordinal)
         && DeliveryReceiptValidation.DigestEquals(
             left.RawPackageBytesDigest, right.RawPackageBytesDigest)
         && OptionalDigestEquals(left.OrderedOpcContentDigest, right.OrderedOpcContentDigest)

--- a/Docxodus/Verification/DeliveryReceiptLineageValidator.cs
+++ b/Docxodus/Verification/DeliveryReceiptLineageValidator.cs
@@ -1,0 +1,218 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+namespace Docxodus.Verification;
+
+internal sealed record DeliveryLineageValidationResult
+{
+    required public bool IsValid { get; init; }
+    public IReadOnlyList<string> Findings { get; init; } = Array.Empty<string>();
+    public IReadOnlyList<DeliveryDocumentIdentity> ReachableDocuments { get; init; } =
+        Array.Empty<DeliveryDocumentIdentity>();
+    public IReadOnlyList<DeliveryTransactionEntry> StateChangingTransactions { get; init; } =
+        Array.Empty<DeliveryTransactionEntry>();
+}
+
+/// <summary>
+/// One deterministic state machine shared by receipt construction and independent verification.
+/// Applied and redo histories are LIFO, and only state-changing committed transactions affect them.
+/// </summary>
+internal static class DeliveryReceiptLineageValidator
+{
+    public static DeliveryLineageValidationResult Validate(
+        DeliveryDocumentIdentity sourceDocument,
+        DeliveryDocumentIdentity deliveredDocument,
+        IReadOnlyList<DeliveryTransactionEntry> transactions,
+        IReadOnlyList<DeliveryLineageEvent> lineage)
+    {
+        var reachable = new List<DeliveryDocumentIdentity>();
+        var digestByVersion = new Dictionary<long, string>();
+        var stateChanging = new List<DeliveryTransactionEntry>();
+        var applied = new List<DeliveryTransactionEntry>();
+        var redo = new List<DeliveryTransactionEntry>();
+
+        DeliveryLineageValidationResult Fail(string finding) => new()
+        {
+            IsValid = false,
+            Findings = new[] { finding },
+            ReachableDocuments = reachable.ToArray(),
+            StateChangingTransactions = stateChanging.ToArray(),
+        };
+
+        bool RegisterReachable(DeliveryDocumentIdentity document)
+        {
+            if (digestByVersion.TryGetValue(document.DocumentVersion, out var digest)
+                && !string.Equals(digest, document.RawPackageBytesDigest.Value,
+                    StringComparison.Ordinal))
+            {
+                return false;
+            }
+            digestByVersion[document.DocumentVersion] = document.RawPackageBytesDigest.Value;
+            if (!reachable.Any(existing => DocumentEquals(existing, document)))
+                reachable.Add(document);
+            return true;
+        }
+
+        if (!RegisterReachable(sourceDocument))
+            return Fail("document_version_collision");
+
+        var transactionGroups = transactions
+            .GroupBy(transaction => transaction.Sequence)
+            .ToDictionary(group => group.Key, group => group.ToArray());
+        var lineageGroups = lineage
+            .GroupBy(lineageEvent => lineageEvent.Sequence)
+            .ToDictionary(group => group.Key, group => group.ToArray());
+        var entriesById = transactions
+            .GroupBy(transaction => transaction.EntryId, StringComparer.Ordinal)
+            .Where(group => group.Count() == 1)
+            .ToDictionary(group => group.Key, group => group.Single(), StringComparer.Ordinal);
+        long transitionCount = transactions.Count + lineage.Count;
+        var current = sourceDocument;
+
+        for (long sequence = 0; sequence < transitionCount; sequence++)
+        {
+            transactionGroups.TryGetValue(sequence, out var transactionGroup);
+            lineageGroups.TryGetValue(sequence, out var lineageGroup);
+            if ((transactionGroup?.Length ?? 0) + (lineageGroup?.Length ?? 0) != 1)
+                return Fail("lineage_sequence_mismatch");
+
+            if (transactionGroup is { Length: 1 })
+            {
+                var transaction = transactionGroup[0];
+                if (!DocumentEquals(current, transaction.BeforeDocument))
+                    return Fail("transaction_lineage_gap");
+
+                switch (transaction.Status)
+                {
+                    case DeliveryTransactionStatus.Committed:
+                    case DeliveryTransactionStatus.PartiallyCommitted:
+                        if (DocumentEquals(transaction.BeforeDocument, transaction.AfterDocument))
+                            break;
+                        if (transaction.AfterDocument.DocumentVersion
+                            != transaction.BeforeDocument.DocumentVersion + 1)
+                        {
+                            return Fail("invalid_transaction_version");
+                        }
+                        current = transaction.AfterDocument;
+                        if (!RegisterReachable(current))
+                            return Fail("document_version_collision");
+                        applied.Add(transaction);
+                        redo.Clear();
+                        stateChanging.Add(transaction);
+                        break;
+                    case DeliveryTransactionStatus.Failed:
+                        if (!DocumentEquals(transaction.BeforeDocument, transaction.AfterDocument))
+                            return Fail("failed_transaction_changed_document");
+                        break;
+                    case DeliveryTransactionStatus.Prediction:
+                        break;
+                    default:
+                        return Fail("invalid_transaction_status");
+                }
+                continue;
+            }
+
+            var lineageEvent = lineageGroup![0];
+            if (!DocumentEquals(current, lineageEvent.BeforeDocument))
+                return Fail("lineage_gap");
+            if (lineageEvent.AfterDocument.DocumentVersion
+                != lineageEvent.BeforeDocument.DocumentVersion + 1)
+            {
+                return Fail("invalid_lineage_version");
+            }
+            if (!entriesById.TryGetValue(lineageEvent.AffectedEntryId, out var affected)
+                || affected.Status is not (DeliveryTransactionStatus.Committed
+                    or DeliveryTransactionStatus.PartiallyCommitted)
+                || DocumentEquals(affected.BeforeDocument, affected.AfterDocument))
+            {
+                return Fail("invalid_lineage_target");
+            }
+
+            if (lineageEvent.Action == DeliveryLineageAction.Undo)
+            {
+                if (applied.Count == 0
+                    || !string.Equals(applied[^1].EntryId, affected.EntryId,
+                        StringComparison.Ordinal))
+                {
+                    return Fail("invalid_undo_order");
+                }
+                if (!SamePackageContent(affected.BeforeDocument, lineageEvent.AfterDocument))
+                    return Fail("lineage_package_mismatch");
+                applied.RemoveAt(applied.Count - 1);
+                redo.Add(affected);
+            }
+            else if (lineageEvent.Action == DeliveryLineageAction.Redo)
+            {
+                if (redo.Count == 0
+                    || !string.Equals(redo[^1].EntryId, affected.EntryId,
+                        StringComparison.Ordinal))
+                {
+                    return Fail("invalid_redo_order");
+                }
+                if (!SamePackageContent(affected.AfterDocument, lineageEvent.AfterDocument))
+                    return Fail("lineage_package_mismatch");
+                redo.RemoveAt(redo.Count - 1);
+                applied.Add(affected);
+            }
+            else
+            {
+                return Fail("unknown_lineage_action");
+            }
+
+            current = lineageEvent.AfterDocument;
+            if (!RegisterReachable(current))
+                return Fail("document_version_collision");
+        }
+
+        if (!DocumentEquals(current, deliveredDocument))
+            return Fail("delivered_lineage_mismatch");
+
+        return new DeliveryLineageValidationResult
+        {
+            IsValid = true,
+            ReachableDocuments = reachable.ToArray(),
+            StateChangingTransactions = stateChanging.ToArray(),
+        };
+    }
+
+    public static bool IsReachable(
+        DeliveryLineageValidationResult validation,
+        long documentVersion,
+        VerificationDigest packageDigest) =>
+        validation.ReachableDocuments.Any(document =>
+            document.DocumentVersion == documentVersion
+            && DeliveryReceiptValidation.DigestEquals(
+                document.RawPackageBytesDigest, packageDigest));
+
+    public static bool DocumentEquals(
+        DeliveryDocumentIdentity left,
+        DeliveryDocumentIdentity right) =>
+        left.DocumentVersion == right.DocumentVersion
+        && string.Equals(left.PackageKind, right.PackageKind, StringComparison.Ordinal)
+        && string.Equals(left.PackageManifestSchema, right.PackageManifestSchema,
+            StringComparison.Ordinal)
+        && DeliveryReceiptValidation.DigestEquals(
+            left.RawPackageBytesDigest, right.RawPackageBytesDigest)
+        && OptionalDigestEquals(left.OrderedOpcContentDigest, right.OrderedOpcContentDigest)
+        && OptionalDigestEquals(left.NormalizedSemanticDigest, right.NormalizedSemanticDigest);
+
+    public static bool SamePackageContent(
+        DeliveryDocumentIdentity left,
+        DeliveryDocumentIdentity right)
+    {
+        if (left.OrderedOpcContentDigest is not null
+            && right.OrderedOpcContentDigest is not null)
+        {
+            return DeliveryReceiptValidation.DigestEquals(
+                left.OrderedOpcContentDigest, right.OrderedOpcContentDigest);
+        }
+        return DeliveryReceiptValidation.DigestEquals(
+            left.RawPackageBytesDigest, right.RawPackageBytesDigest);
+    }
+
+    private static bool OptionalDigestEquals(VerificationDigest? left, VerificationDigest? right) =>
+        left is null && right is null
+        || DeliveryReceiptValidation.DigestEquals(left, right);
+}

--- a/Docxodus/Verification/DeliveryReceiptLineageValidator.cs
+++ b/Docxodus/Verification/DeliveryReceiptLineageValidator.cs
@@ -263,6 +263,5 @@ internal static class DeliveryReceiptLineageValidator
     }
 
     private static bool OptionalDigestEquals(VerificationDigest? left, VerificationDigest? right) =>
-        left is null && right is null
-        || DeliveryReceiptValidation.DigestEquals(left, right);
+        DeliveryReceiptValidation.OptionalDigestEquals(left, right);
 }

--- a/Docxodus/Verification/DeliveryReceiptModels.cs
+++ b/Docxodus/Verification/DeliveryReceiptModels.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Docxodus.Verification;
 
@@ -129,6 +130,7 @@ public sealed record DeliveryDocumentIdentity
     required public long DocumentVersion { get; init; }
     required public string PackageKind { get; init; }
     required public string PackageManifestSchema { get; init; }
+    required public string MainDocumentUri { get; init; }
     required public VerificationDigest RawPackageBytesDigest { get; init; }
     public VerificationDigest? OrderedOpcContentDigest { get; init; }
     public VerificationDigest? NormalizedSemanticDigest { get; init; }
@@ -184,6 +186,13 @@ public sealed record DeliveryOperationEvidence
         Array.Empty<DeliveryOperationResultEvidence>();
 }
 
+/// <summary>A privacy-aware diagnostic attached to an owner revision identity.</summary>
+public sealed record DeliveryAuthoredDiagnostic
+{
+    required public string Code { get; init; }
+    required public DeliveryTextEvidence Message { get; init; }
+}
+
 /// <summary>Revision, comment, or annotation evidence copied from MutationBatchResult.</summary>
 public sealed record DeliveryAuthoredChange
 {
@@ -193,9 +202,16 @@ public sealed record DeliveryAuthoredChange
     required public VerificationDigest SourceDigest { get; init; }
     public string? Author { get; init; }
     public string? Date { get; init; }
+    public string? DateUtc { get; init; }
     public string? Type { get; init; }
+    public RevisionFamily? Family { get; init; }
     public string? PartUri { get; init; }
     public string? Scope { get; init; }
+    public string? AnchorId { get; init; }
+    public RevisionResolutionStatus? ResolutionStatus { get; init; }
+    public DeliveryAuthoredDiagnostic? Diagnostic { get; init; }
+    public IReadOnlyList<string> ConstituentIds { get; init; } = Array.Empty<string>();
+    public IReadOnlyList<string> ConstituentKeys { get; init; } = Array.Empty<string>();
     public IReadOnlyList<string> AffectedAnchorIds { get; init; } = Array.Empty<string>();
     public DeliveryTextEvidence? Text { get; init; }
     public JsonElement? FullEvidence { get; init; }
@@ -214,6 +230,7 @@ public sealed record DeliveryTransactionEntry
     required public long ResultVersion { get; init; }
     required public DeliveryDocumentIdentity BeforeDocument { get; init; }
     required public DeliveryDocumentIdentity AfterDocument { get; init; }
+    public VerificationDigest? ReportedPackageContentDigest { get; init; }
     public IReadOnlyList<DeliveryOperationEvidence> Operations { get; init; } =
         Array.Empty<DeliveryOperationEvidence>();
     public IReadOnlyList<DeliveryAuthoredChange> AuthoredChanges { get; init; } =
@@ -348,8 +365,25 @@ public sealed record DeliveryChangeReceipt
     public byte[] ToJsonBytes(bool indented = false) =>
         DeliveryChangeReceiptSerializer.Serialize(this, indented);
 
+    public byte[] ToJsonBytes(DeliveryReceiptLimits limits, bool indented = false) =>
+        DeliveryChangeReceiptSerializer.Serialize(this, limits, indented);
+
     public string ToJson(bool indented = false) =>
         System.Text.Encoding.UTF8.GetString(ToJsonBytes(indented));
+
+    public string ToJson(DeliveryReceiptLimits limits, bool indented = false) =>
+        System.Text.Encoding.UTF8.GetString(ToJsonBytes(limits, indented));
+}
+
+/// <summary>Trim/AOT-safe metadata for the durable delivery-receipt wire contract.</summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.Never)]
+[JsonSerializable(typeof(DeliveryChangeReceiptPayload))]
+[JsonSerializable(typeof(DeliveryChangeReceipt))]
+[JsonSerializable(typeof(DeliveryTransactionEntry))]
+internal partial class DeliveryReceiptJsonContext : JsonSerializerContext
+{
 }
 
 /// <summary>A stable validation error raised while composing a receipt.</summary>

--- a/Docxodus/Verification/DeliveryReceiptModels.cs
+++ b/Docxodus/Verification/DeliveryReceiptModels.cs
@@ -1,0 +1,365 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Text.Json;
+
+namespace Docxodus.Verification;
+
+/// <summary>Controls how much document-derived text a delivery receipt retains.</summary>
+public enum DeliveryReceiptPrivacyProfile
+{
+    /// <summary>Retain identities, counts, and digests, but no text or text summaries.</summary>
+    HashOnly,
+
+    /// <summary>Retain identities, counts, digests, and structural summaries without text values.</summary>
+    HashAndSummary,
+
+    /// <summary>Retain complete normalized operation and result evidence.</summary>
+    FullEvidence,
+}
+
+/// <summary>The terminal meaning of a mutation contribution.</summary>
+public enum DeliveryTransactionStatus
+{
+    Committed,
+    PartiallyCommitted,
+    Failed,
+    Prediction,
+}
+
+/// <summary>Whether one requested operation produced retained, failed, or rolled-back evidence.</summary>
+public enum DeliveryOperationExecutionStatus
+{
+    NotExecuted,
+    Succeeded,
+    Failed,
+    SucceededRolledBack,
+    FailedRolledBack,
+}
+
+/// <summary>A reversible transition in delivered-document history.</summary>
+public enum DeliveryLineageAction
+{
+    Undo,
+    Redo,
+}
+
+/// <summary>Why an observed package change exists.</summary>
+public enum DeliveryChangeDisposition
+{
+    UserRequested,
+    Derived,
+    Unexpected,
+}
+
+/// <summary>Receipt-level package change families derived from two #456 manifests.</summary>
+public enum DeliveryPackageChangeKind
+{
+    PartAdded,
+    PartRemoved,
+    PartModified,
+    RelationshipAdded,
+    RelationshipRemoved,
+    RelationshipModified,
+}
+
+/// <summary>Stable roles for independently verifiable delivery artifacts.</summary>
+public enum DeliveryArtifactRole
+{
+    CleanDocx,
+    ReviewDocx,
+    Html,
+    Pdf,
+    PageImage,
+    PageMap,
+    PackageManifest,
+    SemanticDiff,
+    ValidationReport,
+    ReversibilityProof,
+    RenderReport,
+    OtherReport,
+}
+
+/// <summary>Whether artifact bytes were produced.</summary>
+public enum DeliveryArtifactAvailability
+{
+    Available,
+    Unavailable,
+}
+
+/// <summary>External evidence consumed by, but not redefined inside, a receipt.</summary>
+public enum DeliveryEvidenceKind
+{
+    SemanticChangeSet,
+    ValidationResult,
+    RedlineReversibility,
+}
+
+/// <summary>The document transition covered by one typed semantic change-set artifact.</summary>
+public enum DeliverySemanticComparisonScope
+{
+    SourceToDelivered,
+    Transaction,
+}
+
+/// <summary>Mutation-result entities that retain authorship evidence.</summary>
+public enum DeliveryAuthoredEntityKind
+{
+    Revision,
+    Comment,
+    Annotation,
+}
+
+/// <summary>How an entity or anchor changed in one transaction.</summary>
+public enum DeliveryObjectChangeKind
+{
+    Added,
+    Removed,
+    Modified,
+}
+
+/// <summary>
+/// Exact identity of one package-backed document version. Digest values use the #456
+/// package-manifest contract; the clean delivery identity is independently recomputed from bytes.
+/// </summary>
+public sealed record DeliveryDocumentIdentity
+{
+    required public long DocumentVersion { get; init; }
+    required public string PackageKind { get; init; }
+    required public string PackageManifestSchema { get; init; }
+    required public VerificationDigest RawPackageBytesDigest { get; init; }
+    public VerificationDigest? OrderedOpcContentDigest { get; init; }
+    public VerificationDigest? NormalizedSemanticDigest { get; init; }
+
+    public static DeliveryDocumentIdentity FromManifest(PackageManifest manifest, long documentVersion)
+        => DeliveryPackageManifestAdapter.CreateIdentity(manifest, documentVersion);
+}
+
+/// <summary>A privacy-aware text value. Hash and character count are always retained.</summary>
+public sealed record DeliveryTextEvidence
+{
+    required public VerificationDigest Digest { get; init; }
+    required public int CharacterCount { get; init; }
+    public string? Summary { get; init; }
+    public string? Value { get; init; }
+}
+
+/// <summary>A stable anchor/object identity reported by an edit result.</summary>
+public sealed record DeliveryObjectChange
+{
+    required public DeliveryObjectChangeKind ChangeKind { get; init; }
+    required public string AnchorId { get; init; }
+    required public string Kind { get; init; }
+    required public string Scope { get; init; }
+    required public string Unid { get; init; }
+}
+
+/// <summary>One structured EditResult nested beneath a normalized requested operation.</summary>
+public sealed record DeliveryOperationResultEvidence
+{
+    required public VerificationDigest ResultDigest { get; init; }
+    required public bool Success { get; init; }
+    public string? ErrorCode { get; init; }
+    public DeliveryTextEvidence? ErrorMessage { get; init; }
+    public IReadOnlyList<DeliveryObjectChange> ObjectChanges { get; init; } =
+        Array.Empty<DeliveryObjectChange>();
+    public JsonElement? FullResult { get; init; }
+}
+
+/// <summary>One normalized request and its result evidence, in execution order.</summary>
+public sealed record DeliveryOperationEvidence
+{
+    required public int Index { get; init; }
+    required public string Tool { get; init; }
+    required public string Action { get; init; }
+    required public VerificationDigest ArgumentsDigest { get; init; }
+    public string? ArgumentsSummary { get; init; }
+    public JsonElement? Arguments { get; init; }
+    required public DeliveryOperationExecutionStatus ExecutionStatus { get; init; }
+    required public bool Success { get; init; }
+    required public bool RolledBack { get; init; }
+    public IReadOnlyList<DeliveryOperationResultEvidence> Results { get; init; } =
+        Array.Empty<DeliveryOperationResultEvidence>();
+}
+
+/// <summary>Revision, comment, or annotation evidence copied from MutationBatchResult.</summary>
+public sealed record DeliveryAuthoredChange
+{
+    required public DeliveryAuthoredEntityKind EntityKind { get; init; }
+    required public DeliveryObjectChangeKind ChangeKind { get; init; }
+    required public string EntityId { get; init; }
+    required public VerificationDigest SourceDigest { get; init; }
+    public string? Author { get; init; }
+    public string? Date { get; init; }
+    public string? Type { get; init; }
+    public string? PartUri { get; init; }
+    public string? Scope { get; init; }
+    public IReadOnlyList<string> AffectedAnchorIds { get; init; } = Array.Empty<string>();
+    public DeliveryTextEvidence? Text { get; init; }
+    public JsonElement? FullEvidence { get; init; }
+}
+
+/// <summary>One committed, failed, partial, or predicted batch contribution.</summary>
+public sealed record DeliveryTransactionEntry
+{
+    required public long Sequence { get; init; }
+    required public string EntryId { get; init; }
+    public string? TransactionId { get; init; }
+    required public string RequestFingerprint { get; init; }
+    required public MutationBatchMode Mode { get; init; }
+    required public DeliveryTransactionStatus Status { get; init; }
+    required public long BaseVersion { get; init; }
+    required public long ResultVersion { get; init; }
+    required public DeliveryDocumentIdentity BeforeDocument { get; init; }
+    required public DeliveryDocumentIdentity AfterDocument { get; init; }
+    public IReadOnlyList<DeliveryOperationEvidence> Operations { get; init; } =
+        Array.Empty<DeliveryOperationEvidence>();
+    public IReadOnlyList<DeliveryAuthoredChange> AuthoredChanges { get; init; } =
+        Array.Empty<DeliveryAuthoredChange>();
+    public IReadOnlyList<DeliveryTextEvidence> Warnings { get; init; } =
+        Array.Empty<DeliveryTextEvidence>();
+}
+
+/// <summary>An undo or redo transition tied to one existing committed transaction entry.</summary>
+public sealed record DeliveryLineageEvent
+{
+    required public long Sequence { get; init; }
+    required public DeliveryLineageAction Action { get; init; }
+    required public string AffectedEntryId { get; init; }
+    required public DeliveryDocumentIdentity BeforeDocument { get; init; }
+    required public DeliveryDocumentIdentity AfterDocument { get; init; }
+}
+
+/// <summary>One source-to-delivered part or relationship change.</summary>
+public sealed record DeliveryPackageChange
+{
+    required public string ChangeId { get; init; }
+    required public DeliveryPackageChangeKind Kind { get; init; }
+    required public ChangeLocation Location { get; init; }
+    public DeliveryTextEvidence? Before { get; init; }
+    public DeliveryTextEvidence? After { get; init; }
+    required public DeliveryChangeDisposition Disposition { get; init; }
+    public string? TransactionEntryId { get; init; }
+    public int? RequestedOperationIndex { get; init; }
+    public string? Derivation { get; init; }
+}
+
+/// <summary>One independently hash-addressed output artifact.</summary>
+public sealed record DeliveryArtifact
+{
+    required public string ArtifactId { get; init; }
+    required public DeliveryArtifactRole Role { get; init; }
+    required public string MediaType { get; init; }
+    required public DeliveryArtifactAvailability Availability { get; init; }
+    public long? ByteLength { get; init; }
+    public VerificationDigest? Digest { get; init; }
+    public string? RelativePath { get; init; }
+    public string? UnavailableReason { get; init; }
+    public long? DocumentVersion { get; init; }
+    public VerificationDigest? PackageDigest { get; init; }
+    public string? RendererFingerprint { get; init; }
+    public VerificationDigest? PageMapDigest { get; init; }
+}
+
+/// <summary>A schema-and-digest reference to evidence owned by another verification component.</summary>
+public sealed record DeliveryEvidenceReference
+{
+    required public DeliveryEvidenceKind Kind { get; init; }
+    required public string Schema { get; init; }
+    required public VerificationDigest Digest { get; init; }
+    public string? ArtifactId { get; init; }
+    public string? Summary { get; init; }
+}
+
+/// <summary>
+/// Binding from exact #457 canonical bytes to the document transition they compare. The receipt
+/// retains only #457 identity metadata and never flattens or renames its change records.
+/// </summary>
+public sealed record DeliverySemanticChangeSetBinding
+{
+    required public DeliverySemanticComparisonScope Scope { get; init; }
+    public string? TransactionEntryId { get; init; }
+    required public DeliveryDocumentIdentity BeforeDocument { get; init; }
+    required public DeliveryDocumentIdentity AfterDocument { get; init; }
+    required public string Schema { get; init; }
+    required public int SchemaVersion { get; init; }
+    required public int ChangeCount { get; init; }
+    required public VerificationDigest Digest { get; init; }
+    required public string ArtifactId { get; init; }
+}
+
+/// <summary>A page-map citation bound to exact package and render evidence.</summary>
+public sealed record DeliveryPageCitation
+{
+    required public string AnchorId { get; init; }
+    required public string Scope { get; init; }
+    required public long DocumentVersion { get; init; }
+    required public VerificationDigest PackageDigest { get; init; }
+    required public string RendererFingerprint { get; init; }
+    required public VerificationDigest PageMapDigest { get; init; }
+    required public string PageMapArtifactId { get; init; }
+    required public string RenderArtifactId { get; init; }
+    required public VerificationDigest RenderArtifactDigest { get; init; }
+    public IReadOnlyList<PageMapPage> Pages { get; init; } = Array.Empty<PageMapPage>();
+    public IReadOnlyList<PageMapFragment> Fragments { get; init; } =
+        Array.Empty<PageMapFragment>();
+}
+
+/// <summary>The canonical, digest-covered body of a delivery receipt.</summary>
+public sealed record DeliveryChangeReceiptPayload
+{
+    public const string SchemaId =
+        "https://docxodus.dev/schemas/verification/delivery-change-receipt/v1";
+    public const string CanonicalizationId = "docxodus-canonical-json-v1";
+
+    public string Schema { get; init; } = SchemaId;
+    public int SchemaVersion { get; init; } = 1;
+    public string Canonicalization { get; init; } = CanonicalizationId;
+    required public DeliveryReceiptPrivacyProfile PrivacyProfile { get; init; }
+    required public DeliveryDocumentIdentity SourceDocument { get; init; }
+    required public DeliveryDocumentIdentity DeliveredDocument { get; init; }
+    public IReadOnlyList<DeliveryTransactionEntry> Transactions { get; init; } =
+        Array.Empty<DeliveryTransactionEntry>();
+    public IReadOnlyList<DeliveryLineageEvent> Lineage { get; init; } =
+        Array.Empty<DeliveryLineageEvent>();
+    public IReadOnlyList<DeliveryPackageChange> PackageChanges { get; init; } =
+        Array.Empty<DeliveryPackageChange>();
+    public bool HasUnexpectedChanges { get; init; }
+    public IReadOnlyList<DeliveryEvidenceReference> Evidence { get; init; } =
+        Array.Empty<DeliveryEvidenceReference>();
+    public IReadOnlyList<DeliverySemanticChangeSetBinding> SemanticChangeSets { get; init; } =
+        Array.Empty<DeliverySemanticChangeSetBinding>();
+    public IReadOnlyList<DeliveryArtifact> Artifacts { get; init; } =
+        Array.Empty<DeliveryArtifact>();
+    public IReadOnlyList<DeliveryPageCitation> PageCitations { get; init; } =
+        Array.Empty<DeliveryPageCitation>();
+    public IReadOnlyList<DeliveryTextEvidence> Warnings { get; init; } =
+        Array.Empty<DeliveryTextEvidence>();
+}
+
+/// <summary>Hash-addressed delivery receipt envelope.</summary>
+public sealed record DeliveryChangeReceipt
+{
+    required public DeliveryChangeReceiptPayload Payload { get; init; }
+    required public VerificationDigest ReceiptDigest { get; init; }
+
+    public byte[] ToJsonBytes(bool indented = false) =>
+        DeliveryChangeReceiptSerializer.Serialize(this, indented);
+
+    public string ToJson(bool indented = false) =>
+        System.Text.Encoding.UTF8.GetString(ToJsonBytes(indented));
+}
+
+/// <summary>A stable validation error raised while composing a receipt.</summary>
+public sealed class DeliveryReceiptValidationException : ArgumentException
+{
+    public DeliveryReceiptValidationException(string code, string message)
+        : base(message)
+    {
+        Code = code;
+    }
+
+    public string Code { get; }
+}

--- a/Docxodus/Verification/DeliveryReceiptResourceValidator.cs
+++ b/Docxodus/Verification/DeliveryReceiptResourceValidator.cs
@@ -61,6 +61,7 @@ internal static class DeliveryReceiptResourceValidator
             budget.String(transaction.RequestFingerprint, "request fingerprint");
             ValidateDocument(transaction.BeforeDocument, budget);
             ValidateDocument(transaction.AfterDocument, budget);
+            ValidateDigest(transaction.ReportedPackageContentDigest, budget);
             Add(transaction.Operations, budget, "transaction operations");
             foreach (var operation in transaction.Operations)
             {
@@ -94,10 +95,23 @@ internal static class DeliveryReceiptResourceValidator
                 budget.String(change.EntityId, "authored entity id");
                 budget.String(change.Author, "authored author");
                 budget.String(change.Date, "authored date");
+                budget.String(change.DateUtc, "authored UTC date");
                 budget.String(change.Type, "authored type");
                 budget.String(change.PartUri, "authored part URI");
                 budget.String(change.Scope, "authored scope");
+                budget.String(change.AnchorId, "authored primary anchor");
+                if (change.Diagnostic is { } diagnostic)
+                {
+                    budget.String(diagnostic.Code, "authored diagnostic code");
+                    ValidateText(diagnostic.Message, budget);
+                }
                 ValidateDigest(change.SourceDigest, budget);
+                Add(change.ConstituentIds, budget, "authored constituent ids");
+                foreach (var id in change.ConstituentIds)
+                    budget.String(id, "authored constituent id");
+                Add(change.ConstituentKeys, budget, "authored constituent keys");
+                foreach (var key in change.ConstituentKeys)
+                    budget.String(key, "authored constituent key");
                 Add(change.AffectedAnchorIds, budget, "affected anchor ids");
                 foreach (var anchor in change.AffectedAnchorIds)
                     budget.String(anchor, "affected anchor id");
@@ -201,6 +215,7 @@ internal static class DeliveryReceiptResourceValidator
             return;
         budget.String(document.PackageKind, "package kind");
         budget.String(document.PackageManifestSchema, "manifest schema");
+        budget.String(document.MainDocumentUri, "main document URI");
         ValidateDigest(document.RawPackageBytesDigest, budget);
         ValidateDigest(document.OrderedOpcContentDigest, budget);
         ValidateDigest(document.NormalizedSemanticDigest, budget);

--- a/Docxodus/Verification/DeliveryReceiptResourceValidator.cs
+++ b/Docxodus/Verification/DeliveryReceiptResourceValidator.cs
@@ -1,0 +1,272 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Text.Json;
+
+namespace Docxodus.Verification;
+
+/// <summary>Pre-serialization resource checks for the public object verification surface.</summary>
+internal static class DeliveryReceiptResourceValidator
+{
+    public static void ValidateArtifacts(
+        IReadOnlyDictionary<string, byte[]> artifactBytes,
+        DeliveryReceiptLimits limits)
+    {
+        if (artifactBytes.Count > limits.MaxArtifacts)
+            Fail("Artifact dictionary exceeds the artifact-count limit.", "artifact_resource_limit");
+
+        var budget = new DeliveryReceiptResourceBudget(limits);
+        budget.AddItems(artifactBytes.Count, "artifact dictionary entries");
+        long total = 0;
+        foreach (var pair in artifactBytes)
+        {
+            budget.String(pair.Key, "artifact dictionary key");
+            if (pair.Value is null)
+                throw new ArgumentException("Artifact byte values cannot be null.", nameof(artifactBytes));
+            DeliveryReceiptResourceBudget.Bytes(
+                pair.Value.LongLength, limits.MaxArtifactBytes,
+                "artifact_resource_limit", $"Artifact '{pair.Key}'");
+            if (pair.Value.LongLength > limits.MaxTotalArtifactBytes - total)
+                Fail("Artifact dictionary exceeds the aggregate byte limit.", "artifact_resource_limit");
+            total += pair.Value.LongLength;
+        }
+    }
+
+    public static void ValidatePayload(
+        DeliveryChangeReceiptPayload payload,
+        DeliveryReceiptLimits limits)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        if (payload.Transactions.Count > limits.MaxTransactions)
+            Fail("Receipt exceeds the transaction limit.");
+        if (payload.Artifacts.Count > limits.MaxArtifacts)
+            Fail("Receipt exceeds the artifact-count limit.", "artifact_resource_limit");
+
+        var budget = new DeliveryReceiptResourceBudget(limits);
+        budget.AddSerializedBytes(512, "receipt structure");
+        budget.String(payload.Schema, "receipt schema");
+        budget.String(payload.Canonicalization, "canonicalization id");
+        ValidateDocument(payload.SourceDocument, budget);
+        ValidateDocument(payload.DeliveredDocument, budget);
+
+        Add(payload.Transactions, budget, "transactions");
+        foreach (var transaction in payload.Transactions)
+        {
+            if (transaction.Operations.Count > limits.MaxOperationsPerTransaction)
+                Fail("Transaction exceeds the operation limit.");
+            budget.String(transaction.EntryId, "transaction entry id");
+            budget.String(transaction.TransactionId, "transaction id");
+            budget.String(transaction.RequestFingerprint, "request fingerprint");
+            ValidateDocument(transaction.BeforeDocument, budget);
+            ValidateDocument(transaction.AfterDocument, budget);
+            Add(transaction.Operations, budget, "transaction operations");
+            foreach (var operation in transaction.Operations)
+            {
+                budget.String(operation.Tool, "operation tool");
+                budget.String(operation.Action, "operation action");
+                budget.String(operation.ArgumentsSummary, "operation argument summary");
+                ValidateDigest(operation.ArgumentsDigest, budget);
+                if (operation.Arguments is { } arguments)
+                    ValidateJson(arguments, limits, budget, 6);
+                Add(operation.Results, budget, "operation results");
+                foreach (var result in operation.Results)
+                {
+                    ValidateDigest(result.ResultDigest, budget);
+                    budget.String(result.ErrorCode, "operation error code");
+                    ValidateText(result.ErrorMessage, budget);
+                    Add(result.ObjectChanges, budget, "object changes");
+                    foreach (var change in result.ObjectChanges)
+                    {
+                        budget.String(change.AnchorId, "object-change anchor");
+                        budget.String(change.Kind, "object-change kind");
+                        budget.String(change.Scope, "object-change scope");
+                        budget.String(change.Unid, "object-change unid");
+                    }
+                    if (result.FullResult is { } fullResult)
+                        ValidateJson(fullResult, limits, budget, 8);
+                }
+            }
+            Add(transaction.AuthoredChanges, budget, "authored changes");
+            foreach (var change in transaction.AuthoredChanges)
+            {
+                budget.String(change.EntityId, "authored entity id");
+                budget.String(change.Author, "authored author");
+                budget.String(change.Date, "authored date");
+                budget.String(change.Type, "authored type");
+                budget.String(change.PartUri, "authored part URI");
+                budget.String(change.Scope, "authored scope");
+                ValidateDigest(change.SourceDigest, budget);
+                Add(change.AffectedAnchorIds, budget, "affected anchor ids");
+                foreach (var anchor in change.AffectedAnchorIds)
+                    budget.String(anchor, "affected anchor id");
+                ValidateText(change.Text, budget);
+                if (change.FullEvidence is { } fullEvidence)
+                    ValidateJson(fullEvidence, limits, budget, 6);
+            }
+            Add(transaction.Warnings, budget, "transaction warnings");
+            foreach (var warning in transaction.Warnings)
+                ValidateText(warning, budget);
+        }
+
+        Add(payload.Lineage, budget, "lineage events");
+        foreach (var lineage in payload.Lineage)
+        {
+            budget.String(lineage.AffectedEntryId, "lineage entry id");
+            ValidateDocument(lineage.BeforeDocument, budget);
+            ValidateDocument(lineage.AfterDocument, budget);
+        }
+
+        Add(payload.PackageChanges, budget, "package changes");
+        foreach (var change in payload.PackageChanges)
+        {
+            budget.String(change.ChangeId, "package change id");
+            budget.String(change.Location?.EntryUri, "package entry URI");
+            budget.String(change.Location?.OwnerUri, "relationship owner URI");
+            budget.String(change.Location?.RelationshipId, "relationship id");
+            budget.String(change.Location?.TargetUri, "relationship target URI");
+            budget.String(change.Location?.PropertyPath, "package property path");
+            ValidateText(change.Before, budget);
+            ValidateText(change.After, budget);
+            budget.String(change.TransactionEntryId, "attribution entry id");
+            budget.String(change.Derivation, "derivation");
+        }
+
+        Add(payload.Evidence, budget, "evidence references");
+        foreach (var evidence in payload.Evidence)
+        {
+            budget.String(evidence.Schema, "evidence schema");
+            budget.String(evidence.ArtifactId, "evidence artifact id");
+            budget.String(evidence.Summary, "evidence summary");
+            ValidateDigest(evidence.Digest, budget);
+        }
+
+        Add(payload.SemanticChangeSets, budget, "semantic bindings");
+        foreach (var binding in payload.SemanticChangeSets)
+        {
+            budget.String(binding.TransactionEntryId, "semantic transaction entry id");
+            budget.String(binding.Schema, "semantic schema");
+            budget.String(binding.ArtifactId, "semantic artifact id");
+            ValidateDocument(binding.BeforeDocument, budget);
+            ValidateDocument(binding.AfterDocument, budget);
+            ValidateDigest(binding.Digest, budget);
+        }
+
+        Add(payload.Artifacts, budget, "artifacts");
+        foreach (var artifact in payload.Artifacts)
+        {
+            budget.String(artifact.ArtifactId, "artifact id");
+            budget.String(artifact.MediaType, "artifact media type");
+            budget.String(artifact.RelativePath, "artifact path");
+            budget.String(artifact.UnavailableReason, "artifact unavailable reason");
+            budget.String(artifact.RendererFingerprint, "renderer fingerprint");
+            ValidateDigest(artifact.Digest, budget);
+            ValidateDigest(artifact.PackageDigest, budget);
+            ValidateDigest(artifact.PageMapDigest, budget);
+        }
+
+        Add(payload.PageCitations, budget, "page citations");
+        foreach (var citation in payload.PageCitations)
+        {
+            budget.String(citation.AnchorId, "citation anchor");
+            budget.String(citation.Scope, "citation scope");
+            budget.String(citation.RendererFingerprint, "renderer fingerprint");
+            budget.String(citation.PageMapArtifactId, "PageMap artifact id");
+            budget.String(citation.RenderArtifactId, "render artifact id");
+            ValidateDigest(citation.PackageDigest, budget);
+            ValidateDigest(citation.PageMapDigest, budget);
+            ValidateDigest(citation.RenderArtifactDigest, budget);
+            Add(citation.Pages, budget, "citation pages");
+            foreach (var page in citation.Pages)
+                budget.String(page?.PageName, "page name");
+            Add(citation.Fragments, budget, "citation fragments");
+            foreach (var fragment in citation.Fragments)
+            {
+                budget.String(fragment?.FragmentId, "fragment id");
+                budget.String(fragment?.AnchorId, "fragment anchor id");
+            }
+        }
+
+        Add(payload.Warnings, budget, "receipt warnings");
+        foreach (var warning in payload.Warnings)
+            ValidateText(warning, budget);
+    }
+
+    private static void ValidateDocument(
+        DeliveryDocumentIdentity? document,
+        DeliveryReceiptResourceBudget budget)
+    {
+        if (document is null)
+            return;
+        budget.String(document.PackageKind, "package kind");
+        budget.String(document.PackageManifestSchema, "manifest schema");
+        ValidateDigest(document.RawPackageBytesDigest, budget);
+        ValidateDigest(document.OrderedOpcContentDigest, budget);
+        ValidateDigest(document.NormalizedSemanticDigest, budget);
+    }
+
+    private static void ValidateText(
+        DeliveryTextEvidence? evidence,
+        DeliveryReceiptResourceBudget budget)
+    {
+        if (evidence is null)
+            return;
+        ValidateDigest(evidence.Digest, budget);
+        budget.String(evidence.Summary, "text summary");
+        budget.String(evidence.Value, "text value");
+    }
+
+    private static void ValidateDigest(
+        VerificationDigest? digest,
+        DeliveryReceiptResourceBudget budget)
+    {
+        if (digest is null)
+            return;
+        budget.String(digest.Algorithm, "digest algorithm");
+        budget.String(digest.Value, "digest value");
+    }
+
+    private static void ValidateJson(
+        JsonElement value,
+        DeliveryReceiptLimits limits,
+        DeliveryReceiptResourceBudget budget,
+        int depth)
+    {
+        if (depth > limits.MaxJsonDepth)
+            Fail("Embedded JSON exceeds the depth limit.");
+        switch (value.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (var property in value.EnumerateObject())
+                {
+                    budget.AddItems(1, "embedded JSON properties");
+                    budget.String(property.Name, "JSON property name");
+                    ValidateJson(property.Value, limits, budget, depth + 1);
+                }
+                break;
+            case JsonValueKind.Array:
+                foreach (var item in value.EnumerateArray())
+                {
+                    budget.AddItems(1, "embedded JSON items");
+                    ValidateJson(item, limits, budget, depth + 1);
+                }
+                break;
+            case JsonValueKind.String:
+                budget.String(value.GetString(), "JSON string");
+                break;
+        }
+    }
+
+    private static void Add<T>(
+        IReadOnlyCollection<T> values,
+        DeliveryReceiptResourceBudget budget,
+        string name)
+    {
+        budget.AddItems(values.Count, name);
+        budget.AddSerializedBytes(checked(values.Count * 2L + 2L), name);
+    }
+
+    private static void Fail(string message, string code = "receipt_resource_limit") =>
+        throw new DeliveryReceiptValidationException(code, message);
+}

--- a/Docxodus/Verification/DeliveryReceiptVerifier.cs
+++ b/Docxodus/Verification/DeliveryReceiptVerifier.cs
@@ -195,9 +195,13 @@ public static class DeliveryChangeReceiptVerifier
             payload.DeliveredDocument,
             payload.Transactions,
             payload.Lineage);
+        var artifactDigestMemo = new Dictionary<string, VerificationDigest>(
+            StringComparer.Ordinal);
         bool contractValid = ValidateContract(
-            payload, receiptDigest, artifactBytes, lineageValidation, limits, findings);
-        var artifactResults = VerifyArtifacts(payload.Artifacts, artifactBytes, limits, findings);
+            payload, receiptDigest, artifactBytes, lineageValidation, limits,
+            artifactDigestMemo, findings);
+        var artifactResults = VerifyArtifacts(
+            payload.Artifacts, artifactBytes, limits, artifactDigestMemo, findings);
         bool artifactsValid = artifactResults.All(result => result.Status is
             DeliveryArtifactVerificationStatus.Verified
             or DeliveryArtifactVerificationStatus.Unavailable);
@@ -302,6 +306,7 @@ public static class DeliveryChangeReceiptVerifier
         IReadOnlyDictionary<string, byte[]> artifactBytes,
         DeliveryLineageValidationResult lineageValidation,
         DeliveryReceiptLimits limits,
+        IDictionary<string, VerificationDigest> artifactDigestMemo,
         ICollection<string> findings)
     {
         bool valid = true;
@@ -496,7 +501,8 @@ public static class DeliveryChangeReceiptVerifier
             .GroupBy(artifact => artifact.ArtifactId, StringComparer.Ordinal)
             .Where(group => group.Count() == 1)
             .ToDictionary(group => group.Key, group => group.Single(), StringComparer.Ordinal);
-        valid &= ValidateRequiredCleanDocx(payload, artifactBytes, limits, findings);
+        valid &= ValidateRequiredCleanDocx(
+            payload, artifactBytes, limits, artifactDigestMemo, findings);
         valid &= ValidateSemanticBindings(
             payload, artifactsById, artifactBytes, lineageValidation, limits, findings);
         foreach (var evidence in payload.Evidence)
@@ -583,13 +589,8 @@ public static class DeliveryChangeReceiptVerifier
         return valid;
     }
 
-    private static string ExpectedEvidenceSchema(DeliveryEvidenceKind kind) => kind switch
-    {
-        DeliveryEvidenceKind.ValidationResult => DeliverableVerificationResult.SchemaId,
-        DeliveryEvidenceKind.RedlineReversibility => RedlineReversibilityProof.SchemaId,
-        DeliveryEvidenceKind.SemanticChangeSet => string.Empty,
-        _ => string.Empty,
-    };
+    private static string ExpectedEvidenceSchema(DeliveryEvidenceKind kind) =>
+        DeliveryReceiptContract.EvidenceSchemaFor(kind) ?? string.Empty;
 
     private static bool IsExactEvidence(DeliveryEvidenceKind kind, ReadOnlySpan<byte> bytes) =>
         kind switch
@@ -1010,7 +1011,8 @@ public static class DeliveryChangeReceiptVerifier
         foreach (var anchor in anchors.EnumerateArray())
         {
             if (anchor.ValueKind != JsonValueKind.Object
-                || anchor.EnumerateObject().Count() != 4
+                || anchor.EnumerateObject().Count()
+                    != DeliveryReceiptContract.EditResultAnchorPropertyCount
                 || !TryGetRequiredString(anchor, "id", out var id)
                 || !TryGetRequiredString(anchor, "kind", out var kind)
                 || !TryGetRequiredString(anchor, "scope", out var scope)
@@ -1623,40 +1625,17 @@ public static class DeliveryChangeReceiptVerifier
             return true;
         if (privacyProfile == DeliveryReceiptPrivacyProfile.HashOnly)
             return IsDigestToken(value);
-        var prefix = $"{label}; ";
-        const string separator = " characters; ";
-        if (!value.StartsWith(prefix, StringComparison.Ordinal))
-            return false;
-        int separatorIndex = value.IndexOf(separator, prefix.Length, StringComparison.Ordinal);
-        return separatorIndex > prefix.Length
-            && int.TryParse(
-                value.AsSpan(prefix.Length, separatorIndex - prefix.Length),
-                NumberStyles.None,
-                CultureInfo.InvariantCulture,
-                out var count)
-            && count >= 0
-            && IsDigestToken(value[(separatorIndex + separator.Length)..]);
+        return DeliveryReceiptContract.IsRedactedFreeText(value, label);
     }
 
-    private static bool IsDigestToken(string value)
-    {
-        if (value.Length != 71 || !value.StartsWith("sha256:", StringComparison.Ordinal))
-            return false;
-        foreach (var character in value.AsSpan(7))
-        {
-            if (character is not (>= '0' and <= '9')
-                and not (>= 'a' and <= 'f'))
-            {
-                return false;
-            }
-        }
-        return true;
-    }
+    private static bool IsDigestToken(string value) =>
+        DeliveryReceiptContract.IsSha256DigestToken(value);
 
     private static bool ValidateRequiredCleanDocx(
         DeliveryChangeReceiptPayload payload,
         IReadOnlyDictionary<string, byte[]> artifactBytes,
         DeliveryReceiptLimits limits,
+        IDictionary<string, VerificationDigest> artifactDigestMemo,
         ICollection<string> findings)
     {
         var cleanArtifacts = payload.Artifacts
@@ -1680,9 +1659,7 @@ public static class DeliveryChangeReceiptVerifier
             || !DeliveryReceiptValidation.DigestEquals(
                 clean.PackageDigest, payload.DeliveredDocument.RawPackageBytesDigest)
             || !DeliveryReceiptValidation.DigestEquals(
-                clean.Digest, payload.DeliveredDocument.RawPackageBytesDigest)
-            || !DeliveryReceiptValidation.DigestEquals(
-                clean.Digest, DeliveryReceiptCanonicalJson.Digest(cleanBytes)))
+                clean.Digest, payload.DeliveredDocument.RawPackageBytesDigest))
         {
             findings.Add("clean_docx_delivery_mismatch");
             return false;
@@ -1692,13 +1669,14 @@ public static class DeliveryChangeReceiptVerifier
         {
             var actualManifest = PackageManifestGenerator.Generate(
                 cleanBytes, limits.CleanDocxManifestOptions);
+            var actualIdentity = DeliveryDocumentIdentity.FromManifest(
+                actualManifest, clean.DocumentVersion.Value);
+            artifactDigestMemo[clean.ArtifactId] = actualIdentity.RawPackageBytesDigest;
             if (!actualManifest.IsValid
                 || !string.Equals(actualManifest.PackageKind, "opc", StringComparison.Ordinal)
                 || string.IsNullOrWhiteSpace(actualManifest.Facts.MainDocumentUri)
                 || !DeliveryReceiptLineageValidator.DocumentEquals(
-                    DeliveryDocumentIdentity.FromManifest(
-                        actualManifest, clean.DocumentVersion.Value),
-                    payload.DeliveredDocument))
+                    actualIdentity, payload.DeliveredDocument))
             {
                 findings.Add("clean_docx_delivery_mismatch");
                 return false;
@@ -1933,6 +1911,7 @@ public static class DeliveryChangeReceiptVerifier
         IReadOnlyList<DeliveryArtifact> artifacts,
         IReadOnlyDictionary<string, byte[]> artifactBytes,
         DeliveryReceiptLimits limits,
+        IReadOnlyDictionary<string, VerificationDigest> artifactDigestMemo,
         ICollection<string> findings)
     {
         var results = new List<DeliveryArtifactVerification>();
@@ -2017,7 +1996,10 @@ public static class DeliveryChangeReceiptVerifier
                 continue;
             }
 
-            var actualDigest = DeliveryReceiptCanonicalJson.Digest(bytes);
+            var actualDigest = artifactDigestMemo.TryGetValue(
+                    artifact.ArtifactId, out var memoized)
+                ? memoized
+                : DeliveryReceiptCanonicalJson.Digest(bytes);
             var status = bytes.LongLength != artifact.ByteLength
                 ? DeliveryArtifactVerificationStatus.LengthMismatch
                 : !DeliveryReceiptValidation.DigestEquals(artifact.Digest, actualDigest)
@@ -2214,27 +2196,19 @@ public static class DeliveryChangeReceiptVerifier
     private static bool CitationCoordinatesEqual(
         DeliveryPageCitation receiptCitation,
         PageCitation projected) =>
-        string.Equals(receiptCitation.AnchorId, projected.AnchorId, StringComparison.Ordinal)
-        && receiptCitation.DocumentVersion == projected.DocumentVersion
-        && string.Equals(receiptCitation.RendererFingerprint,
-            projected.RendererFingerprint, StringComparison.Ordinal)
-        && receiptCitation.Pages.SequenceEqual(projected.Pages)
-        && receiptCitation.Fragments.SequenceEqual(projected.Fragments);
+        DeliveryReceiptContract.CitationCoordinatesEqual(
+            projected,
+            receiptCitation.AnchorId,
+            receiptCitation.DocumentVersion,
+            receiptCitation.RendererFingerprint,
+            receiptCitation.Pages,
+            receiptCitation.Fragments);
 
     private static void ValidateDocument(DeliveryDocumentIdentity document) =>
         DeliveryReceiptValidation.ValidateDocument(document);
 
-    private static string ScopeFromAnchor(string anchorId)
-    {
-        var first = anchorId.IndexOf(':');
-        var second = first < 0 ? -1 : anchorId.IndexOf(':', first + 1);
-        if (first <= 0 || second <= first + 1 || second == anchorId.Length - 1)
-        {
-            throw new DeliveryReceiptValidationException(
-                "invalid_anchor_id", "Citation anchor is not a canonical kind:scope:unid value.");
-        }
-        return anchorId[(first + 1)..second];
-    }
+    private static string ScopeFromAnchor(string anchorId) =>
+        DeliveryReceiptContract.ScopeFromAnchor(anchorId);
 
     private static bool IsMalformedReceiptException(Exception exception) =>
         exception is JsonException

--- a/Docxodus/Verification/DeliveryReceiptVerifier.cs
+++ b/Docxodus/Verification/DeliveryReceiptVerifier.cs
@@ -492,6 +492,10 @@ public static class DeliveryChangeReceiptVerifier
                 beforePackage = transaction.BeforeDocument.RawPackageBytesDigest,
                 requestFingerprint = transaction.RequestFingerprint,
                 resultVersion = transaction.ResultVersion,
+                transactionId = transaction.TransactionId,
+                transactionSequence = transaction.TransactionId is null
+                    ? transaction.Sequence
+                    : (long?)null,
             }));
         if (!string.Equals(transaction.EntryId, expectedEntryId, StringComparison.Ordinal))
         {
@@ -795,6 +799,9 @@ public static class DeliveryChangeReceiptVerifier
         comparison = string.CompareOrdinal(
             left.Location.RelationshipId, right.Location.RelationshipId);
         if (comparison != 0) return comparison;
+        comparison = string.CompareOrdinal(
+            left.Location.TargetUri, right.Location.TargetUri);
+        if (comparison != 0) return comparison;
         return string.CompareOrdinal(
             left.Location.PropertyPath, right.Location.PropertyPath);
     }
@@ -835,9 +842,15 @@ public static class DeliveryChangeReceiptVerifier
         int comparison = left.EntityKind.CompareTo(right.EntityKind);
         if (comparison != 0) return comparison;
         comparison = left.ChangeKind.CompareTo(right.ChangeKind);
+        if (comparison != 0) return comparison;
+        comparison = string.CompareOrdinal(left.EntityId, right.EntityId);
+        if (comparison != 0) return comparison;
+        comparison = string.CompareOrdinal(left.PartUri, right.PartUri);
+        if (comparison != 0) return comparison;
+        comparison = string.CompareOrdinal(left.Scope, right.Scope);
         return comparison != 0
             ? comparison
-            : string.CompareOrdinal(left.EntityId, right.EntityId);
+            : string.CompareOrdinal(left.SourceDigest.Value, right.SourceDigest.Value);
     }
 
     private static int CompareObjectChanges(

--- a/Docxodus/Verification/DeliveryReceiptVerifier.cs
+++ b/Docxodus/Verification/DeliveryReceiptVerifier.cs
@@ -127,7 +127,10 @@ public static class DeliveryChangeReceiptVerifier
                 return Malformed("missing_payload");
             DeliveryReceiptResourceValidator.ValidatePayload(payload, limits);
             var knownPayload = DeliveryChangeReceiptSerializer.SerializePayload(payload, limits);
-            using var knownDocument = JsonDocument.Parse(knownPayload);
+            using var knownDocument = JsonDocument.Parse(knownPayload, new JsonDocumentOptions
+        {
+            MaxDepth = DeliveryReceiptLimits.MaxAllowedJsonDepth,
+        });
             if (!DeliveryReceiptCanonicalJson.ContainsCanonicalKnownProjection(
                     payloadElement, knownDocument.RootElement))
             {
@@ -1518,7 +1521,14 @@ public static class DeliveryChangeReceiptVerifier
             DeliveryReceiptValidation.RequireNonBlank(artifact.ArtifactId, "artifact id", 256);
             DeliveryReceiptValidation.RequireNonBlank(
                 artifact.MediaType, "artifact media type", 512);
-            DeliveryReceiptValidation.NormalizeRelativePath(artifact.RelativePath);
+            if (!string.Equals(
+                    DeliveryReceiptValidation.NormalizeRelativePath(artifact.RelativePath),
+                    artifact.RelativePath, StringComparison.Ordinal))
+            {
+                throw new DeliveryReceiptValidationException(
+                    "unsafe_artifact_path",
+                    "Artifact display paths must be stored in normalized form.");
+            }
             DeliveryReceiptValidation.ValidateOptionalDigest(
                 artifact.PackageDigest, "artifact package digest");
             DeliveryReceiptValidation.ValidateOptionalDigest(
@@ -2006,7 +2016,7 @@ public static class DeliveryChangeReceiptVerifier
                 ActualDigest = actualDigest,
             });
             if (status != DeliveryArtifactVerificationStatus.Verified)
-                findings.Add($"artifact_{status.ToString().ToLowerInvariant()}:{artifact.ArtifactId}");
+                findings.Add($"artifact_{DocxSessionJson.EnumToSnake(status)}:{artifact.ArtifactId}");
         }
         return results;
     }

--- a/Docxodus/Verification/DeliveryReceiptVerifier.cs
+++ b/Docxodus/Verification/DeliveryReceiptVerifier.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using Docxodus.Internal;
@@ -43,6 +44,11 @@ public sealed record DeliveryReceiptVerificationResult
 /// <summary>Verifies receipt integrity first, then independently verifies every available artifact.</summary>
 public static class DeliveryChangeReceiptVerifier
 {
+    private static readonly HashSet<string> EditErrorCodes = Enum
+        .GetValues<EditErrorCode>()
+        .Select(value => DocxSessionJson.EnumToSnake(value))
+        .ToHashSet(StringComparer.Ordinal);
+
     public static DeliveryReceiptVerificationResult Verify(
         DeliveryChangeReceipt receipt,
         IReadOnlyDictionary<string, byte[]> artifactBytes,
@@ -60,6 +66,8 @@ public static class DeliveryChangeReceiptVerifier
                 receipt.Payload, limits);
             var digestValid = DeliveryReceiptCanonicalJson.FixedTimeEquals(
                 receipt.ReceiptDigest, canonicalPayload);
+            if (!digestValid)
+                return IntegrityFailure("receipt_digest_mismatch");
             return VerifyCore(
                 receipt.Payload, receipt.ReceiptDigest, digestValid, artifactBytes, limits);
         }
@@ -111,15 +119,26 @@ public static class DeliveryChangeReceiptVerifier
             var canonicalPayload = DeliveryReceiptCanonicalJson.SerializeCanonicalBounded(
                 payloadElement, limits, limits.MaxReceiptJsonBytes, "receipt_resource_limit");
             var digestValid = DeliveryReceiptCanonicalJson.FixedTimeEquals(digest, canonicalPayload);
-            var jsonOptions = new JsonSerializerOptions(DeliveryReceiptCanonicalJson.JsonOptions)
-            {
-                MaxDepth = limits.MaxJsonDepth,
-            };
-            var payload = JsonSerializer.Deserialize<DeliveryChangeReceiptPayload>(
-                payloadElement.GetRawText(), jsonOptions);
+            if (!digestValid)
+                return IntegrityFailure("receipt_digest_mismatch");
+            var payload = payloadElement.Deserialize(
+                DeliveryReceiptCanonicalJson.JsonContext.DeliveryChangeReceiptPayload);
             if (payload is null)
                 return Malformed("missing_payload");
             DeliveryReceiptResourceValidator.ValidatePayload(payload, limits);
+            var knownPayload = DeliveryChangeReceiptSerializer.SerializePayload(payload, limits);
+            using var knownDocument = JsonDocument.Parse(knownPayload);
+            if (!DeliveryReceiptCanonicalJson.ContainsCanonicalKnownProjection(
+                    payloadElement, knownDocument.RootElement))
+            {
+                return Malformed("noncanonical_known_payload");
+            }
+            if (payload.PrivacyProfile != DeliveryReceiptPrivacyProfile.FullEvidence
+                && !DeliveryReceiptCanonicalJson.HasOnlyKnownProperties(
+                    payloadElement, knownDocument.RootElement))
+            {
+                return Malformed("unknown_fields_violate_privacy_profile");
+            }
             return VerifyCore(payload, digest, digestValid, artifactBytes, limits);
         }
         catch (DeliveryReceiptValidationException ex) when (IsResourceLimitCode(ex.Code))
@@ -156,6 +175,18 @@ public static class DeliveryChangeReceiptVerifier
         DeliveryReceiptLimits limits)
     {
         var findings = new List<string>();
+        if (!ValidateHeader(payload, findings)
+            || !ValidatePortableIntegers(payload, findings))
+        {
+            return new DeliveryReceiptVerificationResult
+            {
+                IsValid = false,
+                ReceiptDigestValid = digestValid,
+                ContractValid = false,
+                CitationBindingsValid = false,
+                Findings = findings.ToArray(),
+            };
+        }
         var lineageValidation = DeliveryReceiptLineageValidator.Validate(
             payload.SourceDocument,
             payload.DeliveredDocument,
@@ -167,11 +198,12 @@ public static class DeliveryChangeReceiptVerifier
         bool artifactsValid = artifactResults.All(result => result.Status is
             DeliveryArtifactVerificationStatus.Verified
             or DeliveryArtifactVerificationStatus.Unavailable);
+        var verifiedArtifacts = artifactResults
+            .Where(result => result.Status == DeliveryArtifactVerificationStatus.Verified)
+            .Select(result => result.ArtifactId)
+            .ToHashSet(StringComparer.Ordinal);
         bool citationsValid = ValidateCitationBindings(
-            payload, artifactBytes, lineageValidation, limits, findings);
-        if (!digestValid)
-            findings.Add("receipt_digest_mismatch");
-
+            payload, artifactBytes, verifiedArtifacts, lineageValidation, limits, findings);
         return new DeliveryReceiptVerificationResult
         {
             IsValid = digestValid && contractValid && artifactsValid && citationsValid,
@@ -183,12 +215,8 @@ public static class DeliveryChangeReceiptVerifier
         };
     }
 
-    private static bool ValidateContract(
+    private static bool ValidateHeader(
         DeliveryChangeReceiptPayload payload,
-        VerificationDigest receiptDigest,
-        IReadOnlyDictionary<string, byte[]> artifactBytes,
-        DeliveryLineageValidationResult lineageValidation,
-        DeliveryReceiptLimits limits,
         ICollection<string> findings)
     {
         bool valid = true;
@@ -210,6 +238,70 @@ public static class DeliveryChangeReceiptVerifier
             findings.Add("unknown_privacy_profile");
             valid = false;
         }
+        return valid;
+    }
+
+    private static bool ValidatePortableIntegers(
+        DeliveryChangeReceiptPayload payload,
+        ICollection<string> findings)
+    {
+        bool valid = true;
+
+        void Check(long value, string finding)
+        {
+            if (value < 0 || value > DeliveryReceiptValidation.MaxPortableInteger)
+            {
+                findings.Add(finding);
+                valid = false;
+            }
+        }
+
+        void CheckDocument(DeliveryDocumentIdentity document) =>
+            Check(document.DocumentVersion, "invalid_document_version");
+
+        CheckDocument(payload.SourceDocument);
+        CheckDocument(payload.DeliveredDocument);
+        foreach (var transaction in payload.Transactions)
+        {
+            Check(transaction.Sequence, "invalid_lineage_sequence");
+            Check(transaction.BaseVersion, "invalid_document_version");
+            Check(transaction.ResultVersion, "invalid_document_version");
+            CheckDocument(transaction.BeforeDocument);
+            CheckDocument(transaction.AfterDocument);
+        }
+        foreach (var lineageEvent in payload.Lineage)
+        {
+            Check(lineageEvent.Sequence, "invalid_lineage_sequence");
+            CheckDocument(lineageEvent.BeforeDocument);
+            CheckDocument(lineageEvent.AfterDocument);
+        }
+        foreach (var artifact in payload.Artifacts)
+        {
+            if (artifact.ByteLength is { } byteLength)
+                Check(byteLength, "invalid_artifact_record");
+            if (artifact.DocumentVersion is { } documentVersion)
+                Check(documentVersion, "invalid_document_version");
+        }
+        foreach (var binding in payload.SemanticChangeSets)
+        {
+            CheckDocument(binding.BeforeDocument);
+            CheckDocument(binding.AfterDocument);
+        }
+        foreach (var citation in payload.PageCitations)
+            Check(citation.DocumentVersion, "invalid_citation_identity");
+
+        return valid;
+    }
+
+    private static bool ValidateContract(
+        DeliveryChangeReceiptPayload payload,
+        VerificationDigest receiptDigest,
+        IReadOnlyDictionary<string, byte[]> artifactBytes,
+        DeliveryLineageValidationResult lineageValidation,
+        DeliveryReceiptLimits limits,
+        ICollection<string> findings)
+    {
+        bool valid = true;
         try
         {
             DeliveryReceiptValidation.ValidateDigest(receiptDigest, "receipt digest");
@@ -291,7 +383,8 @@ public static class DeliveryChangeReceiptVerifier
             valid &= ValidateTransaction(transaction, payload.PrivacyProfile, findings);
         foreach (var lineageEvent in payload.Lineage)
         {
-            if (lineageEvent.Sequence < 0)
+            if (lineageEvent.Sequence < 0
+                || lineageEvent.Sequence > DeliveryReceiptValidation.MaxPortableInteger)
             {
                 findings.Add("invalid_lineage_sequence");
                 valid = false;
@@ -354,6 +447,8 @@ public static class DeliveryChangeReceiptVerifier
             if (!transactionsByEntryId.TryGetValue(change.TransactionEntryId, out var transaction)
                 || transaction.Status is not (DeliveryTransactionStatus.Committed
                     or DeliveryTransactionStatus.PartiallyCommitted)
+                || !lineageValidation.AppliedTransactionEntryIds.Contains(
+                    change.TransactionEntryId)
                 || (change.RequestedOperationIndex is { } operationIndex
                     && (operationIndex < 0 || operationIndex >= transaction.Operations.Count
                         || transaction.Operations[operationIndex].ExecutionStatus
@@ -364,7 +459,18 @@ public static class DeliveryChangeReceiptVerifier
             }
         }
         foreach (var artifact in payload.Artifacts)
-            valid &= ValidateArtifactRecord(artifact, findings);
+        {
+            valid &= ValidateArtifactRecord(artifact, payload.PrivacyProfile, findings);
+            if (artifact.Role != DeliveryArtifactRole.ReviewDocx
+                && artifact.DocumentVersion is { } documentVersion
+                && artifact.PackageDigest is { } packageDigest
+                && !DeliveryReceiptLineageValidator.IsReachable(
+                    lineageValidation, documentVersion, packageDigest))
+            {
+                findings.Add("unreachable_artifact_document");
+                valid = false;
+            }
+        }
 
         var artifactsById = payload.Artifacts
             .GroupBy(artifact => artifact.ArtifactId, StringComparer.Ordinal)
@@ -395,6 +501,12 @@ public static class DeliveryChangeReceiptVerifier
             {
                 DeliveryReceiptValidation.RequireNonBlank(
                     evidence.Schema, "evidence schema", 2048);
+                var expectedSchema = ExpectedEvidenceSchema(evidence.Kind);
+                if (!string.Equals(evidence.Schema, expectedSchema, StringComparison.Ordinal))
+                {
+                    findings.Add("evidence_schema_mismatch");
+                    valid = false;
+                }
                 if (evidence.ArtifactId is not null)
                 {
                     DeliveryReceiptValidation.RequireNonBlank(
@@ -425,9 +537,22 @@ public static class DeliveryChangeReceiptVerifier
                     findings.Add("evidence_artifact_binding_mismatch");
                     valid = false;
                 }
+                else if (!artifactBytes.TryGetValue(artifactId, out var evidenceBytes)
+                    || !IsExactEvidence(evidence.Kind, evidenceBytes))
+                {
+                    findings.Add("invalid_evidence_artifact");
+                    valid = false;
+                }
             }
             if (payload.PrivacyProfile == DeliveryReceiptPrivacyProfile.HashOnly
                 && evidence.Summary is not null)
+            {
+                findings.Add("privacy_profile_violation");
+                valid = false;
+            }
+            else if (evidence.Summary is not null
+                && !ValidateProfiledFreeText(
+                    evidence.Summary, payload.PrivacyProfile, "evidence summary"))
             {
                 findings.Add("privacy_profile_violation");
                 valid = false;
@@ -438,13 +563,32 @@ public static class DeliveryChangeReceiptVerifier
         return valid;
     }
 
+    private static string ExpectedEvidenceSchema(DeliveryEvidenceKind kind) => kind switch
+    {
+        DeliveryEvidenceKind.ValidationResult => DeliverableVerificationResult.SchemaId,
+        DeliveryEvidenceKind.RedlineReversibility => RedlineReversibilityProof.SchemaId,
+        DeliveryEvidenceKind.SemanticChangeSet => string.Empty,
+        _ => string.Empty,
+    };
+
+    private static bool IsExactEvidence(DeliveryEvidenceKind kind, ReadOnlySpan<byte> bytes) =>
+        kind switch
+        {
+            DeliveryEvidenceKind.ValidationResult =>
+                DeliverableVerificationResult.IsExactCanonical(bytes),
+            DeliveryEvidenceKind.RedlineReversibility =>
+                RedlineReversibilityProof.IsExactCanonical(bytes),
+            _ => false,
+        };
+
     private static bool ValidateTransaction(
         DeliveryTransactionEntry transaction,
         DeliveryReceiptPrivacyProfile privacyProfile,
         ICollection<string> findings)
     {
         bool valid = true;
-        if (transaction.Sequence < 0)
+        if (transaction.Sequence < 0
+            || transaction.Sequence > DeliveryReceiptValidation.MaxPortableInteger)
         {
             findings.Add("invalid_lineage_sequence");
             valid = false;
@@ -465,13 +609,19 @@ public static class DeliveryChangeReceiptVerifier
             }
             ValidateDocument(transaction.BeforeDocument);
             ValidateDocument(transaction.AfterDocument);
+            DeliveryReceiptValidation.ValidateOptionalDigest(
+                transaction.ReportedPackageContentDigest,
+                "reported package-content digest");
         }
         catch (DeliveryReceiptValidationException ex)
         {
             findings.Add(ex.Code);
             valid = false;
         }
-        if (transaction.BaseVersion < 0 || transaction.ResultVersion < 0
+        if (transaction.BaseVersion < 0
+            || transaction.BaseVersion > DeliveryReceiptValidation.MaxPortableInteger
+            || transaction.ResultVersion < 0
+            || transaction.ResultVersion > DeliveryReceiptValidation.MaxPortableInteger
             || transaction.BeforeDocument.DocumentVersion != transaction.BaseVersion
             || transaction.AfterDocument.DocumentVersion != transaction.ResultVersion)
         {
@@ -484,19 +634,14 @@ public static class DeliveryChangeReceiptVerifier
         {
             valid = false;
         }
-        var expectedEntryId = DeliveryReceiptCanonicalJson.DigestToken(
-            DeliveryReceiptCanonicalJson.SerializeCanonical(new
-            {
-                afterPackage = transaction.AfterDocument.RawPackageBytesDigest,
-                baseVersion = transaction.BaseVersion,
-                beforePackage = transaction.BeforeDocument.RawPackageBytesDigest,
-                requestFingerprint = transaction.RequestFingerprint,
-                resultVersion = transaction.ResultVersion,
-                transactionId = transaction.TransactionId,
-                transactionSequence = transaction.TransactionId is null
-                    ? transaction.Sequence
-                    : (long?)null,
-            }));
+        var expectedEntryId = DeliveryReceiptIdentity.TransactionEntryId(
+            transaction.RequestFingerprint,
+            transaction.BeforeDocument,
+            transaction.AfterDocument,
+            transaction.BaseVersion,
+            transaction.ResultVersion,
+            transaction.TransactionId,
+            transaction.Sequence);
         if (!string.Equals(transaction.EntryId, expectedEntryId, StringComparison.Ordinal))
         {
             findings.Add("transaction_entry_id_mismatch");
@@ -576,9 +721,7 @@ public static class DeliveryChangeReceiptVerifier
                 bool errorShapeValid = result.Success
                     ? result.ErrorCode is null && result.ErrorMessage is null
                     : result.ErrorCode is not null
-                        && Enum.TryParse<EditErrorCode>(
-                            result.ErrorCode, ignoreCase: false, out var errorCode)
-                        && Enum.IsDefined(errorCode)
+                        && EditErrorCodes.Contains(result.ErrorCode)
                         && result.ErrorMessage is not null;
                 if (!errorShapeValid)
                 {
@@ -605,6 +748,12 @@ public static class DeliveryChangeReceiptVerifier
                     findings.Add("operation_result_digest_mismatch");
                     valid = false;
                 }
+                else if (result.FullResult is { } projectedResult
+                    && !OperationResultProjectionMatches(result, projectedResult))
+                {
+                    findings.Add("operation_result_projection_mismatch");
+                    valid = false;
+                }
                 foreach (var change in result.ObjectChanges)
                 {
                     if (!Enum.IsDefined(change.ChangeKind))
@@ -619,6 +768,14 @@ public static class DeliveryChangeReceiptVerifier
                         DeliveryReceiptValidation.RequireNonBlank(change.Kind, "anchor kind", 256);
                         DeliveryReceiptValidation.RequireNonBlank(change.Scope, "anchor scope", 1024);
                         DeliveryReceiptValidation.RequireNonBlank(change.Unid, "anchor unid", 2048);
+                        if (!string.Equals(
+                                change.AnchorId,
+                                $"{change.Kind}:{change.Scope}:{change.Unid}",
+                                StringComparison.Ordinal))
+                        {
+                            throw new DeliveryReceiptValidationException(
+                                "invalid_anchor_id", "Changed anchor identity is inconsistent.");
+                        }
                     }
                     catch (DeliveryReceiptValidationException ex)
                     {
@@ -657,6 +814,29 @@ public static class DeliveryChangeReceiptVerifier
             }
             if (change.Text is not null)
                 valid &= ValidateTextEvidence(change.Text, privacyProfile, findings);
+            if (change.Diagnostic is { } diagnostic)
+            {
+                try
+                {
+                    DeliveryReceiptValidation.RequireNonBlank(
+                        diagnostic.Code, "authored diagnostic code", 1024);
+                }
+                catch (DeliveryReceiptValidationException ex)
+                {
+                    findings.Add(ex.Code);
+                    valid = false;
+                }
+                if (diagnostic.Message is null)
+                {
+                    findings.Add("missing_value");
+                    valid = false;
+                }
+                else
+                {
+                    valid &= ValidateTextEvidence(
+                        diagnostic.Message, privacyProfile, findings);
+                }
+            }
             bool requiresFullEvidence =
                 privacyProfile == DeliveryReceiptPrivacyProfile.FullEvidence;
             if ((!requiresFullEvidence && change.FullEvidence is not null)
@@ -674,6 +854,51 @@ public static class DeliveryChangeReceiptVerifier
                 findings.Add("authored_evidence_digest_mismatch");
                 valid = false;
             }
+            else if (change.FullEvidence is { } projectedEvidence
+                && !AuthoredEvidenceProjectionMatches(change, projectedEvidence))
+            {
+                findings.Add("authored_evidence_projection_mismatch");
+                valid = false;
+            }
+            if (!IsStrictlyOrdered(
+                    change.ConstituentIds,
+                    static (left, right) => string.CompareOrdinal(left, right))
+                || !IsStrictlyOrdered(
+                    change.ConstituentKeys,
+                    static (left, right) => string.CompareOrdinal(left, right)))
+            {
+                findings.Add("constituent_identity_order_mismatch");
+                valid = false;
+            }
+            if (change.EntityKind == DeliveryAuthoredEntityKind.Revision)
+            {
+                if (change.ConstituentIds.Count == 0
+                    || change.ConstituentKeys.Count == 0
+                    || change.Family is not { } family
+                    || !Enum.IsDefined(family)
+                    || string.IsNullOrWhiteSpace(change.PartUri)
+                    || string.IsNullOrWhiteSpace(change.Scope)
+                    || change.ResolutionStatus is not { } resolutionStatus
+                    || !Enum.IsDefined(resolutionStatus)
+                    || (change.AnchorId is not null
+                        && !change.AffectedAnchorIds.Contains(
+                            change.AnchorId, StringComparer.Ordinal)))
+                {
+                    findings.Add("invalid_revision_identity");
+                    valid = false;
+                }
+            }
+            else if (change.ConstituentIds.Count != 0
+                || change.ConstituentKeys.Count != 0
+                || change.DateUtc is not null
+                || change.Family is not null
+                || change.AnchorId is not null
+                || change.ResolutionStatus is not null
+                || change.Diagnostic is not null)
+            {
+                findings.Add("invalid_authored_change_shape");
+                valid = false;
+            }
             if (!IsStrictlyOrdered(
                     change.AffectedAnchorIds,
                     static (left, right) => string.CompareOrdinal(left, right)))
@@ -681,6 +906,17 @@ public static class DeliveryChangeReceiptVerifier
                 findings.Add("affected_anchor_order_mismatch");
                 valid = false;
             }
+        }
+        if (transaction.AuthoredChanges.GroupBy(change => new
+            {
+                change.EntityKind,
+                change.EntityId,
+                change.PartUri,
+                change.Scope,
+            }).Any(group => group.Count() != 1))
+        {
+            findings.Add("duplicate_authored_change");
+            valid = false;
         }
         if (!IsStrictlyOrdered(transaction.AuthoredChanges, CompareAuthoredChanges))
         {
@@ -696,6 +932,333 @@ public static class DeliveryChangeReceiptVerifier
         }
         return valid;
     }
+
+    private static bool OperationResultProjectionMatches(
+        DeliveryOperationResultEvidence receipt,
+        JsonElement fullResult)
+    {
+        if (fullResult.ValueKind != JsonValueKind.Object
+            || !fullResult.TryGetProperty("success", out var success)
+            || success.ValueKind is not (JsonValueKind.True or JsonValueKind.False)
+            || success.GetBoolean() != receipt.Success)
+        {
+            return false;
+        }
+
+        bool hasError = fullResult.TryGetProperty("error", out var error);
+        if (receipt.Success)
+        {
+            if (hasError || receipt.ErrorCode is not null || receipt.ErrorMessage is not null)
+                return false;
+        }
+        else if (!hasError
+            || error.ValueKind != JsonValueKind.Object
+            || !TryGetRequiredString(error, "code", out var errorCode)
+            || !TryGetRequiredString(error, "message", out var errorMessage)
+            || !string.Equals(receipt.ErrorCode, errorCode, StringComparison.Ordinal)
+            || !string.Equals(receipt.ErrorMessage?.Value, errorMessage,
+                StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var changes = new List<DeliveryObjectChange>();
+        if (!TryReadObjectChanges(
+                fullResult, "created", DeliveryObjectChangeKind.Added, changes)
+            || !TryReadObjectChanges(
+                fullResult, "removed", DeliveryObjectChangeKind.Removed, changes)
+            || !TryReadObjectChanges(
+                fullResult, "modified", DeliveryObjectChangeKind.Modified, changes))
+        {
+            return false;
+        }
+        changes.Sort(CompareObjectChanges);
+        return changes.SequenceEqual(receipt.ObjectChanges);
+    }
+
+    private static bool TryReadObjectChanges(
+        JsonElement fullResult,
+        string propertyName,
+        DeliveryObjectChangeKind changeKind,
+        ICollection<DeliveryObjectChange> destination)
+    {
+        if (!fullResult.TryGetProperty(propertyName, out var anchors)
+            || anchors.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
+        foreach (var anchor in anchors.EnumerateArray())
+        {
+            if (anchor.ValueKind != JsonValueKind.Object
+                || anchor.EnumerateObject().Count() != 4
+                || !TryGetRequiredString(anchor, "id", out var id)
+                || !TryGetRequiredString(anchor, "kind", out var kind)
+                || !TryGetRequiredString(anchor, "scope", out var scope)
+                || !TryGetRequiredString(anchor, "unid", out var unid)
+                || !string.Equals(id, $"{kind}:{scope}:{unid}", StringComparison.Ordinal))
+            {
+                return false;
+            }
+            destination.Add(new DeliveryObjectChange
+            {
+                ChangeKind = changeKind,
+                AnchorId = id,
+                Kind = kind,
+                Scope = scope,
+                Unid = unid,
+            });
+        }
+        return true;
+    }
+
+    private static bool AuthoredEvidenceProjectionMatches(
+        DeliveryAuthoredChange receipt,
+        JsonElement evidence)
+    {
+        if (evidence.ValueKind != JsonValueKind.Object)
+            return false;
+        return receipt.EntityKind switch
+        {
+            DeliveryAuthoredEntityKind.Revision =>
+                RevisionProjectionMatches(receipt, evidence),
+            DeliveryAuthoredEntityKind.Comment =>
+                CommentProjectionMatches(receipt, evidence),
+            DeliveryAuthoredEntityKind.Annotation =>
+                AnnotationProjectionMatches(receipt, evidence),
+            _ => false,
+        };
+    }
+
+    private static bool RevisionProjectionMatches(
+        DeliveryAuthoredChange receipt,
+        JsonElement evidence)
+    {
+        if (!TryGetRequiredString(evidence, "id", out var id)
+            || !TryGetRequiredString(evidence, "type", out var type)
+            || !TryGetRequiredString(evidence, "family", out var family)
+            || !TryGetRequiredString(evidence, "author", out var author)
+            || !TryGetRequiredString(evidence, "text", out var text)
+            || !TryGetRequiredString(evidence, "partUri", out var partUri)
+            || !TryGetRequiredString(evidence, "scope", out var scope)
+            || !TryGetOptionalString(evidence, "date", out var date)
+            || !TryGetOptionalString(evidence, "dateUtc", out var dateUtc)
+            || !TryGetOptionalString(evidence, "anchorId", out var anchorId)
+            || !TryGetRequiredString(
+                evidence, "resolutionStatus", out var resolutionStatus)
+            || !TryParseOwnerEnum(family, out RevisionFamily parsedFamily)
+            || !TryParseOwnerEnum(
+                resolutionStatus, out RevisionResolutionStatus parsedResolutionStatus)
+            || !TryGetStringArray(evidence, "constituentIds", out var constituentIds)
+            || !TryGetStringArray(evidence, "constituentKeys", out var constituentKeys)
+            || !TryGetAffectedAnchorIds(evidence, out var affectedAnchors))
+        {
+            return false;
+        }
+        DeliveryAuthoredDiagnostic? diagnostic = null;
+        if (evidence.TryGetProperty("diagnostic", out var diagnosticElement))
+        {
+            if (diagnosticElement.ValueKind != JsonValueKind.Object
+                || !TryGetRequiredString(diagnosticElement, "code", out var code)
+                || !TryGetRequiredString(diagnosticElement, "message", out var message))
+            {
+                return false;
+            }
+            diagnostic = new DeliveryAuthoredDiagnostic
+            {
+                Code = code,
+                Message = new DeliveryTextEvidence
+                {
+                    Digest = DeliveryReceiptCanonicalJson.Digest(
+                        Encoding.UTF8.GetBytes(message)),
+                    CharacterCount = message.Length,
+                    Value = message,
+                },
+            };
+        }
+        return string.Equals(receipt.EntityId, id, StringComparison.Ordinal)
+            && string.Equals(receipt.Type, type, StringComparison.Ordinal)
+            && receipt.Family == parsedFamily
+            && string.Equals(receipt.Author, author, StringComparison.Ordinal)
+            && string.Equals(receipt.Date, date, StringComparison.Ordinal)
+            && string.Equals(receipt.DateUtc, dateUtc, StringComparison.Ordinal)
+            && string.Equals(receipt.PartUri, partUri, StringComparison.Ordinal)
+            && string.Equals(receipt.Scope, scope, StringComparison.Ordinal)
+            && string.Equals(receipt.AnchorId, anchorId, StringComparison.Ordinal)
+            && receipt.ResolutionStatus == parsedResolutionStatus
+            && AuthoredDiagnosticProjectionMatches(receipt.Diagnostic, diagnostic)
+            && string.Equals(receipt.Text?.Value, text, StringComparison.Ordinal)
+            && SortedDistinct(constituentIds).SequenceEqual(receipt.ConstituentIds)
+            && SortedDistinct(constituentKeys).SequenceEqual(receipt.ConstituentKeys)
+            && SortedDistinct(affectedAnchors).SequenceEqual(receipt.AffectedAnchorIds);
+    }
+
+    private static bool TryParseOwnerEnum<TEnum>(string wireValue, out TEnum value)
+        where TEnum : struct, Enum
+    {
+        foreach (var candidate in Enum.GetValues<TEnum>())
+        {
+            if (string.Equals(
+                    DocxSessionJson.EnumToSnake(candidate), wireValue,
+                    StringComparison.Ordinal))
+            {
+                value = candidate;
+                return true;
+            }
+        }
+        value = default;
+        return false;
+    }
+
+    private static bool AuthoredDiagnosticProjectionMatches(
+        DeliveryAuthoredDiagnostic? receipt,
+        DeliveryAuthoredDiagnostic? owner) =>
+        receipt is null && owner is null
+        || receipt is not null
+            && owner is not null
+            && string.Equals(receipt.Code, owner.Code, StringComparison.Ordinal)
+            && receipt.Message is not null
+            && owner.Message is not null
+            && string.Equals(
+                receipt.Message.Value, owner.Message.Value, StringComparison.Ordinal);
+
+    private static bool CommentProjectionMatches(
+        DeliveryAuthoredChange receipt,
+        JsonElement evidence)
+    {
+        if (!TryGetRequiredString(evidence, "anchorId", out var anchorId)
+            || !TryGetRequiredString(evidence, "author", out var author)
+            || !TryGetRequiredString(evidence, "text", out var text)
+            || !TryGetOptionalString(evidence, "date", out var date)
+            || !TryGetOptionalString(evidence, "parentAnchorId", out var parentAnchorId))
+        {
+            return false;
+        }
+        string scope;
+        try { scope = ScopeFromAnchor(anchorId); }
+        catch (DeliveryReceiptValidationException) { return false; }
+        var affected = parentAnchorId is null
+            ? new[] { anchorId }
+            : new[] { anchorId, parentAnchorId };
+        return string.Equals(receipt.EntityId, anchorId, StringComparison.Ordinal)
+            && string.Equals(receipt.Author, author, StringComparison.Ordinal)
+            && string.Equals(receipt.Date, date, StringComparison.Ordinal)
+            && receipt.DateUtc is null
+            && string.Equals(receipt.Type,
+                parentAnchorId is null ? "comment" : "commentReply",
+                StringComparison.Ordinal)
+            && receipt.PartUri is null
+            && string.Equals(receipt.Scope, scope, StringComparison.Ordinal)
+            && string.Equals(receipt.Text?.Value, text, StringComparison.Ordinal)
+            && SortedDistinct(affected).SequenceEqual(receipt.AffectedAnchorIds)
+            && receipt.ConstituentIds.Count == 0
+            && receipt.ConstituentKeys.Count == 0;
+    }
+
+    private static bool AnnotationProjectionMatches(
+        DeliveryAuthoredChange receipt,
+        JsonElement evidence)
+    {
+        if (!TryGetRequiredString(evidence, "id", out var id)
+            || !TryGetRequiredString(evidence, "labelId", out var labelId)
+            || !TryGetOptionalString(evidence, "author", out var author)
+            || !TryGetOptionalString(evidence, "created", out var created)
+            || !TryGetOptionalString(evidence, "annotatedText", out var annotatedText))
+        {
+            return false;
+        }
+        return string.Equals(receipt.EntityId, id, StringComparison.Ordinal)
+            && string.Equals(receipt.Author, author, StringComparison.Ordinal)
+            && string.Equals(receipt.Date, created, StringComparison.Ordinal)
+            && receipt.DateUtc is null
+            && string.Equals(receipt.Type, labelId, StringComparison.Ordinal)
+            && receipt.PartUri is null
+            && receipt.Scope is null
+            && string.Equals(receipt.Text?.Value, annotatedText ?? string.Empty,
+                StringComparison.Ordinal)
+            && receipt.AffectedAnchorIds.Count == 0
+            && receipt.ConstituentIds.Count == 0
+            && receipt.ConstituentKeys.Count == 0;
+    }
+
+    private static bool TryGetRequiredString(
+        JsonElement element,
+        string propertyName,
+        out string value)
+    {
+        value = string.Empty;
+        if (!element.TryGetProperty(propertyName, out var property)
+            || property.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+        value = property.GetString()!;
+        return true;
+    }
+
+    private static bool TryGetOptionalString(
+        JsonElement element,
+        string propertyName,
+        out string? value)
+    {
+        value = null;
+        if (!element.TryGetProperty(propertyName, out var property))
+            return true;
+        if (property.ValueKind != JsonValueKind.String)
+            return false;
+        value = property.GetString();
+        return true;
+    }
+
+    private static bool TryGetStringArray(
+        JsonElement element,
+        string propertyName,
+        out IReadOnlyList<string> values)
+    {
+        values = Array.Empty<string>();
+        if (!element.TryGetProperty(propertyName, out var array)
+            || array.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
+        var parsed = new List<string>();
+        foreach (var item in array.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.String)
+                return false;
+            parsed.Add(item.GetString()!);
+        }
+        values = parsed;
+        return true;
+    }
+
+    private static bool TryGetAffectedAnchorIds(
+        JsonElement evidence,
+        out IReadOnlyList<string> values)
+    {
+        values = Array.Empty<string>();
+        if (!evidence.TryGetProperty("affectedAnchors", out var array)
+            || array.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
+        var parsed = new List<string>();
+        foreach (var anchor in array.EnumerateArray())
+        {
+            if (anchor.ValueKind != JsonValueKind.Object
+                || !TryGetRequiredString(anchor, "id", out var id))
+            {
+                return false;
+            }
+            parsed.Add(id);
+        }
+        values = parsed;
+        return true;
+    }
+
+    private static IReadOnlyList<string> SortedDistinct(IEnumerable<string> values) => values
+        .Distinct(StringComparer.Ordinal)
+        .OrderBy(value => value, StringComparer.Ordinal)
+        .ToArray();
 
     private static bool ValidateTransactionOutcome(
         DeliveryTransactionEntry transaction,
@@ -847,10 +1410,7 @@ public static class DeliveryChangeReceiptVerifier
         if (comparison != 0) return comparison;
         comparison = string.CompareOrdinal(left.PartUri, right.PartUri);
         if (comparison != 0) return comparison;
-        comparison = string.CompareOrdinal(left.Scope, right.Scope);
-        return comparison != 0
-            ? comparison
-            : string.CompareOrdinal(left.SourceDigest.Value, right.SourceDigest.Value);
+        return string.CompareOrdinal(left.Scope, right.Scope);
     }
 
     private static int CompareObjectChanges(
@@ -892,7 +1452,15 @@ public static class DeliveryChangeReceiptVerifier
                     change.Location.RelationshipId, "relationship id", 2048);
             }
             if (change.Disposition == DeliveryChangeDisposition.Derived)
+            {
                 DeliveryReceiptValidation.RequireNonBlank(change.Derivation, "derivation", 4096);
+                if (!ValidateProfiledFreeText(
+                        change.Derivation!, privacyProfile, "derivation"))
+                {
+                    throw new DeliveryReceiptValidationException(
+                        "privacy_profile_violation", "Derivation text violates the privacy profile.");
+                }
+            }
         }
         catch (DeliveryReceiptValidationException ex)
         {
@@ -921,14 +1489,11 @@ public static class DeliveryChangeReceiptVerifier
             valid &= ValidateTextEvidence(change.Before, privacyProfile, findings);
         if (change.After is not null)
             valid &= ValidateTextEvidence(change.After, privacyProfile, findings);
-        var expectedChangeId = DeliveryReceiptCanonicalJson.DigestToken(
-            DeliveryReceiptCanonicalJson.SerializeCanonical(new
-            {
-                after = change.After?.Digest,
-                before = change.Before?.Digest,
-                kind = change.Kind.ToString(),
-                location = change.Location,
-            }));
+        var expectedChangeId = DeliveryReceiptIdentity.PackageChangeId(
+            change.Kind,
+            change.Location,
+            change.Before?.Digest,
+            change.After?.Digest);
         if (!string.Equals(change.ChangeId, expectedChangeId, StringComparison.Ordinal))
         {
             findings.Add("package_change_id_mismatch");
@@ -939,6 +1504,7 @@ public static class DeliveryChangeReceiptVerifier
 
     private static bool ValidateArtifactRecord(
         DeliveryArtifact artifact,
+        DeliveryReceiptPrivacyProfile privacyProfile,
         ICollection<string> findings)
     {
         bool valid = true;
@@ -962,7 +1528,8 @@ public static class DeliveryChangeReceiptVerifier
                 DeliveryReceiptValidation.RequireNonBlank(
                     artifact.RendererFingerprint, "renderer fingerprint", 4096);
             }
-            if (artifact.DocumentVersion is < 0)
+            if (artifact.DocumentVersion is < 0
+                or > DeliveryReceiptValidation.MaxPortableInteger)
             {
                 throw new DeliveryReceiptValidationException(
                     "invalid_document_version", "Artifact document version cannot be negative.");
@@ -997,7 +1564,12 @@ public static class DeliveryChangeReceiptVerifier
                 valid = false;
             }
         }
-        else if (artifact.Availability == DeliveryArtifactAvailability.Unavailable)
+        if ((artifact.DocumentVersion is null) != (artifact.PackageDigest is null))
+        {
+            findings.Add("invalid_artifact_document_binding");
+            valid = false;
+        }
+        if (artifact.Availability == DeliveryArtifactAvailability.Unavailable)
         {
             if (artifact.Digest is not null || artifact.ByteLength is not null
                 || string.IsNullOrWhiteSpace(artifact.UnavailableReason))
@@ -1005,8 +1577,53 @@ public static class DeliveryChangeReceiptVerifier
                 findings.Add("invalid_artifact_record");
                 valid = false;
             }
+            else if (!ValidateProfiledFreeText(
+                artifact.UnavailableReason!, privacyProfile, "artifact unavailable reason"))
+            {
+                findings.Add("privacy_profile_violation");
+                valid = false;
+            }
         }
         return valid;
+    }
+
+    private static bool ValidateProfiledFreeText(
+        string value,
+        DeliveryReceiptPrivacyProfile privacyProfile,
+        string label)
+    {
+        if (privacyProfile == DeliveryReceiptPrivacyProfile.FullEvidence)
+            return true;
+        if (privacyProfile == DeliveryReceiptPrivacyProfile.HashOnly)
+            return IsDigestToken(value);
+        var prefix = $"{label}; ";
+        const string separator = " characters; ";
+        if (!value.StartsWith(prefix, StringComparison.Ordinal))
+            return false;
+        int separatorIndex = value.IndexOf(separator, prefix.Length, StringComparison.Ordinal);
+        return separatorIndex > prefix.Length
+            && int.TryParse(
+                value.AsSpan(prefix.Length, separatorIndex - prefix.Length),
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out var count)
+            && count >= 0
+            && IsDigestToken(value[(separatorIndex + separator.Length)..]);
+    }
+
+    private static bool IsDigestToken(string value)
+    {
+        if (value.Length != 71 || !value.StartsWith("sha256:", StringComparison.Ordinal))
+            return false;
+        foreach (var character in value.AsSpan(7))
+        {
+            if (character is not (>= '0' and <= '9')
+                and not (>= 'a' and <= 'f'))
+            {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static bool ValidateRequiredCleanDocx(
@@ -1397,6 +2014,7 @@ public static class DeliveryChangeReceiptVerifier
     private static bool ValidateCitationBindings(
         DeliveryChangeReceiptPayload payload,
         IReadOnlyDictionary<string, byte[]> artifactBytes,
+        IReadOnlySet<string> verifiedArtifacts,
         DeliveryLineageValidationResult lineageValidation,
         DeliveryReceiptLimits limits,
         ICollection<string> findings)
@@ -1406,6 +2024,9 @@ public static class DeliveryChangeReceiptVerifier
             .GroupBy(artifact => artifact.ArtifactId, StringComparer.Ordinal)
             .Where(group => group.Count() == 1)
             .ToDictionary(group => group.Key, group => group.Single(), StringComparer.Ordinal);
+        var pageMapCache = new Dictionary<string, (PageMap? Map, string? Finding)>(
+            StringComparer.Ordinal);
+        var projectionCache = new Dictionary<(string ArtifactId, string AnchorId), PageCitation>();
         foreach (var citation in payload.PageCitations)
         {
             try
@@ -1427,6 +2048,7 @@ public static class DeliveryChangeReceiptVerifier
                 DeliveryReceiptValidation.ValidateDigest(
                     citation.RenderArtifactDigest, "citation render-artifact digest");
                 if (citation.DocumentVersion < 0
+                    || citation.DocumentVersion > DeliveryReceiptValidation.MaxPortableInteger
                     || !string.Equals(
                         ScopeFromAnchor(citation.AnchorId), citation.Scope,
                         StringComparison.Ordinal))
@@ -1450,7 +2072,6 @@ public static class DeliveryChangeReceiptVerifier
                 || artifact.Availability != DeliveryArtifactAvailability.Available
                 || artifact.Digest is null
                 || artifact.Role is not (DeliveryArtifactRole.Pdf
-                    or DeliveryArtifactRole.PageImage
                     or DeliveryArtifactRole.RenderReport)
                 || artifact.DocumentVersion != citation.DocumentVersion
                 || !string.Equals(artifact.RendererFingerprint,
@@ -1463,6 +2084,11 @@ public static class DeliveryChangeReceiptVerifier
                     artifact.Digest, citation.RenderArtifactDigest))
             {
                 findings.Add($"citation_binding_mismatch:{citation.AnchorId}");
+                valid = false;
+            }
+            else if (!verifiedArtifacts.Contains(citation.RenderArtifactId))
+            {
+                findings.Add($"citation_render_artifact_unverified:{citation.AnchorId}");
                 valid = false;
             }
             if (!artifacts.TryGetValue(citation.PageMapArtifactId, out var pageMapArtifact)
@@ -1481,49 +2107,69 @@ public static class DeliveryChangeReceiptVerifier
                 valid = false;
             }
 
+            if (!verifiedArtifacts.Contains(citation.PageMapArtifactId))
+            {
+                findings.Add($"citation_page_map_artifact_unverified:{citation.AnchorId}");
+                valid = false;
+                continue;
+            }
+
             if (!artifactBytes.TryGetValue(citation.PageMapArtifactId, out var pageMapBytes))
             {
                 findings.Add($"citation_page_map_bytes_missing:{citation.AnchorId}");
                 valid = false;
                 continue;
             }
-            try
+            if (!pageMapCache.TryGetValue(citation.PageMapArtifactId, out var cachedMap))
             {
-                // Strict JSON/duplicate-property gate only; the map digest remains over raw bytes.
-                _ = DeliveryReceiptCanonicalJson.CanonicalizeBounded(
-                    pageMapBytes, limits, limits.MaxPageMapBytes,
-                    "page_map_resource_limit");
-                var pageMap = DocxSessionJson.ParsePageMap(Encoding.UTF8.GetString(pageMapBytes));
-                var mapValidation = PageMapContract.ValidatePortable(
-                    pageMap, citation.DocumentVersion, citation.RendererFingerprint);
-                if (!mapValidation.Success)
+                try
                 {
-                    findings.Add($"invalid_page_map_artifact:{citation.AnchorId}");
-                    valid = false;
-                    continue;
+                    // Strict JSON/duplicate-property gate only; the map digest remains over raw
+                    // bytes already authenticated by VerifyArtifacts.
+                    _ = DeliveryReceiptCanonicalJson.CanonicalizeBounded(
+                        pageMapBytes, limits, limits.MaxPageMapBytes,
+                        "page_map_resource_limit");
+                    var parsedMap = DocxSessionJson.ParsePageMap(
+                        Encoding.UTF8.GetString(pageMapBytes));
+                    var mapValidation = PageMapContract.ValidatePortable(
+                        parsedMap, citation.DocumentVersion, citation.RendererFingerprint);
+                    cachedMap = mapValidation.Success
+                        ? (parsedMap, null)
+                        : (null, "invalid_page_map_artifact");
                 }
-                var projected = PageMapContract.ProjectCitation(
-                    pageMap,
+                catch (DeliveryReceiptValidationException ex)
+                {
+                    cachedMap = (null, ex.Code);
+                }
+                catch (Exception ex) when (ex is JsonException or FormatException)
+                {
+                    cachedMap = (null, "invalid_page_map_artifact");
+                }
+                pageMapCache.Add(citation.PageMapArtifactId, cachedMap);
+            }
+            if (cachedMap.Map is null)
+            {
+                findings.Add($"{cachedMap.Finding}:{citation.AnchorId}");
+                valid = false;
+                continue;
+            }
+
+            var projectionKey = (citation.PageMapArtifactId, citation.AnchorId);
+            if (!projectionCache.TryGetValue(projectionKey, out var projected))
+            {
+                projected = PageMapContract.ProjectCitation(
+                    cachedMap.Map,
                     citation.AnchorId,
                     new PageCitationRequest(
                         citation.DocumentVersion, citation.RendererFingerprint));
-                if (projected.Availability != PageMapAvailability.Available
-                    || !CitationCoordinatesEqual(citation, projected)
-                    || projected.Fragments.Any(fragment =>
-                        !PageMapContract.StoryMatchesScope(fragment.Story, citation.Scope)))
-                {
-                    findings.Add($"citation_page_map_projection_mismatch:{citation.AnchorId}");
-                    valid = false;
-                }
+                projectionCache.Add(projectionKey, projected);
             }
-            catch (DeliveryReceiptValidationException ex)
+            if (projected.Availability != PageMapAvailability.Available
+                || !CitationCoordinatesEqual(citation, projected)
+                || projected.Fragments.Any(fragment =>
+                    !PageMapContract.StoryMatchesScope(fragment.Story, citation.Scope)))
             {
-                findings.Add(ex.Code);
-                valid = false;
-            }
-            catch (Exception ex) when (ex is JsonException or FormatException)
-            {
-                findings.Add($"invalid_page_map_artifact:{citation.AnchorId}");
+                findings.Add($"citation_page_map_projection_mismatch:{citation.AnchorId}");
                 valid = false;
             }
         }
@@ -1543,9 +2189,8 @@ public static class DeliveryChangeReceiptVerifier
     private static void ValidateDocument(DeliveryDocumentIdentity document)
     {
         ArgumentNullException.ThrowIfNull(document);
-        if (document.DocumentVersion < 0)
-            throw new DeliveryReceiptValidationException(
-                "invalid_document_version", "Document version cannot be negative.");
+        DeliveryReceiptValidation.ValidatePortableNonNegativeInteger(
+            document.DocumentVersion, "invalid_document_version", "Document version");
         if (!DeliveryPackageManifestAdapter.IsSupportedSchema(
                 document.PackageManifestSchema))
         {
@@ -1554,6 +2199,13 @@ public static class DeliveryChangeReceiptVerifier
         }
         DeliveryReceiptValidation.RequireNonBlank(
             document.PackageKind, "document package kind", 256);
+        if (!string.Equals(document.PackageKind, "opc", StringComparison.Ordinal))
+        {
+            throw new DeliveryReceiptValidationException(
+                "not_wordprocessing_package", "Document identity must be an OPC package.");
+        }
+        DeliveryReceiptValidation.RequireOpcMainDocumentUri(
+            document.MainDocumentUri, "main document URI");
         DeliveryReceiptValidation.ValidateDigest(
             document.RawPackageBytesDigest, "document package digest");
         DeliveryReceiptValidation.ValidateOptionalDigest(
@@ -1625,6 +2277,15 @@ public static class DeliveryChangeReceiptVerifier
     }
 
     private static DeliveryReceiptVerificationResult Malformed(string finding) => new()
+    {
+        IsValid = false,
+        ReceiptDigestValid = false,
+        ContractValid = false,
+        CitationBindingsValid = false,
+        Findings = new[] { finding },
+    };
+
+    private static DeliveryReceiptVerificationResult IntegrityFailure(string finding) => new()
     {
         IsValid = false,
         ReceiptDigestValid = false,

--- a/Docxodus/Verification/DeliveryReceiptVerifier.cs
+++ b/Docxodus/Verification/DeliveryReceiptVerifier.cs
@@ -1,0 +1,1631 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Text;
+using System.Text.Json;
+using Docxodus.Internal;
+
+namespace Docxodus.Verification;
+
+public enum DeliveryArtifactVerificationStatus
+{
+    Verified,
+    Unavailable,
+    Missing,
+    LengthMismatch,
+    DigestMismatch,
+    InvalidRecord,
+}
+
+public sealed record DeliveryArtifactVerification
+{
+    required public string ArtifactId { get; init; }
+    required public DeliveryArtifactVerificationStatus Status { get; init; }
+    public long? ExpectedLength { get; init; }
+    public long? ActualLength { get; init; }
+    public VerificationDigest? ExpectedDigest { get; init; }
+    public VerificationDigest? ActualDigest { get; init; }
+}
+
+public sealed record DeliveryReceiptVerificationResult
+{
+    required public bool IsValid { get; init; }
+    required public bool ReceiptDigestValid { get; init; }
+    required public bool ContractValid { get; init; }
+    required public bool CitationBindingsValid { get; init; }
+    public IReadOnlyList<DeliveryArtifactVerification> Artifacts { get; init; } =
+        Array.Empty<DeliveryArtifactVerification>();
+    public IReadOnlyList<string> Findings { get; init; } = Array.Empty<string>();
+}
+
+/// <summary>Verifies receipt integrity first, then independently verifies every available artifact.</summary>
+public static class DeliveryChangeReceiptVerifier
+{
+    public static DeliveryReceiptVerificationResult Verify(
+        DeliveryChangeReceipt receipt,
+        IReadOnlyDictionary<string, byte[]> artifactBytes,
+        DeliveryReceiptVerificationOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(receipt);
+        ArgumentNullException.ThrowIfNull(artifactBytes);
+        var limits = (options ?? new DeliveryReceiptVerificationOptions())
+            .ValidateAndClone().Limits;
+        try
+        {
+            DeliveryReceiptResourceValidator.ValidateArtifacts(artifactBytes, limits);
+            DeliveryReceiptResourceValidator.ValidatePayload(receipt.Payload, limits);
+            var canonicalPayload = DeliveryChangeReceiptSerializer.SerializePayload(
+                receipt.Payload, limits);
+            var digestValid = DeliveryReceiptCanonicalJson.FixedTimeEquals(
+                receipt.ReceiptDigest, canonicalPayload);
+            return VerifyCore(
+                receipt.Payload, receipt.ReceiptDigest, digestValid, artifactBytes, limits);
+        }
+        catch (DeliveryReceiptValidationException ex) when (IsResourceLimitCode(ex.Code))
+        {
+            return Rejected(ex.Code);
+        }
+        catch (Exception ex) when (IsMalformedReceiptException(ex))
+        {
+            return Malformed($"malformed_receipt:{ex.GetType().Name}");
+        }
+    }
+
+    /// <summary>
+    /// Parse and verify a portable JSON receipt. Unknown optional properties remain covered by
+    /// the raw canonical payload digest even though this v1 reader ignores them semantically.
+    /// </summary>
+    public static DeliveryReceiptVerificationResult VerifyJson(
+        ReadOnlySpan<byte> receiptJson,
+        IReadOnlyDictionary<string, byte[]> artifactBytes,
+        DeliveryReceiptVerificationOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(artifactBytes);
+        var limits = (options ?? new DeliveryReceiptVerificationOptions())
+            .ValidateAndClone().Limits;
+        try
+        {
+            DeliveryReceiptResourceValidator.ValidateArtifacts(artifactBytes, limits);
+            var canonicalEnvelope = DeliveryReceiptCanonicalJson.CanonicalizeBounded(
+                receiptJson, limits, limits.MaxReceiptJsonBytes, "receipt_resource_limit");
+            using var document = JsonDocument.Parse(canonicalEnvelope, new JsonDocumentOptions
+            {
+                AllowTrailingCommas = false,
+                CommentHandling = JsonCommentHandling.Disallow,
+                MaxDepth = limits.MaxJsonDepth,
+            });
+            if (document.RootElement.ValueKind != JsonValueKind.Object
+                || document.RootElement.EnumerateObject().Any(property =>
+                    property.Name is not ("payload" or "receiptDigest"))
+                || !document.RootElement.TryGetProperty("payload", out var payloadElement)
+                || payloadElement.ValueKind != JsonValueKind.Object
+                || !document.RootElement.TryGetProperty("receiptDigest", out var digestElement)
+                || digestElement.ValueKind != JsonValueKind.Object)
+            {
+                return Malformed("malformed_envelope");
+            }
+
+            var digest = ReadDigest(digestElement);
+            var canonicalPayload = DeliveryReceiptCanonicalJson.SerializeCanonicalBounded(
+                payloadElement, limits, limits.MaxReceiptJsonBytes, "receipt_resource_limit");
+            var digestValid = DeliveryReceiptCanonicalJson.FixedTimeEquals(digest, canonicalPayload);
+            var jsonOptions = new JsonSerializerOptions(DeliveryReceiptCanonicalJson.JsonOptions)
+            {
+                MaxDepth = limits.MaxJsonDepth,
+            };
+            var payload = JsonSerializer.Deserialize<DeliveryChangeReceiptPayload>(
+                payloadElement.GetRawText(), jsonOptions);
+            if (payload is null)
+                return Malformed("missing_payload");
+            DeliveryReceiptResourceValidator.ValidatePayload(payload, limits);
+            return VerifyCore(payload, digest, digestValid, artifactBytes, limits);
+        }
+        catch (DeliveryReceiptValidationException ex) when (IsResourceLimitCode(ex.Code))
+        {
+            return Rejected(ex.Code);
+        }
+        catch (Exception ex) when (IsMalformedReceiptException(ex))
+        {
+            return Malformed($"malformed_receipt:{ex.GetType().Name}");
+        }
+    }
+
+    public static DeliveryReceiptVerificationResult VerifyJson(
+        string receiptJson,
+        IReadOnlyDictionary<string, byte[]> artifactBytes,
+        DeliveryReceiptVerificationOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(receiptJson);
+        var validatedOptions = (options ?? new DeliveryReceiptVerificationOptions())
+            .ValidateAndClone();
+        if (Encoding.UTF8.GetByteCount(receiptJson)
+            > validatedOptions.Limits.MaxReceiptJsonBytes)
+        {
+            return Rejected("receipt_resource_limit");
+        }
+        return VerifyJson(Encoding.UTF8.GetBytes(receiptJson), artifactBytes, validatedOptions);
+    }
+
+    private static DeliveryReceiptVerificationResult VerifyCore(
+        DeliveryChangeReceiptPayload payload,
+        VerificationDigest receiptDigest,
+        bool digestValid,
+        IReadOnlyDictionary<string, byte[]> artifactBytes,
+        DeliveryReceiptLimits limits)
+    {
+        var findings = new List<string>();
+        var lineageValidation = DeliveryReceiptLineageValidator.Validate(
+            payload.SourceDocument,
+            payload.DeliveredDocument,
+            payload.Transactions,
+            payload.Lineage);
+        bool contractValid = ValidateContract(
+            payload, receiptDigest, artifactBytes, lineageValidation, limits, findings);
+        var artifactResults = VerifyArtifacts(payload.Artifacts, artifactBytes, limits, findings);
+        bool artifactsValid = artifactResults.All(result => result.Status is
+            DeliveryArtifactVerificationStatus.Verified
+            or DeliveryArtifactVerificationStatus.Unavailable);
+        bool citationsValid = ValidateCitationBindings(
+            payload, artifactBytes, lineageValidation, limits, findings);
+        if (!digestValid)
+            findings.Add("receipt_digest_mismatch");
+
+        return new DeliveryReceiptVerificationResult
+        {
+            IsValid = digestValid && contractValid && artifactsValid && citationsValid,
+            ReceiptDigestValid = digestValid,
+            ContractValid = contractValid,
+            CitationBindingsValid = citationsValid,
+            Artifacts = artifactResults,
+            Findings = findings.Distinct(StringComparer.Ordinal).ToArray(),
+        };
+    }
+
+    private static bool ValidateContract(
+        DeliveryChangeReceiptPayload payload,
+        VerificationDigest receiptDigest,
+        IReadOnlyDictionary<string, byte[]> artifactBytes,
+        DeliveryLineageValidationResult lineageValidation,
+        DeliveryReceiptLimits limits,
+        ICollection<string> findings)
+    {
+        bool valid = true;
+        if (!string.Equals(payload.Schema, DeliveryChangeReceiptPayload.SchemaId,
+                StringComparison.Ordinal)
+            || payload.SchemaVersion != 1)
+        {
+            findings.Add("unsupported_receipt_schema");
+            valid = false;
+        }
+        if (!string.Equals(payload.Canonicalization,
+                DeliveryChangeReceiptPayload.CanonicalizationId, StringComparison.Ordinal))
+        {
+            findings.Add("unsupported_canonicalization");
+            valid = false;
+        }
+        if (!Enum.IsDefined(payload.PrivacyProfile))
+        {
+            findings.Add("unknown_privacy_profile");
+            valid = false;
+        }
+        try
+        {
+            DeliveryReceiptValidation.ValidateDigest(receiptDigest, "receipt digest");
+            ValidateDocument(payload.SourceDocument);
+            ValidateDocument(payload.DeliveredDocument);
+        }
+        catch (DeliveryReceiptValidationException ex)
+        {
+            findings.Add(ex.Code);
+            valid = false;
+        }
+
+        if (payload.HasUnexpectedChanges != payload.PackageChanges.Any(change =>
+                change.Disposition == DeliveryChangeDisposition.Unexpected))
+        {
+            findings.Add("unexpected_change_flag_mismatch");
+            valid = false;
+        }
+        if (payload.Transactions.Select(entry => entry.EntryId)
+            .Distinct(StringComparer.Ordinal).Count() != payload.Transactions.Count)
+        {
+            findings.Add("duplicate_transaction_entry");
+            valid = false;
+        }
+        var transactionIds = payload.Transactions.Where(entry => entry.TransactionId is not null)
+            .Select(entry => entry.TransactionId!);
+        if (transactionIds.Distinct(StringComparer.Ordinal).Count() != transactionIds.Count())
+        {
+            findings.Add("duplicate_transaction_id");
+            valid = false;
+        }
+        if (payload.Artifacts.Select(artifact => artifact.ArtifactId)
+            .Distinct(StringComparer.Ordinal).Count() != payload.Artifacts.Count)
+        {
+            findings.Add("duplicate_artifact_id");
+            valid = false;
+        }
+        if (!IsStrictlyOrdered(payload.Transactions,
+                static (left, right) => left.Sequence.CompareTo(right.Sequence)))
+        {
+            findings.Add("transaction_order_mismatch");
+            valid = false;
+        }
+        if (!IsStrictlyOrdered(payload.Lineage,
+                static (left, right) => left.Sequence.CompareTo(right.Sequence)))
+        {
+            findings.Add("lineage_order_mismatch");
+            valid = false;
+        }
+        if (!IsStrictlyOrdered(payload.Artifacts,
+                static (left, right) => string.CompareOrdinal(
+                    left.ArtifactId, right.ArtifactId)))
+        {
+            findings.Add("artifact_order_mismatch");
+            valid = false;
+        }
+        if (!IsStrictlyOrdered(payload.PackageChanges, ComparePackageChanges))
+        {
+            findings.Add("package_change_order_mismatch");
+            valid = false;
+        }
+        if (!IsStrictlyOrdered(payload.PageCitations, CompareCitations))
+        {
+            findings.Add("citation_order_mismatch");
+            valid = false;
+        }
+        if (!IsStrictlyOrdered(payload.Evidence, CompareEvidence))
+        {
+            findings.Add("evidence_order_mismatch");
+            valid = false;
+        }
+        if (!IsStrictlyOrdered(payload.Warnings, CompareTextEvidence))
+        {
+            findings.Add("warning_order_mismatch");
+            valid = false;
+        }
+
+        foreach (var transaction in payload.Transactions)
+            valid &= ValidateTransaction(transaction, payload.PrivacyProfile, findings);
+        foreach (var lineageEvent in payload.Lineage)
+        {
+            if (lineageEvent.Sequence < 0)
+            {
+                findings.Add("invalid_lineage_sequence");
+                valid = false;
+            }
+            if (!Enum.IsDefined(lineageEvent.Action))
+            {
+                findings.Add("unknown_lineage_action");
+                valid = false;
+            }
+            try
+            {
+                DeliveryReceiptValidation.RequireNonBlank(
+                    lineageEvent.AffectedEntryId, "lineage entry id", 256);
+                ValidateDocument(lineageEvent.BeforeDocument);
+                ValidateDocument(lineageEvent.AfterDocument);
+            }
+            catch (DeliveryReceiptValidationException ex)
+            {
+                findings.Add(ex.Code);
+                valid = false;
+            }
+        }
+        if (!lineageValidation.IsValid)
+        {
+            foreach (var finding in lineageValidation.Findings)
+                findings.Add(finding);
+            valid = false;
+        }
+        foreach (var change in payload.PackageChanges)
+            valid &= ValidatePackageChange(change, payload.PrivacyProfile, findings);
+        if (payload.PackageChanges.Select(change => change.ChangeId)
+            .Distinct(StringComparer.Ordinal).Count() != payload.PackageChanges.Count)
+        {
+            findings.Add("duplicate_package_change_id");
+            valid = false;
+        }
+        var transactionsByEntryId = payload.Transactions
+            .GroupBy(transaction => transaction.EntryId, StringComparer.Ordinal)
+            .Where(group => group.Count() == 1)
+            .ToDictionary(group => group.Key, group => group.Single(), StringComparer.Ordinal);
+        foreach (var change in payload.PackageChanges)
+        {
+            if (change.Disposition == DeliveryChangeDisposition.UserRequested
+                && (change.TransactionEntryId is null
+                    || change.RequestedOperationIndex is null))
+            {
+                findings.Add("invalid_package_change_attribution");
+                valid = false;
+                continue;
+            }
+            if (change.TransactionEntryId is null)
+            {
+                if (change.RequestedOperationIndex is not null)
+                {
+                    findings.Add("invalid_package_change_attribution");
+                    valid = false;
+                }
+                continue;
+            }
+            if (!transactionsByEntryId.TryGetValue(change.TransactionEntryId, out var transaction)
+                || transaction.Status is not (DeliveryTransactionStatus.Committed
+                    or DeliveryTransactionStatus.PartiallyCommitted)
+                || (change.RequestedOperationIndex is { } operationIndex
+                    && (operationIndex < 0 || operationIndex >= transaction.Operations.Count
+                        || transaction.Operations[operationIndex].ExecutionStatus
+                            != DeliveryOperationExecutionStatus.Succeeded)))
+            {
+                findings.Add("invalid_package_change_attribution");
+                valid = false;
+            }
+        }
+        foreach (var artifact in payload.Artifacts)
+            valid &= ValidateArtifactRecord(artifact, findings);
+
+        var artifactsById = payload.Artifacts
+            .GroupBy(artifact => artifact.ArtifactId, StringComparer.Ordinal)
+            .Where(group => group.Count() == 1)
+            .ToDictionary(group => group.Key, group => group.Single(), StringComparer.Ordinal);
+        valid &= ValidateRequiredCleanDocx(payload, artifactBytes, limits, findings);
+        valid &= ValidateSemanticBindings(
+            payload, artifactsById, artifactBytes, lineageValidation, limits, findings);
+        foreach (var evidence in payload.Evidence)
+        {
+            if (!Enum.IsDefined(evidence.Kind))
+            {
+                findings.Add("unknown_evidence_kind");
+                valid = false;
+            }
+            if (evidence.Kind == DeliveryEvidenceKind.SemanticChangeSet)
+            {
+                findings.Add("semantic_evidence_requires_typed_factory");
+                valid = false;
+            }
+            try { DeliveryReceiptValidation.ValidateDigest(evidence.Digest, "evidence digest"); }
+            catch (DeliveryReceiptValidationException ex)
+            {
+                findings.Add(ex.Code);
+                valid = false;
+            }
+            try
+            {
+                DeliveryReceiptValidation.RequireNonBlank(
+                    evidence.Schema, "evidence schema", 2048);
+                if (evidence.ArtifactId is not null)
+                {
+                    DeliveryReceiptValidation.RequireNonBlank(
+                        evidence.ArtifactId, "evidence artifact id", 256);
+                }
+            }
+            catch (DeliveryReceiptValidationException ex)
+            {
+                findings.Add(ex.Code);
+                valid = false;
+            }
+            if (evidence.ArtifactId is { } artifactId)
+            {
+                var expectedRole = evidence.Kind switch
+                {
+                    DeliveryEvidenceKind.SemanticChangeSet => DeliveryArtifactRole.SemanticDiff,
+                    DeliveryEvidenceKind.ValidationResult => DeliveryArtifactRole.ValidationReport,
+                    DeliveryEvidenceKind.RedlineReversibility =>
+                        DeliveryArtifactRole.ReversibilityProof,
+                    _ => (DeliveryArtifactRole?)null,
+                };
+                if (!artifactsById.TryGetValue(artifactId, out var artifact)
+                    || artifact.Digest is null
+                    || artifact.Availability != DeliveryArtifactAvailability.Available
+                    || artifact.Role != expectedRole
+                    || !DeliveryReceiptValidation.DigestEquals(artifact.Digest, evidence.Digest))
+                {
+                    findings.Add("evidence_artifact_binding_mismatch");
+                    valid = false;
+                }
+            }
+            if (payload.PrivacyProfile == DeliveryReceiptPrivacyProfile.HashOnly
+                && evidence.Summary is not null)
+            {
+                findings.Add("privacy_profile_violation");
+                valid = false;
+            }
+        }
+        foreach (var warning in payload.Warnings)
+            valid &= ValidateTextEvidence(warning, payload.PrivacyProfile, findings);
+        return valid;
+    }
+
+    private static bool ValidateTransaction(
+        DeliveryTransactionEntry transaction,
+        DeliveryReceiptPrivacyProfile privacyProfile,
+        ICollection<string> findings)
+    {
+        bool valid = true;
+        if (transaction.Sequence < 0)
+        {
+            findings.Add("invalid_lineage_sequence");
+            valid = false;
+        }
+        if (!Enum.IsDefined(transaction.Mode) || !Enum.IsDefined(transaction.Status))
+        {
+            findings.Add("unknown_transaction_enum");
+            valid = false;
+        }
+        try
+        {
+            DeliveryTransactionContribution.ValidateFingerprint(transaction.EntryId);
+            DeliveryTransactionContribution.ValidateFingerprint(transaction.RequestFingerprint);
+            if (transaction.TransactionId is not null)
+            {
+                DeliveryReceiptValidation.RequireNonBlank(
+                    transaction.TransactionId, "transaction id", 1024);
+            }
+            ValidateDocument(transaction.BeforeDocument);
+            ValidateDocument(transaction.AfterDocument);
+        }
+        catch (DeliveryReceiptValidationException ex)
+        {
+            findings.Add(ex.Code);
+            valid = false;
+        }
+        if (transaction.BaseVersion < 0 || transaction.ResultVersion < 0
+            || transaction.BeforeDocument.DocumentVersion != transaction.BaseVersion
+            || transaction.AfterDocument.DocumentVersion != transaction.ResultVersion)
+        {
+            findings.Add("transaction_version_mismatch");
+            valid = false;
+        }
+
+        if (!Enum.IsDefined(transaction.Status)
+            || !ValidateTransactionOutcome(transaction, findings))
+        {
+            valid = false;
+        }
+        var expectedEntryId = DeliveryReceiptCanonicalJson.DigestToken(
+            DeliveryReceiptCanonicalJson.SerializeCanonical(new
+            {
+                afterPackage = transaction.AfterDocument.RawPackageBytesDigest,
+                baseVersion = transaction.BaseVersion,
+                beforePackage = transaction.BeforeDocument.RawPackageBytesDigest,
+                requestFingerprint = transaction.RequestFingerprint,
+                resultVersion = transaction.ResultVersion,
+            }));
+        if (!string.Equals(transaction.EntryId, expectedEntryId, StringComparison.Ordinal))
+        {
+            findings.Add("transaction_entry_id_mismatch");
+            valid = false;
+        }
+
+        for (int i = 0; i < transaction.Operations.Count; i++)
+        {
+            var operation = transaction.Operations[i];
+            if (operation.Index != i)
+            {
+                findings.Add("operation_order_mismatch");
+                valid = false;
+            }
+            if (!Enum.IsDefined(operation.ExecutionStatus)
+                || !OperationShapeMatchesStatus(operation))
+            {
+                findings.Add("invalid_operation_execution");
+                valid = false;
+            }
+            if (operation.ExecutionStatus != DeliveryOperationExecutionStatus.NotExecuted
+                && operation.Success != operation.Results.All(result => result.Success))
+            {
+                findings.Add("operation_success_mismatch");
+                valid = false;
+            }
+            try
+            {
+                DeliveryReceiptValidation.RequireNonBlank(operation.Tool, "operation tool", 256);
+                DeliveryReceiptValidation.RequireNonBlank(operation.Action, "operation action", 256);
+                DeliveryReceiptValidation.ValidateDigest(
+                    operation.ArgumentsDigest, "operation arguments digest");
+            }
+            catch (DeliveryReceiptValidationException ex)
+            {
+                findings.Add(ex.Code);
+                valid = false;
+            }
+            bool requiresFullEvidence =
+                privacyProfile == DeliveryReceiptPrivacyProfile.FullEvidence;
+            if ((privacyProfile == DeliveryReceiptPrivacyProfile.HashOnly
+                    && operation.ArgumentsSummary is not null)
+                || (privacyProfile != DeliveryReceiptPrivacyProfile.HashOnly
+                    && operation.ArgumentsSummary is null)
+                || (!requiresFullEvidence && operation.Arguments is not null)
+                || (requiresFullEvidence && operation.Arguments is null))
+            {
+                findings.Add("privacy_profile_violation");
+                valid = false;
+            }
+            if (operation.Arguments is { } arguments)
+            {
+                if (arguments.ValueKind != JsonValueKind.Object
+                    || !DeliveryReceiptValidation.DigestEquals(
+                        operation.ArgumentsDigest,
+                        DeliveryReceiptCanonicalJson.Digest(
+                            DeliveryReceiptCanonicalJson.SerializeCanonical(arguments))))
+                {
+                    findings.Add("operation_arguments_digest_mismatch");
+                    valid = false;
+                }
+            }
+            foreach (var result in operation.Results)
+            {
+                try
+                {
+                    DeliveryReceiptValidation.ValidateDigest(
+                        result.ResultDigest, "operation result digest");
+                }
+                catch (DeliveryReceiptValidationException ex)
+                {
+                    findings.Add(ex.Code);
+                    valid = false;
+                }
+                if (result.ErrorMessage is not null)
+                    valid &= ValidateTextEvidence(result.ErrorMessage, privacyProfile, findings);
+                bool errorShapeValid = result.Success
+                    ? result.ErrorCode is null && result.ErrorMessage is null
+                    : result.ErrorCode is not null
+                        && Enum.TryParse<EditErrorCode>(
+                            result.ErrorCode, ignoreCase: false, out var errorCode)
+                        && Enum.IsDefined(errorCode)
+                        && result.ErrorMessage is not null;
+                if (!errorShapeValid)
+                {
+                    findings.Add("invalid_operation_result");
+                    valid = false;
+                }
+                if ((!requiresFullEvidence && result.FullResult is not null)
+                    || (requiresFullEvidence && result.FullResult is null))
+                {
+                    findings.Add("privacy_profile_violation");
+                    valid = false;
+                }
+                if (result.FullResult is { } fullResult
+                    && (!DeliveryReceiptValidation.DigestEquals(
+                            result.ResultDigest,
+                            DeliveryReceiptCanonicalJson.Digest(
+                                DeliveryReceiptCanonicalJson.SerializeCanonical(fullResult)))
+                        || fullResult.ValueKind != JsonValueKind.Object
+                        || !fullResult.TryGetProperty("success", out var fullSuccess)
+                        || fullSuccess.ValueKind is not
+                            (JsonValueKind.True or JsonValueKind.False)
+                        || fullSuccess.GetBoolean() != result.Success))
+                {
+                    findings.Add("operation_result_digest_mismatch");
+                    valid = false;
+                }
+                foreach (var change in result.ObjectChanges)
+                {
+                    if (!Enum.IsDefined(change.ChangeKind))
+                    {
+                        findings.Add("unknown_object_change_kind");
+                        valid = false;
+                    }
+                    try
+                    {
+                        DeliveryReceiptValidation.RequireNonBlank(
+                            change.AnchorId, "changed anchor id", 4096);
+                        DeliveryReceiptValidation.RequireNonBlank(change.Kind, "anchor kind", 256);
+                        DeliveryReceiptValidation.RequireNonBlank(change.Scope, "anchor scope", 1024);
+                        DeliveryReceiptValidation.RequireNonBlank(change.Unid, "anchor unid", 2048);
+                    }
+                    catch (DeliveryReceiptValidationException ex)
+                    {
+                        findings.Add(ex.Code);
+                        valid = false;
+                    }
+                }
+                if (!IsStrictlyOrdered(
+                        result.ObjectChanges,
+                        CompareObjectChanges))
+                {
+                    findings.Add("object_change_order_mismatch");
+                    valid = false;
+                }
+            }
+        }
+
+        foreach (var change in transaction.AuthoredChanges)
+        {
+            if (!Enum.IsDefined(change.EntityKind) || !Enum.IsDefined(change.ChangeKind))
+            {
+                findings.Add("unknown_authored_change_enum");
+                valid = false;
+            }
+            try
+            {
+                DeliveryReceiptValidation.RequireNonBlank(
+                    change.EntityId, "authored entity id", 2048);
+                DeliveryReceiptValidation.ValidateDigest(
+                    change.SourceDigest, "authored evidence digest");
+            }
+            catch (DeliveryReceiptValidationException ex)
+            {
+                findings.Add(ex.Code);
+                valid = false;
+            }
+            if (change.Text is not null)
+                valid &= ValidateTextEvidence(change.Text, privacyProfile, findings);
+            bool requiresFullEvidence =
+                privacyProfile == DeliveryReceiptPrivacyProfile.FullEvidence;
+            if ((!requiresFullEvidence && change.FullEvidence is not null)
+                || (requiresFullEvidence && change.FullEvidence is null))
+            {
+                findings.Add("privacy_profile_violation");
+                valid = false;
+            }
+            if (change.FullEvidence is { } fullEvidence
+                && !DeliveryReceiptValidation.DigestEquals(
+                    change.SourceDigest,
+                    DeliveryReceiptCanonicalJson.Digest(
+                        DeliveryReceiptCanonicalJson.SerializeCanonical(fullEvidence))))
+            {
+                findings.Add("authored_evidence_digest_mismatch");
+                valid = false;
+            }
+            if (!IsStrictlyOrdered(
+                    change.AffectedAnchorIds,
+                    static (left, right) => string.CompareOrdinal(left, right)))
+            {
+                findings.Add("affected_anchor_order_mismatch");
+                valid = false;
+            }
+        }
+        if (!IsStrictlyOrdered(transaction.AuthoredChanges, CompareAuthoredChanges))
+        {
+            findings.Add("authored_change_order_mismatch");
+            valid = false;
+        }
+        foreach (var warning in transaction.Warnings)
+            valid &= ValidateTextEvidence(warning, privacyProfile, findings);
+        if (!IsStrictlyOrdered(transaction.Warnings, CompareTextEvidence))
+        {
+            findings.Add("transaction_warning_order_mismatch");
+            valid = false;
+        }
+        return valid;
+    }
+
+    private static bool ValidateTransactionOutcome(
+        DeliveryTransactionEntry transaction,
+        ICollection<string> findings)
+    {
+        bool valid = transaction.Status switch
+        {
+            DeliveryTransactionStatus.Committed =>
+                transaction.Operations.All(operation => operation.ExecutionStatus
+                    == DeliveryOperationExecutionStatus.Succeeded),
+            DeliveryTransactionStatus.PartiallyCommitted =>
+                transaction.Mode == MutationBatchMode.BestEffort
+                && transaction.Operations.Any(operation => operation.ExecutionStatus
+                    == DeliveryOperationExecutionStatus.Succeeded)
+                && transaction.Operations.Any(operation => operation.ExecutionStatus
+                    == DeliveryOperationExecutionStatus.Failed)
+                && transaction.Operations.All(operation => operation.ExecutionStatus is
+                    DeliveryOperationExecutionStatus.Succeeded
+                    or DeliveryOperationExecutionStatus.Failed),
+            DeliveryTransactionStatus.Failed when transaction.Mode == MutationBatchMode.Atomic =>
+                ValidFailedAtomicOperations(transaction.Operations),
+            DeliveryTransactionStatus.Failed when transaction.Mode == MutationBatchMode.BestEffort =>
+                transaction.Operations.Count > 0
+                && transaction.Operations.All(operation => operation.ExecutionStatus
+                    == DeliveryOperationExecutionStatus.Failed),
+            DeliveryTransactionStatus.Prediction when transaction.Mode == MutationBatchMode.Atomic =>
+                transaction.TransactionId is null
+                && (transaction.Operations.All(operation => operation.ExecutionStatus
+                        == DeliveryOperationExecutionStatus.Succeeded)
+                    || ValidFailedAtomicOperations(transaction.Operations)),
+            DeliveryTransactionStatus.Prediction when transaction.Mode == MutationBatchMode.BestEffort =>
+                transaction.TransactionId is null
+                && transaction.Operations.All(operation => operation.ExecutionStatus is
+                    DeliveryOperationExecutionStatus.Succeeded
+                    or DeliveryOperationExecutionStatus.Failed),
+            _ => false,
+        };
+        if (!valid)
+            findings.Add("transaction_outcome_mismatch");
+        return valid;
+    }
+
+    private static bool ValidFailedAtomicOperations(
+        IReadOnlyList<DeliveryOperationEvidence> operations)
+    {
+        var failures = operations
+            .Where(operation => operation.ExecutionStatus
+                == DeliveryOperationExecutionStatus.FailedRolledBack)
+            .ToArray();
+        if (failures.Length != 1)
+            return false;
+        int failedIndex = failures[0].Index;
+        var preceding = operations.Take(failedIndex).ToArray();
+        bool preflightFailure = preceding.All(operation => operation.ExecutionStatus
+            == DeliveryOperationExecutionStatus.NotExecuted);
+        bool executionFailure = preceding.All(operation => operation.ExecutionStatus
+            == DeliveryOperationExecutionStatus.SucceededRolledBack);
+        return (preflightFailure || executionFailure)
+            && operations.Skip(failedIndex + 1).All(operation => operation.ExecutionStatus
+                == DeliveryOperationExecutionStatus.NotExecuted);
+    }
+
+    private static bool OperationShapeMatchesStatus(DeliveryOperationEvidence operation) =>
+        operation.ExecutionStatus switch
+        {
+            DeliveryOperationExecutionStatus.NotExecuted =>
+                !operation.Success && !operation.RolledBack && operation.Results.Count == 0,
+            DeliveryOperationExecutionStatus.Succeeded =>
+                operation.Success && !operation.RolledBack,
+            DeliveryOperationExecutionStatus.Failed =>
+                !operation.Success && !operation.RolledBack && operation.Results.Count > 0,
+            DeliveryOperationExecutionStatus.SucceededRolledBack =>
+                operation.Success && operation.RolledBack,
+            DeliveryOperationExecutionStatus.FailedRolledBack =>
+                !operation.Success && operation.RolledBack && operation.Results.Count > 0,
+            _ => false,
+        };
+
+    private static bool IsStrictlyOrdered<T>(
+        IReadOnlyList<T> values,
+        Comparison<T> comparison)
+    {
+        for (int i = 1; i < values.Count; i++)
+        {
+            if (comparison(values[i - 1], values[i]) >= 0)
+                return false;
+        }
+        return true;
+    }
+
+    private static int ComparePackageChanges(
+        DeliveryPackageChange left,
+        DeliveryPackageChange right)
+    {
+        int comparison = left.Kind.CompareTo(right.Kind);
+        if (comparison != 0) return comparison;
+        comparison = string.CompareOrdinal(left.Location.EntryUri, right.Location.EntryUri);
+        if (comparison != 0) return comparison;
+        comparison = string.CompareOrdinal(left.Location.OwnerUri, right.Location.OwnerUri);
+        if (comparison != 0) return comparison;
+        comparison = string.CompareOrdinal(
+            left.Location.RelationshipId, right.Location.RelationshipId);
+        if (comparison != 0) return comparison;
+        return string.CompareOrdinal(
+            left.Location.PropertyPath, right.Location.PropertyPath);
+    }
+
+    private static int CompareCitations(
+        DeliveryPageCitation left,
+        DeliveryPageCitation right)
+    {
+        int comparison = string.CompareOrdinal(left.AnchorId, right.AnchorId);
+        if (comparison != 0) return comparison;
+        comparison = string.CompareOrdinal(left.RenderArtifactId, right.RenderArtifactId);
+        return comparison != 0
+            ? comparison
+            : string.CompareOrdinal(left.PageMapArtifactId, right.PageMapArtifactId);
+    }
+
+    private static int CompareEvidence(
+        DeliveryEvidenceReference left,
+        DeliveryEvidenceReference right)
+    {
+        int comparison = left.Kind.CompareTo(right.Kind);
+        if (comparison != 0) return comparison;
+        comparison = string.CompareOrdinal(left.Schema, right.Schema);
+        return comparison != 0
+            ? comparison
+            : string.CompareOrdinal(left.Digest.Value, right.Digest.Value);
+    }
+
+    private static int CompareTextEvidence(
+        DeliveryTextEvidence left,
+        DeliveryTextEvidence right) =>
+        string.CompareOrdinal(left.Digest.Value, right.Digest.Value);
+
+    private static int CompareAuthoredChanges(
+        DeliveryAuthoredChange left,
+        DeliveryAuthoredChange right)
+    {
+        int comparison = left.EntityKind.CompareTo(right.EntityKind);
+        if (comparison != 0) return comparison;
+        comparison = left.ChangeKind.CompareTo(right.ChangeKind);
+        return comparison != 0
+            ? comparison
+            : string.CompareOrdinal(left.EntityId, right.EntityId);
+    }
+
+    private static int CompareObjectChanges(
+        DeliveryObjectChange left,
+        DeliveryObjectChange right)
+    {
+        int comparison = left.ChangeKind.CompareTo(right.ChangeKind);
+        return comparison != 0
+            ? comparison
+            : string.CompareOrdinal(left.AnchorId, right.AnchorId);
+    }
+
+    private static bool ValidatePackageChange(
+        DeliveryPackageChange change,
+        DeliveryReceiptPrivacyProfile privacyProfile,
+        ICollection<string> findings)
+    {
+        bool valid = true;
+        if (!Enum.IsDefined(change.Kind) || !Enum.IsDefined(change.Disposition))
+        {
+            findings.Add("unknown_package_change_enum");
+            valid = false;
+        }
+        try
+        {
+            DeliveryTransactionContribution.ValidateFingerprint(change.ChangeId);
+            if (change.Kind is DeliveryPackageChangeKind.PartAdded
+                or DeliveryPackageChangeKind.PartRemoved
+                or DeliveryPackageChangeKind.PartModified)
+            {
+                DeliveryReceiptValidation.RequireNonBlank(
+                    change.Location.EntryUri, "changed entry URI", 4096);
+            }
+            else
+            {
+                DeliveryReceiptValidation.RequireNonBlank(
+                    change.Location.OwnerUri, "relationship owner URI", 4096);
+                DeliveryReceiptValidation.RequireNonBlank(
+                    change.Location.RelationshipId, "relationship id", 2048);
+            }
+            if (change.Disposition == DeliveryChangeDisposition.Derived)
+                DeliveryReceiptValidation.RequireNonBlank(change.Derivation, "derivation", 4096);
+        }
+        catch (DeliveryReceiptValidationException ex)
+        {
+            findings.Add(ex.Code);
+            valid = false;
+        }
+        bool evidenceShapeValid = change.Kind switch
+        {
+            DeliveryPackageChangeKind.PartAdded
+                or DeliveryPackageChangeKind.RelationshipAdded =>
+                change.Before is null && change.After is not null,
+            DeliveryPackageChangeKind.PartRemoved
+                or DeliveryPackageChangeKind.RelationshipRemoved =>
+                change.Before is not null && change.After is null,
+            DeliveryPackageChangeKind.PartModified
+                or DeliveryPackageChangeKind.RelationshipModified =>
+                change.Before is not null && change.After is not null,
+            _ => false,
+        };
+        if (!evidenceShapeValid)
+        {
+            findings.Add("package_change_evidence_mismatch");
+            valid = false;
+        }
+        if (change.Before is not null)
+            valid &= ValidateTextEvidence(change.Before, privacyProfile, findings);
+        if (change.After is not null)
+            valid &= ValidateTextEvidence(change.After, privacyProfile, findings);
+        var expectedChangeId = DeliveryReceiptCanonicalJson.DigestToken(
+            DeliveryReceiptCanonicalJson.SerializeCanonical(new
+            {
+                after = change.After?.Digest,
+                before = change.Before?.Digest,
+                kind = change.Kind.ToString(),
+                location = change.Location,
+            }));
+        if (!string.Equals(change.ChangeId, expectedChangeId, StringComparison.Ordinal))
+        {
+            findings.Add("package_change_id_mismatch");
+            valid = false;
+        }
+        return valid;
+    }
+
+    private static bool ValidateArtifactRecord(
+        DeliveryArtifact artifact,
+        ICollection<string> findings)
+    {
+        bool valid = true;
+        if (!Enum.IsDefined(artifact.Role) || !Enum.IsDefined(artifact.Availability))
+        {
+            findings.Add("unknown_artifact_enum");
+            valid = false;
+        }
+        try
+        {
+            DeliveryReceiptValidation.RequireNonBlank(artifact.ArtifactId, "artifact id", 256);
+            DeliveryReceiptValidation.RequireNonBlank(
+                artifact.MediaType, "artifact media type", 512);
+            DeliveryReceiptValidation.NormalizeRelativePath(artifact.RelativePath);
+            DeliveryReceiptValidation.ValidateOptionalDigest(
+                artifact.PackageDigest, "artifact package digest");
+            DeliveryReceiptValidation.ValidateOptionalDigest(
+                artifact.PageMapDigest, "artifact page-map digest");
+            if (artifact.RendererFingerprint is not null)
+            {
+                DeliveryReceiptValidation.RequireNonBlank(
+                    artifact.RendererFingerprint, "renderer fingerprint", 4096);
+            }
+            if (artifact.DocumentVersion is < 0)
+            {
+                throw new DeliveryReceiptValidationException(
+                    "invalid_document_version", "Artifact document version cannot be negative.");
+            }
+        }
+        catch (DeliveryReceiptValidationException ex)
+        {
+            findings.Add(ex.Code);
+            valid = false;
+        }
+
+        if (artifact.Availability == DeliveryArtifactAvailability.Available)
+        {
+            try { DeliveryReceiptValidation.ValidateDigest(artifact.Digest, "artifact digest"); }
+            catch (DeliveryReceiptValidationException ex)
+            {
+                findings.Add(ex.Code);
+                valid = false;
+            }
+            if (artifact.ByteLength is null or < 0 || artifact.UnavailableReason is not null)
+            {
+                findings.Add("invalid_artifact_record");
+                valid = false;
+            }
+            if (artifact.Role is (DeliveryArtifactRole.CleanDocx
+                    or DeliveryArtifactRole.ReviewDocx)
+                && artifact.PackageDigest is not null
+                && !DeliveryReceiptValidation.DigestEquals(
+                    artifact.Digest, artifact.PackageDigest))
+            {
+                findings.Add("docx_artifact_identity_mismatch");
+                valid = false;
+            }
+        }
+        else if (artifact.Availability == DeliveryArtifactAvailability.Unavailable)
+        {
+            if (artifact.Digest is not null || artifact.ByteLength is not null
+                || string.IsNullOrWhiteSpace(artifact.UnavailableReason))
+            {
+                findings.Add("invalid_artifact_record");
+                valid = false;
+            }
+        }
+        return valid;
+    }
+
+    private static bool ValidateRequiredCleanDocx(
+        DeliveryChangeReceiptPayload payload,
+        IReadOnlyDictionary<string, byte[]> artifactBytes,
+        DeliveryReceiptLimits limits,
+        ICollection<string> findings)
+    {
+        var cleanArtifacts = payload.Artifacts
+            .Where(artifact => artifact.Role == DeliveryArtifactRole.CleanDocx)
+            .ToArray();
+        if (cleanArtifacts.Length != 1)
+        {
+            findings.Add(cleanArtifacts.Length == 0
+                ? "missing_clean_docx"
+                : "multiple_clean_docx_artifacts");
+            return false;
+        }
+
+        var clean = cleanArtifacts[0];
+        if (clean.Availability != DeliveryArtifactAvailability.Available
+            || clean.Digest is null
+            || clean.ByteLength is null
+            || !artifactBytes.TryGetValue(clean.ArtifactId, out var cleanBytes)
+            || clean.ByteLength != cleanBytes.LongLength
+            || clean.DocumentVersion != payload.DeliveredDocument.DocumentVersion
+            || !DeliveryReceiptValidation.DigestEquals(
+                clean.PackageDigest, payload.DeliveredDocument.RawPackageBytesDigest)
+            || !DeliveryReceiptValidation.DigestEquals(
+                clean.Digest, payload.DeliveredDocument.RawPackageBytesDigest)
+            || !DeliveryReceiptValidation.DigestEquals(
+                clean.Digest, DeliveryReceiptCanonicalJson.Digest(cleanBytes)))
+        {
+            findings.Add("clean_docx_delivery_mismatch");
+            return false;
+        }
+
+        try
+        {
+            var actualManifest = PackageManifestGenerator.Generate(
+                cleanBytes, limits.CleanDocxManifestOptions);
+            if (!actualManifest.IsValid
+                || !string.Equals(actualManifest.PackageKind, "opc", StringComparison.Ordinal)
+                || string.IsNullOrWhiteSpace(actualManifest.Facts.MainDocumentUri)
+                || !DeliveryReceiptLineageValidator.DocumentEquals(
+                    DeliveryDocumentIdentity.FromManifest(
+                        actualManifest, clean.DocumentVersion.Value),
+                    payload.DeliveredDocument))
+            {
+                findings.Add("clean_docx_delivery_mismatch");
+                return false;
+            }
+        }
+        catch (DeliveryReceiptValidationException ex)
+        {
+            findings.Add(IsResourceLimitCode(ex.Code)
+                ? ex.Code
+                : "clean_docx_delivery_mismatch");
+            return false;
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidDataException)
+        {
+            findings.Add("clean_docx_delivery_mismatch");
+            return false;
+        }
+        return true;
+    }
+
+    private static bool ValidateSemanticBindings(
+        DeliveryChangeReceiptPayload payload,
+        IReadOnlyDictionary<string, DeliveryArtifact> artifactsById,
+        IReadOnlyDictionary<string, byte[]> artifactBytes,
+        DeliveryLineageValidationResult lineageValidation,
+        DeliveryReceiptLimits limits,
+        ICollection<string> findings)
+    {
+        bool valid = true;
+        var aggregates = payload.SemanticChangeSets
+            .Where(binding => binding.Scope
+                == DeliverySemanticComparisonScope.SourceToDelivered)
+            .ToArray();
+        if (aggregates.Length != 1)
+        {
+            findings.Add("missing_source_to_delivered_semantic_evidence");
+            valid = false;
+        }
+
+        var expectedTransactions = lineageValidation.StateChangingTransactions
+            .GroupBy(transaction => transaction.EntryId, StringComparer.Ordinal)
+            .Where(group => group.Count() == 1)
+            .ToDictionary(group => group.Key, group => group.Single(), StringComparer.Ordinal);
+        var transactionBindings = payload.SemanticChangeSets
+            .Where(binding => binding.Scope == DeliverySemanticComparisonScope.Transaction
+                && binding.TransactionEntryId is not null)
+            .GroupBy(binding => binding.TransactionEntryId!, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.ToArray(), StringComparer.Ordinal);
+        if (transactionBindings.Any(pair => pair.Value.Length != 1
+                || !expectedTransactions.ContainsKey(pair.Key))
+            || expectedTransactions.Keys.Any(entryId => !transactionBindings.ContainsKey(entryId)))
+        {
+            findings.Add("semantic_transaction_coverage_mismatch");
+            valid = false;
+        }
+
+        foreach (var binding in payload.SemanticChangeSets)
+        {
+            if (!Enum.IsDefined(binding.Scope))
+            {
+                findings.Add("unknown_semantic_comparison_scope");
+                valid = false;
+                continue;
+            }
+
+            DeliveryDocumentIdentity? expectedBefore = null;
+            DeliveryDocumentIdentity? expectedAfter = null;
+            if (binding.Scope == DeliverySemanticComparisonScope.SourceToDelivered)
+            {
+                if (binding.TransactionEntryId is not null)
+                {
+                    findings.Add("semantic_binding_identity_mismatch");
+                    valid = false;
+                }
+                expectedBefore = payload.SourceDocument;
+                expectedAfter = payload.DeliveredDocument;
+            }
+            else if (binding.TransactionEntryId is null
+                || !expectedTransactions.TryGetValue(
+                    binding.TransactionEntryId, out var transaction))
+            {
+                findings.Add("semantic_binding_identity_mismatch");
+                valid = false;
+            }
+            else
+            {
+                expectedBefore = transaction.BeforeDocument;
+                expectedAfter = transaction.AfterDocument;
+            }
+
+            if (expectedBefore is not null
+                && (!DeliveryReceiptLineageValidator.DocumentEquals(
+                        binding.BeforeDocument, expectedBefore)
+                    || !DeliveryReceiptLineageValidator.DocumentEquals(
+                        binding.AfterDocument, expectedAfter!)))
+            {
+                findings.Add("semantic_binding_identity_mismatch");
+                valid = false;
+            }
+
+            try
+            {
+                ValidateDocument(binding.BeforeDocument);
+                ValidateDocument(binding.AfterDocument);
+                DeliveryReceiptValidation.ValidateDigest(
+                    binding.Digest, "semantic change-set digest");
+                DeliveryReceiptValidation.RequireNonBlank(
+                    binding.ArtifactId, "semantic artifact id", 256);
+            }
+            catch (DeliveryReceiptValidationException ex)
+            {
+                findings.Add(ex.Code);
+                valid = false;
+            }
+            if (!string.Equals(binding.Schema, SemanticChangeSet.CurrentSchema,
+                    StringComparison.Ordinal)
+                || binding.SchemaVersion != SemanticChangeSet.CurrentSchemaVersion
+                || binding.ChangeCount < 0)
+            {
+                findings.Add("unsupported_semantic_change_set");
+                valid = false;
+            }
+
+            byte[]? bytes = null;
+            bool artifactBindingValid =
+                artifactsById.TryGetValue(binding.ArtifactId, out var artifact)
+                && artifact.Role == DeliveryArtifactRole.SemanticDiff
+                && artifact.Availability == DeliveryArtifactAvailability.Available
+                && artifact.Digest is not null
+                && artifact.DocumentVersion is null
+                && artifact.PackageDigest is null
+                && artifact.RendererFingerprint is null
+                && artifact.PageMapDigest is null
+                && DeliveryReceiptValidation.DigestEquals(artifact.Digest, binding.Digest)
+                && artifactBytes.TryGetValue(binding.ArtifactId, out bytes);
+            if (artifactBindingValid)
+            {
+                try
+                {
+                    DeliveryReceiptResourceBudget.Bytes(
+                        bytes!.LongLength,
+                        limits.MaxSemanticEvidenceBytes,
+                        "semantic_resource_limit",
+                        "Semantic artifact");
+                    var projection = DeliverySemanticChangeSetAdapter.InspectExact(bytes, limits);
+                    artifactBindingValid =
+                        DeliveryReceiptCanonicalJson.FixedTimeEquals(binding.Digest, bytes)
+                        && string.Equals(
+                            projection.Schema, binding.Schema, StringComparison.Ordinal)
+                        && projection.SchemaVersion == binding.SchemaVersion
+                        && projection.ChangeCount == binding.ChangeCount
+                        && DeliveryReceiptValidation.DigestEquals(
+                            projection.Digest, binding.Digest);
+                }
+                catch (DeliveryReceiptValidationException ex)
+                {
+                    findings.Add(ex.Code);
+                    artifactBindingValid = false;
+                }
+                catch (Exception ex) when (ex is JsonException or FormatException
+                    or ArgumentException or InvalidOperationException)
+                {
+                    findings.Add("invalid_semantic_change_set");
+                    artifactBindingValid = false;
+                }
+            }
+            if (!artifactBindingValid)
+            {
+                findings.Add($"semantic_artifact_binding_mismatch:{binding.ArtifactId}");
+                valid = false;
+            }
+        }
+
+        var expectedOrder = new List<(DeliverySemanticComparisonScope Scope, string? EntryId)>
+        {
+            (DeliverySemanticComparisonScope.SourceToDelivered, null),
+        };
+        expectedOrder.AddRange(lineageValidation.StateChangingTransactions.Select(transaction =>
+            (DeliverySemanticComparisonScope.Transaction, (string?)transaction.EntryId)));
+        var actualOrder = payload.SemanticChangeSets
+            .Select(binding => (binding.Scope, binding.TransactionEntryId))
+            .ToArray();
+        if (!actualOrder.SequenceEqual(expectedOrder))
+        {
+            findings.Add("semantic_binding_order_mismatch");
+            valid = false;
+        }
+        return valid;
+    }
+
+    private static bool ValidateTextEvidence(
+        DeliveryTextEvidence evidence,
+        DeliveryReceiptPrivacyProfile privacyProfile,
+        ICollection<string> findings)
+    {
+        bool valid = true;
+        try { DeliveryReceiptValidation.ValidateDigest(evidence.Digest, "text digest"); }
+        catch (DeliveryReceiptValidationException ex)
+        {
+            findings.Add(ex.Code);
+            valid = false;
+        }
+        if (evidence.CharacterCount < 0)
+        {
+            findings.Add("invalid_text_character_count");
+            valid = false;
+        }
+        if (evidence.Value is { } value
+            && (value.Length != evidence.CharacterCount
+                || !DeliveryReceiptValidation.DigestEquals(
+                    evidence.Digest,
+                    DeliveryReceiptCanonicalJson.Digest(Encoding.UTF8.GetBytes(value)))))
+        {
+            findings.Add("text_evidence_digest_mismatch");
+            valid = false;
+        }
+        bool fullEvidence = privacyProfile == DeliveryReceiptPrivacyProfile.FullEvidence;
+        if ((privacyProfile == DeliveryReceiptPrivacyProfile.HashOnly
+                && evidence.Summary is not null)
+            || (privacyProfile != DeliveryReceiptPrivacyProfile.HashOnly
+                && evidence.Summary is null)
+            || (fullEvidence && evidence.Value is null)
+            || (!fullEvidence && evidence.Value is not null))
+        {
+            findings.Add("privacy_profile_violation");
+            valid = false;
+        }
+        return valid;
+    }
+
+    private static IReadOnlyList<DeliveryArtifactVerification> VerifyArtifacts(
+        IReadOnlyList<DeliveryArtifact> artifacts,
+        IReadOnlyDictionary<string, byte[]> artifactBytes,
+        DeliveryReceiptLimits limits,
+        ICollection<string> findings)
+    {
+        var results = new List<DeliveryArtifactVerification>();
+        foreach (var artifact in artifacts.OrderBy(value => value.ArtifactId, StringComparer.Ordinal))
+        {
+            if (artifact.Availability == DeliveryArtifactAvailability.Unavailable)
+            {
+                bool recordValid = artifact.Digest is null && artifact.ByteLength is null
+                    && artifact.UnavailableReason is not null;
+                results.Add(new DeliveryArtifactVerification
+                {
+                    ArtifactId = artifact.ArtifactId,
+                    Status = recordValid
+                        ? DeliveryArtifactVerificationStatus.Unavailable
+                        : DeliveryArtifactVerificationStatus.InvalidRecord,
+                });
+                if (!recordValid)
+                    findings.Add($"invalid_artifact_record:{artifact.ArtifactId}");
+                continue;
+            }
+            if (artifact.Availability != DeliveryArtifactAvailability.Available
+                || artifact.Digest is null || artifact.ByteLength is null
+                || artifact.ByteLength < 0)
+            {
+                results.Add(new DeliveryArtifactVerification
+                {
+                    ArtifactId = artifact.ArtifactId,
+                    Status = DeliveryArtifactVerificationStatus.InvalidRecord,
+                });
+                findings.Add($"invalid_artifact_record:{artifact.ArtifactId}");
+                continue;
+            }
+            try { DeliveryReceiptValidation.ValidateDigest(artifact.Digest, "artifact digest"); }
+            catch (DeliveryReceiptValidationException)
+            {
+                results.Add(new DeliveryArtifactVerification
+                {
+                    ArtifactId = artifact.ArtifactId,
+                    Status = DeliveryArtifactVerificationStatus.InvalidRecord,
+                    ExpectedLength = artifact.ByteLength,
+                    ExpectedDigest = artifact.Digest,
+                });
+                findings.Add($"invalid_artifact_record:{artifact.ArtifactId}");
+                continue;
+            }
+            if (!artifactBytes.TryGetValue(artifact.ArtifactId, out var bytes))
+            {
+                results.Add(new DeliveryArtifactVerification
+                {
+                    ArtifactId = artifact.ArtifactId,
+                    Status = DeliveryArtifactVerificationStatus.Missing,
+                    ExpectedLength = artifact.ByteLength,
+                    ExpectedDigest = artifact.Digest,
+                });
+                findings.Add($"artifact_missing:{artifact.ArtifactId}");
+                continue;
+            }
+
+            var roleLimit = artifact.Role switch
+            {
+                DeliveryArtifactRole.SemanticDiff => limits.MaxSemanticEvidenceBytes,
+                DeliveryArtifactRole.PageMap => limits.MaxPageMapBytes,
+                _ => limits.MaxArtifactBytes,
+            };
+            if (bytes.LongLength > roleLimit)
+            {
+                var finding = artifact.Role switch
+                {
+                    DeliveryArtifactRole.SemanticDiff => "semantic_resource_limit",
+                    DeliveryArtifactRole.PageMap => "page_map_resource_limit",
+                    _ => "artifact_resource_limit",
+                };
+                results.Add(new DeliveryArtifactVerification
+                {
+                    ArtifactId = artifact.ArtifactId,
+                    Status = DeliveryArtifactVerificationStatus.InvalidRecord,
+                    ExpectedLength = artifact.ByteLength,
+                    ActualLength = bytes.LongLength,
+                    ExpectedDigest = artifact.Digest,
+                });
+                findings.Add(finding);
+                continue;
+            }
+
+            var actualDigest = DeliveryReceiptCanonicalJson.Digest(bytes);
+            var status = bytes.LongLength != artifact.ByteLength
+                ? DeliveryArtifactVerificationStatus.LengthMismatch
+                : !DeliveryReceiptValidation.DigestEquals(artifact.Digest, actualDigest)
+                    ? DeliveryArtifactVerificationStatus.DigestMismatch
+                    : DeliveryArtifactVerificationStatus.Verified;
+            results.Add(new DeliveryArtifactVerification
+            {
+                ArtifactId = artifact.ArtifactId,
+                Status = status,
+                ExpectedLength = artifact.ByteLength,
+                ActualLength = bytes.LongLength,
+                ExpectedDigest = artifact.Digest,
+                ActualDigest = actualDigest,
+            });
+            if (status != DeliveryArtifactVerificationStatus.Verified)
+                findings.Add($"artifact_{status.ToString().ToLowerInvariant()}:{artifact.ArtifactId}");
+        }
+        return results;
+    }
+
+    private static bool ValidateCitationBindings(
+        DeliveryChangeReceiptPayload payload,
+        IReadOnlyDictionary<string, byte[]> artifactBytes,
+        DeliveryLineageValidationResult lineageValidation,
+        DeliveryReceiptLimits limits,
+        ICollection<string> findings)
+    {
+        bool valid = true;
+        var artifacts = payload.Artifacts
+            .GroupBy(artifact => artifact.ArtifactId, StringComparer.Ordinal)
+            .Where(group => group.Count() == 1)
+            .ToDictionary(group => group.Key, group => group.Single(), StringComparer.Ordinal);
+        foreach (var citation in payload.PageCitations)
+        {
+            try
+            {
+                DeliveryReceiptValidation.RequireNonBlank(
+                    citation.AnchorId, "citation anchor id", 4096);
+                DeliveryReceiptValidation.RequireNonBlank(
+                    citation.Scope, "citation scope", 1024);
+                DeliveryReceiptValidation.RequireNonBlank(
+                    citation.RendererFingerprint, "citation renderer fingerprint", 4096);
+                DeliveryReceiptValidation.RequireNonBlank(
+                    citation.RenderArtifactId, "citation artifact id", 256);
+                DeliveryReceiptValidation.RequireNonBlank(
+                    citation.PageMapArtifactId, "citation page-map artifact id", 256);
+                DeliveryReceiptValidation.ValidateDigest(
+                    citation.PackageDigest, "citation package digest");
+                DeliveryReceiptValidation.ValidateDigest(
+                    citation.PageMapDigest, "citation page-map digest");
+                DeliveryReceiptValidation.ValidateDigest(
+                    citation.RenderArtifactDigest, "citation render-artifact digest");
+                if (citation.DocumentVersion < 0
+                    || !string.Equals(
+                        ScopeFromAnchor(citation.AnchorId), citation.Scope,
+                        StringComparison.Ordinal))
+                {
+                    throw new DeliveryReceiptValidationException(
+                        "invalid_citation_identity", "Citation identity is invalid.");
+                }
+            }
+            catch (DeliveryReceiptValidationException ex)
+            {
+                findings.Add($"{ex.Code}:{citation.AnchorId}");
+                valid = false;
+            }
+            if (!DeliveryReceiptLineageValidator.IsReachable(
+                    lineageValidation, citation.DocumentVersion, citation.PackageDigest))
+            {
+                findings.Add($"unreachable_citation_document:{citation.AnchorId}");
+                valid = false;
+            }
+            if (!artifacts.TryGetValue(citation.RenderArtifactId, out var artifact)
+                || artifact.Availability != DeliveryArtifactAvailability.Available
+                || artifact.Digest is null
+                || artifact.Role is not (DeliveryArtifactRole.Pdf
+                    or DeliveryArtifactRole.PageImage
+                    or DeliveryArtifactRole.RenderReport)
+                || artifact.DocumentVersion != citation.DocumentVersion
+                || !string.Equals(artifact.RendererFingerprint,
+                    citation.RendererFingerprint, StringComparison.Ordinal)
+                || !DeliveryReceiptValidation.DigestEquals(
+                    artifact.PackageDigest, citation.PackageDigest)
+                || !DeliveryReceiptValidation.DigestEquals(
+                    artifact.PageMapDigest, citation.PageMapDigest)
+                || !DeliveryReceiptValidation.DigestEquals(
+                    artifact.Digest, citation.RenderArtifactDigest))
+            {
+                findings.Add($"citation_binding_mismatch:{citation.AnchorId}");
+                valid = false;
+            }
+            if (!artifacts.TryGetValue(citation.PageMapArtifactId, out var pageMapArtifact)
+                || pageMapArtifact.Availability != DeliveryArtifactAvailability.Available
+                || pageMapArtifact.Role != DeliveryArtifactRole.PageMap
+                || pageMapArtifact.Digest is null
+                || pageMapArtifact.DocumentVersion != citation.DocumentVersion
+                || !string.Equals(pageMapArtifact.RendererFingerprint,
+                    citation.RendererFingerprint, StringComparison.Ordinal)
+                || !DeliveryReceiptValidation.DigestEquals(
+                    pageMapArtifact.PackageDigest, citation.PackageDigest)
+                || !DeliveryReceiptValidation.DigestEquals(
+                    pageMapArtifact.Digest, citation.PageMapDigest))
+            {
+                findings.Add($"citation_page_map_binding_mismatch:{citation.AnchorId}");
+                valid = false;
+            }
+
+            if (!artifactBytes.TryGetValue(citation.PageMapArtifactId, out var pageMapBytes))
+            {
+                findings.Add($"citation_page_map_bytes_missing:{citation.AnchorId}");
+                valid = false;
+                continue;
+            }
+            try
+            {
+                // Strict JSON/duplicate-property gate only; the map digest remains over raw bytes.
+                _ = DeliveryReceiptCanonicalJson.CanonicalizeBounded(
+                    pageMapBytes, limits, limits.MaxPageMapBytes,
+                    "page_map_resource_limit");
+                var pageMap = DocxSessionJson.ParsePageMap(Encoding.UTF8.GetString(pageMapBytes));
+                var mapValidation = PageMapContract.ValidatePortable(
+                    pageMap, citation.DocumentVersion, citation.RendererFingerprint);
+                if (!mapValidation.Success)
+                {
+                    findings.Add($"invalid_page_map_artifact:{citation.AnchorId}");
+                    valid = false;
+                    continue;
+                }
+                var projected = PageMapContract.ProjectCitation(
+                    pageMap,
+                    citation.AnchorId,
+                    new PageCitationRequest(
+                        citation.DocumentVersion, citation.RendererFingerprint));
+                if (projected.Availability != PageMapAvailability.Available
+                    || !CitationCoordinatesEqual(citation, projected)
+                    || projected.Fragments.Any(fragment =>
+                        !PageMapContract.StoryMatchesScope(fragment.Story, citation.Scope)))
+                {
+                    findings.Add($"citation_page_map_projection_mismatch:{citation.AnchorId}");
+                    valid = false;
+                }
+            }
+            catch (DeliveryReceiptValidationException ex)
+            {
+                findings.Add(ex.Code);
+                valid = false;
+            }
+            catch (Exception ex) when (ex is JsonException or FormatException)
+            {
+                findings.Add($"invalid_page_map_artifact:{citation.AnchorId}");
+                valid = false;
+            }
+        }
+        return valid;
+    }
+
+    private static bool CitationCoordinatesEqual(
+        DeliveryPageCitation receiptCitation,
+        PageCitation projected) =>
+        string.Equals(receiptCitation.AnchorId, projected.AnchorId, StringComparison.Ordinal)
+        && receiptCitation.DocumentVersion == projected.DocumentVersion
+        && string.Equals(receiptCitation.RendererFingerprint,
+            projected.RendererFingerprint, StringComparison.Ordinal)
+        && receiptCitation.Pages.SequenceEqual(projected.Pages)
+        && receiptCitation.Fragments.SequenceEqual(projected.Fragments);
+
+    private static void ValidateDocument(DeliveryDocumentIdentity document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        if (document.DocumentVersion < 0)
+            throw new DeliveryReceiptValidationException(
+                "invalid_document_version", "Document version cannot be negative.");
+        if (!DeliveryPackageManifestAdapter.IsSupportedSchema(
+                document.PackageManifestSchema))
+        {
+            throw new DeliveryReceiptValidationException(
+                "unsupported_package_manifest", "Unsupported package-manifest schema.");
+        }
+        DeliveryReceiptValidation.RequireNonBlank(
+            document.PackageKind, "document package kind", 256);
+        DeliveryReceiptValidation.ValidateDigest(
+            document.RawPackageBytesDigest, "document package digest");
+        DeliveryReceiptValidation.ValidateOptionalDigest(
+            document.OrderedOpcContentDigest, "document content digest");
+        DeliveryReceiptValidation.ValidateOptionalDigest(
+            document.NormalizedSemanticDigest, "document semantic digest");
+    }
+
+    private static string ScopeFromAnchor(string anchorId)
+    {
+        var first = anchorId.IndexOf(':');
+        var second = first < 0 ? -1 : anchorId.IndexOf(':', first + 1);
+        if (first <= 0 || second <= first + 1 || second == anchorId.Length - 1)
+        {
+            throw new DeliveryReceiptValidationException(
+                "invalid_anchor_id", "Citation anchor is not a canonical kind:scope:unid value.");
+        }
+        return anchorId[(first + 1)..second];
+    }
+
+    private static bool IsMalformedReceiptException(Exception exception) =>
+        exception is JsonException
+            or NotSupportedException
+            or FormatException
+            or InvalidOperationException
+            or ArgumentException
+            or NullReferenceException
+            or KeyNotFoundException
+            or OverflowException;
+
+    private static bool IsResourceLimitCode(string code) => code is
+        "receipt_resource_limit"
+        or "semantic_resource_limit"
+        or "page_map_resource_limit"
+        or "artifact_resource_limit";
+
+    private static VerificationDigest ReadDigest(JsonElement element)
+    {
+        int propertyCount = 0;
+        bool hasAlgorithm = false;
+        bool hasValue = false;
+        foreach (var property in element.EnumerateObject())
+        {
+            propertyCount++;
+            if (propertyCount > 2)
+                break;
+            hasAlgorithm |= string.Equals(
+                property.Name, "algorithm", StringComparison.Ordinal);
+            hasValue |= string.Equals(property.Name, "value", StringComparison.Ordinal);
+        }
+        if (propertyCount != 2
+            || !hasAlgorithm
+            || !hasValue
+            || !element.TryGetProperty("algorithm", out var algorithm)
+            || algorithm.ValueKind != JsonValueKind.String
+            || !element.TryGetProperty("value", out var value)
+            || value.ValueKind != JsonValueKind.String)
+        {
+            throw new DeliveryReceiptValidationException(
+                "invalid_digest", "Receipt digest is malformed.");
+        }
+        var digest = new VerificationDigest
+        {
+            Algorithm = algorithm.GetString()!,
+            Value = value.GetString()!,
+        };
+        DeliveryReceiptValidation.ValidateDigest(digest, "receipt digest");
+        return digest;
+    }
+
+    private static DeliveryReceiptVerificationResult Malformed(string finding) => new()
+    {
+        IsValid = false,
+        ReceiptDigestValid = false,
+        ContractValid = false,
+        CitationBindingsValid = false,
+        Findings = new[] { finding },
+    };
+
+    private static DeliveryReceiptVerificationResult Rejected(string finding) => new()
+    {
+        IsValid = false,
+        ReceiptDigestValid = false,
+        ContractValid = false,
+        CitationBindingsValid = false,
+        Findings = new[] { finding },
+    };
+}

--- a/Docxodus/Verification/DeliveryReceiptVerifier.cs
+++ b/Docxodus/Verification/DeliveryReceiptVerifier.cs
@@ -2036,7 +2036,9 @@ public static class DeliveryChangeReceiptVerifier
             .ToDictionary(group => group.Key, group => group.Single(), StringComparer.Ordinal);
         var pageMapCache = new Dictionary<string, (PageMap? Map, string? Finding)>(
             StringComparer.Ordinal);
-        var projectionCache = new Dictionary<(string ArtifactId, string AnchorId), PageCitation>();
+        var projectionCache = new Dictionary<
+            (string ArtifactId, string AnchorId, long DocumentVersion, string Renderer),
+            PageCitation>();
         foreach (var citation in payload.PageCitations)
         {
             try
@@ -2139,13 +2141,10 @@ public static class DeliveryChangeReceiptVerifier
                     _ = DeliveryReceiptCanonicalJson.CanonicalizeBounded(
                         pageMapBytes, limits, limits.MaxPageMapBytes,
                         "page_map_resource_limit");
-                    var parsedMap = DocxSessionJson.ParsePageMap(
-                        Encoding.UTF8.GetString(pageMapBytes));
-                    var mapValidation = PageMapContract.ValidatePortable(
-                        parsedMap, citation.DocumentVersion, citation.RendererFingerprint);
-                    cachedMap = mapValidation.Success
-                        ? (parsedMap, null)
-                        : (null, "invalid_page_map_artifact");
+                    // Cache only the citation-independent parse; ValidatePortable is
+                    // parameterized per citation and must not share a cached verdict.
+                    cachedMap = (DocxSessionJson.ParsePageMap(
+                        Encoding.UTF8.GetString(pageMapBytes)), null);
                 }
                 catch (DeliveryReceiptValidationException ex)
                 {
@@ -2163,8 +2162,17 @@ public static class DeliveryChangeReceiptVerifier
                 valid = false;
                 continue;
             }
+            if (!PageMapContract.ValidatePortable(
+                    cachedMap.Map, citation.DocumentVersion,
+                    citation.RendererFingerprint).Success)
+            {
+                findings.Add($"invalid_page_map_artifact:{citation.AnchorId}");
+                valid = false;
+                continue;
+            }
 
-            var projectionKey = (citation.PageMapArtifactId, citation.AnchorId);
+            var projectionKey = (citation.PageMapArtifactId, citation.AnchorId,
+                citation.DocumentVersion, citation.RendererFingerprint);
             if (!projectionCache.TryGetValue(projectionKey, out var projected))
             {
                 projected = PageMapContract.ProjectCitation(

--- a/Docxodus/Verification/DeliveryReceiptVerifier.cs
+++ b/Docxodus/Verification/DeliveryReceiptVerifier.cs
@@ -416,6 +416,23 @@ public static class DeliveryChangeReceiptVerifier
                 findings.Add(finding);
             valid = false;
         }
+        var boundEvidenceArtifacts = payload.SemanticChangeSets
+            .Select(binding => binding.ArtifactId)
+            .Concat(payload.Evidence.Select(item => item.ArtifactId)
+                .Where(artifactId => artifactId is not null)
+                .Select(artifactId => artifactId!))
+            .ToHashSet(StringComparer.Ordinal);
+        foreach (var artifact in payload.Artifacts)
+        {
+            if (artifact.Role is DeliveryArtifactRole.SemanticDiff
+                    or DeliveryArtifactRole.ValidationReport
+                    or DeliveryArtifactRole.ReversibilityProof
+                && !boundEvidenceArtifacts.Contains(artifact.ArtifactId))
+            {
+                findings.Add($"unbound_evidence_artifact:{artifact.ArtifactId}");
+                valid = false;
+            }
+        }
         foreach (var change in payload.PackageChanges)
             valid &= ValidatePackageChange(change, payload.PrivacyProfile, findings);
         if (payload.PackageChanges.Select(change => change.ChangeId)
@@ -467,8 +484,8 @@ public static class DeliveryChangeReceiptVerifier
             if (artifact.Role != DeliveryArtifactRole.ReviewDocx
                 && artifact.DocumentVersion is { } documentVersion
                 && artifact.PackageDigest is { } packageDigest
-                && !DeliveryReceiptLineageValidator.IsReachable(
-                    lineageValidation, documentVersion, packageDigest))
+                && !DeliveryReceiptLineageValidator.IsArtifactDocumentReachable(
+                    lineageValidation, documentVersion, packageDigest, payload.Artifacts))
             {
                 findings.Add("unreachable_artifact_document");
                 valid = false;

--- a/Docxodus/Verification/DeliveryReceiptVerifier.cs
+++ b/Docxodus/Verification/DeliveryReceiptVerifier.cs
@@ -2221,33 +2221,8 @@ public static class DeliveryChangeReceiptVerifier
         && receiptCitation.Pages.SequenceEqual(projected.Pages)
         && receiptCitation.Fragments.SequenceEqual(projected.Fragments);
 
-    private static void ValidateDocument(DeliveryDocumentIdentity document)
-    {
-        ArgumentNullException.ThrowIfNull(document);
-        DeliveryReceiptValidation.ValidatePortableNonNegativeInteger(
-            document.DocumentVersion, "invalid_document_version", "Document version");
-        if (!DeliveryPackageManifestAdapter.IsSupportedSchema(
-                document.PackageManifestSchema))
-        {
-            throw new DeliveryReceiptValidationException(
-                "unsupported_package_manifest", "Unsupported package-manifest schema.");
-        }
-        DeliveryReceiptValidation.RequireNonBlank(
-            document.PackageKind, "document package kind", 256);
-        if (!string.Equals(document.PackageKind, "opc", StringComparison.Ordinal))
-        {
-            throw new DeliveryReceiptValidationException(
-                "not_wordprocessing_package", "Document identity must be an OPC package.");
-        }
-        DeliveryReceiptValidation.RequireOpcMainDocumentUri(
-            document.MainDocumentUri, "main document URI");
-        DeliveryReceiptValidation.ValidateDigest(
-            document.RawPackageBytesDigest, "document package digest");
-        DeliveryReceiptValidation.ValidateOptionalDigest(
-            document.OrderedOpcContentDigest, "document content digest");
-        DeliveryReceiptValidation.ValidateOptionalDigest(
-            document.NormalizedSemanticDigest, "document semantic digest");
-    }
+    private static void ValidateDocument(DeliveryDocumentIdentity document) =>
+        DeliveryReceiptValidation.ValidateDocument(document);
 
     private static string ScopeFromAnchor(string anchorId)
     {

--- a/Docxodus/Verification/DeliverySemanticChangeSetAdapter.cs
+++ b/Docxodus/Verification/DeliverySemanticChangeSetAdapter.cs
@@ -1,0 +1,430 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Text.Encodings.Web;
+using System.Text.Json;
+
+namespace Docxodus.Verification;
+
+internal sealed record DeliverySemanticChangeSetProjection(
+    string Schema,
+    int SchemaVersion,
+    int ChangeCount,
+    byte[] CanonicalBytes,
+    VerificationDigest Digest);
+
+/// <summary>
+/// The sole #457 integration seam. It reconstructs the complete closed typed contract and accepts
+/// bytes only when they are byte-for-byte identical to <see cref="SemanticChangeSet.ToCanonicalUtf8Bytes"/>.
+/// </summary>
+internal static class DeliverySemanticChangeSetAdapter
+{
+    public static DeliverySemanticChangeSetProjection Project(
+        SemanticChangeSet changeSet,
+        DeliveryReceiptLimits limits)
+    {
+        ArgumentNullException.ThrowIfNull(changeSet);
+        ArgumentNullException.ThrowIfNull(limits);
+        ValidateTyped(changeSet, limits);
+        var bytes = SerializeExactBounded(changeSet, limits);
+        var inspected = InspectExact(bytes, limits);
+        if (!string.Equals(inspected.Schema, changeSet.Schema, StringComparison.Ordinal)
+            || inspected.SchemaVersion != changeSet.SchemaVersion
+            || inspected.ChangeCount != changeSet.ChangeCount)
+        {
+            throw Invalid("Semantic change-set canonical bytes are inconsistent.");
+        }
+        return inspected;
+    }
+
+    public static DeliverySemanticChangeSetProjection InspectExact(
+        ReadOnlySpan<byte> bytes,
+        DeliveryReceiptLimits limits)
+    {
+        ArgumentNullException.ThrowIfNull(limits);
+        DeliveryReceiptResourceBudget.Bytes(
+            bytes.Length,
+            limits.MaxSemanticEvidenceBytes,
+            "semantic_resource_limit",
+            "SemanticChangeSet artifact");
+
+        // Strict UTF-8/JSON/depth/duplicate-property gate. The generic canonical bytes are not
+        // used as #457's digest or representation because #457 owns a different fixed field order.
+        _ = DeliveryReceiptCanonicalJson.CanonicalizeBounded(
+            bytes,
+            limits,
+            limits.MaxSemanticEvidenceBytes,
+            "semantic_resource_limit");
+        using var document = JsonDocument.Parse(bytes.ToArray(), new JsonDocumentOptions
+        {
+            AllowTrailingCommas = false,
+            CommentHandling = JsonCommentHandling.Disallow,
+            MaxDepth = limits.MaxJsonDepth,
+        });
+        var budget = new DeliveryReceiptResourceBudget(
+            limits, limits.MaxSemanticEvidenceBytes, "semantic_resource_limit");
+        budget.AddSerializedBytes(64, "semantic root");
+        var root = document.RootElement;
+        ExactObject(root, budget, "schema", "schemaVersion", "changeCount", "changes");
+        var schema = RequiredString(root, "schema", budget);
+        if (!string.Equals(schema, SemanticChangeSet.CurrentSchema, StringComparison.Ordinal)
+            || !root.GetProperty("schemaVersion").TryGetInt32(out var schemaVersion)
+            || schemaVersion != SemanticChangeSet.CurrentSchemaVersion
+            || !root.GetProperty("changeCount").TryGetInt32(out var declaredCount)
+            || declaredCount < 0)
+        {
+            throw Invalid("Semantic change-set root identity is invalid.");
+        }
+
+        var changesElement = root.GetProperty("changes");
+        if (changesElement.ValueKind != JsonValueKind.Array)
+            throw Invalid("Semantic change-set changes must be an array.");
+        var changes = new List<SemanticChange>();
+        foreach (var change in changesElement.EnumerateArray())
+        {
+            budget.AddItems(1, "semantic changes");
+            changes.Add(ParseChange(change, budget));
+        }
+        if (changes.Count != declaredCount)
+            throw Invalid("Semantic change-set count does not match its changes array.");
+        var typed = new SemanticChangeSet(changes);
+        var canonicalBytes = SerializeExactBounded(typed, limits);
+        if (!bytes.SequenceEqual(canonicalBytes))
+        {
+            throw Invalid(
+                "Semantic artifact bytes are not the exact canonical #457 representation.");
+        }
+        return new DeliverySemanticChangeSetProjection(
+            typed.Schema,
+            typed.SchemaVersion,
+            typed.ChangeCount,
+            canonicalBytes,
+            DeliveryReceiptCanonicalJson.Digest(canonicalBytes));
+    }
+
+    private static SemanticChange ParseChange(
+        JsonElement element,
+        DeliveryReceiptResourceBudget budget)
+    {
+        ExactObject(
+            element,
+            budget,
+            "id",
+            "operation",
+            "family",
+            "partUri",
+            "path",
+            "leftAnchor",
+            "rightAnchor",
+            "leftScope",
+            "rightScope",
+            "moveId",
+            "before",
+            "after");
+        budget.AddSerializedBytes(192, "semantic change");
+        var id = RequiredString(element, "id", budget);
+        if (!ValidChangeId(id))
+            throw Invalid("Semantic change id is invalid.");
+        var operationName = RequiredString(element, "operation", budget);
+        var familyName = RequiredString(element, "family", budget);
+        var partUri = RequiredString(element, "partUri", budget);
+        if (!partUri.StartsWith("/", StringComparison.Ordinal))
+            throw Invalid("Semantic change partUri must be package-absolute.");
+        return new SemanticChange
+        {
+            Id = id,
+            Operation = ParseOperation(operationName),
+            Family = ParseFamily(familyName),
+            PartUri = partUri,
+            Path = RequiredString(element, "path", budget, allowEmpty: true),
+            LeftAnchor = NullableString(element, "leftAnchor", budget),
+            RightAnchor = NullableString(element, "rightAnchor", budget),
+            LeftScope = NullableString(element, "leftScope", budget),
+            RightScope = NullableString(element, "rightScope", budget),
+            MoveId = NullableString(element, "moveId", budget),
+            Before = ParseValue(element.GetProperty("before"), budget, depth: 4),
+            After = ParseValue(element.GetProperty("after"), budget, depth: 4),
+        };
+    }
+
+    private static SemanticValue ParseValue(
+        JsonElement element,
+        DeliveryReceiptResourceBudget budget,
+        int depth)
+    {
+        budget.Depth(depth, "semantic value");
+        budget.AddSerializedBytes(24, "semantic value");
+        if (element.ValueKind != JsonValueKind.Object)
+            throw Invalid("Semantic values must be non-null objects.");
+        var kindName = RequiredString(element, "kind", budget);
+        switch (kindName)
+        {
+            case "absent":
+                ExactObject(element, budget, "kind");
+                return SemanticValue.Absent;
+            case "string":
+                ExactObject(element, budget, "kind", "value");
+                return SemanticValue.String(RequiredString(
+                    element, "value", budget, allowEmpty: true));
+            case "boolean":
+                ExactObject(element, budget, "kind", "value");
+                if (element.GetProperty("value").ValueKind is not
+                    (JsonValueKind.True or JsonValueKind.False))
+                {
+                    throw Invalid("Semantic Boolean value is invalid.");
+                }
+                return SemanticValue.Boolean(element.GetProperty("value").GetBoolean());
+            case "integer":
+                ExactObject(element, budget, "kind", "value");
+                if (!element.GetProperty("value").TryGetInt64(out var integer))
+                    throw Invalid("Semantic integer value is outside Int64.");
+                return SemanticValue.Integer(integer);
+            case "digest":
+                ExactObject(element, budget, "kind", "algorithm", "profile", "value");
+                var algorithm = RequiredString(element, "algorithm", budget);
+                var digestValue = RequiredString(element, "value", budget);
+                var profile = NullableString(element, "profile", budget);
+                if (profile is not null && string.IsNullOrWhiteSpace(profile))
+                    throw Invalid("Semantic digest profile cannot be blank.");
+                return SemanticValue.Digest(algorithm, digestValue, profile);
+            case "object":
+                ExactObject(element, budget, "kind", "value");
+                var objectElement = element.GetProperty("value");
+                if (objectElement.ValueKind != JsonValueKind.Object)
+                    throw Invalid("Semantic object value must be an object.");
+                var properties = new List<SemanticProperty>();
+                foreach (var property in objectElement.EnumerateObject())
+                {
+                    budget.AddItems(1, "semantic object properties");
+                    budget.String(property.Name, "semantic property name");
+                    if (string.IsNullOrWhiteSpace(property.Name))
+                        throw Invalid("Semantic object property names must be non-blank.");
+                    properties.Add(new SemanticProperty(
+                        property.Name, ParseValue(property.Value, budget, depth + 2)));
+                }
+                return SemanticValue.Object(properties);
+            case "array":
+                ExactObject(element, budget, "kind", "value");
+                var arrayElement = element.GetProperty("value");
+                if (arrayElement.ValueKind != JsonValueKind.Array)
+                    throw Invalid("Semantic array value must be an array.");
+                var items = new List<SemanticValue>();
+                foreach (var item in arrayElement.EnumerateArray())
+                {
+                    budget.AddItems(1, "semantic array items");
+                    items.Add(ParseValue(item, budget, depth + 2));
+                }
+                return SemanticValue.Array(items);
+            default:
+                throw Invalid($"Unknown semantic value kind '{kindName}'.");
+        }
+    }
+
+    private static void ValidateTyped(
+        SemanticChangeSet changeSet,
+        DeliveryReceiptLimits limits)
+    {
+        if (!string.Equals(changeSet.Schema, SemanticChangeSet.CurrentSchema,
+                StringComparison.Ordinal)
+            || changeSet.SchemaVersion != SemanticChangeSet.CurrentSchemaVersion
+            || changeSet.ChangeCount != changeSet.Changes.Count)
+        {
+            throw Invalid("Semantic change-set identity is inconsistent.");
+        }
+        var budget = new DeliveryReceiptResourceBudget(
+            limits, limits.MaxSemanticEvidenceBytes, "semantic_resource_limit");
+        budget.AddSerializedBytes(64, "semantic root");
+        budget.AddItems(changeSet.Changes.Count, "semantic changes");
+        foreach (var change in changeSet.Changes)
+        {
+            if (change is null || change.Before is null || change.After is null
+                || !Enum.IsDefined(change.Operation) || !Enum.IsDefined(change.Family)
+                || string.IsNullOrWhiteSpace(change.PartUri)
+                || !change.PartUri.StartsWith("/", StringComparison.Ordinal)
+                || change.Path is null)
+            {
+                throw Invalid("Semantic change contains invalid typed fields.");
+            }
+            budget.String(change.Id, "semantic change id");
+            budget.String(change.PartUri, "semantic part URI");
+            budget.String(change.Path, "semantic path");
+            budget.String(change.LeftAnchor, "semantic anchor");
+            budget.String(change.RightAnchor, "semantic anchor");
+            budget.String(change.LeftScope, "semantic scope");
+            budget.String(change.RightScope, "semantic scope");
+            budget.String(change.MoveId, "semantic move id");
+            budget.AddSerializedBytes(192, "semantic change");
+            ValidateTypedValue(change.Before, budget, depth: 4);
+            ValidateTypedValue(change.After, budget, depth: 4);
+        }
+    }
+
+    private static void ValidateTypedValue(
+        SemanticValue value,
+        DeliveryReceiptResourceBudget budget,
+        int depth)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        budget.Depth(depth, "semantic value");
+        budget.AddSerializedBytes(24, "semantic value");
+        switch (value.Kind)
+        {
+            case SemanticValueKind.Absent:
+                break;
+            case SemanticValueKind.String when value.StringValue is not null:
+                budget.String(value.StringValue, "semantic string value");
+                break;
+            case SemanticValueKind.Boolean when value.BooleanValue is not null:
+            case SemanticValueKind.Integer when value.IntegerValue is not null:
+                break;
+            case SemanticValueKind.Digest
+                when !string.IsNullOrWhiteSpace(value.DigestAlgorithm)
+                    && !string.IsNullOrWhiteSpace(value.DigestValue)
+                    && (value.DigestProfile is null
+                        || !string.IsNullOrWhiteSpace(value.DigestProfile)):
+                budget.String(value.DigestAlgorithm, "semantic digest algorithm");
+                budget.String(value.DigestProfile, "semantic digest profile");
+                budget.String(value.DigestValue, "semantic digest value");
+                break;
+            case SemanticValueKind.Object:
+                budget.AddItems(value.Properties.Count, "semantic object properties");
+                string? priorName = null;
+                foreach (var property in value.Properties)
+                {
+                    if (property is null || string.IsNullOrWhiteSpace(property.Name)
+                        || property.Value is null
+                        || (priorName is not null && string.CompareOrdinal(
+                            priorName, property.Name) >= 0))
+                    {
+                        throw Invalid("Semantic object properties are invalid or noncanonical.");
+                    }
+                    budget.String(property.Name, "semantic property name");
+                    ValidateTypedValue(property.Value, budget, depth + 2);
+                    priorName = property.Name;
+                }
+                break;
+            case SemanticValueKind.Array:
+                budget.AddItems(value.Items.Count, "semantic array items");
+                foreach (var item in value.Items)
+                {
+                    if (item is null)
+                        throw Invalid("Semantic arrays cannot contain null.");
+                    ValidateTypedValue(item, budget, depth + 2);
+                }
+                break;
+            default:
+                throw Invalid("Semantic value fields do not match their kind.");
+        }
+    }
+
+    private static void ExactObject(
+        JsonElement element,
+        DeliveryReceiptResourceBudget budget,
+        params string[] names)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+            throw Invalid("Expected a semantic JSON object.");
+        int count = 0;
+        foreach (var property in element.EnumerateObject())
+        {
+            budget.AddItems(1, "semantic object fields");
+            count++;
+            if (count > names.Length
+                || !names.Contains(property.Name, StringComparer.Ordinal))
+            {
+                throw Invalid("Semantic JSON object fields are missing or unknown.");
+            }
+        }
+        if (count != names.Length)
+            throw Invalid("Semantic JSON object fields are missing or unknown.");
+    }
+
+    private static string RequiredString(
+        JsonElement owner,
+        string name,
+        DeliveryReceiptResourceBudget budget,
+        bool allowEmpty = false)
+    {
+        if (!owner.TryGetProperty(name, out var element)
+            || element.ValueKind != JsonValueKind.String)
+        {
+            throw Invalid($"Semantic field '{name}' must be a string.");
+        }
+        var value = element.GetString()!;
+        budget.String(value, $"semantic field '{name}'");
+        if (!allowEmpty && string.IsNullOrWhiteSpace(value))
+            throw Invalid($"Semantic field '{name}' cannot be blank.");
+        return value;
+    }
+
+    private static string? NullableString(
+        JsonElement owner,
+        string name,
+        DeliveryReceiptResourceBudget budget)
+    {
+        var element = owner.GetProperty(name);
+        if (element.ValueKind == JsonValueKind.Null)
+            return null;
+        if (element.ValueKind != JsonValueKind.String)
+            throw Invalid($"Semantic field '{name}' must be a string or null.");
+        var value = element.GetString()!;
+        budget.String(value, $"semantic field '{name}'");
+        return value;
+    }
+
+    private static SemanticChangeOperation ParseOperation(string value)
+    {
+        foreach (var candidate in Enum.GetValues<SemanticChangeOperation>())
+        {
+            if (string.Equals(
+                    SemanticChangeSet.OperationName(candidate), value, StringComparison.Ordinal))
+            {
+                return candidate;
+            }
+        }
+        throw Invalid($"Unknown semantic operation '{value}'.");
+    }
+
+    private static SemanticChangeFamily ParseFamily(string value)
+    {
+        foreach (var candidate in Enum.GetValues<SemanticChangeFamily>())
+        {
+            if (string.Equals(
+                    SemanticChangeSet.FamilyName(candidate), value, StringComparison.Ordinal))
+            {
+                return candidate;
+            }
+        }
+        throw Invalid($"Unknown semantic family '{value}'.");
+    }
+
+    private static bool ValidChangeId(string value) =>
+        value.StartsWith("chg-", StringComparison.Ordinal)
+        && value.Length >= 10
+        && value.AsSpan(4).IndexOfAnyExceptInRange('0', '9') < 0;
+
+    private static byte[] SerializeExactBounded(
+        SemanticChangeSet changeSet,
+        DeliveryReceiptLimits limits)
+    {
+        using var stream = new DeliveryReceiptBoundedMemoryStream(
+            limits.MaxSemanticEvidenceBytes,
+            "semantic_resource_limit",
+            "SemanticChangeSet");
+        using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
+        {
+            Encoder = JavaScriptEncoder.Default,
+            Indented = false,
+            MaxDepth = limits.MaxJsonDepth,
+        }))
+        {
+            changeSet.WriteCanonical(writer);
+        }
+        return stream.ToArray();
+    }
+
+    private static DeliveryReceiptValidationException Invalid(string message) =>
+        new("invalid_semantic_change_set", message);
+}

--- a/Docxodus/Verification/PackageDelta.cs
+++ b/Docxodus/Verification/PackageDelta.cs
@@ -209,9 +209,9 @@ internal static class PackageDelta
         location.PropertyPath ?? string.Empty,
     });
 
+    // Mutual absence is equality here (an entry legitimately has no XML digest);
+    // comparison is the shared strict ordinal one — internally generated digests are
+    // always lower-case, so the previous case-insensitivity was dead tolerance.
     private static bool DigestEquals(VerificationDigest? left, VerificationDigest? right) =>
-        left is null && right is null
-        || left is not null && right is not null
-        && string.Equals(left.Algorithm, right.Algorithm, StringComparison.OrdinalIgnoreCase)
-        && string.Equals(left.Value, right.Value, StringComparison.OrdinalIgnoreCase);
+        DeliveryReceiptValidation.OptionalDigestEquals(left, right);
 }

--- a/Docxodus/Verification/RedlineReversibilityProof.cs
+++ b/Docxodus/Verification/RedlineReversibilityProof.cs
@@ -265,17 +265,17 @@ public sealed record RedlineReversibilityProof
                 WriteIndented = indented,
             };
             options.Converters.Add(new JsonStringEnumConverter<RedlineRevisionDisposition>(
-                JsonNamingPolicy.CamelCase));
+                JsonNamingPolicy.CamelCase, allowIntegerValues: false));
             options.Converters.Add(new JsonStringEnumConverter<RedlineProofDirection>(
-                JsonNamingPolicy.CamelCase));
+                JsonNamingPolicy.CamelCase, allowIntegerValues: false));
             options.Converters.Add(new JsonStringEnumConverter<RedlinePackageDivergenceKind>(
-                JsonNamingPolicy.CamelCase));
+                JsonNamingPolicy.CamelCase, allowIntegerValues: false));
             options.Converters.Add(new JsonStringEnumConverter<RevisionFamily>(
-                JsonNamingPolicy.CamelCase));
+                JsonNamingPolicy.CamelCase, allowIntegerValues: false));
             options.Converters.Add(new JsonStringEnumConverter<RevisionResolutionStatus>(
-                JsonNamingPolicy.CamelCase));
+                JsonNamingPolicy.CamelCase, allowIntegerValues: false));
             options.Converters.Add(new JsonStringEnumConverter<VerificationFindingSeverity>(
-                JsonNamingPolicy.CamelCase));
+                JsonNamingPolicy.CamelCase, allowIntegerValues: false));
             return new RedlineReversibilityProofJsonContext(options);
         }
     }

--- a/Docxodus/Verification/RedlineReversibilityProof.cs
+++ b/Docxodus/Verification/RedlineReversibilityProof.cs
@@ -233,6 +233,23 @@ public sealed record RedlineReversibilityProof
         this, (indented ? JsonOptions.Indented : JsonOptions.Canonical)
             .RedlineReversibilityProof);
 
+    internal static bool IsExactCanonical(ReadOnlySpan<byte> bytes)
+    {
+        try
+        {
+            var proof = JsonSerializer.Deserialize(
+                bytes, JsonOptions.Canonical.RedlineReversibilityProof);
+            return proof is not null
+                && string.Equals(proof.Schema, SchemaId, StringComparison.Ordinal)
+                && proof.SchemaVersion == 1
+                && bytes.SequenceEqual(proof.ToCanonicalUtf8Bytes());
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
     private static class JsonOptions
     {
         internal static readonly RedlineReversibilityProofJsonContext Canonical =

--- a/Docxodus/Verification/RedlineReversibilityVerifier.cs
+++ b/Docxodus/Verification/RedlineReversibilityVerifier.cs
@@ -1549,9 +1549,7 @@ public static class RedlineReversibilityVerifier
     };
 
     private static bool DigestEquals(VerificationDigest? left, VerificationDigest? right) =>
-        left is not null && right is not null
-        && string.Equals(left.Algorithm, right.Algorithm, StringComparison.Ordinal)
-        && string.Equals(left.Value, right.Value, StringComparison.Ordinal);
+        DeliveryReceiptValidation.DigestEquals(left, right);
 
     private static DocxSession OpenProofSession(
         byte[] bytes,

--- a/Docxodus/Verification/SemanticChangeSet.cs
+++ b/Docxodus/Verification/SemanticChangeSet.cs
@@ -256,19 +256,23 @@ public sealed class SemanticChangeSet
     {
         using var buffer = new MemoryStream();
         using (var writer = new Utf8JsonWriter(buffer, new JsonWriterOptions { Indented = indented }))
-        {
-            writer.WriteStartObject();
-            writer.WriteString("schema", Schema);
-            writer.WriteNumber("schemaVersion", SchemaVersion);
-            writer.WriteNumber("changeCount", ChangeCount);
-            writer.WriteStartArray("changes");
-            foreach (var change in Changes)
-                WriteChange(writer, change);
-            writer.WriteEndArray();
-            writer.WriteEndObject();
-        }
+            WriteCanonical(writer);
 
         return Encoding.UTF8.GetString(buffer.ToArray());
+    }
+
+    internal void WriteCanonical(Utf8JsonWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        writer.WriteStartObject();
+        writer.WriteString("schema", Schema);
+        writer.WriteNumber("schemaVersion", SchemaVersion);
+        writer.WriteNumber("changeCount", ChangeCount);
+        writer.WriteStartArray("changes");
+        foreach (var change in Changes)
+            WriteChange(writer, change);
+        writer.WriteEndArray();
+        writer.WriteEndObject();
     }
 
     private static void WriteChange(Utf8JsonWriter writer, SemanticChange change)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ cites are the final document's.
   validation, cross-part closure, workflow residue, baseline-aware findings, expected deltas, and
   digest-bound renderer artifacts into one canonical pass/failed report. Default report operations
   are also available through WASM/npm, Python, and MCP.
+- **Delivery change receipts.** `DeliveryChangeReceiptBuilder` binds one delivery into a
+  canonical, hash-addressed record — source/delivered package identities, every normalized
+  request and transaction with its undo/redo lineage, requested/derived/unexpected change
+  attribution, typed semantic evidence, page citations pinned to a render fingerprint, and
+  the digest of every artifact — and `DeliveryChangeReceiptVerifier` re-checks all of it
+  from raw bytes, so a recipient can verify what an automated edit did (and that nothing
+  else changed) without trusting the system that produced it. Core .NET today; the
+  cross-surface ripple is tracked in #520.
 - **N-way consolidate.** Merge many reviewers' copies against one base into a single multi-author
   tracked-changes document, with a structured conflict report.
 - Headers and footers are compared too — the way Word's own "Headers and footers" option does, and

--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ reading first:
 | [`semantic_diff.md`](docs/architecture/semantic_diff.md) | Stable semantic-change schema, package coverage, canonicalization, and limits |
 | [`docx_mutation_api.md`](docs/architecture/docx_mutation_api.md) | `DocxSession` — full surface, anchor lifecycle, error catalog, markdown subset |
 | [`native_content_controls.md`](docs/architecture/native_content_controls.md) | Native Word content-control registry, fills, binding/lock safety, and transports |
+| [`delivery_change_receipt.md`](docs/architecture/delivery_change_receipt.md) | Deterministic delivery receipts, LIFO lineage, exact semantic/package artifacts, privacy, citations, and verification |
 | [`markdown_projection.md`](docs/architecture/markdown_projection.md) | The projection spec and anchor format |
 | [`docx_converter.md`](docs/architecture/docx_converter.md) | `WmlToHtmlConverter` internals |
 | [`editor_ui_surface.md`](docs/architecture/editor_ui_surface.md) | The browser editor, control by control |

--- a/docs/architecture/delivery_change_receipt.md
+++ b/docs/architecture/delivery_change_receipt.md
@@ -21,6 +21,47 @@ trusting the producer — tampering with the receipt, an artifact, or the docume
 verification with a specific finding. Privacy profiles let a producer prove *what changed
 and that nothing else did* without shipping document text at all.
 
+## Trust model
+
+Verification relocates trust; it does not remove it. Precisely:
+
+**Established by a passing verification, with no trust in the producer.**
+
+- Post-delivery integrity. The receipt digest covers the canonical payload and every
+  available artifact is bound by its own digest and byte length, so substituting or
+  editing the document, an artifact, or the receipt after delivery fails verification.
+- Internal consistency. A receipt cannot tell a partial story: every package-level
+  change carries an attribution — user-requested changes must reference a successful
+  retained operation, and unattributed changes are recorded as unexpected rather than
+  omitted; lineage must replay as a valid undo/redo state machine; citations must
+  project from the exact page-map bytes for the claimed document version and renderer
+  fingerprint; typed evidence must reconstruct byte-for-byte.
+- Re-derivable claims. The receipt identifies the source package and the delivered
+  bytes, so a consumer can recompute the semantic comparison with independent tooling
+  and compare it against the recorded change set. The redline-reversibility proof
+  records what accepting and rejecting every revision produces; a consumer can re-run
+  those operations on the delivered redline and check the recorded equivalences and
+  divergences directly.
+
+**Still trusted after a passing verification.**
+
+- The emission path at production time. A producer that fabricates a false delivery
+  together with internally consistent evidence for it produces a receipt that
+  verifies. Verification bounds what a lie must look like — a complete, mutually
+  consistent forgery spanning manifests, transactions, lineage, semantic evidence, and
+  artifacts — it does not prevent one.
+- The verifier implementation the consumer runs.
+
+**How that residue is reduced.**
+
+- The wire contract is a published, closed schema with fully specified
+  canonicalization, so independent verifier implementations are possible, and any two
+  must accept exactly the same bytes.
+- Determinism gives external mechanisms a stable target. Non-repudiation is out of
+  scope by design: a caller who needs it signs the canonical receipt bytes, and
+  anchoring the receipt digest in an external timestamped log pins the production
+  moment. Both depend on canonical bytes existing; neither is provided by this schema.
+
 Issue #458 composes evidence that already belongs to the document transaction, package,
 semantic-diff, rendering, and verification layers. It does not create a second mutation
 engine or reinterpret those components' schemas.

--- a/docs/architecture/delivery_change_receipt.md
+++ b/docs/architecture/delivery_change_receipt.md
@@ -48,10 +48,12 @@ evidence, warnings, authored changes, object changes, affected-anchor sets, tran
 lineage events therefore remains invalid.
 
 Wall-clock receipt-generation time, local paths, ZIP timestamps, random identifiers, and
-renderer process details are excluded. A caller-provided transaction ID is retained, but
-the receipt entry identity is deterministically derived from its request fingerprint,
-base/result document versions, and before/after package identities. Replaying an already
-committed idempotent transaction contributes the same entry rather than a second edit.
+renderer process details are excluded. A caller-provided transaction ID is retained and included
+in the receipt entry identity; entries without one use their deterministic receipt sequence. The
+remaining identity inputs are the request fingerprint, base/result document versions, and
+before/after package identities. Replaying an already committed identified transaction contributes
+the same entry rather than a second edit, while distinct identified or anonymous no-op
+transactions remain distinct entries.
 
 ## Transaction evidence
 
@@ -92,24 +94,25 @@ advances the document version by exactly one, and a new state-changing transacti
 A committed no-op neither enters applied history nor clears redo. Undo followed by redo therefore
 preserves one transaction entry plus two reversible state transitions. Repeated undo, redo before
 undo, and undo of an older entry while a newer entry is applied all fail closed. A retry with an
-identical transaction ID and request fingerprint references the original entry; a conflicting
-fingerprint fails before receipt composition.
+identical transaction ID, request fingerprint, and result evidence references the original entry;
+a conflicting fingerprint or result fails before receipt composition.
 
 ## Change attribution
 
-Receipt change records use one of three dispositions:
+Receipt package-change records use one of three dispositions:
 
 - `userRequested`: directly covered by a normalized requested operation;
 - `derived`: required fallout whose derivation is known, such as a relationship or content
   type added for requested media;
-- `unexpected`: observed in the package or semantic change set but not covered by requested
-  or declared derived-change rules.
+- `unexpected`: observed in the package delta but not covered by requested or declared
+  derived-change rules.
 
-Attribution never hides evidence. The complete semantic change set and changed manifest
-entries remain referenced even when every change is expected. A caller may provide an
-expected-change policy, but unknown parts, relationships, or semantic locations default to
-`unexpected`. Receipt success can be configured to fail on any unexpected change without
-altering the underlying evidence.
+Attribution never hides evidence. The complete semantic change set remains referenced and every
+changed manifest entry remains recorded even when each package change is expected. Attribution
+rules apply to the package delta; semantic changes retain their owner-defined #457 classification
+instead of receiving a second receipt-level disposition. Unknown parts and relationships default
+to `unexpected`. Receipt success can be configured to fail on any unexpected package change
+without altering the underlying evidence.
 
 Every package-change record carrying an operation index, including `derived`, must identify an
 operation that succeeded and was not rolled back in a committed or partially committed
@@ -266,15 +269,20 @@ new digest, not the original evidence.
 
 ## Dependency boundary
 
-The receipt consumes package manifests from #456 and semantic change sets from #457. All
-package-manifest API assumptions are confined to `DeliveryPackageManifestAdapter`, which uses the
-corrected #493 contract and rejects manifests whose `IsValid` flag is false while preserving the
-distinction between unavailable optional content/semantic digests and invalid packages. The sole
-#457 seam accepts a typed `SemanticChangeSet`, stores its exact `ToCanonicalUtf8Bytes()` output,
-and records the public schema, version, and count. Portable verification strictly reconstructs the
-full nested #457 change/value schema and requires its exact canonical bytes; receipt fields are not
-used as a substitute for that owner-defined contract.
-The receipt embeds validation and reversibility results from #463/#464 when supplied, without
-flattening or renaming their fields. The delivery operation in #465 assembles artifacts and
-invokes the receipt builder; receipt construction itself performs no document mutation,
+The receipt consumes package manifests from #456, semantic change sets from #457, and the
+policy-neutral package delta from #463. All package-manifest API assumptions are confined to
+`DeliveryPackageManifestAdapter`, which uses the corrected #493 contract, rejects manifests whose
+`IsValid` flag is false, preserves the distinction between unavailable optional content/semantic
+digests and invalid packages, and adapts the shared delta instead of defining another entry or
+relationship comparator. The sole #457 seam accepts a typed `SemanticChangeSet`, stores its exact
+`ToCanonicalUtf8Bytes()` output, and records the public schema, version, and count. Portable
+verification strictly reconstructs the full nested #457 change/value schema and requires its exact
+canonical bytes; receipt fields are not used as a substitute for that owner-defined contract.
+The receipt hash-addresses exact validation and reversibility artifacts from #463/#464 when
+supplied, using their owner-defined schema identifiers and canonical bytes without flattening or
+renaming their fields. This generic evidence boundary verifies artifact identity and availability;
+it does not reinterpret the owner's pass/fail decision. A consumer that needs to trust that
+decision must parse and verify the artifact with the #463 or #464 contract. The delivery operation
+in #465 assembles artifacts and invokes the receipt builder; receipt construction itself performs
+no document mutation,
 rendering, ZIP inspection, or OOXML parsing outside those shared components.

--- a/docs/architecture/delivery_change_receipt.md
+++ b/docs/architecture/delivery_change_receipt.md
@@ -1,5 +1,26 @@
 # Delivery change receipt
 
+## Why this exists
+
+When an automated system — increasingly an AI agent driving `DocxSession` through MCP —
+edits a document and hands back a delivery, the recipient has to take three claims on
+faith: that the delivered document is exactly what the recorded edits produced and nothing
+else changed; that every artifact (clean DOCX, redline, PDF, HTML, page citations) really
+corresponds to that exact document version; and that all of this can still be proven later,
+to an auditor, a counterparty, or a court, without re-running the pipeline.
+
+The delivery change receipt turns those claims into checkable facts. It is a signed-build-
+manifest equivalent for a document delivery: one canonical, hash-addressed JSON record that
+binds the source and delivered package identities to every requested operation, every
+transaction and its undo/redo lineage, the semantic before/after changes, an attribution of
+every package-level change as requested, derived, or unexpected, page citations pinned to
+the document version and render fingerprint that produced them, and the digest of every
+delivered artifact. The verifier is the other half of the feature: it re-derives everything
+from raw bytes, adversarially and offline, so a consumer can validate a delivery without
+trusting the producer — tampering with the receipt, an artifact, or the document fails
+verification with a specific finding. Privacy profiles let a producer prove *what changed
+and that nothing else did* without shipping document text at all.
+
 Issue #458 composes evidence that already belongs to the document transaction, package,
 semantic-diff, rendering, and verification layers. It does not create a second mutation
 engine or reinterpret those components' schemas.

--- a/docs/architecture/delivery_change_receipt.md
+++ b/docs/architecture/delivery_change_receipt.md
@@ -17,12 +17,16 @@ A delivery receipt connects these immutable inputs:
 - optional review DOCX, HTML, PDF, image, and report artifacts;
 - optional page citations produced for a specific document version and render fingerprint.
 
-The schema identifier is
-`https://docxodus.dev/schemas/verification/delivery-change-receipt/v1`. A receipt is an
-envelope containing a canonical `payload` and a `receiptDigest`. The digest is SHA-256
-over the canonical UTF-8 JSON bytes of `payload`; it never includes itself. Every artifact
-record carries its own SHA-256 and byte length. Verification first checks the receipt
-digest, then independently hashes each available artifact.
+The exact writer contract is published as
+[delivery-change-receipt-v1.schema.json](../schemas/delivery-change-receipt-v1.schema.json),
+with schema identifier
+`https://docxodus.dev/schemas/verification/delivery-change-receipt/v1`. The schema is the
+closed projection emitted by the v1 writer: nullable members are present as JSON `null` and
+collections are present as arrays, including when empty. A receipt is an envelope containing a
+canonical `payload` and a `receiptDigest`. The digest is SHA-256 over the canonical UTF-8 JSON
+bytes of `payload`; it never includes itself. Every available artifact record carries its own
+SHA-256 and byte length. Verification first checks the receipt digest, then independently hashes
+each available artifact.
 
 The receipt proves what the supplied evidence says and whether referenced bytes still
 match. It is not a signature or an assertion about who controlled a transaction ID.
@@ -31,16 +35,32 @@ this schema.
 
 ## Deterministic payload
 
-Canonical serialization uses UTF-8 without a byte-order mark, camel-case property names,
-JSON strings for enums, no insignificant whitespace, and invariant number formatting.
-Every JSON object's properties are sorted by property name using ordinal comparison;
-duplicate property names are rejected. Map-shaped inputs are emitted as arrays sorted by
-their stable key. Sets, findings, package parts, relationships, artifacts, and warnings have
-defined ordinal sort keys. Operation, transaction, and lineage-event arrays retain their
-meaningful execution order. Transactions and undo/redo events also carry one contiguous shared
-`sequence`, so chronology remains unambiguous when an edit follows an undo. Numeric spelling
-inside arbitrary operation or external-evidence extensions is retained in v1, while core receipt
-numbers use the invariant spelling emitted by `System.Text.Json`.
+Canonical serialization uses UTF-8 without a byte-order mark, camel-case property names, JSON
+strings for enums, and no insignificant whitespace. String escaping is exactly
+`Utf8JsonWriter` with `JavaScriptEncoder.Default`, not `UnsafeRelaxedJsonEscaping`: JSON quote,
+backslash, and control-character escapes use the writer's fixed spellings; HTML-sensitive Basic
+Latin characters are escaped; and non-Basic-Latin scalar values are emitted as uppercase
+`\uXXXX` UTF-16 code-unit escapes, using a surrogate pair for a supplementary scalar. `/` is not
+escaped. These escape spellings, including escape-letter and hexadecimal case, are hash-significant.
+
+Every JSON object's properties are sorted with `string.CompareOrdinal`. This is a comparison of
+UTF-16 code units with no culture, case folding, or Unicode normalization; it is not UTF-8 byte or
+Unicode scalar-value order. Duplicate property names are rejected. Map-shaped inputs are emitted
+as arrays sorted by their stable key. Sets, findings, package parts, relationships, artifacts, and
+warnings have defined ordinal sort keys. Operation, transaction, and lineage-event arrays retain
+their meaningful execution order. Transactions and undo/redo events also carry one contiguous
+shared `sequence`, so chronology remains unambiguous when an edit follows an undo.
+
+Core receipt numbers use the exact invariant token emitted by the typed `System.Text.Json` writer.
+When raw JSON is verified, every known numeric field must have the same raw token as that typed
+projection: numerically equivalent alternatives such as `1.0` or `1e0` do not match core `1`.
+Conversely, a numeric value in an unknown `fullEvidence` extension is grammar-validated and then
+written with its original `JsonElement.GetRawText()` token; it is never rounded through `double`.
+Different extension lexemes therefore produce different receipt digests even when they denote the
+same mathematical value. All typed non-negative 64-bit receipt integers (versions, sequences,
+artifact lengths, and citation versions) are restricted to the JavaScript-portable interval
+0 through 9007199254740991 inclusive. Typed 32-bit counts and indexes retain their narrower CLR
+range. The portable-integer rule does not reinterpret arbitrary extension-number tokens.
 
 Portable verification enforces the builder's order, not merely the enclosing payload digest.
 Rehashing a payload after reordering or duplicating artifacts, package changes, citations,
@@ -64,8 +84,12 @@ The entry records:
 - atomic or best-effort mode, base version, result version, and outcome;
 - normalized operations in step order, including tool, action, and normalized arguments;
 - resolved anchors, scopes, created/modified/removed objects, and structured errors;
-- revision, comment, and annotation changes with their recorded authorship;
+- revision, comment, and annotation changes with their recorded authorship; revision evidence also
+  retains the owner record's `dateUtc`, family, part URI, scope, primary anchor, resolution status,
+  privacy-aware diagnostic, constituent IDs, and constituent keys;
 - before/after package identities and the semantic changes attributable to the entry;
+- the batch result's optional reported package-content digest as evidence distinct from the
+  independently manifested before/after package identities;
 - warnings emitted by the transaction and evidence collectors.
 
 Operation arguments are data, never embedded JSON fragments. Normalization rejects
@@ -81,9 +105,13 @@ prefix `succeededRolledBack`, the failing operation `failedRolledBack`, and the 
 verifier recomputes operation success from every nested result and checks execution/rollback state
 against the transaction outcome. A best-effort transaction is partially committed only when it
 retained at least one successful step and at least one failed step. Isolated previews may be
-recorded as predictions, but they are distinct from committed entries and cannot advance the
-delivered-document lineage. Because `MutationBatchStepResult.Success` is the conjunction of its
-results, an executed step may legitimately return an empty result list: it is retained as a
+recorded as predictions, but they are distinct from committed entries. A prediction must start at
+the current receipt state. Its after identity may equal its before identity, or it may report a
+version exactly one greater when at least one operation succeeded. Either way, prediction output is
+not registered as reachable, does not become current, does not enter the applied stack, and does
+not clear or populate the redo stack; the next real transition must still start from the
+pre-prediction current identity. Because `MutationBatchStepResult.Success` is the conjunction of
+its results, an executed step may legitimately return an empty result list: it is retained as a
 successful no-op operation rather than being rewritten as an internal failure.
 
 Undo and redo do not masquerade as new user-requested changes. They are ordered lineage
@@ -114,26 +142,44 @@ instead of receiving a second receipt-level disposition. Unknown parts and relat
 to `unexpected`. Receipt success can be configured to fail on any unexpected package change
 without altering the underlying evidence.
 
-Every package-change record carrying an operation index, including `derived`, must identify an
-operation that succeeded and was not rolled back in a committed or partially committed
-transaction. This is especially important for partially committed best-effort batches: a failed
-step remains visible as evidence, but it cannot be used to explain bytes retained by a different
-successful step. `derived` changes may reference their originating transaction and operation with
-an explicit derivation.
+Every package-change record that names a transaction must name a committed or partially committed
+transaction that remains on the final applied stack. If it also carries an operation index,
+including for `derived`, that operation must have succeeded and must not have been rolled back. An
+undone transaction cannot explain delivered bytes; a subsequent valid redo makes it applied again.
+This is especially important for partially committed best-effort batches: a failed step remains
+visible as evidence, but it cannot be used to explain bytes retained by a different successful
+step. `derived` changes may reference their originating transaction and operation with an explicit
+derivation.
 
 ## Privacy profiles
 
-The default `hashAndSummary` profile includes stable locations, change kinds, counts,
-digests, and bounded summaries, but excludes full paragraph, comment, and operation text.
-`hashOnly` retains identities, dispositions, counts, and hashes with text summaries omitted.
-`fullEvidence` includes complete normalized operation, result, authorship, and package-record
-values. Semantic evidence remains an exact, separately hashed artifact owned by the #457 schema;
-the receipt records only its root schema/version/count and transition binding.
+The default `hashAndSummary` profile includes stable locations, change kinds, counts, digests, and
+bounded structural summaries, but excludes full paragraph, comment, and operation text. `hashOnly`
+retains identities, dispositions, counts, and hashes with `DeliveryTextEvidence.summary` and
+`.value` both null. `hashAndSummary` requires a non-textual summary and a null value;
+`fullEvidence` requires both the summary and exact value. `characterCount` is .NET `string.Length`,
+so it counts UTF-16 code units rather than Unicode scalar values or grapheme clusters; `digest` is
+SHA-256 over the exact UTF-8 encoding of the value.
+
+Revision diagnostic messages use `DeliveryTextEvidence`. Free-form derivations,
+artifact-unavailable reasons, and supplied evidence summaries use the same profile boundary.
+`hashOnly` stores only `sha256:<64 lower-case hex>`; `hashAndSummary` stores
+`<field label>; <UTF-16 count> characters; sha256:<64 lower-case hex>`; and `fullEvidence` stores
+the original text. Operation argument summaries are structural property counts and full argument,
+result, authored, and package-record values occur only in `fullEvidence`. Semantic evidence remains
+an exact, separately hashed artifact owned by the #457 schema; the receipt records only its root
+schema/version/count and transition binding.
 
 The selected profile is part of the canonical payload. Redaction is performed before
-canonicalization and hashing; removing text from an already generated receipt invalidates
-its digest. Artifact hashes remain available in every profile, so a verifier with authorized
-access to the bytes can validate them independently.
+canonicalization and hashing; removing text from an already generated receipt invalidates its
+digest. Artifact hashes remain available in every profile, so a verifier with authorized access to
+the bytes can validate them independently. The JSON verifier authenticates the raw payload before
+deserialization and then requires every known field, array position, value, and core numeric lexeme
+to equal the typed projection. Unknown optional object properties may be retained only for
+`fullEvidence`. They are rejected recursively for `hashOnly` and `hashAndSummary`, because an
+otherwise ignored field could smuggle free text past redaction. The published schema describes the
+closed output of the current writer; this `fullEvidence` reader allowance is the additive
+compatibility rule, not permission for the v1 writer to invent fields.
 
 ## Page citations and render evidence
 
@@ -149,11 +195,13 @@ A page citation is accepted only with all of:
 
 Receipt construction rejects a citation whose version, package identity, renderer
 fingerprint, or artifact reference does not match the supplied delivery evidence. A
-continuous HTML projection is not promoted to a page citation. Both construction and portable
-verification strictly parse the referenced PageMap bytes, reject malformed UTF-8 and duplicate
-JSON properties, apply the same portable geometry/order/story contract used by
-`DocxSession.RegisterPageMap`, and project the citation again. The PageMap artifact digest remains
-over the renderer's original bytes; JSON canonicalization is only an input-validity gate.
+continuous HTML projection is not promoted to a page citation. A `PageImage` artifact is also
+excluded: the citation's render artifact must have role `Pdf` or `RenderReport`, even when an image
+represents one physical page. Both construction and portable verification strictly parse the
+referenced PageMap bytes, reject malformed UTF-8 and duplicate JSON properties, apply the same
+portable geometry/order/story contract used by `DocxSession.RegisterPageMap`, and project the
+citation again. The PageMap artifact digest remains over the renderer's original bytes; JSON
+canonicalization is only an input-validity gate.
 
 ## Artifact records
 
@@ -170,23 +218,27 @@ package manifest, validation result, reversibility proof, and render reports. An
 artifact has an explicit reason and no digest or byte length; it cannot masquerade as an output
 that was produced and verified.
 
-The caller's manifest is not accepted as proof of the clean output. Construction and verification
-both run the corrected bounded package-manifest generator over the exact supplied bytes, require a
-valid OPC package with a WordprocessingML main document, and compare the recomputed raw, ordered
-OPC-content, and normalized-semantic identities with `DeliveredDocument`. The recomputed clean
-manifest's entries and relationships—not a same-identity caller inventory—are also the sole source
-for delivered package-change observations. Semantic JSON receives
+The caller's manifest is not accepted as proof of the clean output. Every document identity carries
+the package-manifest schema and the manifest's `MainDocumentUri`, in addition to its raw and
+optional content/semantic digests. Construction and verification both run the corrected bounded
+package-manifest generator over the exact supplied clean bytes, require a valid OPC package with a
+WordprocessingML main document, and compare the recomputed package kind, schema, main-document URI,
+raw digest, ordered OPC-content digest, and normalized-semantic digest with `DeliveredDocument`.
+The recomputed clean manifest's entries and relationships—not a same-identity caller inventory—are
+also the sole source for delivered package-change observations. Semantic JSON receives
 the analogous treatment: the complete closed #457 type graph is reconstructed and accepted only
 when serializing it again produces byte-for-byte identical canonical evidence. Whitespace,
 property-order variants, partial objects, null nested records, and merely rehashed substitutes fail.
 
 The source side has a narrower trust boundary in v1: receipt construction receives a source
 manifest but not the exact source DOCX bytes, so it cannot independently reparse that inventory.
-Source entries and relationships are therefore trusted caller input and affect the reported deltas
-even when the manifest carries a genuine raw-package digest identity. Consumers must not treat that
-digest alone as authentication of the supplied source inventory. A future exact-source artifact
-registration can make source and delivered inventory verification symmetric without changing this
-v1 behavior.
+The adapter does require the supported manifest schema/version, `IsValid`, package kind `opc`, and
+a nonblank Word main-document URI before creating `SourceDocument`; those are caller-attested
+manifest facts, not a reparse of source bytes. Source entries and relationships are therefore
+trusted caller input and affect the reported deltas even when the manifest carries a genuine
+raw-package digest identity. Consumers must not treat that digest or main-document URI alone as
+authentication of the supplied source inventory. A future exact-source artifact registration can
+make source and delivered inventory verification symmetric without changing this v1 behavior.
 
 The receipt envelope is stored beside those outputs and is verified by hashing its canonical
 payload. Artifact records are covered by that digest, and their bytes are covered by their
@@ -247,20 +299,29 @@ inspection additionally uses `CleanDocxManifestOptions`, whose corrected #493 pa
 authoritative. Verification accepts overrides through `DeliveryReceiptVerificationOptions` and
 returns stable `*_resource_limit` findings rather than parsing, decoding, copying, or hashing past
 the applicable boundary. Object-based construction and verification preflight aggregate collection,
-escaped-string, semantic-value depth, and serialized-byte budgets before canonicalization; receipt,
+escaped-string, semantic-value depth, and serialized-byte budgets before canonicalization. Receipt,
 canonical JSON, and exact typed-semantic writers additionally write through hard-capped streams, so
 the configured ceiling is enforced while bytes are produced rather than after an oversized buffer
-already exists. JSON arrays are charged one item at a time before recursion, and object properties
-are charged before entering the capped sortable property list; neither path first materializes an
-untrusted collection merely to learn that it exceeds the item budget.
+already exists. Every public receipt-output path is bounded: the overloads without limits use
+validated defaults; the overloads accepting `DeliveryReceiptLimits` cap payload and compact
+envelope output at that instance's `MaxReceiptJsonBytes`; and an indented request re-emits the
+already canonical envelope through a second stream capped at the same configured value. Indented
+output may therefore be rejected even when its compact equivalent fits. JSON arrays are charged one
+item at a time before recursion, and object properties are charged before entering the capped
+sortable property list; neither path first materializes an untrusted collection merely to learn
+that it exceeds the item budget.
 
 ## Schema evolution
 
-Within `payload`, schema v1 is additive: readers must ignore unknown optional fields but must
-reject unknown enum values, digest algorithms, required evidence kinds, and major versions.
-The envelope itself has exactly `payload` and `receiptDigest`, preventing unprotected top-level
-extensions. A new required field, changed canonicalization rule, changed field meaning, or
-changed default attribution/privacy behavior requires v2 and a new schema identifier.
+The checked-in v1 schema is the exact, closed writer projection. Portable readers provide a narrow
+additive rule only for a `fullEvidence` payload: after authenticating the raw payload, they may
+ignore unknown optional object properties but still require the complete known projection with
+exact values and array lengths. Redacted profiles reject unknown properties recursively. All
+profiles reject unknown enum values, digest algorithms, required evidence kinds, and major
+versions. The envelope itself has exactly `payload` and `receiptDigest`, preventing unprotected
+top-level extensions. A new required field, changed canonicalization or escaping rule, changed
+field meaning, or changed default attribution/privacy behavior requires v2 and a new schema
+identifier.
 
 Writers always emit one exact schema identifier and canonicalization profile. Readers may
 migrate an older payload to an internal model for display, but verification uses the rules
@@ -278,11 +339,16 @@ relationship comparator. The sole #457 seam accepts a typed `SemanticChangeSet`,
 `ToCanonicalUtf8Bytes()` output, and records the public schema, version, and count. Portable
 verification strictly reconstructs the full nested #457 change/value schema and requires its exact
 canonical bytes; receipt fields are not used as a substitute for that owner-defined contract.
-The receipt hash-addresses exact validation and reversibility artifacts from #463/#464 when
-supplied, using their owner-defined schema identifiers and canonical bytes without flattening or
-renaming their fields. This generic evidence boundary verifies artifact identity and availability;
-it does not reinterpret the owner's pass/fail decision. A consumer that needs to trust that
-decision must parse and verify the artifact with the #463 or #464 contract. The delivery operation
-in #465 assembles artifacts and invokes the receipt builder; receipt construction itself performs
-no document mutation,
-rendering, ZIP inspection, or OOXML parsing outside those shared components.
+The receipt hash-addresses validation and reversibility artifacts from #463/#464 without flattening
+or renaming their fields. Their generic references require the exact owner schema identifier. When
+a reference names an artifact, the artifact must be available under the owner-specific role, its
+digest must equal the reference digest, and both construction and portable verification require the
+supplied bytes to be the owner's exact canonical serialization: the full closed owner type is
+deserialized and reserialized, so whitespace, reordered properties, omitted/null substitutions,
+unknown fields, and merely rehashed lookalikes fail. A reference without an artifact ID is only a
+schema-and-digest assertion because no owner bytes are present to parse. In either case, the receipt
+does not reinterpret the owner's pass/fail or success decision; a consumer that relies on that
+decision applies the #463 or #464 semantics to the authenticated owner object. The delivery
+operation in #465 assembles artifacts and invokes the receipt builder; receipt construction itself
+performs no document mutation, rendering, ZIP inspection, or OOXML parsing outside those shared
+components.

--- a/docs/architecture/delivery_change_receipt.md
+++ b/docs/architecture/delivery_change_receipt.md
@@ -352,3 +352,12 @@ decision applies the #463 or #464 semantics to the authenticated owner object. T
 operation in #465 assembles artifacts and invokes the receipt builder; receipt construction itself
 performs no document mutation, rendering, ZIP inspection, or OOXML parsing outside those shared
 components.
+
+## Surface scope
+
+The builder and verifier are deliberately core-.NET-only for now: nothing is exposed on the
+`*Ops` facades, WASM bridge, npm/TypeScript, stdio Python host, or MCP server, matching the rest
+of the verify track until the delivery operation (#465) fixes the shape callers actually need.
+The cross-surface ripple required by the CLAUDE.md checklist is tracked in #520; the JSON
+receipt itself is already portable, so non-.NET consumers can verify receipts once the ripple
+lands without a schema change.

--- a/docs/architecture/delivery_change_receipt.md
+++ b/docs/architecture/delivery_change_receipt.md
@@ -1,0 +1,280 @@
+# Delivery change receipt
+
+Issue #458 composes evidence that already belongs to the document transaction, package,
+semantic-diff, rendering, and verification layers. It does not create a second mutation
+engine or reinterpret those components' schemas.
+
+## Contract and trust boundary
+
+A delivery receipt connects these immutable inputs:
+
+- the source and delivered DOCX package identities from the package manifest;
+- one or more committed mutation-batch results and their normalized requests;
+- exactly one typed source-to-delivered semantic change set and one for every state-changing
+  transaction;
+- exactly one available clean DOCX whose bytes are the delivered package;
+- optional validation and redline-reversibility results;
+- optional review DOCX, HTML, PDF, image, and report artifacts;
+- optional page citations produced for a specific document version and render fingerprint.
+
+The schema identifier is
+`https://docxodus.dev/schemas/verification/delivery-change-receipt/v1`. A receipt is an
+envelope containing a canonical `payload` and a `receiptDigest`. The digest is SHA-256
+over the canonical UTF-8 JSON bytes of `payload`; it never includes itself. Every artifact
+record carries its own SHA-256 and byte length. Verification first checks the receipt
+digest, then independently hashes each available artifact.
+
+The receipt proves what the supplied evidence says and whether referenced bytes still
+match. It is not a signature or an assertion about who controlled a transaction ID.
+Callers that need authorship or non-repudiation sign the canonical receipt bytes outside
+this schema.
+
+## Deterministic payload
+
+Canonical serialization uses UTF-8 without a byte-order mark, camel-case property names,
+JSON strings for enums, no insignificant whitespace, and invariant number formatting.
+Every JSON object's properties are sorted by property name using ordinal comparison;
+duplicate property names are rejected. Map-shaped inputs are emitted as arrays sorted by
+their stable key. Sets, findings, package parts, relationships, artifacts, and warnings have
+defined ordinal sort keys. Operation, transaction, and lineage-event arrays retain their
+meaningful execution order. Transactions and undo/redo events also carry one contiguous shared
+`sequence`, so chronology remains unambiguous when an edit follows an undo. Numeric spelling
+inside arbitrary operation or external-evidence extensions is retained in v1, while core receipt
+numbers use the invariant spelling emitted by `System.Text.Json`.
+
+Portable verification enforces the builder's order, not merely the enclosing payload digest.
+Rehashing a payload after reordering or duplicating artifacts, package changes, citations,
+evidence, warnings, authored changes, object changes, affected-anchor sets, transactions, or
+lineage events therefore remains invalid.
+
+Wall-clock receipt-generation time, local paths, ZIP timestamps, random identifiers, and
+renderer process details are excluded. A caller-provided transaction ID is retained, but
+the receipt entry identity is deterministically derived from its request fingerprint,
+base/result document versions, and before/after package identities. Replaying an already
+committed idempotent transaction contributes the same entry rather than a second edit.
+
+## Transaction evidence
+
+Every `DocxSession.ExecuteBatch` result that belongs to the delivery must contribute one entry.
+The entry records:
+
+- transaction ID and canonical request fingerprint when the transport supplied them;
+- atomic or best-effort mode, base version, result version, and outcome;
+- normalized operations in step order, including tool, action, and normalized arguments;
+- resolved anchors, scopes, created/modified/removed objects, and structured errors;
+- revision, comment, and annotation changes with their recorded authorship;
+- before/after package identities and the semantic changes attributable to the entry;
+- warnings emitted by the transaction and evidence collectors.
+
+Operation arguments are data, never embedded JSON fragments. Normalization rejects
+duplicate properties and uses the same operation vocabulary as the executing surface.
+Transport-only fields such as storage paths and preview controls are not document
+operations and are omitted.
+
+An atomic failure contributes diagnostic evidence but is not labeled committed. Its complete
+normalized request remains authoritative even though the core result is sparse: a preflight
+failure marks every other operation `notExecuted`, while an execution failure marks the successful
+prefix `succeededRolledBack`, the failing operation `failedRolledBack`, and the unvisited suffix
+`notExecuted`. Best-effort results cover every request and never use rolled-back states. The
+verifier recomputes operation success from every nested result and checks execution/rollback state
+against the transaction outcome. A best-effort transaction is partially committed only when it
+retained at least one successful step and at least one failed step. Isolated previews may be
+recorded as predictions, but they are distinct from committed entries and cannot advance the
+delivered-document lineage. Because `MutationBatchStepResult.Success` is the conjunction of its
+results, an executed step may legitimately return an empty result list: it is retained as a
+successful no-op operation rather than being rewritten as an internal failure.
+
+Undo and redo do not masquerade as new user-requested changes. They are ordered lineage
+events that reference the affected committed entry and record their before/after document
+versions and package identities. The builder and verifier run the same deterministic state
+machine: applied and redo histories are LIFO, every state-changing transaction or lineage event
+advances the document version by exactly one, and a new state-changing transaction clears redo.
+A committed no-op neither enters applied history nor clears redo. Undo followed by redo therefore
+preserves one transaction entry plus two reversible state transitions. Repeated undo, redo before
+undo, and undo of an older entry while a newer entry is applied all fail closed. A retry with an
+identical transaction ID and request fingerprint references the original entry; a conflicting
+fingerprint fails before receipt composition.
+
+## Change attribution
+
+Receipt change records use one of three dispositions:
+
+- `userRequested`: directly covered by a normalized requested operation;
+- `derived`: required fallout whose derivation is known, such as a relationship or content
+  type added for requested media;
+- `unexpected`: observed in the package or semantic change set but not covered by requested
+  or declared derived-change rules.
+
+Attribution never hides evidence. The complete semantic change set and changed manifest
+entries remain referenced even when every change is expected. A caller may provide an
+expected-change policy, but unknown parts, relationships, or semantic locations default to
+`unexpected`. Receipt success can be configured to fail on any unexpected change without
+altering the underlying evidence.
+
+Every package-change record carrying an operation index, including `derived`, must identify an
+operation that succeeded and was not rolled back in a committed or partially committed
+transaction. This is especially important for partially committed best-effort batches: a failed
+step remains visible as evidence, but it cannot be used to explain bytes retained by a different
+successful step. `derived` changes may reference their originating transaction and operation with
+an explicit derivation.
+
+## Privacy profiles
+
+The default `hashAndSummary` profile includes stable locations, change kinds, counts,
+digests, and bounded summaries, but excludes full paragraph, comment, and operation text.
+`hashOnly` retains identities, dispositions, counts, and hashes with text summaries omitted.
+`fullEvidence` includes complete normalized operation, result, authorship, and package-record
+values. Semantic evidence remains an exact, separately hashed artifact owned by the #457 schema;
+the receipt records only its root schema/version/count and transition binding.
+
+The selected profile is part of the canonical payload. Redaction is performed before
+canonicalization and hashing; removing text from an already generated receipt invalidates
+its digest. Artifact hashes remain available in every profile, so a verifier with authorized
+access to the bytes can validate them independently.
+
+## Page citations and render evidence
+
+A page citation is accepted only with all of:
+
+- a document version and raw package digest reachable through the validated transaction and
+  undo/redo history;
+- the anchor and scope resolved at that version;
+- page/section/fragment coordinates;
+- the complete renderer fingerprint and page-map fingerprint;
+- the independently hashed raw PageMap artifact bytes that supplied those coordinates;
+- the hash of the PDF or render report that carries the cited pagination.
+
+Receipt construction rejects a citation whose version, package identity, renderer
+fingerprint, or artifact reference does not match the supplied delivery evidence. A
+continuous HTML projection is not promoted to a page citation. Both construction and portable
+verification strictly parse the referenced PageMap bytes, reject malformed UTF-8 and duplicate
+JSON properties, apply the same portable geometry/order/story contract used by
+`DocxSession.RegisterPageMap`, and project the citation again. The PageMap artifact digest remains
+over the renderer's original bytes; JSON canonicalization is only an input-validity gate.
+
+## Artifact records
+
+Each artifact has a stable role, media type, byte length, SHA-256, availability status,
+and optional document-version/render binding. Paths are optional display hints and must be
+relative; identity never depends on them. Interior slash and backslash separators are normalized
+to `/`, while POSIX roots, UNC/backslash roots, drive-qualified paths, empty segments, and dot or
+parent segments are rejected identically on every host OS. Every receipt requires exactly one available
+`CleanDocx`: its artifact digest, package digest, document version, and actual bytes must exactly
+match `DeliveredDocument`. It also requires a `SemanticDiff` artifact containing the exact
+`SemanticChangeSet.ToCanonicalUtf8Bytes()` output for the aggregate comparison and one typed
+binding per state-changing transaction. Other roles include review DOCX, HTML, PDF, page map,
+package manifest, validation result, reversibility proof, and render reports. An unavailable
+artifact has an explicit reason and no digest or byte length; it cannot masquerade as an output
+that was produced and verified.
+
+The caller's manifest is not accepted as proof of the clean output. Construction and verification
+both run the corrected bounded package-manifest generator over the exact supplied bytes, require a
+valid OPC package with a WordprocessingML main document, and compare the recomputed raw, ordered
+OPC-content, and normalized-semantic identities with `DeliveredDocument`. The recomputed clean
+manifest's entries and relationships—not a same-identity caller inventory—are also the sole source
+for delivered package-change observations. Semantic JSON receives
+the analogous treatment: the complete closed #457 type graph is reconstructed and accepted only
+when serializing it again produces byte-for-byte identical canonical evidence. Whitespace,
+property-order variants, partial objects, null nested records, and merely rehashed substitutes fail.
+
+The source side has a narrower trust boundary in v1: receipt construction receives a source
+manifest but not the exact source DOCX bytes, so it cannot independently reparse that inventory.
+Source entries and relationships are therefore trusted caller input and affect the reported deltas
+even when the manifest carries a genuine raw-package digest identity. Consumers must not treat that
+digest alone as authentication of the supplied source inventory. A future exact-source artifact
+registration can make source and delivered inventory verification symmetric without changing this
+v1 behavior.
+
+The receipt envelope is stored beside those outputs and is verified by hashing its canonical
+payload. Artifact records are covered by that digest, and their bytes are covered by their
+individual digests. Thus changing either a record or a referenced artifact is detectable.
+
+## .NET composition and verification
+
+`DeliveryChangeReceiptBuilder` composes caller-supplied source/delivered manifests, every
+`MutationBatchResult` that belongs to the delivery, normalized operation arguments, and any
+artifacts or external evidence. It does not mutate or render a document; it does independently
+re-inspect the clean DOCX and semantic artifacts at their trust boundaries. `Build()` validates
+the document lineage and returns an immutable envelope:
+
+```csharp
+var builder = new DeliveryChangeReceiptBuilder(sourceManifest, sourceVersion)
+    .SetDeliveredDocument(deliveredManifest, deliveredVersion);
+
+string entryId = builder.AddTransaction(
+    DeliveryTransactionContribution.FromMutationBatchResult(
+        batchResult, beforeManifest, afterManifest, normalizedOperations, transactionIdentity));
+builder.AddArtifact(DeliveryArtifactInput.Available(
+    "clean-docx", DeliveryArtifactRole.CleanDocx, docxMediaType, deliveredBytes) with
+{
+    Document = DeliveryDocumentIdentity.FromManifest(deliveredManifest, deliveredVersion),
+});
+SemanticChangeSet sourceToDelivered = SemanticDiff.Compare(sourceDocument, deliveredDocument);
+SemanticChangeSet transactionChanges = SemanticDiff.Compare(beforeDocument, afterDocument);
+builder.AddSemanticChangeSet(DeliverySemanticChangeSetInput.ForSourceToDelivered(
+    sourceToDelivered));
+builder.AddSemanticChangeSet(DeliverySemanticChangeSetInput.ForTransaction(
+    entryId,
+    transactionChanges,
+    "semantic-transaction-1"));
+
+DeliveryChangeReceipt receipt = builder.Build();
+File.WriteAllBytes("delivery/change-receipt.json", receipt.ToJsonBytes(indented: true));
+```
+
+The portable verifier accepts either that object or its JSON bytes plus an artifact-id-to-bytes
+map. It verifies the raw receipt payload first and then hashes every artifact independently:
+
+```csharp
+DeliveryReceiptVerificationResult result = DeliveryChangeReceiptVerifier.VerifyJson(
+    receiptBytes,
+    new Dictionary<string, byte[]>
+    {
+        ["clean-docx"] = deliveredBytes,
+        ["semantic-source-to-delivered"] = sourceToDelivered.ToCanonicalUtf8Bytes(),
+        ["semantic-transaction-1"] = transactionChanges.ToCanonicalUtf8Bytes(),
+    });
+```
+
+Construction and verification share `DeliveryReceiptLimits`. Defaults cap the complete receipt
+JSON at 16 MiB, each semantic artifact and PageMap at 64 MiB, any artifact at 256 MiB, all supplied
+artifacts at 512 MiB, JSON depth at 128, aggregate collection items at 100,000, transactions and
+operations per transaction at 10,000, artifacts at 1,024, and strings at 1 MiB. Clean-DOCX ZIP/XML
+inspection additionally uses `CleanDocxManifestOptions`, whose corrected #493 package limits are
+authoritative. Verification accepts overrides through `DeliveryReceiptVerificationOptions` and
+returns stable `*_resource_limit` findings rather than parsing, decoding, copying, or hashing past
+the applicable boundary. Object-based construction and verification preflight aggregate collection,
+escaped-string, semantic-value depth, and serialized-byte budgets before canonicalization; receipt,
+canonical JSON, and exact typed-semantic writers additionally write through hard-capped streams, so
+the configured ceiling is enforced while bytes are produced rather than after an oversized buffer
+already exists. JSON arrays are charged one item at a time before recursion, and object properties
+are charged before entering the capped sortable property list; neither path first materializes an
+untrusted collection merely to learn that it exceeds the item budget.
+
+## Schema evolution
+
+Within `payload`, schema v1 is additive: readers must ignore unknown optional fields but must
+reject unknown enum values, digest algorithms, required evidence kinds, and major versions.
+The envelope itself has exactly `payload` and `receiptDigest`, preventing unprotected top-level
+extensions. A new required field, changed canonicalization rule, changed field meaning, or
+changed default attribution/privacy behavior requires v2 and a new schema identifier.
+
+Writers always emit one exact schema identifier and canonicalization profile. Readers may
+migrate an older payload to an internal model for display, but verification uses the rules
+declared by that payload's own version. A migrated reserialization is a new receipt with a
+new digest, not the original evidence.
+
+## Dependency boundary
+
+The receipt consumes package manifests from #456 and semantic change sets from #457. All
+package-manifest API assumptions are confined to `DeliveryPackageManifestAdapter`, which uses the
+corrected #493 contract and rejects manifests whose `IsValid` flag is false while preserving the
+distinction between unavailable optional content/semantic digests and invalid packages. The sole
+#457 seam accepts a typed `SemanticChangeSet`, stores its exact `ToCanonicalUtf8Bytes()` output,
+and records the public schema, version, and count. Portable verification strictly reconstructs the
+full nested #457 change/value schema and requires its exact canonical bytes; receipt fields are not
+used as a substitute for that owner-defined contract.
+The receipt embeds validation and reversibility results from #463/#464 when supplied, without
+flattening or renaming their fields. The delivery operation in #465 assembles artifacts and
+invokes the receipt builder; receipt construction itself performs no document mutation,
+rendering, ZIP inspection, or OOXML parsing outside those shared components.

--- a/docs/schemas/delivery-change-receipt-v1.schema.json
+++ b/docs/schemas/delivery-change-receipt-v1.schema.json
@@ -1,0 +1,1339 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docxodus.dev/schemas/verification/delivery-change-receipt/v1",
+  "title": "Docxodus delivery change receipt v1",
+  "description": "The exact deterministic JSON envelope emitted by DeliveryChangeReceiptSerializer. Nullable properties and arrays are always present on the wire.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "payload",
+    "receiptDigest"
+  ],
+  "properties": {
+    "payload": {
+      "$ref": "#/$defs/payload"
+    },
+    "receiptDigest": {
+      "$ref": "#/$defs/digest"
+    }
+  },
+  "$defs": {
+    "nullableString": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "nullableEditErrorCode": {
+      "enum": [
+        null,
+        "anchor_not_found",
+        "anchor_wrong_kind",
+        "anchors_not_adjacent",
+        "session_disposed",
+        "malformed_markdown",
+        "unsupported_markdown_syntax",
+        "table_insert_not_supported",
+        "footnote_ref_not_supported",
+        "comment_marker_not_supported",
+        "image_insert_not_supported",
+        "anchor_token_in_payload",
+        "offset_out_of_range",
+        "invalid_position",
+        "unknown_style",
+        "invalid_list_level",
+        "invalid_list_start_value",
+        "invalid_page_numbering",
+        "invalid_paragraph_format",
+        "invalid_table_styling",
+        "invalid_table_merge",
+        "table_anchor_migration_required",
+        "malformed_xml",
+        "disallowed_namespace",
+        "incompatible_element_type",
+        "validation_failed",
+        "nothing_to_undo",
+        "nothing_to_redo",
+        "duplicate_annotation_id",
+        "annotation_not_found",
+        "empty_annotation_span",
+        "hyperlink_not_found",
+        "bookmark_not_found",
+        "duplicate_bookmark_name",
+        "invalid_bookmark_name",
+        "invalid_hyperlink_target",
+        "missing_bookmark_target",
+        "bookmark_in_use",
+        "managed_bookmark",
+        "empty_hyperlink_span",
+        "unsupported_inline_boundary",
+        "image_not_found",
+        "invalid_image_data",
+        "unsupported_image_format",
+        "image_too_large",
+        "invalid_image_dimensions",
+        "unsupported_image_markup",
+        "linked_image_read_only",
+        "invalid_image_layout",
+        "content_control_not_found",
+        "content_control_malformed",
+        "content_control_unsupported",
+        "content_control_locked",
+        "content_control_bound",
+        "content_control_wrong_type",
+        "invalid_content_control_value",
+        "content_control_placement_unsupported",
+        "content_control_nested_fill_unsupported",
+        "repeating_section_constraint",
+        "empty_comment_span",
+        "revision_not_found",
+        "precondition_failed",
+        "invalid_batch_step",
+        "invalid_transaction",
+        "transaction_conflict",
+        "transaction_result_evicted",
+        "transaction_incomplete",
+        "revision_unsupported",
+        "revision_malformed",
+        "revision_ambiguous",
+        "tracked_operation_unsupported",
+        "unresolved_structural_revision",
+        "internal_error"
+      ]
+    },
+    "portableInteger": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "nullablePortableInteger": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "nonNegativeInt32": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "nullableNonNegativeInt32": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "digest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "algorithm",
+        "value"
+      ],
+      "properties": {
+        "algorithm": {
+          "const": "SHA-256"
+        },
+        "value": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    },
+    "nullableDigest": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/digest"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "nullableJsonObject": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "documentIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "documentVersion",
+        "packageKind",
+        "packageManifestSchema",
+        "mainDocumentUri",
+        "rawPackageBytesDigest",
+        "orderedOpcContentDigest",
+        "normalizedSemanticDigest"
+      ],
+      "properties": {
+        "documentVersion": {
+          "$ref": "#/$defs/portableInteger"
+        },
+        "packageKind": {
+          "const": "opc"
+        },
+        "packageManifestSchema": {
+          "const": "https://docxodus.dev/schemas/verification/package-manifest/v1"
+        },
+        "mainDocumentUri": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4096,
+          "pattern": "^/[^\\\\]*$"
+        },
+        "rawPackageBytesDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "orderedOpcContentDigest": {
+          "$ref": "#/$defs/nullableDigest"
+        },
+        "normalizedSemanticDigest": {
+          "$ref": "#/$defs/nullableDigest"
+        }
+      }
+    },
+    "textEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "digest",
+        "characterCount",
+        "summary",
+        "value"
+      ],
+      "properties": {
+        "digest": {
+          "$ref": "#/$defs/digest"
+        },
+        "characterCount": {
+          "$ref": "#/$defs/nonNegativeInt32"
+        },
+        "summary": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "value": {
+          "$ref": "#/$defs/nullableString"
+        }
+      }
+    },
+    "nullableTextEvidence": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/textEvidence"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "authoredDiagnostic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "message": {
+          "$ref": "#/$defs/textEvidence"
+        }
+      }
+    },
+    "nullableAuthoredDiagnostic": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/authoredDiagnostic"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "objectChange": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "changeKind",
+        "anchorId",
+        "kind",
+        "scope",
+        "unid"
+      ],
+      "properties": {
+        "changeKind": {
+          "enum": [
+            "added",
+            "removed",
+            "modified"
+          ]
+        },
+        "anchorId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "scope": {
+          "type": "string",
+          "minLength": 1
+        },
+        "unid": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "operationResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "resultDigest",
+        "success",
+        "errorCode",
+        "errorMessage",
+        "objectChanges",
+        "fullResult"
+      ],
+      "properties": {
+        "resultDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "success": {
+          "type": "boolean"
+        },
+        "errorCode": {
+          "$ref": "#/$defs/nullableEditErrorCode"
+        },
+        "errorMessage": {
+          "$ref": "#/$defs/nullableTextEvidence"
+        },
+        "objectChanges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/objectChange"
+          }
+        },
+        "fullResult": {
+          "$ref": "#/$defs/nullableJsonObject"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "success": {
+                "const": true
+              }
+            },
+            "required": [
+              "success"
+            ]
+          },
+          "then": {
+            "properties": {
+              "errorCode": {
+                "type": "null"
+              },
+              "errorMessage": {
+                "type": "null"
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "errorCode": {
+                "not": {
+                  "type": "null"
+                }
+              },
+              "errorMessage": {
+                "$ref": "#/$defs/textEvidence"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "index",
+        "tool",
+        "action",
+        "argumentsDigest",
+        "argumentsSummary",
+        "arguments",
+        "executionStatus",
+        "success",
+        "rolledBack",
+        "results"
+      ],
+      "properties": {
+        "index": {
+          "$ref": "#/$defs/nonNegativeInt32"
+        },
+        "tool": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action": {
+          "type": "string",
+          "minLength": 1
+        },
+        "argumentsDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "argumentsSummary": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "arguments": {
+          "$ref": "#/$defs/nullableJsonObject"
+        },
+        "executionStatus": {
+          "enum": [
+            "notExecuted",
+            "succeeded",
+            "failed",
+            "succeededRolledBack",
+            "failedRolledBack"
+          ]
+        },
+        "success": {
+          "type": "boolean"
+        },
+        "rolledBack": {
+          "type": "boolean"
+        },
+        "results": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/operationResult"
+          }
+        }
+      }
+    },
+    "authoredChange": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "entityKind",
+        "changeKind",
+        "entityId",
+        "sourceDigest",
+        "author",
+        "date",
+        "dateUtc",
+        "type",
+        "family",
+        "partUri",
+        "scope",
+        "anchorId",
+        "resolutionStatus",
+        "diagnostic",
+        "constituentIds",
+        "constituentKeys",
+        "affectedAnchorIds",
+        "text",
+        "fullEvidence"
+      ],
+      "properties": {
+        "entityKind": {
+          "enum": [
+            "revision",
+            "comment",
+            "annotation"
+          ]
+        },
+        "changeKind": {
+          "enum": [
+            "added",
+            "removed",
+            "modified"
+          ]
+        },
+        "entityId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sourceDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "author": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "date": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "dateUtc": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "type": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "family": {
+          "enum": [
+            "contentInsert",
+            "contentDelete",
+            "move",
+            "paragraphMark",
+            "rowInsert",
+            "rowDelete",
+            "cellInsert",
+            "cellDelete",
+            "cellMerge",
+            "contentControlInsert",
+            "contentControlDelete",
+            "numberingPropertiesInsert",
+            "numberingChange",
+            "propertiesChange",
+            "unsupported",
+            null
+          ]
+        },
+        "partUri": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "scope": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "anchorId": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "resolutionStatus": {
+          "enum": [
+            "supported",
+            "unsupported",
+            "malformed",
+            "ambiguous",
+            null
+          ]
+        },
+        "diagnostic": {
+          "$ref": "#/$defs/nullableAuthoredDiagnostic"
+        },
+        "constituentIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "constituentKeys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "affectedAnchorIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "text": {
+          "$ref": "#/$defs/nullableTextEvidence"
+        },
+        "fullEvidence": {
+          "$ref": "#/$defs/nullableJsonObject"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "entityKind": {
+                "const": "revision"
+              }
+            },
+            "required": [
+              "entityKind"
+            ]
+          },
+          "then": {
+            "properties": {
+              "family": {
+                "not": {
+                  "type": "null"
+                }
+              },
+              "partUri": {
+                "type": "string",
+                "minLength": 1
+              },
+              "scope": {
+                "type": "string",
+                "minLength": 1
+              },
+              "resolutionStatus": {
+                "not": {
+                  "type": "null"
+                }
+              },
+              "constituentIds": {
+                "minItems": 1
+              },
+              "constituentKeys": {
+                "minItems": 1
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "dateUtc": {
+                "type": "null"
+              },
+              "family": {
+                "type": "null"
+              },
+              "anchorId": {
+                "type": "null"
+              },
+              "resolutionStatus": {
+                "type": "null"
+              },
+              "diagnostic": {
+                "type": "null"
+              },
+              "constituentIds": {
+                "maxItems": 0
+              },
+              "constituentKeys": {
+                "maxItems": 0
+              }
+            }
+          }
+        }
+      ]
+    },
+    "transaction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sequence",
+        "entryId",
+        "transactionId",
+        "requestFingerprint",
+        "mode",
+        "status",
+        "baseVersion",
+        "resultVersion",
+        "beforeDocument",
+        "afterDocument",
+        "reportedPackageContentDigest",
+        "operations",
+        "authoredChanges",
+        "warnings"
+      ],
+      "properties": {
+        "sequence": {
+          "$ref": "#/$defs/portableInteger"
+        },
+        "entryId": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "transactionId": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "requestFingerprint": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "mode": {
+          "enum": [
+            "atomic",
+            "bestEffort"
+          ]
+        },
+        "status": {
+          "enum": [
+            "committed",
+            "partiallyCommitted",
+            "failed",
+            "prediction"
+          ]
+        },
+        "baseVersion": {
+          "$ref": "#/$defs/portableInteger"
+        },
+        "resultVersion": {
+          "$ref": "#/$defs/portableInteger"
+        },
+        "beforeDocument": {
+          "$ref": "#/$defs/documentIdentity"
+        },
+        "afterDocument": {
+          "$ref": "#/$defs/documentIdentity"
+        },
+        "reportedPackageContentDigest": {
+          "$ref": "#/$defs/nullableDigest"
+        },
+        "operations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/operation"
+          }
+        },
+        "authoredChanges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/authoredChange"
+          }
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/textEvidence"
+          }
+        }
+      }
+    },
+    "lineageEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sequence",
+        "action",
+        "affectedEntryId",
+        "beforeDocument",
+        "afterDocument"
+      ],
+      "properties": {
+        "sequence": {
+          "$ref": "#/$defs/portableInteger"
+        },
+        "action": {
+          "enum": [
+            "undo",
+            "redo"
+          ]
+        },
+        "affectedEntryId": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "beforeDocument": {
+          "$ref": "#/$defs/documentIdentity"
+        },
+        "afterDocument": {
+          "$ref": "#/$defs/documentIdentity"
+        }
+      }
+    },
+    "location": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "entryUri",
+        "ownerUri",
+        "relationshipId",
+        "targetUri",
+        "propertyPath"
+      ],
+      "properties": {
+        "entryUri": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "ownerUri": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "relationshipId": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "targetUri": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "propertyPath": {
+          "$ref": "#/$defs/nullableString"
+        }
+      }
+    },
+    "packageChange": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "changeId",
+        "kind",
+        "location",
+        "before",
+        "after",
+        "disposition",
+        "transactionEntryId",
+        "requestedOperationIndex",
+        "derivation"
+      ],
+      "properties": {
+        "changeId": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "kind": {
+          "enum": [
+            "partAdded",
+            "partRemoved",
+            "partModified",
+            "relationshipAdded",
+            "relationshipRemoved",
+            "relationshipModified"
+          ]
+        },
+        "location": {
+          "$ref": "#/$defs/location"
+        },
+        "before": {
+          "$ref": "#/$defs/nullableTextEvidence"
+        },
+        "after": {
+          "$ref": "#/$defs/nullableTextEvidence"
+        },
+        "disposition": {
+          "enum": [
+            "userRequested",
+            "derived",
+            "unexpected"
+          ]
+        },
+        "transactionEntryId": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "requestedOperationIndex": {
+          "$ref": "#/$defs/nullableNonNegativeInt32"
+        },
+        "derivation": {
+          "$ref": "#/$defs/nullableString"
+        }
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifactId",
+        "role",
+        "mediaType",
+        "availability",
+        "byteLength",
+        "digest",
+        "relativePath",
+        "unavailableReason",
+        "documentVersion",
+        "packageDigest",
+        "rendererFingerprint",
+        "pageMapDigest"
+      ],
+      "properties": {
+        "artifactId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "role": {
+          "enum": [
+            "cleanDocx",
+            "reviewDocx",
+            "html",
+            "pdf",
+            "pageImage",
+            "pageMap",
+            "packageManifest",
+            "semanticDiff",
+            "validationReport",
+            "reversibilityProof",
+            "renderReport",
+            "otherReport"
+          ]
+        },
+        "mediaType": {
+          "type": "string",
+          "minLength": 1
+        },
+        "availability": {
+          "enum": [
+            "available",
+            "unavailable"
+          ]
+        },
+        "byteLength": {
+          "$ref": "#/$defs/nullablePortableInteger"
+        },
+        "digest": {
+          "$ref": "#/$defs/nullableDigest"
+        },
+        "relativePath": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "unavailableReason": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "documentVersion": {
+          "$ref": "#/$defs/nullablePortableInteger"
+        },
+        "packageDigest": {
+          "$ref": "#/$defs/nullableDigest"
+        },
+        "rendererFingerprint": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "pageMapDigest": {
+          "$ref": "#/$defs/nullableDigest"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "availability": {
+                "const": "available"
+              }
+            },
+            "required": [
+              "availability"
+            ]
+          },
+          "then": {
+            "properties": {
+              "byteLength": {
+                "$ref": "#/$defs/portableInteger"
+              },
+              "digest": {
+                "$ref": "#/$defs/digest"
+              },
+              "unavailableReason": {
+                "type": "null"
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "byteLength": {
+                "type": "null"
+              },
+              "digest": {
+                "type": "null"
+              },
+              "unavailableReason": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "documentVersion": {
+                "type": "null"
+              }
+            },
+            "required": [
+              "documentVersion"
+            ]
+          },
+          "then": {
+            "properties": {
+              "packageDigest": {
+                "type": "null"
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "packageDigest": {
+                "$ref": "#/$defs/digest"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "evidenceReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "schema",
+        "digest",
+        "artifactId",
+        "summary"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "validationResult",
+            "redlineReversibility"
+          ]
+        },
+        "schema": {
+          "type": "string",
+          "minLength": 1
+        },
+        "digest": {
+          "$ref": "#/$defs/digest"
+        },
+        "artifactId": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "summary": {
+          "$ref": "#/$defs/nullableString"
+        }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "kind": {
+              "const": "validationResult"
+            },
+            "schema": {
+              "const": "https://docxodus.dev/schemas/verification/deliverable-verification/v1"
+            }
+          }
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "redlineReversibility"
+            },
+            "schema": {
+              "const": "https://docxodus.dev/schemas/verification/redline-reversibility-proof/v1"
+            }
+          }
+        }
+      ]
+    },
+    "semanticChangeSetBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scope",
+        "transactionEntryId",
+        "beforeDocument",
+        "afterDocument",
+        "schema",
+        "schemaVersion",
+        "changeCount",
+        "digest",
+        "artifactId"
+      ],
+      "properties": {
+        "scope": {
+          "enum": [
+            "sourceToDelivered",
+            "transaction"
+          ]
+        },
+        "transactionEntryId": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "beforeDocument": {
+          "$ref": "#/$defs/documentIdentity"
+        },
+        "afterDocument": {
+          "$ref": "#/$defs/documentIdentity"
+        },
+        "schema": {
+          "const": "docxodus.semantic-changes"
+        },
+        "schemaVersion": {
+          "const": 1
+        },
+        "changeCount": {
+          "$ref": "#/$defs/nonNegativeInt32"
+        },
+        "digest": {
+          "$ref": "#/$defs/digest"
+        },
+        "artifactId": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "pageMapRect": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "x",
+        "y",
+        "width",
+        "height"
+      ],
+      "properties": {
+        "x": {
+          "type": "number",
+          "minimum": 0
+        },
+        "y": {
+          "type": "number",
+          "minimum": 0
+        },
+        "width": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "height": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        }
+      }
+    },
+    "pageMapPage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "pageNumber",
+        "pageInSection",
+        "width",
+        "height",
+        "sectionIndex",
+        "pageName"
+      ],
+      "properties": {
+        "pageNumber": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 2147483647
+        },
+        "pageInSection": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 2147483647
+        },
+        "width": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "height": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "sectionIndex": {
+          "$ref": "#/$defs/nullableNonNegativeInt32"
+        },
+        "pageName": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "pageMapFragment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "fragmentId",
+        "anchorId",
+        "fragmentIndex",
+        "pageNumber",
+        "geometry",
+        "story",
+        "inTableCell"
+      ],
+      "properties": {
+        "fragmentId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "anchorId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "fragmentIndex": {
+          "$ref": "#/$defs/nonNegativeInt32"
+        },
+        "pageNumber": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 2147483647
+        },
+        "geometry": {
+          "$ref": "#/$defs/pageMapRect"
+        },
+        "story": {
+          "enum": [
+            "body",
+            "header",
+            "footer",
+            "footnote",
+            "endnote",
+            "comment"
+          ]
+        },
+        "inTableCell": {
+          "type": "boolean"
+        }
+      }
+    },
+    "pageCitation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "anchorId",
+        "scope",
+        "documentVersion",
+        "packageDigest",
+        "rendererFingerprint",
+        "pageMapDigest",
+        "pageMapArtifactId",
+        "renderArtifactId",
+        "renderArtifactDigest",
+        "pages",
+        "fragments"
+      ],
+      "properties": {
+        "anchorId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "scope": {
+          "type": "string",
+          "minLength": 1
+        },
+        "documentVersion": {
+          "$ref": "#/$defs/portableInteger"
+        },
+        "packageDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "rendererFingerprint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pageMapDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "pageMapArtifactId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "renderArtifactId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "renderArtifactDigest": {
+          "$ref": "#/$defs/digest"
+        },
+        "pages": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/pageMapPage"
+          }
+        },
+        "fragments": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/pageMapFragment"
+          }
+        }
+      }
+    },
+    "payload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "schemaVersion",
+        "canonicalization",
+        "privacyProfile",
+        "sourceDocument",
+        "deliveredDocument",
+        "transactions",
+        "lineage",
+        "packageChanges",
+        "hasUnexpectedChanges",
+        "evidence",
+        "semanticChangeSets",
+        "artifacts",
+        "pageCitations",
+        "warnings"
+      ],
+      "properties": {
+        "schema": {
+          "const": "https://docxodus.dev/schemas/verification/delivery-change-receipt/v1"
+        },
+        "schemaVersion": {
+          "const": 1
+        },
+        "canonicalization": {
+          "const": "docxodus-canonical-json-v1"
+        },
+        "privacyProfile": {
+          "enum": [
+            "hashOnly",
+            "hashAndSummary",
+            "fullEvidence"
+          ]
+        },
+        "sourceDocument": {
+          "$ref": "#/$defs/documentIdentity"
+        },
+        "deliveredDocument": {
+          "$ref": "#/$defs/documentIdentity"
+        },
+        "transactions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/transaction"
+          }
+        },
+        "lineage": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/lineageEvent"
+          }
+        },
+        "packageChanges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/packageChange"
+          }
+        },
+        "hasUnexpectedChanges": {
+          "type": "boolean"
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/evidenceReference"
+          }
+        },
+        "semanticChangeSets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/semanticChangeSetBinding"
+          }
+        },
+        "artifacts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/artifact"
+          }
+        },
+        "pageCitations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/pageCitation"
+          }
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/textEvidence"
+          }
+        }
+      }
+    }
+  }
+}

--- a/npm/src/session.ts
+++ b/npm/src/session.ts
@@ -325,10 +325,11 @@ export class DocxSession {
       try {
         const value = step.mutation();
         const results = Array.isArray(value) ? value : [value];
-        if (results.length === 0 || results.some(result =>
+        if (results.some(result =>
           result === null || typeof result !== "object" || typeof result.success !== "boolean")) {
-          return [internalFailure("batch mutation returned no valid edit results")];
+          return [internalFailure("batch mutation returned invalid edit results")];
         }
+        // An empty list is a successful no-op step, matching the core contract.
         return results;
       } catch (error) {
         return [internalFailure(error)];

--- a/npm/tests/atomic-batch.spec.ts
+++ b/npm/tests/atomic-batch.spec.ts
@@ -19,6 +19,36 @@ test.describe('DocxSession atomic batches (#445)', () => {
     await waitForDocxodus(page);
   });
 
+  test('an empty mutation result list is a successful no-op step (core parity)', async ({ page }) => {
+    const result = await page.evaluate((bytes: number[]) => {
+      const session = (window as any).Docxodus.openTypedSession(new Uint8Array(bytes));
+      try {
+        const projection = session.project();
+        const anchors = (Object.entries(projection.anchorIndex) as [string, any][])
+          .filter(([id, value]) => value.scope === 'body'
+            && ['p', 'h', 'li'].includes(value.kind)
+            && projection.markdown.includes(`{#${id}}`))
+          .map(([id]) => id);
+        const batch = session.executeBatch([
+          { tool: 'docx_edit', action: 'replace_text_range',
+            mutation: () => [] },
+          { tool: 'docx_edit', action: 'replace_text',
+            mutation: () => session.replaceText(anchors[0], 'Committed after the noop step.') },
+        ]);
+        return {
+          success: batch.success,
+          status: batch.status,
+          stepSuccess: batch.steps.map((step: any) => step.success),
+          markdown: session.project().markdown.includes('Committed after the noop step.'),
+        };
+      } finally { session.close(); }
+    }, Array.from(fixture));
+    expect(result.success).toBe(true);
+    expect(result.status).toBe('ok');
+    expect(result.stepSuccess).toEqual([true, true]);
+    expect(result.markdown).toBe(true);
+  });
+
   test('rollback is exact and success is one version/undo unit', async ({ page }) => {
     const result = await page.evaluate((bytes: number[]) => {
       const session = (window as any).Docxodus.openTypedSession(new Uint8Array(bytes));


### PR DESCRIPTION
## Summary

- add deterministic, hash-addressed delivery change receipts over source and delivered package identities
- retain normalized transaction, attribution, authored-change, lineage, privacy-profile, PageMap, artifact, and tamper-verification evidence
- consume #457 canonical semantic evidence, #463 shared package deltas and deliverable reports, and #464 canonical reversibility proofs
- enforce bounded parsing/serialization and portable artifact paths with fail-closed schema, lineage, digest, and resource validation
- distinguish exact idempotent retries from conflicting results while preserving distinct identified and anonymous no-op transactions

## Stack

**Rebased onto `main`; targets `main` directly.** Every dependency has landed — #493, #494, and
#496 are all in `main` — so this branch no longer carries their commits. It previously replayed
18 commits that existed elsewhere (8 of #456/#457, 5 of #463, 6 of #464), which is why its diff
read as +40,189 against a merge-base predating the whole stack.

`git rebase --onto origin/main <last-inherited-commit>` dropped all 18 with **zero conflicts**,
leaving the three commits that are actually this PR's work:

| | Before | After |
|---|---|---|
| Commits | 21 | **3** |
| Diff | +40,189 / −372 | **+11,891 / −16** (21 files) |
| Mergeable | conflicting | **clean** |

The inherited #464 commits it had been carrying were the *older* lineage — the one predating the
#515 `delText` fix and the fixture sweep. Taking main's versions rather than replaying them keeps
that work intact.

## Verification

Run against the rebased tree:

- full suite: 4,236 passed / 0 failed / 3 pre-existing skips
- `dotnet build`: 0 errors
- rebase produced no conflicts in any of the three replayed commits

The rebase was verified against the #496 branch head, then re-parented onto main's squash of it
(`4ee78d5`) once that merged. The two trees are byte-identical, so the verification above applies
to the pushed commits unchanged.

Earlier stack-local results, superseded by the run above: 179 passed in the Release
dependency-stack run, 34 passed in the focused delivery-receipt run, independent post-restack
review approved with no blocker/high/medium findings, covering shared target-aware package
ordering, exact retry evidence, distinct no-op identities, duplicate revision IDs across parts,
and real #463/#464 canonical artifacts.

Closes #458
