### PR TITLE
Continue long footnotes within paragraphs

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -44,6 +44,12 @@ jobs:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
         run: cd npm-export && npm ci --ignore-scripts
 
+      # The export runtime deliberately keeps Chromium's process sandbox on, so the runner has to
+      # permit unprivileged user namespaces. Ubuntu 24.04 restricts them through AppArmor by
+      # default, which fails every launched-browser export with browser_launch_failure.
+      - name: Permit Chromium's unprivileged user-namespace sandbox
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
       - name: Install Playwright browsers
         run: cd npm && npx playwright install --with-deps chromium firefox
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -70,4 +70,5 @@ jobs:
             npm/playwright-report/
             npm/test-results/
             npm-export/test-artifacts/
+          if-no-files-found: ignore
           retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -461,6 +461,28 @@ All notable changes to this project will be documented in this file.
   unsafe or indivisible layout retains the visible clipped fallback for that one
   element, while later sibling paragraphs continue instead of disappearing inside
   the same clipped band. Documents whose notes fit paginate unchanged.
+
+  Two rules govern the fallbacks. A note is only deferred to the next page when
+  that page's band is larger than what the current page can already offer —
+  otherwise the deferral evacuates the citing page and buys nothing. And the
+  fragmenter's below-line-breaking fallbacks (arbitrary grapheme boundaries, and
+  forcing a first fragment that does not fit) apply only to an element that owns
+  the whole band; with earlier siblings already packed, a paragraph that will not
+  start belongs intact in the next note band rather than cut mid-word. A queue of
+  whole notes larger than the band no longer claims the whole page either: the
+  band takes what fits and the rest of the page still sets body text.
+- **Word's authored footnote separator stories are rendered, and a continued note
+  gets the continuation rule (#489).** `w:separator` and `w:continuationSeparator`
+  were previously dropped, and the paginator drew its own two-inch rule above
+  every note band. Both reserved stories are now converted into the hidden
+  paginated-footnote registry as inert, non-addressable templates; the paginator
+  clones the normal story where a note starts and the continuation story on a
+  page that carries a note over, falling back to typed 2in/full-width rules when
+  a document defines neither. Identities are stripped from these repeated clones
+  so no id, editor anchor, or `PageMap` anchor is duplicated across pages. A
+  marker-only story renders exactly its rule: the pipeline's synthetic
+  empty-paragraph run no longer counts as authored content and no longer draws a
+  blank line under the continuation rule.
 - **The GitHub Pages landing page serves THE DOCX ARCADE on a phone, keeps its
   navigation, and gives the arcade thumb controls** — three fixes to the same
   problem, that the demo's mobile visit was its worst one:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -450,17 +450,17 @@ All notable changes to this project will be documented in this file.
   must land" semantics should pass `ExpectedMatchCount` (or a preflight) so a
   zero-match step fails explicitly instead of vacuously succeeding. Delivery
   receipts record such steps as portable no-op evidence.
-- **A footnote too long for its page now keeps flowing instead of being clipped.**
-  Browser pagination reserves at most 60% of the body height for the note band; a
-  note whose tail did not fit there used to be handed to the next page whole and
-  drawn past the band's bottom edge, so the overflow was in the DOM but not on the
-  page — and therefore missing from the `PageMap` a citation resolves against. The
-  tail is now partitioned at whole-paragraph boundaries and drained across as many
-  note areas as it needs, opening note-only pages after the last body block when
-  the document runs out of pages first. A note is still never split below one
-  paragraph, so an indivisible oversized paragraph keeps the established clipped
-  fallback. Documents whose notes always fit paginate unchanged; a document with a
-  note longer than one page's band gains pages it previously dropped content on.
+- **A footnote too long for its page now keeps flowing instead of being clipped
+  (#489).** Browser pagination reserves at most 60% of the body height for the note
+  band. Continuations were already partitioned at whole-paragraph boundaries, but
+  one ordinary paragraph taller than the band was still drawn past its clipped
+  bottom on every attempt. Footnote paragraphs now reuse the conservative DOM Range
+  fragmenter used by body flow, measured inside the exact initial-note or
+  continuation wrapper, and drain across as many note areas as needed. Every
+  fragment keeps its canonical source anchor for `PageMap` citations. Content with
+  unsafe or indivisible layout retains the visible clipped fallback for that one
+  element, while later sibling paragraphs continue instead of disappearing inside
+  the same clipped band. Documents whose notes fit paginate unchanged.
 - **The GitHub Pages landing page serves THE DOCX ARCADE on a phone, keeps its
   navigation, and gives the arcade thumb controls** — three fixes to the same
   problem, that the demo's mobile visit was its worst one:

--- a/Docxodus.Tests/HtmlConverterTests.cs
+++ b/Docxodus.Tests/HtmlConverterTests.cs
@@ -792,8 +792,19 @@ namespace OxPt
                         .First(note => (string)note.Attribute(w + "type") == "continuationSeparator");
                     normal.Add(new XElement(w + "p", new XElement(w + "r",
                         new XElement(w + "t", "NORMAL-SEPARATOR-TOKEN"))));
-                    continuation.Add(new XElement(w + "p", new XElement(w + "r",
-                        new XElement(w + "t", "CONTINUATION-SEPARATOR-TOKEN"))));
+                    // A separator story is cloned onto every note band, so any
+                    // identity or local target it carries would be duplicated
+                    // across pages. Author both kinds here and assert they are
+                    // stripped from the rendered template.
+                    continuation.Add(new XElement(w + "p",
+                        new XElement(w + "bookmarkStart",
+                            new XAttribute(w + "id", "77"),
+                            new XAttribute(w + "name", "SEPARATOR-BOOKMARK")),
+                        new XElement(w + "bookmarkEnd", new XAttribute(w + "id", "77")),
+                        new XElement(w + "hyperlink",
+                            new XAttribute(w + "anchor", "SEPARATOR-BOOKMARK"),
+                            new XElement(w + "r",
+                                new XElement(w + "t", "CONTINUATION-SEPARATOR-TOKEN")))));
                     footnotes.Root.Add(new XElement(w + "footnote",
                         new XAttribute(w + "type", "continuationNotice"),
                         new XAttribute(w + "id", "999"),
@@ -822,7 +833,18 @@ namespace OxPt
                     Assert.DoesNotContain(registry.Elements(), element =>
                         (string)element.Attribute("data-footnote-id") == "999");
                     Assert.DoesNotContain("MUST-NOT-BECOME-A-NOTE", registry.Value);
-                    Assert.Contains("data-footnote-separator=\"continuation\"", html.ToString());
+
+                    // No identity and no local target survives on a repeated story,
+                    // and nothing in it is editable.
+                    var repeated = separators[1].DescendantsAndSelf().ToList();
+                    Assert.DoesNotContain(repeated, element => element.Attributes()
+                        .Any(attribute => attribute.Name.LocalName is "id" or "name"
+                            or "data-anchor" or "data-source-anchor-id"));
+                    Assert.DoesNotContain(repeated, element => element.Attributes()
+                        .Any(attribute => attribute.Name.LocalName == "href"
+                            && attribute.Value.StartsWith("#", StringComparison.Ordinal)));
+                    Assert.All(repeated, element =>
+                        Assert.Equal("false", (string)element.Attribute("contenteditable")));
                 }
             }
         }

--- a/Docxodus.Tests/HtmlConverterTests.cs
+++ b/Docxodus.Tests/HtmlConverterTests.cs
@@ -730,6 +730,19 @@ namespace OxPt
 
                     Assert.NotNull(footnoteRegistry);
 
+                    // Stock marker-only stories contain formatting properties
+                    // under pPr/rPr, but no authored presentation paragraph.
+                    // They must render exactly the rule, without an empty line.
+                    var separatorStories = footnoteRegistry.Elements()
+                        .Where(e => e.Attribute("data-footnote-separator") != null)
+                        .ToList();
+                    Assert.Equal(2, separatorStories.Count);
+                    Assert.All(separatorStories, story =>
+                    {
+                        Assert.Single(story.Elements().Where(e => e.Name.LocalName == "hr"));
+                        Assert.DoesNotContain(story.Elements(), e => e.Name.LocalName == "p");
+                    });
+
                     // Check footnote-content spans for empty children
                     var footnoteContentSpans = footnoteRegistry.Descendants()
                         .Where(e => e.Name.LocalName == "span" &&
@@ -756,6 +769,60 @@ namespace OxPt
                                 $"Found empty span in footnote registry content with class '{(string)span.Attribute("class")}'");
                         }
                     }
+                }
+            }
+        }
+
+        [Fact]
+        public void HC008c2_PaginatedFootnoteSeparators_ArePreservedAndTypedBoilerplateIsExcluded()
+        {
+            DirectoryInfo sourceDir = new DirectoryInfo("../../../../TestFiles/WC");
+            FileInfo doc = new FileInfo(Path.Combine(sourceDir.FullName, "WC034-Footnotes-Before.docx"));
+            byte[] byteArray = File.ReadAllBytes(doc.FullName);
+            using (MemoryStream ms = new MemoryStream())
+            {
+                ms.Write(byteArray, 0, byteArray.Length);
+                using (WordprocessingDocument wDoc = WordprocessingDocument.Open(ms, true))
+                {
+                    XNamespace w = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+                    var footnotes = wDoc.MainDocumentPart.FootnotesPart.GetXDocument();
+                    var normal = footnotes.Root.Elements(w + "footnote")
+                        .First(note => (string)note.Attribute(w + "type") == "separator");
+                    var continuation = footnotes.Root.Elements(w + "footnote")
+                        .First(note => (string)note.Attribute(w + "type") == "continuationSeparator");
+                    normal.Add(new XElement(w + "p", new XElement(w + "r",
+                        new XElement(w + "t", "NORMAL-SEPARATOR-TOKEN"))));
+                    continuation.Add(new XElement(w + "p", new XElement(w + "r",
+                        new XElement(w + "t", "CONTINUATION-SEPARATOR-TOKEN"))));
+                    footnotes.Root.Add(new XElement(w + "footnote",
+                        new XAttribute(w + "type", "continuationNotice"),
+                        new XAttribute(w + "id", "999"),
+                        new XElement(w + "p", new XElement(w + "r",
+                            new XElement(w + "t", "MUST-NOT-BECOME-A-NOTE")))));
+
+                    XElement html = WmlToHtmlConverter.ConvertToHtml(wDoc,
+                        new WmlToHtmlConverterSettings
+                        {
+                            PageTitle = "Footnote separator stories",
+                            FabricateCssClasses = true,
+                            RenderFootnotesAndEndnotes = true,
+                            RenderPagination = PaginationMode.Paginated,
+                        });
+                    var registry = html.Descendants()
+                        .First(element => element.Name.LocalName == "div" &&
+                            (string)element.Attribute("id") == "pagination-footnote-registry");
+                    var separators = registry.Elements()
+                        .Where(element => element.Attribute("data-footnote-separator") != null)
+                        .ToList();
+
+                    Assert.Equal(new[] { "normal", "continuation" }, separators
+                        .Select(element => (string)element.Attribute("data-footnote-separator")));
+                    Assert.Contains("NORMAL-SEPARATOR-TOKEN", separators[0].Value);
+                    Assert.Contains("CONTINUATION-SEPARATOR-TOKEN", separators[1].Value);
+                    Assert.DoesNotContain(registry.Elements(), element =>
+                        (string)element.Attribute("data-footnote-id") == "999");
+                    Assert.DoesNotContain("MUST-NOT-BECOME-A-NOTE", registry.Value);
+                    Assert.Contains("data-footnote-separator=\"continuation\"", html.ToString());
                 }
             }
         }

--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -1914,6 +1914,14 @@ namespace Docxodus
             sb.AppendLine("    margin: 0 0 3pt 0;");
             sb.AppendLine("    opacity: 0.6;");
             sb.AppendLine("}");
+            // A continuation separator spans the text column; Word's ordinary
+            // separator remains the calibrated two-inch rule above. Both the
+            // converter-produced story wrapper and the paginator fallback carry
+            // the same kind attribute so measurement and paint select one rule.
+            sb.AppendLine($".{prefix}footnotes [data-footnote-separator=\"continuation\"] > hr,");
+            sb.AppendLine($".{prefix}footnotes > hr[data-footnote-separator=\"continuation\"] {{");
+            sb.AppendLine("    width: 100%;");
+            sb.AppendLine("}");
 
             // Individual footnote item (in registry and on page). Word stacks notes with no
             // spacing of its own — any inter-note gap belongs to the FootnoteText paragraph's
@@ -3682,6 +3690,78 @@ namespace Docxodus
             return li;
         }
 
+        private static XElement RenderPaginatedFootnoteSeparator(
+            WordprocessingDocument wordDoc,
+            WmlToHtmlConverterSettings settings,
+            XElement source,
+            string kind)
+        {
+            if (source == null)
+                return null;
+
+            var markerName = kind == "continuation"
+                ? W.continuationSeparator
+                : W.separator;
+            var hasAuthoredContent = source.Descendants().Any(e =>
+                !e.AncestorsAndSelf().Any(ancestor =>
+                    ancestor.Name == W.pPr || ancestor.Name == W.rPr) &&
+                e.Name != W.p && e.Name != W.r &&
+                e.Name != W.separator && e.Name != W.continuationSeparator &&
+                e.Name != W.footnoteRef && e.Name != W.endnoteRef);
+
+            var story = new XElement(Xhtml.div,
+                new XAttribute("class", $"footnote-separator-story footnote-separator-{kind}"),
+                new XAttribute("data-footnote-separator", kind));
+
+            // The ordinary run transform intentionally ignores this Word-only
+            // control. Keep an authored mark explicit, but do not invent one for
+            // an intentionally empty/custom text-only reserved story. Only an
+            // absent definition causes the paginator's typed fallback rule.
+            if (source.Descendants(markerName).Any())
+            {
+                story.Add(new XElement(Xhtml.hr,
+                    new XAttribute("data-footnote-separator-rule", markerName.LocalName)));
+            }
+
+            if (hasAuthoredContent)
+            {
+                story.Add(source.Elements()
+                    .Select(e => ConvertToHtmlTransform(wordDoc, settings, e, false, 0m)));
+            }
+            SanitizeRepeatedFootnoteSeparator(story);
+            return story;
+        }
+
+        /// <summary>
+        /// A separator story is repeated on multiple physical pages. Source and
+        /// editor identities therefore cannot survive on its presentation clones:
+        /// duplicate ids/local targets would be ambiguous and canonical anchor
+        /// metadata would incorrectly admit the decoration into PageMap.
+        /// </summary>
+        private static void SanitizeRepeatedFootnoteSeparator(XElement story)
+        {
+            var repeatedElements = story.DescendantsAndSelf().ToList();
+            foreach (var element in repeatedElements)
+            {
+                foreach (var attributeName in new[]
+                {
+                    "id", "name", "data-anchor", "data-committed-text",
+                    "data-source-anchor-id", "data-page-fragment-id", "data-fragment-index",
+                    "data-footnote-id", "data-comment-id",
+                })
+                {
+                    element.Attributes()
+                        .Where(attribute => attribute.Name.LocalName == attributeName)
+                        .Remove();
+                }
+                var href = element.Attributes()
+                    .FirstOrDefault(attribute => attribute.Name.LocalName == "href");
+                if (href != null && href.Value.StartsWith("#", StringComparison.Ordinal))
+                    href.Remove();
+                element.SetAttributeValue("contenteditable", "false");
+            }
+        }
+
         /// <summary>
         /// Renders a footnote registry for paginated mode.
         /// In paginated mode, footnotes are stored in a hidden registry and distributed
@@ -3697,12 +3777,10 @@ namespace Docxodus
 
             var footnotesXDoc = footnotesPart.GetXDocument();
             var allFootnotes = footnotesXDoc.Root?.Elements(W.footnote)
-                .Where(fn =>
-                {
-                    var typeAttr = (string)fn.Attribute(W.type);
-                    // Skip separator and continuationSeparator footnotes
-                    return typeAttr != "separator" && typeAttr != "continuationSeparator";
-                })
+                // Every typed non-normal definition is page-rendering boilerplate;
+                // continuationNotice can carry a positive id in real documents and
+                // must not leak into the user-note registry.
+                .Where(fn => !WmlToMarkdownConverter.IsBoilerplateNote(fn))
                 .ToDictionary(fn => (string)fn.Attribute(W.id), fn => fn);
 
             if (allFootnotes == null || !allFootnotes.Any())
@@ -3728,6 +3806,19 @@ namespace Docxodus
             var registry = new XElement(Xhtml.div,
                 new XAttribute("id", "pagination-footnote-registry"),
                 new XAttribute("style", "display:none"));
+
+            var normalSeparator = footnotesXDoc.Root?.Elements(W.footnote)
+                .FirstOrDefault(fn => (string)fn.Attribute(W.type) == "separator");
+            var continuationSeparator = footnotesXDoc.Root?.Elements(W.footnote)
+                .FirstOrDefault(fn => (string)fn.Attribute(W.type) == "continuationSeparator");
+            var renderedNormalSeparator = RenderPaginatedFootnoteSeparator(
+                wordDoc, settings, normalSeparator, "normal");
+            var renderedContinuationSeparator = RenderPaginatedFootnoteSeparator(
+                wordDoc, settings, continuationSeparator, "continuation");
+            if (renderedNormalSeparator != null)
+                registry.Add(renderedNormalSeparator);
+            if (renderedContinuationSeparator != null)
+                registry.Add(renderedContinuationSeparator);
 
             foreach (var fn in orderedFootnotes)
             {

--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -3702,12 +3702,19 @@ namespace Docxodus
             var markerName = kind == "continuation"
                 ? W.continuationSeparator
                 : W.separator;
+            // Whitespace is not authored content. This runs after the pipeline's
+            // empty-paragraph pass, which annotates a marker-only story's
+            // paragraph and gives it a synthetic ` ` run so the empty line keeps
+            // its height. Counting that run as authored drew a blank line under
+            // the rule on every continued-note page and ate the band height the
+            // paginator had just budgeted.
             var hasAuthoredContent = source.Descendants().Any(e =>
                 !e.AncestorsAndSelf().Any(ancestor =>
                     ancestor.Name == W.pPr || ancestor.Name == W.rPr) &&
                 e.Name != W.p && e.Name != W.r &&
                 e.Name != W.separator && e.Name != W.continuationSeparator &&
-                e.Name != W.footnoteRef && e.Name != W.endnoteRef);
+                e.Name != W.footnoteRef && e.Name != W.endnoteRef &&
+                !(e.Name == W.t && string.IsNullOrWhiteSpace(e.Value)));
 
             var story = new XElement(Xhtml.div,
                 new XAttribute("class", $"footnote-separator-story footnote-separator-{kind}"),

--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -1918,8 +1918,11 @@ namespace Docxodus
             // separator remains the calibrated two-inch rule above. Both the
             // converter-produced story wrapper and the paginator fallback carry
             // the same kind attribute so measurement and paint select one rule.
-            sb.AppendLine($".{prefix}footnotes [data-footnote-separator=\"continuation\"] > hr,");
-            sb.AppendLine($".{prefix}footnotes > hr[data-footnote-separator=\"continuation\"] {{");
+            // Descendant selectors only: this CSS is serialized as XML, so a `>`
+            // child combinator ships as `&gt;` and the browser drops the rule
+            // (GeneratedCssEscapingTests).
+            sb.AppendLine($".{prefix}footnotes [data-footnote-separator=\"continuation\"] hr,");
+            sb.AppendLine($".{prefix}footnotes hr[data-footnote-separator=\"continuation\"] {{");
             sb.AppendLine("    width: 100%;");
             sb.AppendLine("}");
 

--- a/docs/architecture/docx_mutation_api.md
+++ b/docs/architecture/docx_mutation_api.md
@@ -1064,9 +1064,11 @@ already had a footnote engine (per-page distribution, continuations, splitting),
 render flag on activates it — notes land in a note area at the bottom of the page that cites them,
 above a separator rule, and a note too long for its page continues onto the next. Endnotes render as
 a `section.endnotes` appended after the page stack rather than on their own final page, which is a
-layout imperfection, not a correctness one: they are visible and editable. A note split across pages
-puts a *different paragraph* of the note in each half, so each half stays independently addressable
-— no two editable nodes ever share one anchor.
+layout imperfection, not a correctness one: they are visible and editable. A note can split between
+paragraphs or, for conservatively eligible text-only content, inside one paragraph. Every visible
+piece keeps the paragraph's canonical `data-source-anchor-id`, producing contiguous PageMap
+fragments, while only the leading piece retains the editable bare `data-anchor`/`id`; active editor
+identity therefore remains unique.
 
 Note content lives inside the body flow, so anything that walks "the body blocks" must exclude
 `section.footnotes`, `section.endnotes` and `.footnote-item` — the header/footer band already does
@@ -1075,7 +1077,7 @@ note leaves the bands on the last body section rather than blanking them).
 
 **Paginated mode's footnote engine.** `pagination.ts` already had per-page distribution, splitting
 and continuations; turning the render flag on exercised it against a dense real document for the
-first time and it needed four fixes, each worth knowing about because each failed *silently*:
+first time and it needed five fixes, each worth knowing about because each failed *silently*:
 
 - an unfitted note was held in a **single** continuation slot assigned once per note in a page's
   citation list, so a second unfitted note on the same page overwrote the first and it rendered
@@ -1088,11 +1090,18 @@ first time and it needed four fixes, each worth knowing about because each faile
   and note glyphs could be painted on top of each other. The content area is now shrunk to what the
   notes leave, making that impossible by construction — worst case is a clean clip — and note
   heights are measured in the `.page-footnotes` styling context they render in so the reserve
-  matches the paint.
+  matches the paint;
+- a single paragraph taller than the note band was treated as fully consumed after one clipped
+  rendering, so its invisible tail had no later page or PageMap fragment. The body paragraph's
+  conservative DOM Range fragmenter is now shared with note flow and measured in the exact initial
+  note or continuation wrapper. Unsafe/indivisible content keeps the bounded clipped fallback, but
+  only for that one element; later sibling paragraphs still drain normally.
 
 `DS340`–`DS345` pin the engine half (marker + section emitted, note paragraphs stamped, stamped
 anchors resolve through the session, edit-then-re-render, the stateless path, and reserved-note
-filtering); `npm/tests/editor-footnotes.spec.ts` pins the browser half.
+filtering); `npm/tests/editor-footnotes.spec.ts` pins the editor half, while
+`pagination-footnote-layout.spec.ts` and `page-map-real-converter.spec.ts` pin multi-page paragraph
+continuation, unclipped text preservation, and PageMap closure.
 
 **Word-reserved notes never surface as editable blocks.** `IsBoilerplateNote` now treats *any*
 typed note as reserved: ECMA-376 §17.11.17 defines the type as `normal` | `separator` |

--- a/docs/architecture/standalone_paginated_export.md
+++ b/docs/architecture/standalone_paginated_export.md
@@ -1074,9 +1074,10 @@ faithful rendering. Native SVG image parts are not claimed until their current p
 replaced and covered by readiness/vector tests. Password-protected/encrypted or malformed packages
 fail before rendering.
 
-Issue #489's current whole-paragraph footnote splitter can clip a note tail and omit its PageMap
-geometry. Full footnote fidelity is explicitly unsupported until #489 lands; the exporter detects
-the clipped/oversized condition and fails rather than shipping a complete result with missing text.
+Eligible text-only footnote paragraphs continue within the paragraph at deterministic Unicode-safe
+boundaries, preserving inline structure, identities, ordering, and PageMap fragments. Structurally
+indivisible note content retains the typed clipped-content failure rather than shipping a complete
+result with missing text.
 
 Package preflight, raw source identity, revision/comment/media inventory, safety findings, and ZIP
 resource ceilings reuse #493's `PackageManifestGenerator` contract through its WASM surface. The
@@ -1091,7 +1092,7 @@ the #501 acceptance boundary; code written against the former numeric entry-size
 | #438 / #501 | isolated final page-tree materialization, offline serializer, complete v1 browser types/schema/docs/tests |
 | #439 / #502 | `@docxodus/export`, CLI, local runtime serving, bundle/PDF bytes and typed failures |
 | #440 / #503 | mixed-section effective PDF-box and sequencing proof |
-| #489 / #504 | lossless mid-paragraph footnote continuation before complete note text/PageMap coverage |
+| #489 / #504 | lossless mid-paragraph footnote continuation and complete note text/PageMap coverage |
 | #441 / #505 | phased readiness barrier, quiet interval, cancellation, delayed-resource tests |
 | #442 / #506 | font directories/resolver, license policy, resolution evidence, fingerprint integration |
 | #443 / #507 | generated-PDF raster/text/link ratchet and reproducibility documentation |

--- a/docs/architecture/wml_to_html_converter_gaps.md
+++ b/docs/architecture/wml_to_html_converter_gaps.md
@@ -287,7 +287,7 @@ Several Word elements are not handled in `ConvertToHtmlTransform`:
 | `W.softHyphen` | Soft hyphen | Loses word-wrap hints |
 | `W.yearLong`, `W.monthLong`, etc. | Date/time fields | No output |
 | `W.pgNum` | Page numbers | Cannot resolve |
-| `W.separator`, `W.continuationSeparator` | Footnote separators | Ignored |
+| `W.separator`, `W.continuationSeparator` | Footnote separators | Preserved as inert normal/continuation story templates in the hidden paginated-footnote registry; the paginator clones the normal story when a note starts and the continuation story on carried-note pages, falling back to typed 2in/full-width rules only when the corresponding story is absent. |
 
 ---
 

--- a/npm-export/tests/export.test.mjs
+++ b/npm-export/tests/export.test.mjs
@@ -690,14 +690,16 @@ describe("@docxodus/export", { concurrency: false }, () => {
       paragraphFragments.map((_, index) => index),
     );
 
+    // Match on word boundaries, never substrings: `footnote-1-1-1` occurs inside
+    // `footnote-1-1-10`, so a bare indexOf reports every low-numbered word twice.
     let priorPdfOffset = -1;
     for (const index of [1, 2, 150, 300, 450, 599, 600]) {
       const token = `footnote-1-1-${index}`;
       assert.equal(result.html.match(new RegExp(`\\b${token}\\b`, "g"))?.length, 1);
-      const pdfOffset = inspection.searchableText.indexOf(token);
-      assert.ok(pdfOffset > priorPdfOffset, `${token} missing or out of order in PDF text`);
-      assert.equal(inspection.searchableText.indexOf(token, pdfOffset + token.length), -1);
-      priorPdfOffset = pdfOffset;
+      const pdfMatches = [...inspection.searchableText.matchAll(new RegExp(`\\b${token}\\b`, "g"))];
+      assert.equal(pdfMatches.length, 1, `${token} must appear exactly once in the PDF text`);
+      assert.ok(pdfMatches[0].index > priorPdfOffset, `${token} out of order in PDF text`);
+      priorPdfOffset = pdfMatches[0].index;
     }
 
     await writeFile(join(successArtifacts, "long-footnote.pdf"), result.pdf);

--- a/npm-export/tests/export.test.mjs
+++ b/npm-export/tests/export.test.mjs
@@ -23,7 +23,10 @@ import {
   renderDocxFile,
 } from "../dist/index.js";
 import { canonicalJson } from "../dist/canonical.js";
-import { generateMixedSectionDocx } from "./mixed-section-fixture.mjs";
+import {
+  generateLongFootnoteDocx,
+  generateMixedSectionDocx,
+} from "./mixed-section-fixture.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const packageRoot = dirname(here);
@@ -661,6 +664,46 @@ describe("@docxodus/export", { concurrency: false }, () => {
       columnContainers,
     });
     await writeFile(join(successArtifacts, "mixed-sections-scaled-viewer.png"), screenshot);
+  });
+
+  test("preserves one converter-produced footnote paragraph across HTML and PDF pages", {
+    timeout: 180_000,
+  }, async () => {
+    const source = generateLongFootnoteDocx(600);
+    const result = await renderDocxArtifacts(source, {
+      ...baseOptions,
+      browser,
+      outputs: ["html", "pdf"],
+    });
+    const inspection = await inspectPdf(result.pdf);
+
+    assert.ok(result.pageCount > 2);
+    assert.equal(inspection.pageCount, result.pageCount);
+    assert.deepEqual(result.renderReport.pages, result.pageMap.pages);
+    assertPdfBoxes(inspection, result.pageMap.pages);
+    const paragraphFragments = result.pageMap.fragments.filter((fragment) =>
+      fragment.story === "footnote" && fragment.anchorId.startsWith("p:fn:"));
+    assert.ok(paragraphFragments.length > 2);
+    assert.ok(new Set(paragraphFragments.map((fragment) => fragment.pageNumber)).size > 2);
+    assert.deepEqual(
+      paragraphFragments.map((fragment) => fragment.fragmentIndex),
+      paragraphFragments.map((_, index) => index),
+    );
+
+    let priorPdfOffset = -1;
+    for (const index of [1, 2, 150, 300, 450, 599, 600]) {
+      const token = `footnote-1-1-${index}`;
+      assert.equal(result.html.match(new RegExp(`\\b${token}\\b`, "g"))?.length, 1);
+      const pdfOffset = inspection.searchableText.indexOf(token);
+      assert.ok(pdfOffset > priorPdfOffset, `${token} missing or out of order in PDF text`);
+      assert.equal(inspection.searchableText.indexOf(token, pdfOffset + token.length), -1);
+      priorPdfOffset = pdfOffset;
+    }
+
+    await writeFile(join(successArtifacts, "long-footnote.pdf"), result.pdf);
+    await writeFile(join(successArtifacts, "long-footnote.html"), result.html);
+    await writeJson(join(successArtifacts, "long-footnote-page-map.json"), result.pageMap);
+    await writeJson(join(successArtifacts, "long-footnote-pdf-inspection.json"), inspection);
   });
 
   test("retains a structured report when post-layout PDF verification fails", { timeout: 180_000 }, async () => {

--- a/npm-export/tests/mixed-section-fixture.mjs
+++ b/npm-export/tests/mixed-section-fixture.mjs
@@ -202,3 +202,83 @@ export function generateMixedSectionDocx() {
   }
   return storedZip(entries);
 }
+
+/** One real-converter footnote paragraph long enough to span several PDF pages. */
+export function generateLongFootnoteDocx(wordCount = 600) {
+  const noteText = Array.from(
+    { length: wordCount },
+    (_, index) => `footnote-1-1-${index + 1}`,
+  ).join(" ");
+  return storedZip([
+    {
+      name: "[Content_Types].xml",
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
+  <Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>
+</Types>`),
+    },
+    {
+      name: "_rels/.rels",
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${R_NS}/officeDocument" Target="word/document.xml"/>
+</Relationships>`),
+    },
+    {
+      name: "word/_rels/document.xml.rels",
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${R_NS}/styles" Target="styles.xml"/>
+  <Relationship Id="rId2" Type="${R_NS}/footnotes" Target="footnotes.xml"/>
+</Relationships>`),
+    },
+    {
+      name: "word/styles.xml",
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles xmlns:w="${W_NS}">
+  <w:docDefaults><w:rPrDefault><w:rPr>
+    <w:rFonts w:ascii="Liberation Serif" w:hAnsi="Liberation Serif"/>
+    <w:sz w:val="24"/><w:szCs w:val="24"/>
+  </w:rPr></w:rPrDefault></w:docDefaults>
+  <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+  <w:style w:type="paragraph" w:styleId="FootnoteText"><w:name w:val="footnote text"/>
+    <w:basedOn w:val="Normal"/><w:pPr><w:spacing w:before="0" w:after="0" w:line="240" w:lineRule="auto"/></w:pPr>
+    <w:rPr><w:sz w:val="20"/><w:szCs w:val="20"/></w:rPr>
+  </w:style>
+  <w:style w:type="character" w:styleId="FootnoteReference"><w:name w:val="footnote reference"/>
+    <w:rPr><w:vertAlign w:val="superscript"/></w:rPr>
+  </w:style>
+</w:styles>`),
+    },
+    {
+      name: "word/footnotes.xml",
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:footnotes xmlns:w="${W_NS}">
+  <w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>
+  <w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>
+  <w:footnote w:id="1"><w:p><w:pPr><w:pStyle w:val="FootnoteText"/></w:pPr>
+    <w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r>
+    <w:r><w:t xml:space="preserve"> ${noteText}</w:t></w:r>
+  </w:p></w:footnote>
+</w:footnotes>`),
+    },
+    {
+      name: "word/document.xml",
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="${W_NS}" xmlns:r="${R_NS}"><w:body>
+  <w:p><w:pPr><w:spacing w:before="0" w:after="0" w:line="240" w:lineRule="auto"/></w:pPr>
+    <w:r><w:t>Body cites long footnote</w:t></w:r>
+    <w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteReference w:id="1"/></w:r>
+  </w:p>
+  <w:sectPr><w:pgSz w:w="12240" w:h="15840"/>
+    <w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"
+      w:header="720" w:footer="720" w:gutter="0"/><w:cols w:space="720"/>
+  </w:sectPr>
+</w:body></w:document>`),
+    },
+  ]);
+}

--- a/npm/src/export-browser.ts
+++ b/npm/src/export-browser.ts
@@ -2403,7 +2403,7 @@ function assertNoClippedContent(document: Document): void {
     if (hasVisibleOverflow) {
       fail("pagination_failure", "running_story_placement",
         "A footnote continuation is clipped in the final page tree.",
-        "Split the oversized footnote paragraph; full continuation support is tracked by issue #489.");
+        "Report the unsupported note structure; eligible text paragraphs are continued losslessly.");
     }
   }
   for (const content of Array.from(document.querySelectorAll<HTMLElement>(".page-content"))) {

--- a/npm/src/pagination.ts
+++ b/npm/src/pagination.ts
@@ -1781,7 +1781,7 @@ export class PaginationEngine {
    * fallback instead of risking broken content or duplicate anchors.
    */
   private canFragmentParagraph(block: MeasuredBlock): boolean {
-    if (!this.fragmentParagraphs || block.element.tagName !== "P") {
+    if (!this.fragmentParagraphs) {
       return false;
     }
 
@@ -1791,6 +1791,30 @@ export class PaginationEngine {
       block.keepLines ||
       block.pageBreakBefore ||
       block.isPageBreak ||
+      paragraph.dataset.widowControl === "true" ||
+      paragraph.hasAttribute("contenteditable")
+    ) {
+      return false;
+    }
+
+    return this.canRangeFragmentParagraph(paragraph);
+  }
+
+  /**
+   * Shared structural gate for body and note paragraph fragmentation. Footnote
+   * first paragraphs are inline beside their marker, so that one known layout
+   * context may opt into an inline root while retaining every descendant and
+   * break-safety restriction used for body text.
+   */
+  private canRangeFragmentParagraph(
+    paragraph: HTMLElement,
+    allowInlineRoot: boolean = false,
+  ): boolean {
+    if (
+      paragraph.tagName !== "P" ||
+      paragraph.dataset.keepWithNext === "true" ||
+      paragraph.dataset.keepLines === "true" ||
+      paragraph.dataset.pageBreakBefore === "true" ||
       paragraph.dataset.widowControl === "true" ||
       paragraph.hasAttribute("contenteditable")
     ) {
@@ -1839,7 +1863,7 @@ export class PaginationEngine {
     }
 
     const isValidatedEndnote = paragraph.dataset.paginationSafeEndnote === "true";
-    return isValidatedEndnote || this.hasRangeFragmentSafeLayout(paragraph);
+    return isValidatedEndnote || this.hasRangeFragmentSafeLayout(paragraph, allowInlineRoot);
   }
 
   /**
@@ -1847,13 +1871,18 @@ export class PaginationEngine {
    * box/layout context is deferred until a future fragmenter can model it accurately. Callers
    * must invoke this while the paragraph is attached to the styled document.
    */
-  private hasRangeFragmentSafeLayout(paragraph: HTMLElement): boolean {
+  private hasRangeFragmentSafeLayout(
+    paragraph: HTMLElement,
+    allowInlineRoot: boolean = false,
+  ): boolean {
     const paragraphStyle = this.view.getComputedStyle(paragraph);
     if (
-      paragraphStyle.display !== "block" ||
+      (paragraphStyle.display !== "block" &&
+        !(allowInlineRoot && paragraphStyle.display === "inline")) ||
       paragraphStyle.position !== "static" ||
       paragraphStyle.float !== "none" ||
-      paragraphStyle.whiteSpace !== "normal" ||
+      (paragraphStyle.whiteSpace !== "normal" &&
+        !(allowInlineRoot && paragraphStyle.whiteSpace === "pre-wrap")) ||
       paragraphStyle.breakBefore !== "auto" ||
       paragraphStyle.breakAfter !== "auto" ||
       paragraphStyle.breakInside === "avoid" ||
@@ -1911,6 +1940,58 @@ export class PaginationEngine {
   }
 
   /**
+   * Range-clone the largest safe prefix accepted by `fits`. The measurement
+   * policy stays with the caller, allowing body blocks and note bands to share
+   * one DOM fragmenter while measuring in their respective layout contexts.
+   */
+  private splitParagraphAtLargestFit(
+    paragraph: HTMLElement,
+    fits: (head: HTMLElement) => boolean,
+  ): { head: HTMLElement; tail: HTMLElement } | null {
+    const endpoints = this.paragraphFragmentEndpoints(paragraph);
+    // The final endpoint is the full paragraph and cannot leave a tail. A
+    // single run without an earlier whitespace boundary remains indivisible.
+    if (endpoints.length < 2) return null;
+
+    let low = 0;
+    let high = endpoints.length - 2;
+    let best: { endpoint: { node: Text; offset: number }; head: HTMLElement } | null = null;
+    while (low <= high) {
+      this.checkpoint();
+      const middle = Math.floor((low + high) / 2);
+      const endpoint = endpoints[middle];
+      const headRange = this.document.createRange();
+      headRange.setStart(paragraph, 0);
+      headRange.setEnd(endpoint.node, endpoint.offset);
+      const headContents = headRange.cloneContents();
+      if (!this.hasVisibleFragmentText(headContents)) {
+        low = middle + 1;
+        continue;
+      }
+
+      const head = this.createParagraphFragment(paragraph, headRange, true, false);
+      if (fits(head)) {
+        best = { endpoint, head };
+        low = middle + 1;
+      } else {
+        high = middle - 1;
+      }
+    }
+    if (!best) return null;
+
+    const tailRange = this.document.createRange();
+    tailRange.setStart(best.endpoint.node, best.endpoint.offset);
+    tailRange.setEnd(paragraph, paragraph.childNodes.length);
+    const tailContents = tailRange.cloneContents();
+    if (!this.hasVisibleFragmentText(tailContents)) return null;
+
+    return {
+      head: best.head,
+      tail: this.createParagraphFragment(paragraph, tailRange, false, true),
+    };
+  }
+
+  /**
    * Splits a simple paragraph at the largest DOM Range endpoint that fits the
    * currently available body space. The caller then processes the tail normally,
    * allowing it to fragment again on later pages when necessary.
@@ -1925,63 +2006,19 @@ export class PaginationEngine {
       return null;
     }
 
-    const paragraph = block.element;
-    const endpoints = this.paragraphFragmentEndpoints(paragraph);
-    // The final endpoint is the full paragraph and cannot leave a tail. A
-    // single text run with no earlier whitespace remains an overflow fallback.
-    if (endpoints.length < 2) {
-      return null;
-    }
-
-    let low = 0;
-    let high = endpoints.length - 2;
-    let best: { endpoint: { node: Text; offset: number }; element: HTMLElement; measured: MeasuredBlock } | null = null;
-
-    // Fragment height is monotonic for the deliberately narrow eligible subset,
-    // so binary search avoids measuring every word in long body paragraphs.
-    while (low <= high) {
-      this.checkpoint();
-      const middle = Math.floor((low + high) / 2);
-      const endpoint = endpoints[middle];
-      const headRange = this.document.createRange();
-      headRange.setStart(paragraph, 0);
-      headRange.setEnd(endpoint.node, endpoint.offset);
-      const headContents = headRange.cloneContents();
-
-      if (!this.hasVisibleFragmentText(headContents)) {
-        low = middle + 1;
-        continue;
-      }
-
-      const head = this.createParagraphFragment(paragraph, headRange, true, false);
+    const split = this.splitParagraphAtLargestFit(block.element, (head) => {
       const measured = this.measureElement(head, dims, block.sectionIndex);
-      if (effectiveMarginTopPt + measured.heightPt <= availableHeightPt) {
-        best = { endpoint, element: head, measured };
-        low = middle + 1;
-      } else {
-        high = middle - 1;
-      }
-    }
+      return effectiveMarginTopPt + measured.heightPt <= availableHeightPt;
+    });
+    if (!split) return null;
 
-    if (!best) {
-      return null;
-    }
-
-    const tailRange = this.document.createRange();
-    tailRange.setStart(best.endpoint.node, best.endpoint.offset);
-    tailRange.setEnd(paragraph, paragraph.childNodes.length);
-    const tailContents = tailRange.cloneContents();
-    if (!this.hasVisibleFragmentText(tailContents)) {
-      return null;
-    }
-
-    const tail = this.createParagraphFragment(paragraph, tailRange, false, true);
-    const tailMeasured = this.measureElement(tail, dims, block.sectionIndex);
+    const headMeasured = this.measureElement(split.head, dims, block.sectionIndex);
+    const tailMeasured = this.measureElement(split.tail, dims, block.sectionIndex);
 
     return [
       {
-        ...best.measured,
-        element: best.element,
+        ...headMeasured,
+        element: split.head,
         keepWithNext: false,
         keepLines: false,
         pageBreakBefore: false,
@@ -1989,7 +2026,7 @@ export class PaginationEngine {
       },
       {
         ...tailMeasured,
-        element: tail,
+        element: split.tail,
         keepWithNext: false,
         keepLines: false,
         pageBreakBefore: false,
@@ -2214,10 +2251,17 @@ export class PaginationEngine {
     const hr = this.document.createElement("hr");
     measureContainer.appendChild(hr);
 
-    // Add continuation content
-    for (const el of continuation.remainingElements) {
-      measureContainer.appendChild(el.cloneNode(true));
+    // Measure the same wrapper shape addPageFootnotes renders. Selectors on the
+    // continuation wrapper may change line boxes and must participate here.
+    const continuationWrapper = document.createElement("div");
+    continuationWrapper.className = "footnote-continuation";
+    if (continuation.sourceAnchorId) {
+      continuationWrapper.dataset.sourceAnchorId = continuation.sourceAnchorId;
     }
+    for (const el of continuation.remainingElements) {
+      continuationWrapper.appendChild(el.cloneNode(true));
+    }
+    measureContainer.appendChild(continuationWrapper);
 
     this.stagingElement.appendChild(measureContainer);
     const rect = measureContainer.getBoundingClientRect();
@@ -2228,9 +2272,10 @@ export class PaginationEngine {
   }
 
   /**
-   * Partition a continuation at complete child boundaries for one page's note band.
-   * Always advances by at least one element so an indivisible oversized paragraph
-   * follows the established clipped fallback without trapping pagination in a loop.
+   * Partition a continuation for one page's note band, preferring complete children
+   * and range-fragmenting an eligible paragraph when necessary. Always advances by
+   * at least one element so an indivisible oversized paragraph follows the established
+   * clipped fallback without trapping pagination in a loop.
    */
   private splitContinuationForPage(
     continuation: FootnoteContinuation,
@@ -2238,22 +2283,43 @@ export class PaginationEngine {
     contentWidth: number,
   ): { current: FootnoteContinuation; overflow: FootnoteContinuation | null } {
     const fitting: HTMLElement[] = [];
-    let fittingHeight = 0;
+    let remaining: HTMLElement[] = [];
 
-    for (const element of continuation.remainingElements) {
+    for (let index = 0; index < continuation.remainingElements.length; index++) {
+      const element = continuation.remainingElements[index];
       const candidate: FootnoteContinuation = {
         footnoteId: continuation.footnoteId,
         sourceAnchorId: continuation.sourceAnchorId,
         remainingElements: [...fitting, element],
       };
       const candidateHeight = this.measureContinuationHeight(candidate, contentWidth);
-      if (fitting.length > 0 && candidateHeight > availableHeightPt) break;
-      fitting.push(element);
-      fittingHeight = candidateHeight;
-      if (fittingHeight >= availableHeightPt) break;
+      if (candidateHeight <= availableHeightPt) {
+        fitting.push(element);
+        continue;
+      }
+
+      const split = this.splitContinuationParagraphAtFit(
+        element,
+        fitting,
+        continuation,
+        availableHeightPt,
+        contentWidth,
+      );
+      if (split) {
+        fitting.push(split.head);
+        remaining = [split.tail, ...continuation.remainingElements.slice(index + 1)];
+      } else if (fitting.length === 0) {
+        // A genuinely indivisible first element retains the established visible
+        // clipped fallback, but only for itself. Its siblings must continue on
+        // later pages rather than being swallowed by the same clipped band.
+        fitting.push(element);
+        remaining = continuation.remainingElements.slice(index + 1);
+      } else {
+        remaining = continuation.remainingElements.slice(index);
+      }
+      break;
     }
 
-    const remaining = continuation.remainingElements.slice(fitting.length);
     return {
       current: {
         footnoteId: continuation.footnoteId,
@@ -2269,6 +2335,77 @@ export class PaginationEngine {
   }
 
   /**
+   * A continuation element is normally detached. Attach a clone in the real
+   * continuation CSS context before applying the shared conservative layout
+   * gate, then range-split it against exact note-band measurements.
+   */
+  private splitContinuationParagraphAtFit(
+    element: HTMLElement,
+    alreadyFitting: HTMLElement[],
+    continuation: FootnoteContinuation,
+    availableHeightPt: number,
+    contentWidth: number,
+  ): { head: HTMLElement; tail: HTMLElement } | null {
+    if (element.tagName !== "P") return null;
+
+    const context = document.createElement("div");
+    context.style.position = "absolute";
+    context.style.visibility = "hidden";
+    context.style.width = `${contentWidth}pt`;
+    context.style.left = "-9999px";
+    context.className = this.cssPrefix + "footnotes";
+    const wrapper = document.createElement("div");
+    wrapper.className = "footnote-continuation";
+    if (continuation.sourceAnchorId) {
+      wrapper.dataset.sourceAnchorId = continuation.sourceAnchorId;
+    }
+    const paragraph = element.cloneNode(true) as HTMLElement;
+    wrapper.appendChild(paragraph);
+    context.appendChild(wrapper);
+    this.stagingElement.appendChild(context);
+    try {
+      if (!this.canRangeFragmentParagraph(paragraph)) return null;
+      return this.splitParagraphAtLargestFit(paragraph, (head) =>
+        this.measureContinuationHeight({
+          footnoteId: continuation.footnoteId,
+          sourceAnchorId: continuation.sourceAnchorId,
+          remainingElements: [...alreadyFitting, head],
+        }, contentWidth) <= availableHeightPt);
+    } finally {
+      this.stagingElement.removeChild(context);
+    }
+  }
+
+  /** Exact initial-note measurement, including separator, marker, and content wrapper. */
+  private measurePartialFootnoteHeight(
+    footnoteElement: HTMLElement,
+    contentElement: Element,
+    elements: HTMLElement[],
+    contentWidth: number,
+  ): number {
+    const measureContainer = document.createElement("div");
+    measureContainer.style.position = "absolute";
+    measureContainer.style.visibility = "hidden";
+    measureContainer.style.width = `${contentWidth}pt`;
+    measureContainer.style.left = "-9999px";
+    measureContainer.className = this.cssPrefix + "footnotes";
+    measureContainer.appendChild(document.createElement("hr"));
+
+    const item = footnoteElement.cloneNode(false) as HTMLElement;
+    const number = footnoteElement.querySelector(".footnote-number");
+    if (number) item.appendChild(number.cloneNode(true));
+    const content = contentElement.cloneNode(false) as HTMLElement;
+    for (const element of elements) content.appendChild(element.cloneNode(true));
+    item.appendChild(content);
+    measureContainer.appendChild(item);
+
+    this.stagingElement.appendChild(measureContainer);
+    const heightPt = pxToPt(measureContainer.getBoundingClientRect().height);
+    this.stagingElement.removeChild(measureContainer);
+    return heightPt;
+  }
+
+  /**
    * Splits a footnote element into parts that fit within the available height.
    * Returns the elements that fit and the elements that need to continue.
    */
@@ -2277,6 +2414,20 @@ export class PaginationEngine {
     availableHeightPt: number,
     contentWidth: number
   ): { fits: HTMLElement[]; overflow: HTMLElement[] } {
+    // Registry entries are detached clones, so getComputedStyle() cannot validate
+    // their real paragraph layout. Attach an exact clone in the rendered note
+    // context for the duration of the conservative range-fragmentation check.
+    const layoutContext = document.createElement("div");
+    layoutContext.style.position = "absolute";
+    layoutContext.style.visibility = "hidden";
+    layoutContext.style.width = `${contentWidth}pt`;
+    layoutContext.style.left = "-9999px";
+    layoutContext.className = this.cssPrefix + "footnotes";
+    layoutContext.appendChild(document.createElement("hr"));
+    const attachedFootnote = footnoteElement.cloneNode(true) as HTMLElement;
+    layoutContext.appendChild(attachedFootnote);
+    this.stagingElement.appendChild(layoutContext);
+
     // Get child elements (paragraphs) of the footnote content.
     //
     // `fits` is spliced into a freshly built `.footnote-item` > `.footnote-content` wrapper by
@@ -2285,76 +2436,65 @@ export class PaginationEngine {
     // inside another item's content span; the inner block-level div then broke the line, so the
     // note's number rendered alone above its text — the same visible symptom as the escaped-CSS
     // bug, from an unrelated cause, on the notes that happened to take a can't-split path.
-    const footnoteContent = footnoteElement.querySelector(".footnote-content");
-    if (!footnoteContent) {
-      // No content structure to split — hand back the element's own children.
-      return {
-        fits: Array.from(footnoteElement.children).map((el) => el.cloneNode(true) as HTMLElement),
-        overflow: [],
-      };
-    }
+    try {
+      const footnoteContent = attachedFootnote.querySelector(".footnote-content");
+      if (!footnoteContent) {
+        // No content structure to split — hand back the element's own children.
+        return {
+          fits: Array.from(attachedFootnote.children).map((el) =>
+            el.cloneNode(true) as HTMLElement),
+          overflow: [],
+        };
+      }
 
-    const children = Array.from(footnoteContent.children) as HTMLElement[];
-    if (children.length <= 1) {
-      // Single paragraph: can't split at paragraph level, but the whole content still fits.
-      return {
-        fits: children.map((el) => el.cloneNode(true) as HTMLElement),
-        overflow: [],
-      };
-    }
+      const children = Array.from(footnoteContent.children) as HTMLElement[];
+      const fits: HTMLElement[] = [];
+      let overflow: HTMLElement[] = [];
 
-    const fits: HTMLElement[] = [];
-    const overflow: HTMLElement[] = [];
-    let currentHeight = 0;
+      for (let i = 0; i < children.length; i++) {
+        this.checkpoint();
+        const child = children[i];
+        const candidate = [...fits, child];
+        if (this.measurePartialFootnoteHeight(
+          attachedFootnote,
+          footnoteContent,
+          candidate,
+          contentWidth,
+        ) <= availableHeightPt) {
+          fits.push(child.cloneNode(true) as HTMLElement);
+          continue;
+        }
 
-    // Measure separator line height
-    const hrMeasure = this.document.createElement("div");
-    hrMeasure.style.position = "absolute";
-    hrMeasure.style.visibility = "hidden";
-    hrMeasure.style.width = `${contentWidth}pt`;
-    hrMeasure.style.left = "-9999px";
-    hrMeasure.className = this.cssPrefix + "footnotes";
-    const hr = this.document.createElement("hr");
-    hrMeasure.appendChild(hr);
-    this.stagingElement.appendChild(hrMeasure);
-    const hrHeight = pxToPt(hrMeasure.getBoundingClientRect().height);
-    this.stagingElement.removeChild(hrMeasure);
-
-    currentHeight = hrHeight;
-
-    // Also account for footnote number
-    const footnoteNumber = footnoteElement.querySelector(".footnote-number");
-
-    for (let i = 0; i < children.length; i++) {
-      this.checkpoint();
-      const child = children[i];
-
-      // Measure this element
-      const measureContainer = this.document.createElement("div");
-      measureContainer.style.position = "absolute";
-      measureContainer.style.visibility = "hidden";
-      measureContainer.style.width = `${contentWidth}pt`;
-      measureContainer.style.left = "-9999px";
-      measureContainer.className = this.cssPrefix + "footnotes";
-      measureContainer.appendChild(child.cloneNode(true));
-      this.stagingElement.appendChild(measureContainer);
-      const childHeight = pxToPt(measureContainer.getBoundingClientRect().height);
-      this.stagingElement.removeChild(measureContainer);
-
-      if (currentHeight + childHeight <= availableHeightPt) {
-        fits.push(child.cloneNode(true) as HTMLElement);
-        currentHeight += childHeight;
-      } else {
-        // This and remaining elements overflow
-        for (let j = i; j < children.length; j++) {
-          this.checkpoint();
-          overflow.push(children[j].cloneNode(true) as HTMLElement);
+        const split = this.canRangeFragmentParagraph(child, true)
+          ? this.splitParagraphAtLargestFit(child, (head) =>
+            this.measurePartialFootnoteHeight(
+              attachedFootnote,
+              footnoteContent,
+              [...fits, head],
+              contentWidth,
+            ) <= availableHeightPt)
+          : null;
+        if (split) {
+          fits.push(split.head);
+          overflow = [split.tail, ...children.slice(i + 1).map((element) =>
+            element.cloneNode(true) as HTMLElement)];
+        } else if (fits.length === 0) {
+          // Preserve the one-element clipping fallback for content that cannot be
+          // range-fragmented, while allowing every later sibling to continue.
+          fits.push(child.cloneNode(true) as HTMLElement);
+          overflow = children.slice(i + 1).map((element) =>
+            element.cloneNode(true) as HTMLElement);
+        } else {
+          overflow = children.slice(i).map((element) =>
+            element.cloneNode(true) as HTMLElement);
         }
         break;
       }
-    }
 
-    return { fits, overflow };
+      return { fits, overflow };
+    } finally {
+      this.stagingElement.removeChild(layoutContext);
+    }
   }
 
   /**

--- a/npm/src/pagination.ts
+++ b/npm/src/pagination.ts
@@ -2609,6 +2609,22 @@ export class PaginationEngine {
   }
 
   /**
+   * Where a note measurement tree is attached.
+   *
+   * A note band is reserved from a measurement and then painted; if the two
+   * happen under different inherited typography the painted notes overflow the
+   * reserve, which is the invisible clipping this engine exists to avoid. The
+   * registry lives in the staging tree but a band paints inside the output
+   * container, so measure there. The host is never a page box, so a page's
+   * `zoom` cannot scale a reserve that is accounted for in unscaled points.
+   */
+  private noteMeasurementHost(): HTMLElement {
+    return this.containerElement.isConnected
+      ? this.containerElement
+      : this.stagingElement;
+  }
+
+  /**
    * Measures the height of footnotes for given IDs (in points).
    * Creates a temporary container to measure the footnotes.
    * @param footnoteIds - IDs of footnotes to measure
@@ -2623,6 +2639,12 @@ export class PaginationEngine {
   ): number {
     const hasContinuation = continuation && continuation.remainingElements.length > 0;
     if (footnoteIds.length === 0 && !hasContinuation) {
+      return 0;
+    }
+    // Mirror addPageFootnotes: with no registry and nothing carried, no band is
+    // painted, so reserving the separator's height would shrink every page's
+    // body for a document whose note references resolve to nothing.
+    if (this.footnoteRegistry.size === 0 && !hasContinuation) {
       return 0;
     }
 
@@ -2661,7 +2683,7 @@ export class PaginationEngine {
     }
 
     // Append to staging for measurement
-    this.stagingElement.appendChild(measureContainer);
+    this.noteMeasurementHost().appendChild(measureContainer);
     try {
       return pxToPt(measureContainer.getBoundingClientRect().height);
     } finally {
@@ -2700,7 +2722,7 @@ export class PaginationEngine {
       throw new Error("Footnote continuation is missing its content shell");
     }
     measureContainer.appendChild(wrapper);
-    this.stagingElement.appendChild(measureContainer);
+    this.noteMeasurementHost().appendChild(measureContainer);
 
     try {
       for (let index = 0; index < continuation.remainingElements.length; index++) {
@@ -2744,10 +2766,14 @@ export class PaginationEngine {
               head.remove();
             }
           }, {
-            emergencyGraphemeBreaks: true,
+            // Both fallbacks below cut where ordinary line breaking would not,
+            // so they are only ever right for an element that owns the whole
+            // band: if this page already carries earlier content, a paragraph
+            // that will not start here belongs intact in the next note band.
+            emergencyGraphemeBreaks: fitting.length === 0,
             // A continuation page owns the full note band. If even one legal
             // grapheme is taller than it, clip only that unit and keep draining.
-            forceFirstOnNoFit: true,
+            forceFirstOnNoFit: fitting.length === 0,
           });
         }
         if (split?.kind === "split") {
@@ -2808,7 +2834,7 @@ export class PaginationEngine {
     this.appendFootnoteSeparator(layoutContext, false);
     const attachedFootnote = footnoteElement.cloneNode(true) as HTMLElement;
     layoutContext.appendChild(attachedFootnote);
-    this.stagingElement.appendChild(layoutContext);
+    this.noteMeasurementHost().appendChild(layoutContext);
 
     // A second live tree represents the exact already-packed page payload plus
     // an initially empty partial item. Candidates are appended once and layout
@@ -2846,7 +2872,7 @@ export class PaginationEngine {
       throw new Error("Footnote is missing its content shell");
     }
     measureContainer.appendChild(measuredPartial);
-    this.stagingElement.appendChild(measureContainer);
+    this.noteMeasurementHost().appendChild(measureContainer);
 
     // Get child elements (paragraphs) of the footnote content.
     //
@@ -2895,8 +2921,12 @@ export class PaginationEngine {
               head.remove();
             }
           }, {
-            emergencyGraphemeBreaks: true,
-            forceFirstOnNoFit: forceProgress,
+            // Both fallbacks cut where ordinary line breaking would not, so they
+            // are only ever right for an element that owns the whole band: with
+            // earlier siblings already packed here, a paragraph that will not
+            // start belongs intact in the next note band.
+            emergencyGraphemeBreaks: fits.length === 0 && forceProgress,
+            forceFirstOnNoFit: fits.length === 0 && forceProgress,
           })
           : null;
         if (split?.kind === "split") {
@@ -3462,12 +3492,40 @@ export class PaginationEngine {
           pageSectionIndex,
           pageInSection(),
         );
-        if (currentFootnoteHeight > ownerBands.bodyHeight * MAX_FOOTNOTE_AREA_RATIO) {
-          // Pack an oversized carried/queued payload before admitting another
-          // body block. finishPage partitions it into visible note-only bands.
-          finishPage(block.sectionIndex);
-          i--;
-          continue;
+        const ownerMaxFootnoteArea = ownerBands.bodyHeight * MAX_FOOTNOTE_AREA_RATIO;
+        if (currentFootnoteHeight > ownerMaxFootnoteArea) {
+          // A queue of whole notes larger than the band does not entitle it to
+          // the whole page: the band is capped and the rest of the page still
+          // belongs to body text. Keep the notes that fit here, defer the rest,
+          // and only fall back to a note-owned page when not even one note fits
+          // — that case needs the splitting finishPage performs.
+          const fittingIds: string[] = [];
+          let fittingHeight = 0;
+          if ((currentContinuation?.remainingElements.length ?? 0) === 0
+              && currentPartialFootnotes.length === 0) {
+            for (const footnoteId of currentFootnoteIds) {
+              this.checkpoint();
+              const candidateHeight = this.measureFootnotesHeight(
+                [...fittingIds, footnoteId],
+                ownerDimensions.contentWidth,
+              );
+              if (candidateHeight + FOOTNOTE_MEASUREMENT_GUARD_PT > ownerMaxFootnoteArea) break;
+              fittingIds.push(footnoteId);
+              fittingHeight = candidateHeight;
+            }
+          }
+          if (fittingIds.length > 0) {
+            deferredFootnoteIds = [
+              ...currentFootnoteIds.slice(fittingIds.length),
+              ...deferredFootnoteIds,
+            ];
+            currentFootnoteIds = fittingIds;
+            currentFootnoteHeight = fittingHeight;
+          } else {
+            finishPage(block.sectionIndex);
+            i--;
+            continue;
+          }
         }
       }
       const blockDimensions = dimensionsFor(block.sectionIndex);
@@ -3677,6 +3735,14 @@ export class PaginationEngine {
             maxFootnoteArea,
             effectiveContentHeight - bodyContentUsed - blockSpaceWithoutFootnotes
           );
+          // Deferring a note costs a page turn, and it only buys anything if the
+          // next page's band is larger than what this page can already offer.
+          // When this page already offers the maximum band, a note that cannot
+          // start here cannot start there either: keep the established clipped
+          // fallback on the citing page rather than evacuating it.
+          const nextPageMaxFootnoteArea =
+            freshBlockPageBodyHeight * MAX_FOOTNOTE_AREA_RATIO;
+          const deferralCannotHelp = availableForFootnotes >= nextPageMaxFootnoteArea;
 
           // Try to fit as much of each new footnote as possible in expanded area
           for (let noteIndex = 0; noteIndex < newFootnoteIds.length; noteIndex++) {
@@ -3712,7 +3778,7 @@ export class PaginationEngine {
                   footnote,
                   availableForFootnotes,
                   blockDimensions.contentWidth,
-                  false,
+                  deferralCannotHelp,
                   {
                     footnoteIds: currentFootnoteIds,
                     continuation: currentContinuation,

--- a/npm/src/pagination.ts
+++ b/npm/src/pagination.ts
@@ -340,9 +340,8 @@ const MAX_FOOTNOTE_AREA_RATIO = 0.6; // 60% of content height
 // Hidden measurement and final absolutely-positioned note bands differ by sub-pixel border/margin
 // rounding in Chromium. Reserve a small physical-unit guard so the last baseline stays visible.
 const FOOTNOTE_MEASUREMENT_GUARD_PT = 2;
-
-// Minimum body content height per page (to avoid pages with only footnotes)
-const MIN_BODY_CONTENT_HEIGHT = 72; // 1 inch minimum body content
+/** Internal provenance retained only while a note element waits between pages. */
+const FOOTNOTE_SOURCE_POSITION_ATTR = "data-pagination-footnote-source-position";
 
 /**
  * Pagination engine that converts HTML with pagination metadata
@@ -375,6 +374,27 @@ interface PartialFootnote {
   fittingElements: HTMLElement[];
 }
 
+/** Existing page payload that a newly split note must fit beside. */
+interface FootnotePackingContext {
+  footnoteIds: readonly string[];
+  continuation?: FootnoteContinuation | null;
+  partialFootnotes?: readonly PartialFootnote[];
+}
+
+type ParagraphSplitAttempt =
+  | { kind: "split"; head: HTMLElement; tail: HTMLElement }
+  | { kind: "no-fit" }
+  | { kind: "indivisible" };
+
+interface ParagraphFragmentEndpoint {
+  node: Node;
+  offset: number;
+  /** UTF-16 offset in the paragraph's flattened text. */
+  textOffset: number;
+  /** Prefer a DOM boundary outside an atomic field over its last text-node boundary. */
+  priority: number;
+}
+
 /**
  * A section's `w:pgNumType`, as stamped on its wrapper by the converter. Both fields are optional
  * because both attributes are: an absent `start` means the section continues the previous section's
@@ -402,6 +422,8 @@ export class PaginationEngine {
   private layoutToken?: { documentVersion: number; rendererFingerprint: string };
   private hfRegistry: HeaderFooterRegistry;
   private footnoteRegistry: FootnoteRegistry;
+  private footnoteSeparator: HTMLElement | null = null;
+  private footnoteContinuationSeparator: HTMLElement | null = null;
   private commentMarginRegistry: Map<string, HTMLElement>;
   private footnoteLayoutLikeWord8 = false;
   private pendingFootnoteContinuation: FootnoteContinuation | null = null;
@@ -495,6 +517,10 @@ export class PaginationEngine {
 
     // Parse the footnote registry if present
     this.footnoteRegistry = this.parseFootnoteRegistry();
+    ({
+      normal: this.footnoteSeparator,
+      continuation: this.footnoteContinuationSeparator,
+    } = this.parseFootnoteSeparators());
 
     // Parse the margin-comment registry if present. Its entries are cloned into
     // the side substrate of pages that contain the corresponding range marker.
@@ -541,7 +567,17 @@ export class PaginationEngine {
     for (const id of referencedFootnoteIds) {
       this.checkpoint();
       const source = this.footnoteRegistry.get(id);
-      if (source) this.collectExpectedSourceAnchors(source, this.expectedPageMapAnchorIds);
+      if (!source) continue;
+      this.collectExpectedSourceAnchors(source, this.expectedPageMapAnchorIds);
+      // Margin comments are presentation stories selected by markers. Markers
+      // inside a cited footnote are just as visible/addressable as body markers.
+      for (const reference of Array.from(
+        source.querySelectorAll<HTMLElement>("[data-comment-id]"),
+      )) {
+        this.checkpoint();
+        const commentId = reference.dataset.commentId;
+        if (commentId) referencedCommentIds.add(commentId);
+      }
     }
     for (const id of referencedCommentIds) {
       this.checkpoint();
@@ -1732,34 +1768,218 @@ export class PaginationEngine {
   }
 
   /**
-   * A DOM endpoint that can finish a paragraph fragment. Endpoints are chosen
-   * after whitespace or at a run boundary so the paginator never deliberately
-   * cuts through an ordinary word merely to fill a little more of a page.
+   * DOM endpoints that can finish a paragraph fragment. The flattened UTF-16
+   * offsets are checked against the browser's Unicode grapheme segmenter, so a
+   * formatting-run boundary can never bisect a surrogate pair, combining
+   * sequence, or joined emoji. NBSP/word-joiner boundaries remain indivisible.
+   * PAGE/NUMPAGES field results are atomic because splitting their marker would
+   * make later substitution duplicate or replace only half of the field.
    */
-  private paragraphFragmentEndpoints(paragraph: HTMLElement): Array<{ node: Text; offset: number }> {
-    const endpoints: Array<{ node: Text; offset: number }> = [];
+  private paragraphFragmentEndpoints(
+    paragraph: HTMLElement,
+    emergencyGraphemeBreaks = false,
+  ): ParagraphFragmentEndpoint[] {
+    const textNodes: Text[] = [];
+    const textStarts = new Map<Text, number>();
+    const lastTextByField = new Map<HTMLElement, Text>();
     const walker = this.document.createTreeWalker(paragraph, this.view.NodeFilter.SHOW_TEXT);
+    const flattenedChunks: string[] = [];
+    let flattenedLength = 0;
     let textNode: Text | null;
-
     while ((textNode = walker.nextNode() as Text | null)) {
-      const text = textNode.data;
-      if (text.length === 0) continue;
-
-      // A whitespace boundary preserves normal word wrapping. Always retain the
-      // end of a run too: adjacent runs can change formatting without containing
-      // a whitespace character between them.
-      const whitespace = /\s+/g;
-      let match: RegExpExecArray | null;
-      while ((match = whitespace.exec(text)) !== null) {
-        endpoints.push({ node: textNode, offset: match.index + match[0].length });
+      this.checkpoint();
+      textStarts.set(textNode, flattenedLength);
+      textNodes.push(textNode);
+      flattenedChunks.push(textNode.data);
+      flattenedLength += textNode.data.length;
+      let field = textNode.parentElement?.closest<HTMLElement>("[data-field]") ?? null;
+      while (field?.parentElement?.closest<HTMLElement>("[data-field]")) {
+        field = field.parentElement.closest<HTMLElement>("[data-field]");
       }
-      if (endpoints.length === 0 || endpoints[endpoints.length - 1].node !== textNode ||
-          endpoints[endpoints.length - 1].offset !== text.length) {
-        endpoints.push({ node: textNode, offset: text.length });
+      if (field && paragraph.contains(field)) lastTextByField.set(field, textNode);
+    }
+    const flattenedText = flattenedChunks.join("");
+    if (!this.hasVisibleText(flattenedText)) return [];
+
+    const invisible = /[\s\u200B-\u200F\uFEFF]/;
+    let firstVisibleOffset = -1;
+    let lastVisibleOffset = -1;
+    for (let index = 0; index < flattenedText.length; index++) {
+      if (index % 4096 === 0) this.checkpoint();
+      if (invisible.test(flattenedText[index])) continue;
+      if (firstVisibleOffset < 0) firstVisibleOffset = index;
+      lastVisibleOffset = index;
+    }
+
+    const graphemeBoundaries = this.graphemeBoundaryOffsets(flattenedText);
+    const candidates: ParagraphFragmentEndpoint[] = [];
+    const addCandidate = (candidate: ParagraphFragmentEndpoint): void => {
+      const { textOffset } = candidate;
+      if (textOffset <= 0 || textOffset >= flattenedText.length) return;
+      if (textOffset <= firstVisibleOffset || textOffset > lastVisibleOffset) return;
+      if (this.isNonBreakingTextBoundary(flattenedText, textOffset)) return;
+      if (!this.isLegalParagraphLineBoundary(paragraph, flattenedText, textOffset)) return;
+      if (graphemeBoundaries) {
+        if (!graphemeBoundaries.has(textOffset)) return;
+      } else if (!this.isConservativeFallbackTextBoundary(flattenedText, textOffset)) {
+        return;
+      }
+      candidates.push(candidate);
+    };
+
+    for (const node of textNodes) {
+      this.checkpoint();
+      const start = textStarts.get(node)!;
+      // Field results and converter list markers are semantic atoms. A field
+      // receives one boundary outside its wrapper below; a list marker stays
+      // with the first real text fragment and is never emitted by itself.
+      const atomic = node.parentElement?.closest<HTMLElement>(
+        "[data-field], [data-list-marker], a[data-comment-id]",
+      );
+      if (atomic && paragraph.contains(atomic)) continue;
+
+      // Only CSS-collapsible ASCII whitespace is a wrapping opportunity. JS's
+      // broader `\s` class includes NBSP and other explicitly non-breaking text.
+      const whitespace = /[\u0009-\u000D\u0020]+/g;
+      let match: RegExpExecArray | null;
+      let matchesSinceCheckpoint = 0;
+      while ((match = whitespace.exec(node.data)) !== null) {
+        if (++matchesSinceCheckpoint % 256 === 0) this.checkpoint();
+        const offset = match.index + match[0].length;
+        addCandidate({ node, offset, textOffset: start + offset, priority: 0 });
+      }
+      addCandidate({
+        node,
+        offset: node.data.length,
+        textOffset: start + node.data.length,
+        priority: 0,
+      });
+      if (emergencyGraphemeBreaks) {
+        for (let offset = 1; offset < node.data.length; offset++) {
+          if (offset % 256 === 0) this.checkpoint();
+          addCandidate({
+            node,
+            offset,
+            textOffset: start + offset,
+            priority: -1,
+          });
+        }
       }
     }
 
+    // A field is splittable only immediately after its complete outer wrapper.
+    // Starting the tail at the parent's child boundary prevents Range from
+    // cloning an empty `[data-field]` shell that substitution could repopulate.
+    for (const field of Array.from(paragraph.querySelectorAll<HTMLElement>("[data-field]"))) {
+      this.checkpoint();
+      if (field.parentElement?.closest("[data-field]")) continue;
+      const last = lastTextByField.get(field);
+      const parent = field.parentNode;
+      if (!last || !parent) continue;
+      const childIndex = Array.prototype.indexOf.call(parent.childNodes, field);
+      if (childIndex < 0) continue;
+      addCandidate({
+        node: parent,
+        offset: childIndex + 1,
+        textOffset: textStarts.get(last)! + last.data.length,
+        priority: 1,
+      });
+    }
+
+    // Several DOM boundaries can represent the same flattened offset. Prefer
+    // the outer atomic boundary, then keep one stable document-order candidate.
+    candidates.sort((left, right) =>
+      left.textOffset - right.textOffset || right.priority - left.priority);
+    const endpoints: ParagraphFragmentEndpoint[] = [];
+    for (const candidate of candidates) {
+      if (endpoints[endpoints.length - 1]?.textOffset !== candidate.textOffset) {
+        endpoints.push(candidate);
+      }
+    }
     return endpoints;
+  }
+
+  /** Browser-native UAX #29 boundaries; null keeps older runtimes conservative. */
+  private graphemeBoundaryOffsets(text: string): Set<number> | null {
+    type Segment = { segment: string; index: number };
+    type Segmenter = new (
+      locale?: string,
+      options?: { granularity: "grapheme" },
+    ) => { segment(value: string): Iterable<Segment> };
+    const SegmenterConstructor = (this.view.Intl as typeof Intl & {
+      Segmenter?: Segmenter;
+    }).Segmenter;
+    if (!SegmenterConstructor) return null;
+
+    const boundaries = new Set<number>([0, text.length]);
+    let segmentCount = 0;
+    for (const part of new SegmenterConstructor("en", { granularity: "grapheme" }).segment(text)) {
+      if (++segmentCount % 256 === 0) this.checkpoint();
+      boundaries.add(part.index);
+      boundaries.add(part.index + part.segment.length);
+    }
+    return boundaries;
+  }
+
+  /**
+   * Conservative UAX #14/CSS wrapping opportunities used for synthetic page
+   * boundaries. In particular, a formatting-run boundary is not itself a word
+   * boundary, and Japanese opening/closing punctuation stays with its pair.
+   * Arbitrary grapheme breaks are admitted only when the paragraph's CSS asks
+   * the browser to wrap anywhere.
+   */
+  private isLegalParagraphLineBoundary(
+    paragraph: HTMLElement,
+    text: string,
+    offset: number,
+  ): boolean {
+    const lastCodeUnit = text.charCodeAt(offset - 1);
+    const beforeOffset = lastCodeUnit >= 0xDC00 && lastCodeUnit <= 0xDFFF
+      ? Math.max(0, offset - 2)
+      : offset - 1;
+    const beforeCodePoint = text.codePointAt(beforeOffset);
+    const afterCodePoint = text.codePointAt(offset);
+    const before = beforeCodePoint === undefined ? "" : String.fromCodePoint(beforeCodePoint);
+    const after = afterCodePoint === undefined ? "" : String.fromCodePoint(afterCodePoint);
+    if (/^[\u0009-\u000D\u0020]$/.test(before)
+        || /^[\u0009-\u000D\u0020]$/.test(after)) return true;
+    if (/[-\u00AD\u2010]$/u.test(before)) return true;
+
+    const style = this.view.getComputedStyle(paragraph);
+    if (style.wordBreak === "break-all"
+        || style.overflowWrap === "anywhere"
+        || style.overflowWrap === "break-word") return true;
+
+    const eastAsian = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
+    if (!eastAsian.test(before) && !eastAsian.test(after)) return false;
+    const opening = "([{<\u2018\u201C\u3008\u300A\u300C\u300E\u3010\u3014\u3016\u3018\u301A\uFF08\uFF3B\uFF5B";
+    const closing = ")]}>\u2019\u201D\u3001\u3002\u3009\u300B\u300D\u300F\u3011\u3015\u3017\u3019\u301B\uFF01\uFF05\uFF09\uFF0C\uFF0E\uFF1A\uFF1B\uFF1F\uFF3D\uFF5D";
+    return !opening.includes(before) && !closing.includes(after);
+  }
+
+  /** Never fragment across characters whose line-break meaning is explicitly non-breaking. */
+  private isNonBreakingTextBoundary(text: string, offset: number): boolean {
+    const codePointBefore = (index: number): number | undefined => {
+      if (index <= 0) return undefined;
+      const last = text.charCodeAt(index - 1);
+      const start = last >= 0xDC00 && last <= 0xDFFF ? index - 2 : index - 1;
+      return text.codePointAt(Math.max(0, start));
+    };
+    const nonBreaking = new Set([
+      0x00A0, 0x200E, 0x200F, 0x2011, 0x202A, 0x202B, 0x202C,
+      0x202D, 0x202E, 0x202F, 0x2060, 0x2066, 0x2067, 0x2068,
+      0x2069, 0xFEFF,
+    ]);
+    return nonBreaking.has(codePointBefore(offset) ?? -1)
+      || nonBreaking.has(text.codePointAt(offset) ?? -1);
+  }
+
+  /**
+   * Without Intl.Segmenter, admit only an all-ASCII boundary. This still
+   * fragments ordinary prose while refusing to guess about Unicode clusters.
+   */
+  private isConservativeFallbackTextBoundary(text: string, offset: number): boolean {
+    return text.charCodeAt(offset - 1) <= 0x7F && text.charCodeAt(offset) <= 0x7F;
   }
 
   /**
@@ -1768,7 +1988,11 @@ export class PaginationEngine {
    * this is enough to reject empty head or tail fragments.
    */
   private hasVisibleFragmentText(fragment: DocumentFragment): boolean {
-    return (fragment.textContent || "")
+    return this.hasVisibleText(fragment.textContent || "");
+  }
+
+  private hasVisibleText(text: string): boolean {
+    return text
       .replace(/[\u200B-\u200F\uFEFF]/g, "")
       .trim()
       .length > 0;
@@ -1821,8 +2045,9 @@ export class PaginationEngine {
       return false;
     }
 
-    // The outer paragraph may carry its source identity. Descendant identities
-    // are not safe to duplicate in a continuation fragment, so reject them.
+    // Non-textual/out-of-flow descendants still need dedicated fragmenters.
+    // Inline ids/editor anchors are reconciled after Range cloning, and list
+    // markers are kept atomically with the leading text fragment.
     const unsupportedDescendants = [
       "br",
       "img",
@@ -1853,9 +2078,6 @@ export class PaginationEngine {
       "fieldset",
       "details",
       "[data-footnote-id]",
-      "[data-list-marker]",
-      "[data-anchor]",
-      "[id]",
       "[contenteditable]",
     ].join(", ");
     if (paragraph.querySelector(unsupportedDescendants)) {
@@ -1881,8 +2103,7 @@ export class PaginationEngine {
         !(allowInlineRoot && paragraphStyle.display === "inline")) ||
       paragraphStyle.position !== "static" ||
       paragraphStyle.float !== "none" ||
-      (paragraphStyle.whiteSpace !== "normal" &&
-        !(allowInlineRoot && paragraphStyle.whiteSpace === "pre-wrap")) ||
+      (paragraphStyle.whiteSpace !== "normal" && paragraphStyle.whiteSpace !== "pre-wrap") ||
       paragraphStyle.breakBefore !== "auto" ||
       paragraphStyle.breakAfter !== "auto" ||
       paragraphStyle.breakInside === "avoid" ||
@@ -1940,6 +2161,36 @@ export class PaginationEngine {
   }
 
   /**
+   * Range clones repeat an inline ancestor when the split lands inside it. Keep
+   * semantic wrappers (links, comments, formatting) on both sides, but retain a
+   * duplicated HTML/editor identity only on the leading fragment. Targets that
+   * occur wholly after the split are absent from `head` and remain on `tail`.
+   */
+  private reconcileParagraphFragmentIdentities(
+    head: HTMLElement,
+    tail: HTMLElement,
+  ): void {
+    const elements = (root: HTMLElement, selector: string): HTMLElement[] => [
+      ...(root.matches(selector) ? [root] : []),
+      ...Array.from(root.querySelectorAll<HTMLElement>(selector)),
+    ];
+
+    const headIds = new Set(elements(head, "[id]").map((element) => element.id));
+    for (const element of elements(tail, "[id]")) {
+      if (headIds.has(element.id)) element.removeAttribute("id");
+    }
+
+    const headAnchors = new Set(elements(head, "[data-anchor]")
+      .map((element) => element.dataset.anchor)
+      .filter((anchor): anchor is string => Boolean(anchor)));
+    for (const element of elements(tail, "[data-anchor]")) {
+      if (!element.dataset.anchor || !headAnchors.has(element.dataset.anchor)) continue;
+      element.removeAttribute("data-anchor");
+      element.removeAttribute("data-committed-text");
+    }
+  }
+
+  /**
    * Range-clone the largest safe prefix accepted by `fits`. The measurement
    * policy stays with the caller, allowing body blocks and note bands to share
    * one DOM fragmenter while measuring in their respective layout contexts.
@@ -1947,47 +2198,88 @@ export class PaginationEngine {
   private splitParagraphAtLargestFit(
     paragraph: HTMLElement,
     fits: (head: HTMLElement) => boolean,
-  ): { head: HTMLElement; tail: HTMLElement } | null {
-    const endpoints = this.paragraphFragmentEndpoints(paragraph);
-    // The final endpoint is the full paragraph and cannot leave a tail. A
-    // single run without an earlier whitespace boundary remains indivisible.
-    if (endpoints.length < 2) return null;
+    options: {
+      emergencyGraphemeBreaks?: boolean;
+      forceFirstOnNoFit?: boolean;
+    } = {},
+  ): ParagraphSplitAttempt {
+    const largestFit = (endpoints: ParagraphFragmentEndpoint[]) => {
+      // Prefix height is usually monotone, but selector-sensitive inline CSS
+      // (`:last-child`, `:only-child`) can make a longer Range clone shorter.
+      // Probe the largest legal endpoint first so the common non-monotone case
+      // cannot be discarded by the binary search below.
+      const lastEndpoint = endpoints[endpoints.length - 1];
+      if (lastEndpoint) {
+        const lastRange = this.document.createRange();
+        lastRange.setStart(paragraph, 0);
+        lastRange.setEnd(lastEndpoint.node, lastEndpoint.offset);
+        const lastContents = lastRange.cloneContents();
+        if (this.hasVisibleFragmentText(lastContents)) {
+          const lastHead = this.createParagraphFragment(paragraph, lastRange, true, false);
+          if (fits(lastHead)) return { endpoint: lastEndpoint, head: lastHead };
+        }
+      }
 
-    let low = 0;
-    let high = endpoints.length - 2;
-    let best: { endpoint: { node: Text; offset: number }; head: HTMLElement } | null = null;
-    while (low <= high) {
-      this.checkpoint();
-      const middle = Math.floor((low + high) / 2);
-      const endpoint = endpoints[middle];
+      let low = 0;
+      let high = endpoints.length - 2;
+      let best: { endpoint: ParagraphFragmentEndpoint; head: HTMLElement } | null = null;
+      while (low <= high) {
+        this.checkpoint();
+        const middle = Math.floor((low + high) / 2);
+        const endpoint = endpoints[middle];
+        const headRange = this.document.createRange();
+        headRange.setStart(paragraph, 0);
+        headRange.setEnd(endpoint.node, endpoint.offset);
+        const headContents = headRange.cloneContents();
+        if (!this.hasVisibleFragmentText(headContents)) {
+          low = middle + 1;
+          continue;
+        }
+
+        const head = this.createParagraphFragment(paragraph, headRange, true, false);
+        if (fits(head)) {
+          best = { endpoint, head };
+          low = middle + 1;
+        } else {
+          high = middle - 1;
+        }
+      }
+      return best;
+    };
+
+    let endpoints = this.paragraphFragmentEndpoints(paragraph);
+    let best = largestFit(endpoints);
+    if (!best && options.emergencyGraphemeBreaks) {
+      endpoints = this.paragraphFragmentEndpoints(paragraph, true);
+      best = largestFit(endpoints);
+    }
+    if (!best && options.forceFirstOnNoFit && endpoints.length > 0) {
+      const endpoint = endpoints[0];
       const headRange = this.document.createRange();
       headRange.setStart(paragraph, 0);
       headRange.setEnd(endpoint.node, endpoint.offset);
-      const headContents = headRange.cloneContents();
-      if (!this.hasVisibleFragmentText(headContents)) {
-        low = middle + 1;
-        continue;
-      }
-
-      const head = this.createParagraphFragment(paragraph, headRange, true, false);
-      if (fits(head)) {
-        best = { endpoint, head };
-        low = middle + 1;
-      } else {
-        high = middle - 1;
-      }
+      best = {
+        endpoint,
+        head: this.createParagraphFragment(paragraph, headRange, true, false),
+      };
     }
-    if (!best) return null;
+    if (!best) {
+      return endpoints.length > 0 ? { kind: "no-fit" } : { kind: "indivisible" };
+    }
 
     const tailRange = this.document.createRange();
     tailRange.setStart(best.endpoint.node, best.endpoint.offset);
     tailRange.setEnd(paragraph, paragraph.childNodes.length);
     const tailContents = tailRange.cloneContents();
-    if (!this.hasVisibleFragmentText(tailContents)) return null;
+    if (!this.hasVisibleFragmentText(tailContents)) return { kind: "indivisible" };
+
+    const tail = this.createParagraphFragment(paragraph, tailRange, false, true);
+    this.reconcileParagraphFragmentIdentities(best.head, tail);
 
     return {
+      kind: "split",
       head: best.head,
-      tail: this.createParagraphFragment(paragraph, tailRange, false, true),
+      tail,
     };
   }
 
@@ -2010,7 +2302,7 @@ export class PaginationEngine {
       const measured = this.measureElement(head, dims, block.sectionIndex);
       return effectiveMarginTopPt + measured.heightPt <= availableHeightPt;
     });
-    if (!split) return null;
+    if (split.kind !== "split") return null;
 
     const headMeasured = this.measureElement(split.head, dims, block.sectionIndex);
     const tailMeasured = this.measureElement(split.tail, dims, block.sectionIndex);
@@ -2116,7 +2408,12 @@ export class PaginationEngine {
 
     if (!registryEl) return registry;
 
-    const entries = Array.from(registryEl.querySelectorAll<HTMLElement>("[data-footnote-id]"));
+    // Only direct registry entries are definitions. Custom separator stories may
+    // legitimately contain arbitrary converted markup, including stale semantic
+    // attributes that must never be mistaken for another note definition.
+    const entries = Array.from(registryEl.children)
+      .filter((entry): entry is HTMLElement =>
+        entry instanceof this.view.HTMLElement && entry.hasAttribute("data-footnote-id"));
 
     for (const entry of entries) {
       const footnoteId = entry.dataset.footnoteId;
@@ -2127,6 +2424,56 @@ export class PaginationEngine {
     }
 
     return registry;
+  }
+
+  /** Read Word's optional normal and continuation separator stories. */
+  private parseFootnoteSeparators(): {
+    normal: HTMLElement | null;
+    continuation: HTMLElement | null;
+  } {
+    const registry = this.stagingElement.querySelector("#pagination-footnote-registry");
+    const clone = (kind: "normal" | "continuation") => {
+      const source = Array.from(registry?.children ?? []).find((entry) =>
+        entry instanceof this.view.HTMLElement
+        && entry.getAttribute("data-footnote-separator") === kind,
+      );
+      return source?.cloneNode(true) as HTMLElement | undefined;
+    };
+    return {
+      normal: clone("normal") ?? null,
+      continuation: clone("continuation") ?? null,
+    };
+  }
+
+  /** Append the exact separator story selected for this initial/continued note band. */
+  private appendFootnoteSeparator(container: HTMLElement, continuation: boolean): void {
+    const kind = continuation ? "continuation" : "normal";
+    const source = continuation ? this.footnoteContinuationSeparator : this.footnoteSeparator;
+    if (!source) {
+      const fallback = this.document.createElement("hr");
+      fallback.dataset.footnoteSeparator = kind;
+      container.appendChild(fallback);
+      return;
+    }
+
+    const clone = source.cloneNode(true) as HTMLElement;
+    for (const element of [clone, ...Array.from(clone.querySelectorAll<HTMLElement>("*"))]) {
+      element.removeAttribute("id");
+      element.removeAttribute("data-anchor");
+      element.removeAttribute("data-committed-text");
+      element.removeAttribute("data-source-anchor-id");
+      element.removeAttribute("data-page-fragment-id");
+      element.removeAttribute("data-fragment-index");
+      element.removeAttribute("data-footnote-id");
+      element.removeAttribute("data-comment-id");
+      element.removeAttribute("name");
+      if (element instanceof this.view.HTMLAnchorElement
+          && element.getAttribute("href")?.startsWith("#")) {
+        element.removeAttribute("href");
+      }
+      element.setAttribute("contenteditable", "false");
+    }
+    container.appendChild(clone);
   }
 
   /** Parses the hidden source notes used to render paginated margin comments. */
@@ -2161,6 +2508,106 @@ export class PaginationEngine {
     return ids;
   }
 
+  /** Clone a note child for the continuation queue with its original selector position. */
+  private cloneFootnoteElementForContinuation(
+    element: HTMLElement,
+    sourceIndex: number,
+  ): HTMLElement {
+    const clone = element.cloneNode(true) as HTMLElement;
+    clone.setAttribute(
+      FOOTNOTE_SOURCE_POSITION_ATTR,
+      sourceIndex === 0 ? "first" : "later",
+    );
+    return clone;
+  }
+
+  /** Remove identities that belong only to the initial registry presentation shell. */
+  private makeContinuationShellInert(element: HTMLElement): void {
+    element.removeAttribute("id");
+    element.removeAttribute("data-anchor");
+    element.removeAttribute("data-committed-text");
+  }
+
+  /**
+   * Build the exact continuation shape shared by measurement and paint.
+   *
+   * Keep the source `.footnote-item > .footnote-content` ancestry: document
+   * CSS, inherited direction/language, and custom classes frequently target
+   * those shells. Only the number and initial HTML/editor identities are
+   * omitted. A hidden sentinel preserves `p:not(:first-of-type)` for a page
+   * whose first carried element was a later source paragraph.
+   */
+  private createFootnoteContinuationWrapper(
+    continuation: FootnoteContinuation,
+    elements: readonly HTMLElement[] = continuation.remainingElements,
+  ): HTMLElement {
+    const source = this.footnoteRegistry.get(continuation.footnoteId);
+    const wrapper = source
+      ? source.cloneNode(false) as HTMLElement
+      : this.document.createElement("div");
+    this.makeContinuationShellInert(wrapper);
+    wrapper.classList.add("footnote-continuation");
+    wrapper.dataset.footnoteId = continuation.footnoteId;
+    if (continuation.sourceAnchorId) {
+      wrapper.dataset.sourceAnchorId = continuation.sourceAnchorId;
+    }
+
+    const sourceContent = source?.querySelector<HTMLElement>(".footnote-content");
+    const content = sourceContent
+      ? sourceContent.cloneNode(false) as HTMLElement
+      : this.document.createElement("span");
+    this.makeContinuationShellInert(content);
+    if (!sourceContent) content.className = "footnote-content";
+
+    const first = elements[0];
+    if (
+      first?.tagName === "P"
+      && first.getAttribute(FOOTNOTE_SOURCE_POSITION_ATTR) === "later"
+    ) {
+      const sentinel = this.document.createElement("p");
+      sentinel.className = "footnote-continuation-position-sentinel";
+      sentinel.setAttribute("aria-hidden", "true");
+      sentinel.style.setProperty("display", "none", "important");
+      content.appendChild(sentinel);
+    }
+    for (let index = 0; index < elements.length; index++) {
+      this.checkpoint();
+      const element = elements[index];
+      const clone = element.cloneNode(true) as HTMLElement;
+      clone.removeAttribute(FOOTNOTE_SOURCE_POSITION_ATTR);
+      if (index === 0 && clone.tagName === "P") {
+        // Without the initial number, a carried paragraph always starts a new
+        // line even when source CSS made the note's first paragraph inline.
+        clone.style.setProperty("display", "block", "important");
+      }
+      content.appendChild(clone);
+    }
+    wrapper.appendChild(content);
+    return wrapper;
+  }
+
+  /** Build the exact partial-note item shape shared by measurement and paint. */
+  private createPartialFootnoteItem(
+    footnote: HTMLElement,
+    fittingElements: readonly HTMLElement[],
+  ): HTMLElement {
+    const item = footnote.cloneNode(false) as HTMLElement;
+    const number = footnote.querySelector(".footnote-number");
+    if (number) item.appendChild(number.cloneNode(true));
+
+    const sourceContent = footnote.querySelector<HTMLElement>(".footnote-content");
+    const content = sourceContent
+      ? sourceContent.cloneNode(false) as HTMLElement
+      : this.document.createElement("span");
+    if (!sourceContent) content.className = "footnote-content";
+    for (const element of fittingElements) {
+      this.checkpoint();
+      content.appendChild(element.cloneNode(true));
+    }
+    item.appendChild(content);
+    return item;
+  }
+
   /**
    * Measures the height of footnotes for given IDs (in points).
    * Creates a temporary container to measure the footnotes.
@@ -2171,10 +2618,11 @@ export class PaginationEngine {
   private measureFootnotesHeight(
     footnoteIds: string[],
     contentWidth: number,
-    continuation?: FootnoteContinuation | null
+    continuation?: FootnoteContinuation | null,
+    partialFootnotes?: readonly PartialFootnote[],
   ): number {
     const hasContinuation = continuation && continuation.remainingElements.length > 0;
-    if ((footnoteIds.length === 0 && !hasContinuation) || this.footnoteRegistry.size === 0) {
+    if (footnoteIds.length === 0 && !hasContinuation) {
       return 0;
     }
 
@@ -2189,86 +2637,36 @@ export class PaginationEngine {
     measureContainer.style.left = "-9999px";
     measureContainer.className = this.cssPrefix + "footnotes";
 
-    // Add separator line (same as will be rendered)
-    const hr = this.document.createElement("hr");
-    measureContainer.appendChild(hr);
+    // Add the same normal/continuation separator story that will be painted.
+    this.appendFootnoteSeparator(measureContainer, Boolean(hasContinuation));
 
     // Add continuation content first (if any)
     if (hasContinuation) {
-      const contWrapper = this.document.createElement("div");
-      contWrapper.className = "footnote-continuation";
-      contWrapper.dataset.footnoteId = continuation!.footnoteId;
-      if (continuation!.sourceAnchorId) {
-        contWrapper.dataset.sourceAnchorId = continuation!.sourceAnchorId;
-      }
-      for (const el of continuation!.remainingElements) {
-        contWrapper.appendChild(el.cloneNode(true));
-      }
-      measureContainer.appendChild(contWrapper);
+      measureContainer.appendChild(this.createFootnoteContinuationWrapper(continuation!));
     }
 
     // Add footnotes
+    const partialById = new Map(
+      partialFootnotes?.map((partial) => [partial.footnoteId, partial] as const) ?? [],
+    );
     for (const id of footnoteIds) {
       this.checkpoint();
       const footnote = this.footnoteRegistry.get(id);
       if (footnote) {
-        measureContainer.appendChild(footnote.cloneNode(true));
+        const partial = partialById.get(id);
+        measureContainer.appendChild(partial
+          ? this.createPartialFootnoteItem(footnote, partial.fittingElements)
+          : footnote.cloneNode(true));
       }
     }
 
     // Append to staging for measurement
     this.stagingElement.appendChild(measureContainer);
-
-    // Measure
-    const rect = measureContainer.getBoundingClientRect();
-    const heightPt = pxToPt(rect.height);
-
-    // Clean up
-    this.stagingElement.removeChild(measureContainer);
-
-    return heightPt;
-  }
-
-  /**
-   * Measures the height of just the continuation content (in points).
-   */
-  private measureContinuationHeight(
-    continuation: FootnoteContinuation,
-    contentWidth: number
-  ): number {
-    if (!continuation || continuation.remainingElements.length === 0) {
-      return 0;
+    try {
+      return pxToPt(measureContainer.getBoundingClientRect().height);
+    } finally {
+      measureContainer.remove();
     }
-
-    const measureContainer = this.document.createElement("div");
-    measureContainer.style.position = "absolute";
-    measureContainer.style.visibility = "hidden";
-    measureContainer.style.width = `${contentWidth}pt`;
-    measureContainer.style.left = "-9999px";
-    measureContainer.className = this.cssPrefix + "footnotes";
-
-    // Add separator line
-    const hr = this.document.createElement("hr");
-    measureContainer.appendChild(hr);
-
-    // Measure the same wrapper shape addPageFootnotes renders. Selectors on the
-    // continuation wrapper may change line boxes and must participate here.
-    const continuationWrapper = document.createElement("div");
-    continuationWrapper.className = "footnote-continuation";
-    if (continuation.sourceAnchorId) {
-      continuationWrapper.dataset.sourceAnchorId = continuation.sourceAnchorId;
-    }
-    for (const el of continuation.remainingElements) {
-      continuationWrapper.appendChild(el.cloneNode(true));
-    }
-    measureContainer.appendChild(continuationWrapper);
-
-    this.stagingElement.appendChild(measureContainer);
-    const rect = measureContainer.getBoundingClientRect();
-    const heightPt = pxToPt(rect.height);
-    this.stagingElement.removeChild(measureContainer);
-
-    return heightPt;
   }
 
   /**
@@ -2285,39 +2683,92 @@ export class PaginationEngine {
     const fitting: HTMLElement[] = [];
     let remaining: HTMLElement[] = [];
 
-    for (let index = 0; index < continuation.remainingElements.length; index++) {
-      const element = continuation.remainingElements[index];
-      const candidate: FootnoteContinuation = {
-        footnoteId: continuation.footnoteId,
-        sourceAnchorId: continuation.sourceAnchorId,
-        remainingElements: [...fitting, element],
-      };
-      const candidateHeight = this.measureContinuationHeight(candidate, contentWidth);
-      if (candidateHeight <= availableHeightPt) {
-        fitting.push(element);
-        continue;
-      }
+    // Keep one live measurement tree and append each candidate exactly once.
+    // Rebuilding `[...fitting, candidate]` for every child cloned 1+2+...+N
+    // descendants before a page/resource cap could run, which is quadratic for
+    // producer-authored notes containing thousands of tiny paragraphs/runs.
+    const measureContainer = this.document.createElement("div");
+    measureContainer.style.position = "absolute";
+    measureContainer.style.visibility = "hidden";
+    measureContainer.style.width = `${contentWidth}pt`;
+    measureContainer.style.left = "-9999px";
+    measureContainer.className = this.cssPrefix + "footnotes";
+    this.appendFootnoteSeparator(measureContainer, true);
+    const wrapper = this.createFootnoteContinuationWrapper(continuation, []);
+    const content = wrapper.querySelector<HTMLElement>(":scope > .footnote-content");
+    if (!content) {
+      throw new Error("Footnote continuation is missing its content shell");
+    }
+    measureContainer.appendChild(wrapper);
+    this.stagingElement.appendChild(measureContainer);
 
-      const split = this.splitContinuationParagraphAtFit(
-        element,
-        fitting,
-        continuation,
-        availableHeightPt,
-        contentWidth,
-      );
-      if (split) {
-        fitting.push(split.head);
-        remaining = [split.tail, ...continuation.remainingElements.slice(index + 1)];
-      } else if (fitting.length === 0) {
-        // A genuinely indivisible first element retains the established visible
-        // clipped fallback, but only for itself. Its siblings must continue on
-        // later pages rather than being swallowed by the same clipped band.
-        fitting.push(element);
-        remaining = continuation.remainingElements.slice(index + 1);
-      } else {
-        remaining = continuation.remainingElements.slice(index);
+    try {
+      for (let index = 0; index < continuation.remainingElements.length; index++) {
+        this.checkpoint();
+        const element = continuation.remainingElements[index];
+        const sourcePosition = element.getAttribute(FOOTNOTE_SOURCE_POSITION_ATTR);
+        if (
+          fitting.length === 0
+          && element.tagName === "P"
+          && element.getAttribute(FOOTNOTE_SOURCE_POSITION_ATTR) === "later"
+        ) {
+          const sentinel = this.document.createElement("p");
+          sentinel.className = "footnote-continuation-position-sentinel";
+          sentinel.setAttribute("aria-hidden", "true");
+          sentinel.style.setProperty("display", "none", "important");
+          content.appendChild(sentinel);
+        }
+
+        const candidate = element.cloneNode(true) as HTMLElement;
+        candidate.removeAttribute(FOOTNOTE_SOURCE_POSITION_ATTR);
+        if (fitting.length === 0 && candidate.tagName === "P") {
+          candidate.style.setProperty("display", "block", "important");
+        }
+        content.appendChild(candidate);
+        const candidateHeight = pxToPt(measureContainer.getBoundingClientRect().height);
+        if (candidateHeight <= availableHeightPt) {
+          fitting.push(element);
+          continue;
+        }
+
+        const canSplitCandidate = candidate.tagName === "P"
+          && this.canRangeFragmentParagraph(candidate);
+        candidate.remove();
+        let split: ParagraphSplitAttempt | null = null;
+        if (canSplitCandidate) {
+          split = this.splitParagraphAtLargestFit(candidate, (head) => {
+            content.appendChild(head);
+            try {
+              return pxToPt(measureContainer.getBoundingClientRect().height) <= availableHeightPt;
+            } finally {
+              head.remove();
+            }
+          }, {
+            emergencyGraphemeBreaks: true,
+            // A continuation page owns the full note band. If even one legal
+            // grapheme is taller than it, clip only that unit and keep draining.
+            forceFirstOnNoFit: true,
+          });
+        }
+        if (split?.kind === "split") {
+          if (sourcePosition) {
+            split.head.setAttribute(FOOTNOTE_SOURCE_POSITION_ATTR, sourcePosition);
+            split.tail.setAttribute(FOOTNOTE_SOURCE_POSITION_ATTR, sourcePosition);
+          }
+          fitting.push(split.head);
+          remaining = [split.tail, ...continuation.remainingElements.slice(index + 1)];
+        } else if (fitting.length === 0) {
+          // A genuinely indivisible first element retains the established visible
+          // clipped fallback, but only for itself. Its siblings continue later.
+          fitting.push(element);
+          remaining = continuation.remainingElements.slice(index + 1);
+        } else {
+          remaining = continuation.remainingElements.slice(index);
+        }
+        break;
       }
-      break;
+    } finally {
+      measureContainer.remove();
     }
 
     return {
@@ -2335,98 +2786,67 @@ export class PaginationEngine {
   }
 
   /**
-   * A continuation element is normally detached. Attach a clone in the real
-   * continuation CSS context before applying the shared conservative layout
-   * gate, then range-split it against exact note-band measurements.
-   */
-  private splitContinuationParagraphAtFit(
-    element: HTMLElement,
-    alreadyFitting: HTMLElement[],
-    continuation: FootnoteContinuation,
-    availableHeightPt: number,
-    contentWidth: number,
-  ): { head: HTMLElement; tail: HTMLElement } | null {
-    if (element.tagName !== "P") return null;
-
-    const context = document.createElement("div");
-    context.style.position = "absolute";
-    context.style.visibility = "hidden";
-    context.style.width = `${contentWidth}pt`;
-    context.style.left = "-9999px";
-    context.className = this.cssPrefix + "footnotes";
-    const wrapper = document.createElement("div");
-    wrapper.className = "footnote-continuation";
-    if (continuation.sourceAnchorId) {
-      wrapper.dataset.sourceAnchorId = continuation.sourceAnchorId;
-    }
-    const paragraph = element.cloneNode(true) as HTMLElement;
-    wrapper.appendChild(paragraph);
-    context.appendChild(wrapper);
-    this.stagingElement.appendChild(context);
-    try {
-      if (!this.canRangeFragmentParagraph(paragraph)) return null;
-      return this.splitParagraphAtLargestFit(paragraph, (head) =>
-        this.measureContinuationHeight({
-          footnoteId: continuation.footnoteId,
-          sourceAnchorId: continuation.sourceAnchorId,
-          remainingElements: [...alreadyFitting, head],
-        }, contentWidth) <= availableHeightPt);
-    } finally {
-      this.stagingElement.removeChild(context);
-    }
-  }
-
-  /** Exact initial-note measurement, including separator, marker, and content wrapper. */
-  private measurePartialFootnoteHeight(
-    footnoteElement: HTMLElement,
-    contentElement: Element,
-    elements: HTMLElement[],
-    contentWidth: number,
-  ): number {
-    const measureContainer = document.createElement("div");
-    measureContainer.style.position = "absolute";
-    measureContainer.style.visibility = "hidden";
-    measureContainer.style.width = `${contentWidth}pt`;
-    measureContainer.style.left = "-9999px";
-    measureContainer.className = this.cssPrefix + "footnotes";
-    measureContainer.appendChild(document.createElement("hr"));
-
-    const item = footnoteElement.cloneNode(false) as HTMLElement;
-    const number = footnoteElement.querySelector(".footnote-number");
-    if (number) item.appendChild(number.cloneNode(true));
-    const content = contentElement.cloneNode(false) as HTMLElement;
-    for (const element of elements) content.appendChild(element.cloneNode(true));
-    item.appendChild(content);
-    measureContainer.appendChild(item);
-
-    this.stagingElement.appendChild(measureContainer);
-    const heightPt = pxToPt(measureContainer.getBoundingClientRect().height);
-    this.stagingElement.removeChild(measureContainer);
-    return heightPt;
-  }
-
-  /**
    * Splits a footnote element into parts that fit within the available height.
    * Returns the elements that fit and the elements that need to continue.
    */
   private splitFootnoteToFit(
     footnoteElement: HTMLElement,
     availableHeightPt: number,
-    contentWidth: number
+    contentWidth: number,
+    forceProgress = false,
+    existingPayload?: FootnotePackingContext,
   ): { fits: HTMLElement[]; overflow: HTMLElement[] } {
     // Registry entries are detached clones, so getComputedStyle() cannot validate
     // their real paragraph layout. Attach an exact clone in the rendered note
     // context for the duration of the conservative range-fragmentation check.
-    const layoutContext = document.createElement("div");
+    const layoutContext = this.document.createElement("div");
     layoutContext.style.position = "absolute";
     layoutContext.style.visibility = "hidden";
     layoutContext.style.width = `${contentWidth}pt`;
     layoutContext.style.left = "-9999px";
     layoutContext.className = this.cssPrefix + "footnotes";
-    layoutContext.appendChild(document.createElement("hr"));
+    this.appendFootnoteSeparator(layoutContext, false);
     const attachedFootnote = footnoteElement.cloneNode(true) as HTMLElement;
     layoutContext.appendChild(attachedFootnote);
     this.stagingElement.appendChild(layoutContext);
+
+    // A second live tree represents the exact already-packed page payload plus
+    // an initially empty partial item. Candidates are appended once and layout
+    // is read in place, avoiding cumulative prefix re-cloning.
+    const measureContainer = this.document.createElement("div");
+    measureContainer.style.position = "absolute";
+    measureContainer.style.visibility = "hidden";
+    measureContainer.style.width = `${contentWidth}pt`;
+    measureContainer.style.left = "-9999px";
+    measureContainer.className = this.cssPrefix + "footnotes";
+    const hasContinuation = Boolean(existingPayload?.continuation?.remainingElements.length);
+    this.appendFootnoteSeparator(measureContainer, hasContinuation);
+    if (hasContinuation) {
+      measureContainer.appendChild(this.createFootnoteContinuationWrapper(
+        existingPayload!.continuation!,
+      ));
+    }
+    const partialById = new Map(
+      existingPayload?.partialFootnotes?.map((partial) =>
+        [partial.footnoteId, partial] as const) ?? [],
+    );
+    for (const id of existingPayload?.footnoteIds ?? []) {
+      this.checkpoint();
+      const source = this.footnoteRegistry.get(id);
+      if (!source) continue;
+      const partial = partialById.get(id);
+      measureContainer.appendChild(partial
+        ? this.createPartialFootnoteItem(source, partial.fittingElements)
+        : source.cloneNode(true));
+    }
+    const measuredPartial = this.createPartialFootnoteItem(attachedFootnote, []);
+    const measuredContent = measuredPartial.querySelector<HTMLElement>(":scope > .footnote-content");
+    if (!measuredContent) {
+      layoutContext.remove();
+      throw new Error("Footnote is missing its content shell");
+    }
+    measureContainer.appendChild(measuredPartial);
+    this.stagingElement.appendChild(measureContainer);
 
     // Get child elements (paragraphs) of the footnote content.
     //
@@ -2454,70 +2874,64 @@ export class PaginationEngine {
       for (let i = 0; i < children.length; i++) {
         this.checkpoint();
         const child = children[i];
-        const candidate = [...fits, child];
-        if (this.measurePartialFootnoteHeight(
-          attachedFootnote,
-          footnoteContent,
-          candidate,
-          contentWidth,
-        ) <= availableHeightPt) {
+        const measuredCandidate = child.cloneNode(true) as HTMLElement;
+        measuredContent.appendChild(measuredCandidate);
+        const candidateFits = pxToPt(measureContainer.getBoundingClientRect().height)
+          <= availableHeightPt;
+        if (candidateFits) {
           fits.push(child.cloneNode(true) as HTMLElement);
           continue;
         }
 
+        measuredCandidate.remove();
+
         const split = this.canRangeFragmentParagraph(child, true)
-          ? this.splitParagraphAtLargestFit(child, (head) =>
-            this.measurePartialFootnoteHeight(
-              attachedFootnote,
-              footnoteContent,
-              [...fits, head],
-              contentWidth,
-            ) <= availableHeightPt)
+          ? this.splitParagraphAtLargestFit(child, (head) => {
+            measuredContent.appendChild(head);
+            try {
+              return pxToPt(measureContainer.getBoundingClientRect().height)
+                <= availableHeightPt;
+            } finally {
+              head.remove();
+            }
+          }, {
+            emergencyGraphemeBreaks: true,
+            forceFirstOnNoFit: forceProgress,
+          })
           : null;
-        if (split) {
+        if (split?.kind === "split") {
           fits.push(split.head);
-          overflow = [split.tail, ...children.slice(i + 1).map((element) =>
-            element.cloneNode(true) as HTMLElement)];
-        } else if (fits.length === 0) {
+          split.tail.setAttribute(
+            FOOTNOTE_SOURCE_POSITION_ATTR,
+            i === 0 ? "first" : "later",
+          );
+          overflow = [split.tail, ...children.slice(i + 1).map((element, offset) =>
+            this.cloneFootnoteElementForContinuation(element, i + 1 + offset))];
+        } else if (split?.kind === "no-fit") {
+          // The paragraph is splittable, but this citation page has less than
+          // one line left. Defer it whole so a fresh note band can try again.
+          overflow = children.slice(i).map((element, offset) =>
+            this.cloneFootnoteElementForContinuation(element, i + offset));
+        } else if (fits.length === 0 && forceProgress) {
           // Preserve the one-element clipping fallback for content that cannot be
-          // range-fragmented, while allowing every later sibling to continue.
+          // range-fragmented only on a dedicated full note band, while allowing
+          // every later sibling to continue. A residual citation-page band must
+          // defer the whole element: it may fit untouched on the next page.
           fits.push(child.cloneNode(true) as HTMLElement);
-          overflow = children.slice(i + 1).map((element) =>
-            element.cloneNode(true) as HTMLElement);
+          overflow = children.slice(i + 1).map((element, offset) =>
+            this.cloneFootnoteElementForContinuation(element, i + 1 + offset));
         } else {
-          overflow = children.slice(i).map((element) =>
-            element.cloneNode(true) as HTMLElement);
+          overflow = children.slice(i).map((element, offset) =>
+            this.cloneFootnoteElementForContinuation(element, i + offset));
         }
         break;
       }
 
       return { fits, overflow };
     } finally {
-      this.stagingElement.removeChild(layoutContext);
+      measureContainer.remove();
+      layoutContext.remove();
     }
-  }
-
-  /**
-   * Measures a single footnote's height.
-   */
-  private measureSingleFootnoteHeight(footnoteId: string, contentWidth: number): number {
-    const footnote = this.footnoteRegistry.get(footnoteId);
-    if (!footnote) return 0;
-
-    const measureContainer = this.document.createElement("div");
-    measureContainer.style.position = "absolute";
-    measureContainer.style.visibility = "hidden";
-    measureContainer.style.width = `${contentWidth}pt`;
-    measureContainer.style.left = "-9999px";
-    measureContainer.className = this.cssPrefix + "footnotes";
-    measureContainer.appendChild(footnote.cloneNode(true));
-
-    this.stagingElement.appendChild(measureContainer);
-    const rect = measureContainer.getBoundingClientRect();
-    const heightPt = pxToPt(rect.height);
-    this.stagingElement.removeChild(measureContainer);
-
-    return heightPt;
   }
 
   /**
@@ -2540,9 +2954,6 @@ export class PaginationEngine {
       return;
     }
 
-    // Create a set of partial footnote IDs for quick lookup
-    const partialFootnoteIds = new Set(partialFootnotes?.map(p => p.footnoteId) || []);
-
     // Calculate max height for footnotes area (content height minus margin for body content)
     const maxFootnoteHeight = Math.min(
       footnoteHeight,
@@ -2562,21 +2973,11 @@ export class PaginationEngine {
     footnotesDiv.style.maxHeight = `${maxFootnoteHeight}pt`;
     footnotesDiv.style.overflow = "hidden";
 
-    // Add separator line
-    const hr = this.document.createElement("hr");
-    footnotesDiv.appendChild(hr);
+    this.appendFootnoteSeparator(footnotesDiv, Boolean(hasContinuation));
 
     // Add continuation content first (if any)
     if (hasContinuation) {
-      const contWrapper = this.document.createElement("div");
-      contWrapper.className = "footnote-continuation";
-      if (continuation!.sourceAnchorId) {
-        contWrapper.dataset.sourceAnchorId = continuation!.sourceAnchorId;
-      }
-      for (const el of continuation!.remainingElements) {
-        contWrapper.appendChild(el.cloneNode(true));
-      }
-      footnotesDiv.appendChild(contWrapper);
+      footnotesDiv.appendChild(this.createFootnoteContinuationWrapper(continuation!));
     }
 
     // Clone footnotes in order of appearance
@@ -2587,28 +2988,9 @@ export class PaginationEngine {
         // Render partial footnote (only the fitting elements)
         const footnote = this.footnoteRegistry.get(id);
         if (footnote) {
-          const partialDiv = this.document.createElement("div");
-          partialDiv.className = "footnote-item";
-          partialDiv.dataset.footnoteId = id;
-          if (footnote.dataset.sourceAnchorId) {
-            partialDiv.dataset.sourceAnchorId = footnote.dataset.sourceAnchorId;
-          }
-
-          // Add footnote number
-          const numberSpan = footnote.querySelector(".footnote-number");
-          if (numberSpan) {
-            partialDiv.appendChild(numberSpan.cloneNode(true));
-          }
-
-          // Add only the fitting content
-          const contentSpan = this.document.createElement("span");
-          contentSpan.className = "footnote-content";
-          for (const el of partial.fittingElements) {
-            contentSpan.appendChild(el.cloneNode(true));
-          }
-          partialDiv.appendChild(contentSpan);
-
-          footnotesDiv.appendChild(partialDiv);
+          footnotesDiv.appendChild(
+            this.createPartialFootnoteItem(footnote, partial.fittingElements),
+          );
         }
       } else {
         // Render full footnote from registry
@@ -2817,6 +3199,8 @@ export class PaginationEngine {
     let currentContinuation: FootnoteContinuation | null = this.pendingFootnoteContinuation;
     // Track any new continuation that will carry to next page
     let nextPageContinuation: FootnoteContinuation | null = null;
+    let currentContinuationPartitioned = false;
+    let currentPageAdmitted = false;
     /**
      * Whole notes that could not be started on this page and must render on the next one.
      *
@@ -2843,19 +3227,57 @@ export class PaginationEngine {
       remainingHeight = effectiveContentHeight;
     };
 
-    // Account for any continuation from previous section/page
-    if (currentContinuation && currentContinuation.remainingElements.length > 0) {
-      currentFootnoteHeight = this.measureContinuationHeight(currentContinuation, dims.contentWidth);
-    }
+    const admitCurrentPage = () => {
+      if (currentPageAdmitted) return;
+      this.admitPageAllocation();
+      currentPageAdmitted = true;
+    };
 
-    const finishPage = (nextPageSectionIndex = pageSectionIndex) => {
+    const prepareCurrentContinuation = () => {
+      if (currentContinuationPartitioned
+          || (currentContinuation?.remainingElements.length ?? 0) === 0) return;
+      // A continuation guarantees that this physical page will exist. Admit it
+      // before touching the carried DOM, then partition once and retain that
+      // exact head while body placement is decided.
+      admitCurrentPage();
+      const ownedDimensions = dimensionsFor();
+      const pageBands = this.getPageBands(
+        ownedDimensions,
+        pageSectionIndex,
+        pageInSection(),
+      );
+      const partition = this.splitContinuationForPage(
+        currentContinuation!,
+        pageBands.bodyHeight * MAX_FOOTNOTE_AREA_RATIO,
+        ownedDimensions.contentWidth,
+      );
+      currentContinuation = partition.current;
+      if (partition.overflow) nextPageContinuation = partition.overflow;
+      currentContinuationPartitioned = true;
+      currentFootnoteHeight = this.measureFootnotesHeight(
+        currentFootnoteIds,
+        ownedDimensions.contentWidth,
+        currentContinuation,
+        currentPartialFootnotes,
+      );
+    };
+
+    const finishPage = (
+      nextPageSectionIndex = pageSectionIndex,
+      forceEmptyPage = false,
+    ) => {
       const hasCurrentContinuation =
         (currentContinuation?.remainingElements.length ?? 0) > 0;
-      if (currentContent.length === 0 && currentFootnoteIds.length === 0
+      if (!forceEmptyPage && currentContent.length === 0 && currentFootnoteIds.length === 0
           && !hasCurrentContinuation) {
         adoptEmptyPageOwner(nextPageSectionIndex);
         return;
       }
+
+      prepareCurrentContinuation();
+      // Pages without a carried continuation are charged here. Continuation
+      // pages were charged before their page-owned partition above.
+      admitCurrentPage();
 
       let pageContinuation = currentContinuation;
       const ownedPageInSection = pageInSection();
@@ -2870,25 +3292,20 @@ export class PaginationEngine {
         ownedPageInSection,
       );
       const maxFootnoteHeight = pageBands.bodyHeight * MAX_FOOTNOTE_AREA_RATIO;
-      if (currentContinuation && currentContinuation.remainingElements.length > 0) {
-        const partition = this.splitContinuationForPage(
-          currentContinuation,
-          maxFootnoteHeight,
-          ownedDimensions.contentWidth,
-        );
-        pageContinuation = partition.current;
-        if (partition.overflow) {
-          // A carried tail occupies the next page before any newly introduced note.
-          // The normal flow never starts another splittable note while an oversized
-          // continuation already consumes the note budget, so this assignment does
-          // not discard an independent continuation.
-          nextPageContinuation = partition.overflow;
-        }
-        currentFootnoteHeight = this.measureContinuationHeight(
-          pageContinuation,
-          ownedDimensions.contentWidth,
-        );
-      }
+      // `prepareCurrentContinuation` has already packed the exact head for this
+      // page. Keeping that partition stable lets body fit decisions share the
+      // remaining band without rescanning the entire tail.
+      pageContinuation = currentContinuation;
+
+      // Recompute the entire painted payload after continuation partitioning.
+      // Measuring only the carried head here discarded the reserve for a newer
+      // whole/partial note and let the clipped note band silently consume it.
+      currentFootnoteHeight = this.measureFootnotesHeight(
+        currentFootnoteIds,
+        ownedDimensions.contentWidth,
+        pageContinuation,
+        currentPartialFootnotes,
+      );
 
       // A final body page can seed the next page with several whole notes. Partition that queue
       // before materializing a note-only page: addPageFootnotes deliberately clips its band, so
@@ -2921,6 +3338,7 @@ export class PaginationEngine {
                 source,
                 maxFootnoteHeight - FOOTNOTE_MEASUREMENT_GUARD_PT,
                 ownedDimensions.contentWidth,
+                true,
               )
               : null;
             fittingIds.push(footnoteId);
@@ -2954,7 +3372,9 @@ export class PaginationEngine {
         currentFootnoteIds,
         currentFootnoteHeight,
         pageContinuation,
-        currentPartialFootnotes.length > 0 ? currentPartialFootnotes : undefined
+        currentPartialFootnotes.length > 0 ? currentPartialFootnotes : undefined,
+        false,
+        currentPageAdmitted,
       );
       pages.push(page);
       precedingDisplayedPageNumber = ownedDisplayedPageNumber;
@@ -2963,6 +3383,12 @@ export class PaginationEngine {
       currentContent = [];
 
       pageSectionIndex = nextPageSectionIndex;
+      if (!sectionStartPages.has(pageSectionIndex)) {
+        // A carried note can own pages before the first body block of a new
+        // section lands. Count those physical pages in that section so first /
+        // odd / even stories and restarted displayed numbering advance once.
+        sectionStartPages.set(pageSectionIndex, pageNumber);
+      }
 
       // Get effective content height for new page position
       const newBands = this.getPageBands(
@@ -2981,6 +3407,8 @@ export class PaginationEngine {
       // Carry over continuation to next page
       currentContinuation = nextPageContinuation;
       nextPageContinuation = null;
+      currentContinuationPartitioned = false;
+      currentPageAdmitted = false;
 
       // Notes that never got started land at the top of the new page's note area. They are
       // ordinary footnotes from here on, so the normal fitting path handles them — and because
@@ -2990,21 +3418,18 @@ export class PaginationEngine {
         deferredFootnoteIds = [];
       }
 
-      // Account for continuation height on new page
+      // Whole deferred notes have no carried DOM and can be measured directly.
+      // A continuation is partitioned lazily after the prospective page has
+      // passed its resource admission check, so never clone its entire tail here.
       const nextDimensions = dimensionsFor();
-      if (currentContinuation && currentContinuation.remainingElements.length > 0) {
-        currentFootnoteHeight = this.measureContinuationHeight(
-          currentContinuation,
-          nextDimensions.contentWidth,
-        );
-      } else {
-        currentFootnoteHeight = 0;
-      }
-      if (currentFootnoteIds.length > 0) {
-        currentFootnoteHeight += this.measureFootnotesHeight(
-          currentFootnoteIds, nextDimensions.contentWidth, null);
-      }
+      currentFootnoteHeight = currentContinuation
+        ? 0
+        : this.measureFootnotesHeight(currentFootnoteIds, nextDimensions.contentWidth);
     };
+
+    const pageHasPayload = () => currentContent.length > 0
+      || currentFootnoteIds.length > 0
+      || (currentContinuation?.remainingElements.length ?? 0) > 0;
 
     for (let i = 0; i < blocks.length; i++) {
       this.checkpoint();
@@ -3026,6 +3451,24 @@ export class PaginationEngine {
         && (currentContinuation?.remainingElements.length ?? 0) === 0;
       if (pageIsEmpty && block.sectionIndex !== pageSectionIndex) {
         adoptEmptyPageOwner(block.sectionIndex);
+      }
+
+      prepareCurrentContinuation();
+
+      if (currentFootnoteHeight > 0) {
+        const ownerDimensions = dimensionsFor();
+        const ownerBands = this.getPageBands(
+          ownerDimensions,
+          pageSectionIndex,
+          pageInSection(),
+        );
+        if (currentFootnoteHeight > ownerBands.bodyHeight * MAX_FOOTNOTE_AREA_RATIO) {
+          // Pack an oversized carried/queued payload before admitting another
+          // body block. finishPage partitions it into visible note-only bands.
+          finishPage(block.sectionIndex);
+          i--;
+          continue;
+        }
       }
       const blockDimensions = dimensionsFor(block.sectionIndex);
       const nextBlockPageInSection = pageInSection(block.sectionIndex, pageNumber + 1);
@@ -3127,17 +3570,22 @@ export class PaginationEngine {
       const newFootnoteIds = this.collectNewFootnoteIds([block], currentFootnoteIds);
 
       // Calculate additional footnote height if this block is added
+      let combinedFootnoteHeight = currentFootnoteHeight;
       let additionalFootnoteHeight = 0;
       if (newFootnoteIds.length > 0 && this.footnoteRegistry.size > 0) {
         // Measure the combined height of all footnotes that would be on this page
         // (including any continuation)
         const combinedFootnoteIds = [...currentFootnoteIds, ...newFootnoteIds];
-        const totalFootnoteHeight = this.measureFootnotesHeight(
+        combinedFootnoteHeight = this.measureFootnotesHeight(
           combinedFootnoteIds,
           blockDimensions.contentWidth,
-          currentContinuation
+          currentContinuation,
+          currentPartialFootnotes,
         );
-        additionalFootnoteHeight = totalFootnoteHeight - currentFootnoteHeight;
+        additionalFootnoteHeight = Math.max(
+          0,
+          combinedFootnoteHeight - currentFootnoteHeight,
+        );
       }
 
       // Calculate the effective height this block will consume
@@ -3161,7 +3609,6 @@ export class PaginationEngine {
       // Calculate maximum footnote area for this page (can expand into body content space)
       const bodyContentUsed = effectiveContentHeight - remainingHeight;
       const maxFootnoteArea = effectiveContentHeight * MAX_FOOTNOTE_AREA_RATIO;
-      const maxFootnoteExpansion = Math.max(0, maxFootnoteArea - currentFootnoteHeight);
 
       // A paragraph that cannot fit as a whole may still have a simple text-only
       // prefix that fits this page. Fragment before the ordinary next-page or
@@ -3182,7 +3629,11 @@ export class PaginationEngine {
       }
 
       // Check if block fits on current page (including its footnotes)
-      if (blockSpace <= effectiveRemainingHeight) {
+      if (
+        blockSpace <= effectiveRemainingHeight
+        && (combinedFootnoteHeight === 0
+          || combinedFootnoteHeight + FOOTNOTE_MEASUREMENT_GUARD_PT <= maxFootnoteArea)
+      ) {
         // Block fits with current footnote allocation
         markSectionPlaced(block.sectionIndex);
         currentContent.push(this.cloneBlockForPage(
@@ -3195,7 +3646,7 @@ export class PaginationEngine {
         // Add new footnotes to current page
         if (newFootnoteIds.length > 0) {
           currentFootnoteIds.push(...newFootnoteIds);
-          currentFootnoteHeight += additionalFootnoteHeight;
+          currentFootnoteHeight = combinedFootnoteHeight;
         }
         currentPageHasFootnoteReference ||= allBlockFootnoteIds.length > 0;
       } else if (
@@ -3208,11 +3659,6 @@ export class PaginationEngine {
       ) {
         // Block doesn't fit with current allocation - try expanding footnote area
         const blockSpaceWithoutFootnotes = effectiveMarginTop + block.heightPt;
-
-        // Check if block fits if we expand footnote area
-        // We can expand footnotes up to maxFootnoteArea, leaving room for body content
-        const minBodySpaceNeeded = bodyContentUsed + blockSpaceWithoutFootnotes + MIN_BODY_CONTENT_HEIGHT;
-        const canExpandFootnotes = minBodySpaceNeeded <= effectiveContentHeight;
 
         if (newFootnoteIds.length > 0 && blockSpaceWithoutFootnotes <= effectiveRemainingHeight) {
           // Block itself fits, but footnotes don't - expand footnote area
@@ -3233,28 +3679,45 @@ export class PaginationEngine {
           );
 
           // Try to fit as much of each new footnote as possible in expanded area
-          for (const footnoteId of newFootnoteIds) {
+          for (let noteIndex = 0; noteIndex < newFootnoteIds.length; noteIndex++) {
             this.checkpoint();
+            const footnoteId = newFootnoteIds[noteIndex];
             const footnote = this.footnoteRegistry.get(footnoteId);
             if (!footnote) continue;
 
-            const footnoteHeight = this.measureSingleFootnoteHeight(
-              footnoteId,
+            // One page can carry only one split tail. Once that slot is used,
+            // keep every later note in source order on the deferral queue.
+            if (nextPageContinuation) {
+              deferredFootnoteIds.push(...newFootnoteIds.slice(noteIndex));
+              break;
+            }
+
+            const candidateIds = [...currentFootnoteIds, footnoteId];
+            const candidateHeight = this.measureFootnotesHeight(
+              candidateIds,
               blockDimensions.contentWidth,
+              currentContinuation,
+              currentPartialFootnotes,
             );
             const spaceLeftForFootnotes = availableForFootnotes - currentFootnoteHeight;
 
-            if (footnoteHeight <= spaceLeftForFootnotes) {
+            if (candidateHeight + FOOTNOTE_MEASUREMENT_GUARD_PT <= availableForFootnotes) {
               // Whole footnote fits in expanded area
               currentFootnoteIds.push(footnoteId);
-              currentFootnoteHeight += footnoteHeight;
+              currentFootnoteHeight = candidateHeight;
             } else {
               // Footnote needs to be split - use all available expanded space
               if (spaceLeftForFootnotes > 20) { // Minimum space to start a footnote
                 const { fits, overflow } = this.splitFootnoteToFit(
                   footnote,
-                  spaceLeftForFootnotes,
-                  blockDimensions.contentWidth
+                  availableForFootnotes,
+                  blockDimensions.contentWidth,
+                  false,
+                  {
+                    footnoteIds: currentFootnoteIds,
+                    continuation: currentContinuation,
+                    partialFootnotes: currentPartialFootnotes,
+                  },
                 );
 
                 if (fits.length > 0) {
@@ -3271,106 +3734,37 @@ export class PaginationEngine {
                       remainingElements: overflow
                     };
                   }
-                  currentFootnoteHeight = availableForFootnotes;
+                  currentFootnoteHeight = this.measureFootnotesHeight(
+                    currentFootnoteIds,
+                    blockDimensions.contentWidth,
+                    currentContinuation,
+                    currentPartialFootnotes,
+                  );
+                  if (overflow.length > 0) {
+                    deferredFootnoteIds.push(...newFootnoteIds.slice(noteIndex + 1));
+                    break;
+                  }
                 } else {
                   // Nothing of this note fits: defer the WHOLE note rather than assigning the
                   // single continuation slot, which a later note on this page would overwrite.
-                  deferredFootnoteIds.push(footnoteId);
+                  deferredFootnoteIds.push(...newFootnoteIds.slice(noteIndex));
+                  break;
                 }
               } else {
                 // Not enough space to even start the note — same deferral.
-                deferredFootnoteIds.push(footnoteId);
+                deferredFootnoteIds.push(...newFootnoteIds.slice(noteIndex));
+                break;
               }
             }
           }
           currentPageHasFootnoteReference ||= allBlockFootnoteIds.length > 0;
-        } else if (canExpandFootnotes && newFootnoteIds.length > 0) {
-          // Block doesn't fit with current layout, but might fit if we expand footnote area first
-          // This handles the case where we need to give footnotes more space BEFORE adding the block
-
-          // First, try to fit more of current footnotes by expanding the area
-          // Then check if the block fits in reduced body space
-          const expandedFootnoteSpace = Math.min(maxFootnoteArea, additionalFootnoteHeight + currentFootnoteHeight);
-          const bodySpaceAfterExpansion = effectiveContentHeight - expandedFootnoteSpace;
-
-          if (blockSpaceWithoutFootnotes <= bodySpaceAfterExpansion - bodyContentUsed) {
-            // Block fits after expanding footnote area.
-            markSectionPlaced(block.sectionIndex);
-            currentContent.push(this.cloneBlockForPage(
-              block,
-              isFirstOnPage,
-              pageInSection(block.sectionIndex),
-            ));
-            // `remainingHeight` tracks BODY consumption only — every other branch maintains it
-            // that way, and the footnote reserve is applied separately via `effectiveRemainingHeight`
-            // at the top of each iteration. Assigning `bodySpaceAfterExpansion - …` here folded the
-            // reserve in a second time, so a later block would see a body budget short by the whole
-            // footnote area. Consistency fix: no measurable difference on the documents tested, but
-            // the two meanings must not coexist or the next change here inherits a latent bug.
-            remainingHeight = bodySpaceAfterExpansion - bodyContentUsed - blockSpaceWithoutFootnotes;
-            prevMarginBottomPt = block.marginBottomPt;
-            currentFootnoteIds.push(...newFootnoteIds);
-            currentFootnoteHeight = expandedFootnoteSpace;
-            currentPageHasFootnoteReference ||= allBlockFootnoteIds.length > 0;
-          } else {
-            // Still doesn't fit - start new page
-            finishPage(block.sectionIndex);
-            const newPageFootnoteHeight = allBlockFootnoteIds.length > 0
-              ? this.measureFootnotesHeight(
-                allBlockFootnoteIds,
-                blockDimensions.contentWidth,
-                currentContinuation,
-              )
-              : (currentContinuation
-                ? this.measureContinuationHeight(currentContinuation, blockDimensions.contentWidth)
-                : 0);
-            const newPageMarginTop = this.effectiveBlockMarginTop(
-              block, 0, true, pageInSection(block.sectionIndex));
-            const newPageSpace = newPageMarginTop + block.heightPt + block.marginBottomPt;
-            markSectionPlaced(block.sectionIndex);
-            currentContent.push(this.cloneBlockForPage(
-              block,
-              true,
-              pageInSection(block.sectionIndex),
-            ));
-            remainingHeight = effectiveContentHeight - newPageSpace;
-            prevMarginBottomPt = block.marginBottomPt;
-            // Merge, never replace: finishPage() may have just seeded this page with notes deferred
-            // from the previous one, and overwriting here dropped them from the document.
-            currentFootnoteIds = [...currentFootnoteIds, ...allBlockFootnoteIds];
-            currentFootnoteHeight = newPageFootnoteHeight;
-            currentPageHasFootnoteReference ||= allBlockFootnoteIds.length > 0;
-          }
         } else {
-          // Block itself doesn't fit - start new page
-          finishPage(block.sectionIndex);
-          // On new page, recalculate footnote height for just this block's footnotes
-          // (plus any continuation from previous page)
-          const newPageFootnoteHeight = allBlockFootnoteIds.length > 0
-            ? this.measureFootnotesHeight(
-              allBlockFootnoteIds,
-              blockDimensions.contentWidth,
-              currentContinuation,
-            )
-            : (currentContinuation
-              ? this.measureContinuationHeight(currentContinuation, blockDimensions.contentWidth)
-              : 0);
-          const newPageMarginTop = this.effectiveBlockMarginTop(
-            block, 0, true, pageInSection(block.sectionIndex));
-          const newPageSpace = newPageMarginTop + block.heightPt + block.marginBottomPt;
-          markSectionPlaced(block.sectionIndex);
-          currentContent.push(this.cloneBlockForPage(
-            block,
-            true,
-            pageInSection(block.sectionIndex),
-          ));
-          remainingHeight = effectiveContentHeight - newPageSpace;
-          prevMarginBottomPt = block.marginBottomPt;
-          // Merge, never replace: finishPage() may have just seeded this page with notes deferred
-          // from the previous one, and overwriting here dropped them from the document.
-          currentFootnoteIds = [...currentFootnoteIds, ...allBlockFootnoteIds];
-          currentFootnoteHeight = newPageFootnoteHeight;
-          currentPageHasFootnoteReference ||= allBlockFootnoteIds.length > 0;
+          // Block itself doesn't fit. Retry after the page turn so carried
+          // continuations and deferred notes participate in the normal fit and
+          // split decisions instead of being overwritten by forced placement.
+          finishPage(block.sectionIndex, !pageHasPayload());
+          i--;
+          continue;
         }
       } else {
         // Block is taller than a page. Ordinary tables can be split at complete
@@ -3392,8 +3786,10 @@ export class PaginationEngine {
         // Unsupported oversized blocks are intentionally left intact. Splitting
         // arbitrary HTML, merged tables, or footnote-bearing tables would be less
         // correct than the prior clipped fallback.
-        if (currentContent.length > 0) {
+        if (pageHasPayload()) {
           finishPage(block.sectionIndex);
+          i--;
+          continue;
         }
         markSectionPlaced(block.sectionIndex);
         currentContent.push(this.cloneBlockForPage(
@@ -3401,9 +3797,10 @@ export class PaginationEngine {
           true,
           pageInSection(block.sectionIndex),
         ));
-        // Merge, never replace: finishPage() may have just seeded this page with notes deferred
-        // from the previous one, and overwriting here dropped them from the document.
-        currentFootnoteIds = [...currentFootnoteIds, ...allBlockFootnoteIds];
+        // An unsupported body block already occupies/clips its whole body band.
+        // Preserve its notes losslessly on following note-only pages rather
+        // than drawing them underneath that clipped fallback.
+        deferredFootnoteIds.push(...newFootnoteIds);
         currentPageHasFootnoteReference ||= allBlockFootnoteIds.length > 0;
         finishPage(block.sectionIndex);
       }
@@ -3672,6 +4069,13 @@ export class PaginationEngine {
     return reference.start + (reference.size - objectSize) * fraction;
   }
 
+  /** Charge a physical page before any page-owned partitioning or DOM allocation. */
+  private admitPageAllocation(): void {
+    const prospectivePageCount = this.createdPageCount + 1;
+    this.pageCountCheckpoint?.(prospectivePageCount);
+    this.createdPageCount = prospectivePageCount;
+  }
+
   /**
    * Creates a page container element.
    */
@@ -3687,10 +4091,9 @@ export class PaginationEngine {
     continuation?: FootnoteContinuation | null,
     partialFootnotes?: PartialFootnote[],
     isSectionFiller = false,
+    pageAlreadyAdmitted = false,
   ): PageInfo {
-    const prospectivePageCount = this.createdPageCount + 1;
-    this.pageCountCheckpoint?.(prospectivePageCount);
-    this.createdPageCount = prospectivePageCount;
+    if (!pageAlreadyAdmitted) this.admitPageAllocation();
     // Create page box at full size, then scale the entire box
     // This ensures proper clipping and consistent scaling of all elements
     const pageBox = this.document.createElement("div");
@@ -3782,13 +4185,20 @@ export class PaginationEngine {
 
     pageBox.appendChild(contentArea);
 
-    // Materialize margin comments in a page-owned side column. The body only carries range
-    // markers; definition and comment-paragraph identities live on these selected registry
-    // clones, so PageMap geometry describes the actual visible margin presentation.
+    // Add footnotes if any references appear on this page (or continuation from previous)
+    const hasContinuation = continuation && continuation.remainingElements.length > 0;
+    if (!isSectionFiller && (footnoteIds.length > 0 || hasContinuation)) {
+      this.addPageFootnotes(pageBox, footnoteIds, dims, bands, footnoteHeight, continuation, partialFootnotes);
+
+    }
+
+    // Materialize margin comments after footnotes exist so markers inside a
+    // note participate in the same page-owned comment story as body markers.
     const pageCommentIds: string[] = [];
     for (const marker of Array.from(
-      contentArea.querySelectorAll<HTMLElement>("[data-comment-id]"),
+      pageBox.querySelectorAll<HTMLElement>("[data-comment-id]"),
     )) {
+      if (marker.closest(`.${this.cssPrefix}comment-margin`)) continue;
       const id = marker.dataset.commentId;
       if (id && this.commentMarginRegistry.has(id) && !pageCommentIds.includes(id)) {
         pageCommentIds.push(id);
@@ -3813,13 +4223,6 @@ export class PaginationEngine {
         }
       }
       pageBox.appendChild(marginColumn);
-    }
-
-    // Add footnotes if any references appear on this page (or continuation from previous)
-    const hasContinuation = continuation && continuation.remainingElements.length > 0;
-    if (!isSectionFiller && (footnoteIds.length > 0 || hasContinuation)) {
-      this.addPageFootnotes(pageBox, footnoteIds, dims, bands, footnoteHeight, continuation, partialFootnotes);
-
     }
 
     // Add footer if available for this section/page

--- a/npm/tests/docx-footnote-fixture.ts
+++ b/npm/tests/docx-footnote-fixture.ts
@@ -29,13 +29,16 @@ function bodyParagraph(index: number, noteId: number | null): string {
     `<w:r><w:t xml:space="preserve">Body line ${index + 1}</w:t></w:r>${citation}</w:p>`;
 }
 
-function footnote(id: number, paragraphCount: number): string {
+function footnote(id: number, paragraphCount: number, wordsPerParagraph: number): string {
   const paragraphs = Array.from({ length: paragraphCount }, (_, index) =>
     `<w:p><w:pPr><w:pStyle w:val="FootnoteText"/></w:pPr>` +
       (index === 0
         ? `<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r>`
         : '') +
-      `<w:r><w:t xml:space="preserve"> Footnote ${id} paragraph ${index + 1} text.</w:t></w:r></w:p>`)
+      `<w:r><w:t xml:space="preserve"> ${wordsPerParagraph > 0
+        ? Array.from({ length: wordsPerParagraph }, (_, wordIndex) =>
+          `footnote-${id}-${index + 1}-${wordIndex + 1}`).join(' ')
+        : `Footnote ${id} paragraph ${index + 1} text.`}</w:t></w:r></w:p>`)
     .join('');
   return `<w:footnote w:id="${id}">${paragraphs}</w:footnote>`;
 }
@@ -44,11 +47,15 @@ function footnote(id: number, paragraphCount: number): string {
  * @param noteCount distinct footnotes, cited from the first `noteCount` body paragraphs.
  * @param bodyLines total body paragraphs — few enough to keep everything on one page, so the
  *   note area's position is determined purely by the page geometry, not by flow pressure.
+ * @param paragraphsPerNote paragraphs emitted inside each note.
+ * @param wordsPerParagraph when positive, emits this many uniquely numbered words in each note
+ *   paragraph so one real converter paragraph can be made taller than a note band.
  */
 export function generateFootnoteDocx(
   noteCount = 1,
   bodyLines = 5,
   paragraphsPerNote = 1,
+  wordsPerParagraph = 0,
 ): Uint8Array {
   const noteIds = Array.from({ length: noteCount }, (_, i) => i + 1);
   const body = Array.from({ length: bodyLines }, (_, i) =>
@@ -106,7 +113,7 @@ export function generateFootnoteDocx(
 <w:footnotes xmlns:w="${W_NS}">
   <w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>
   <w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>
-  ${noteIds.map((id) => footnote(id, paragraphsPerNote)).join('\n  ')}
+  ${noteIds.map((id) => footnote(id, paragraphsPerNote, wordsPerParagraph)).join('\n  ')}
 </w:footnotes>`),
     },
     {

--- a/npm/tests/docx-footnote-fixture.ts
+++ b/npm/tests/docx-footnote-fixture.ts
@@ -56,10 +56,17 @@ export function generateFootnoteDocx(
   bodyLines = 5,
   paragraphsPerNote = 1,
   wordsPerParagraph = 0,
+  separatorStories: {
+    normalText?: string;
+    continuationText?: string;
+  } = {},
 ): Uint8Array {
   const noteIds = Array.from({ length: noteCount }, (_, i) => i + 1);
   const body = Array.from({ length: bodyLines }, (_, i) =>
     bodyParagraph(i, i < noteCount ? i + 1 : null)).join('');
+
+  const separatorRun = (marker: 'separator' | 'continuationSeparator', text?: string) =>
+    `<w:p><w:r><w:${marker}/>${text ? `<w:t xml:space="preserve"> ${text}</w:t>` : ''}</w:r></w:p>`;
 
   return storedZip([
     {
@@ -111,8 +118,12 @@ export function generateFootnoteDocx(
       name: 'word/footnotes.xml',
       data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:footnotes xmlns:w="${W_NS}">
-  <w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>
-  <w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>
+  <w:footnote w:type="separator" w:id="-1">${separatorRun(
+    'separator', separatorStories.normalText,
+  )}</w:footnote>
+  <w:footnote w:type="continuationSeparator" w:id="0">${separatorRun(
+    'continuationSeparator', separatorStories.continuationText,
+  )}</w:footnote>
   ${noteIds.map((id) => footnote(id, paragraphsPerNote, wordsPerParagraph)).join('\n  ')}
 </w:footnotes>`),
     },

--- a/npm/tests/page-map-real-converter.spec.ts
+++ b/npm/tests/page-map-real-converter.spec.ts
@@ -18,7 +18,9 @@ interface RealPaginationResult {
   htmlCanonicalCount: number;
   pages: number;
   fragments: Array<{
+    fragmentId: string;
     anchorId: string;
+    fragmentIndex: number;
     pageNumber: number;
     story: string;
     inTableCell: boolean;
@@ -35,6 +37,13 @@ interface RealPaginationResult {
   endnoteReferenceResolves: boolean;
   endnoteLinkTargetsUnique: boolean;
   endnoteMarkerText: string | null;
+  visibleFootnoteText: string;
+  clippedFootnoteParagraphs: Array<{
+    anchorId: string | null;
+    pageNumber: number;
+    paragraphBottom: number;
+    bandBottom: number;
+  }>;
 }
 
 async function convertPaginateAndRegister(
@@ -67,6 +76,32 @@ async function convertPaginateAndRegister(
       layoutToken: { documentVersion: 0, rendererFingerprint: fingerprint },
     });
     const pagination = engine.paginate();
+    const footnoteBands = Array.from(
+      container.querySelectorAll<HTMLElement>('.page-footnotes'),
+    );
+    const visibleFootnoteText = footnoteBands.map((band) => {
+      const clone = band.cloneNode(true) as HTMLElement;
+      clone.querySelectorAll('.footnote-number').forEach((number) => number.remove());
+      clone.querySelectorAll('p').forEach((paragraph) => paragraph.after(' '));
+      return clone.textContent ?? '';
+    }).join(' ').replace(/\s+/g, ' ').trim();
+    const clippedFootnoteParagraphs = footnoteBands.flatMap((band) => {
+      const bandRect = band.getBoundingClientRect();
+      const pageNumber = Number(
+        band.closest<HTMLElement>('.page-box')?.dataset.pageNumber ?? '0',
+      );
+      return Array.from(band.querySelectorAll<HTMLElement>('p'))
+        .filter((paragraph) => {
+          const rect = paragraph.getBoundingClientRect();
+          return rect.top < bandRect.top - 1 || rect.bottom > bandRect.bottom + 1;
+        })
+        .map((paragraph) => ({
+          anchorId: paragraph.dataset.sourceAnchorId ?? null,
+          pageNumber,
+          paragraphBottom: paragraph.getBoundingClientRect().bottom,
+          bandBottom: bandRect.bottom,
+        }));
+    });
 
     const bridge = D.DocxSessionBridge;
     const handle = bridge.OpenSession(bin, '');
@@ -113,6 +148,8 @@ async function convertPaginateAndRegister(
       endnoteTargetCount: document.querySelectorAll('#en-1').length,
       endnoteMarkerText: container.querySelector<HTMLElement>('#en-1')?.textContent?.trim()
         ?? null,
+      visibleFootnoteText,
+      clippedFootnoteParagraphs,
     };
   }, {
     bytes: Array.from(docx),
@@ -203,6 +240,75 @@ test.describe('Real converter PageMap pipeline', () => {
       && fragment.geometry.y >= 0
       && fragment.geometry.width > 0
       && fragment.geometry.height > 0)).toBe(true);
+  });
+
+  test('one long real footnote paragraph has contiguous PageMap fragments', async ({
+    page,
+  }, testInfo) => {
+    let result: RealPaginationResult | undefined;
+    let failure: { name?: string; message: string; stack?: string } | undefined;
+    try {
+      result = await convertPaginateAndRegister(
+        page,
+        generateFootnoteDocx(1, 1, 1, 600),
+        -1,
+        true,
+        'real-long-footnote-paragraph-v1',
+      );
+      const paragraphs = result.fragments.filter((fragment) =>
+        fragment.story === 'footnote' && fragment.anchorId.startsWith('p:fn:'));
+      const expectedText = Array.from(
+        { length: 600 },
+        (_, index) => `footnote-1-1-${index + 1}`,
+      ).join(' ');
+
+      expect(result.registration.success, JSON.stringify(result.registration)).toBe(true);
+      expect(result.pages).toBeGreaterThan(1);
+      expect(paragraphs.length).toBeGreaterThan(1);
+      expect(new Set(paragraphs.map((fragment) => fragment.anchorId)).size).toBe(1);
+      expect(new Set(paragraphs.map((fragment) => fragment.pageNumber)).size).toBeGreaterThan(1);
+      expect(paragraphs.map((fragment) => fragment.fragmentIndex))
+        .toEqual(paragraphs.map((_, index) => index));
+      expect(new Set(paragraphs.map((fragment) => fragment.fragmentId)).size)
+        .toBe(paragraphs.length);
+      expect(paragraphs.every((fragment) =>
+        fragment.geometry.x >= 0
+        && fragment.geometry.y >= 0
+        && fragment.geometry.width > 0
+        && fragment.geometry.height > 0)).toBe(true);
+      expect(result.visibleFootnoteText).toBe(expectedText);
+      expect(result.clippedFootnoteParagraphs).toEqual([]);
+    } catch (error) {
+      failure = error instanceof Error
+        ? { name: error.name, message: error.message, stack: error.stack }
+        : { message: String(error) };
+      throw error;
+    } finally {
+      const captureWarnings: string[] = [];
+      try {
+        await testInfo.attach('issue-489-real-long-footnote.html', {
+          body: Buffer.from(await page.content()),
+          contentType: 'text/html',
+        });
+      } catch (error) {
+        captureWarnings.push(`HTML capture failed: ${String(error)}`);
+      }
+      try {
+        const host = page.locator('.real-page-map-host');
+        if (await host.count()) {
+          await testInfo.attach('issue-489-real-long-footnote.png', {
+            body: await host.screenshot(),
+            contentType: 'image/png',
+          });
+        }
+      } catch (error) {
+        captureWarnings.push(`screenshot capture failed: ${String(error)}`);
+      }
+      await testInfo.attach('issue-489-real-long-footnote.json', {
+        body: Buffer.from(JSON.stringify({ result, failure, captureWarnings }, null, 2)),
+        contentType: 'application/json',
+      });
+    }
   });
 
   test('one long real endnote paragraph fragments across final flow pages', async ({ page }) => {

--- a/npm/tests/pagination-continuous-section.spec.ts
+++ b/npm/tests/pagination-continuous-section.spec.ts
@@ -64,16 +64,26 @@ interface PaginatedShape {
   sectionFillers: boolean[];
   pageSizes: Array<{ width: number; height: number }>;
   contentBoxes: Array<{ top: number; left: number; width: number; height: number }>;
+  checkpoints: number;
 }
 
-async function paginate(page: Page): Promise<PaginatedShape> {
+async function paginate(page: Page, checkpointLimit?: number): Promise<PaginatedShape> {
   await page.addScriptTag({ path: path.join(__dirname, '../dist/pagination.bundle.js') });
 
-  return page.evaluate(() => {
+  return page.evaluate((limit) => {
     const staging = document.getElementById('staging') as HTMLElement;
     const container = document.getElementById('container') as HTMLElement;
     const { PaginationEngine } = (window as any).DocxodusPagination;
-    new PaginationEngine(staging, container, { showPageNumbers: false }).paginate();
+    let checkpoints = 0;
+    new PaginationEngine(staging, container, {
+      showPageNumbers: false,
+      checkCancellation: () => {
+        checkpoints++;
+        if (limit !== undefined && checkpoints > limit) {
+          throw new Error(`pagination exceeded ${limit} checkpoints`);
+        }
+      },
+    }).paginate();
 
     const pages = Array.from(container.querySelectorAll<HTMLElement>('.page-content'));
     const boxes = Array.from(container.querySelectorAll<HTMLElement>('.page-box'));
@@ -112,8 +122,9 @@ async function paginate(page: Page): Promise<PaginatedShape> {
         width: parseFloat(content.style.width),
         height: parseFloat(content.style.height),
       })),
+      checkpoints,
     };
-  });
+  }, checkpointLimit);
 }
 
 test.describe('Continuous section breaks', () => {
@@ -266,6 +277,82 @@ test.describe('Continuous section breaks', () => {
     expect(result.pagesInSection).toEqual([1, 1]);
     expect(result.footnotes[0]).toContain('note before section break');
     expect(result.footnotes[1]).toBe('');
+  });
+
+  test('long pre-break note tails advance section pages, stories, and restarted numbering', async ({
+    page,
+  }) => {
+    const words = Array.from({ length: 80 }, (_, index) => `tail-${index}`).join(' ');
+    await page.setContent(staging(`
+      <style>
+        .page-footnotes { font: 10pt/10pt Arial; }
+        .page-footnotes hr { height: 1px; margin: 0 0 3pt; border: 0; }
+        .footnote-item, .footnote-content p, .footnote-continuation p { margin: 0; }
+      </style>
+      <div id="pagination-hf-registry">
+        <div data-section="1" data-hf-type="header-first"><p>section-one-first</p></div>
+        <div data-section="1" data-hf-type="header-even"><p>section-one-even</p></div>
+        <div data-section="1" data-hf-type="header-default"><p>section-one-default</p></div>
+      </div>
+      <div id="pagination-footnote-registry">
+        <div class="footnote-item" data-footnote-id="f-long">
+          <span class="footnote-number">1</span>
+          <span class="footnote-content"><p>${words}</p></span>
+        </div>
+      </div>
+      <div data-section-index="0" ${PAGE_GEOMETRY}>
+        <p style="height:20pt">before <sup data-footnote-id="f-long">1</sup></p>
+      </div>
+      <div data-section-index="1" data-section-type="continuous"
+           data-page-num-start="10" ${PAGE_GEOMETRY}>
+        <p style="height:20pt">after continuation</p>
+      </div>`));
+
+    const result = await paginate(page, 20_000);
+    const ownedBySecondSection = result.sectionIndices
+      .map((owner, index) => ({ owner, index }))
+      .filter(({ owner }) => owner === 1)
+      .map(({ index }) => index);
+
+    expect(ownedBySecondSection.length).toBeGreaterThan(2);
+    expect(ownedBySecondSection.map((index) => result.pagesInSection[index]))
+      .toEqual(ownedBySecondSection.map((_, index) => index + 1));
+    expect(ownedBySecondSection.map((index) => result.displayedPageNumbers[index]))
+      .toEqual(ownedBySecondSection.map((_, index) => index + 10));
+    expect(ownedBySecondSection.map((index) => result.headers[index]))
+      .toEqual(ownedBySecondSection.map((_, index) =>
+        index === 0 ? 'section-one-first'
+          : (index + 1) % 2 === 0 ? 'section-one-even' : 'section-one-default'));
+    expect(result.content.flat()).toEqual(['before 1', 'after continuation']);
+    const renderedWords = result.footnotes.join(' ');
+    for (const word of words.split(' ')) {
+      expect(renderedWords.match(new RegExp(`\\b${word}\\b`, 'g'))).toHaveLength(1);
+    }
+  });
+
+  test('a tall first header advances one empty physical page without retrying forever', async ({
+    page,
+  }) => {
+    await page.setContent(staging(`
+      <div id="pagination-hf-registry">
+        <div data-section="0" data-hf-type="header-first">
+          <p style="height:80pt">tall first header</p>
+        </div>
+      </div>
+      <div data-section-index="0"
+           data-page-width="122" data-page-height="122"
+           data-content-width="120" data-content-height="120"
+           data-margin-top="1" data-margin-right="1"
+           data-margin-bottom="1" data-margin-left="1"
+           data-header-height="1" data-footer-height="1">
+        <p style="height:60pt">fits the default-header page</p>
+      </div>`));
+
+    const result = await paginate(page, 2_000);
+    expect(result.content).toEqual([[], ['fits the default-header page']]);
+    expect(result.pagesInSection).toEqual([1, 2]);
+    expect(result.headers).toEqual(['tall first header', '']);
+    expect(result.checkpoints).toBeLessThan(2_000);
   });
 
   test('footnoteLayoutLikeWW8 shares only post-break paragraphs without references', async ({

--- a/npm/tests/pagination-footnote-geometry.spec.ts
+++ b/npm/tests/pagination-footnote-geometry.spec.ts
@@ -31,6 +31,7 @@ interface NoteGeometry {
   boxBottom: number;
   notesTop: number;
   notesBottom: number;
+  notesWidth: number;
   separator: { top: number; bottom: number; width: number } | null;
   items: { top: number; bottom: number; number: string; text: string }[];
   backrefs: number;
@@ -43,7 +44,7 @@ const MEASURE = () => {
     const r = box.getBoundingClientRect();
     const notes = box.querySelector('.page-footnotes') as HTMLElement | null;
     if (!notes) {
-      return { boxTop: r.top, boxBottom: r.bottom, notesTop: 0, notesBottom: 0,
+      return { boxTop: r.top, boxBottom: r.bottom, notesTop: 0, notesBottom: 0, notesWidth: 0,
         separator: null, items: [], backrefs: 0, lineHeight: '' };
     }
     const nr = notes.getBoundingClientRect();
@@ -54,6 +55,7 @@ const MEASURE = () => {
       boxBottom: r.bottom,
       notesTop: nr.top,
       notesBottom: nr.bottom,
+      notesWidth: nr.width,
       separator: hrRect
         ? { top: hrRect.top, bottom: hrRect.bottom, width: hrRect.width }
         : null,
@@ -105,12 +107,17 @@ async function paginateGeneratedDocument(page: Page, docx: Uint8Array): Promise<
 test.describe('Paginated footnote geometry', () => {
   let onePage: NoteGeometry;
   let twoNotes: NoteGeometry;
+  let continuedNote: NoteGeometry[];
 
   test.beforeAll(async ({ browser }) => {
     const page = await browser.newPage();
     try {
       [onePage] = await paginateGeneratedDocument(page, generateFootnoteDocx(1));
       [twoNotes] = await paginateGeneratedDocument(page, generateFootnoteDocx(2));
+      continuedNote = await paginateGeneratedDocument(
+        page,
+        generateFootnoteDocx(1, 1, 1, 600),
+      );
     } finally {
       await page.close();
     }
@@ -152,6 +159,16 @@ test.describe('Paginated footnote geometry', () => {
     const gap = onePage.items[0].top - onePage.separator!.bottom;
     expect(gap, 'separator to first note gap').toBeGreaterThanOrEqual(2);
     expect(gap, 'separator to first note gap').toBeLessThanOrEqual(10);
+  });
+
+  test('continuation separator spans the full text column', async () => {
+    expect(continuedNote.length).toBeGreaterThan(2);
+    expect(continuedNote[0].separator!.width).toBeCloseTo(192, 0);
+    for (const page of continuedNote.slice(1)) {
+      expect(page.separator, 'every continuation note band needs a separator').not.toBeNull();
+      expect(page.separator!.width, 'continuation separator width')
+        .toBeCloseTo(page.notesWidth, 0);
+    }
   });
 
   test('notes stack with no renderer-invented spacing between them', async () => {

--- a/npm/tests/pagination-footnote-layout.spec.ts
+++ b/npm/tests/pagination-footnote-layout.spec.ts
@@ -127,9 +127,9 @@ function longParagraphFootnoteHtml(
         </aside>
       </div>
       <div data-section-index="0"
-           data-page-width="122" data-page-height="122"
+           data-page-width="140" data-page-height="122"
            data-content-width="120" data-content-height="120"
-           data-margin-top="1" data-margin-right="1"
+           data-margin-top="1" data-margin-right="19"
            data-margin-bottom="1" data-margin-left="1">
         <p class="body" data-source-anchor-id="p:body:citation">
           citing body <sup data-footnote-id="f-long">1</sup>
@@ -790,7 +790,6 @@ test.describe('Paginated footnote layout', () => {
         expect(result.pagesText.slice(1).some((text: string) =>
           text.includes('after-two'))).toBe(true);
         expect(result.pageMapFragments).toHaveLength(1);
-        expect(result.expectedText).toBe('oversized-unsafe after-one after-two');
       },
     );
   });

--- a/npm/tests/pagination-footnote-layout.spec.ts
+++ b/npm/tests/pagination-footnote-layout.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page, type TestInfo } from '@playwright/test';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -79,6 +79,192 @@ function finalBlockDeferralHtml(): string {
     <div id="container"></div>`;
 }
 
+const LONG_NOTE_WORDS = Array.from({ length: 120 }, (_, index) => `word-${index}`).join(' ');
+
+/**
+ * One ordinary long paragraph is deliberately wider than several 60%-height note bands. The
+ * trailing paragraphs make the former C2 failure visible: an oversized leader must not evacuate
+ * the citing page or strand otherwise splittable siblings inside one clipped continuation.
+ */
+function longParagraphFootnoteHtml(
+  trailingParagraphs = '',
+  leadingContent = LONG_NOTE_WORDS,
+  extraCss = '',
+): string {
+  return `
+    <style>
+      #staging { font: 12pt/12pt Arial; }
+      .body { height: 20pt; margin: 0; }
+      .page-footnotes { font-size: 10pt; line-height: 10pt; }
+      .page-footnotes hr { height: 1px; margin: 0 0 3pt; border: 0; }
+      .footnote-item { margin: 0; }
+      .footnote-number { display: inline; vertical-align: super; }
+      .footnote-content { display: inline; }
+      .footnote-content p:first-of-type { display: inline; }
+      .footnote-content p:not(:first-of-type) { display: block; margin: 0; }
+      .footnote-continuation p { margin: 0; }
+      ${extraCss}
+    </style>
+    <div id="staging">
+      <div id="pagination-footnote-registry">
+        <div class="footnote-item" data-footnote-id="f-long"
+             data-source-anchor-id="fn:fn:f-long">
+          <span class="footnote-number">1</span>
+          <span class="footnote-content">
+            <p id="source-long" data-anchor="long-unid"
+               data-source-anchor-id="p:fn:long">${leadingContent}</p>
+            ${trailingParagraphs}
+          </span>
+        </div>
+      </div>
+      <div data-section-index="0"
+           data-page-width="122" data-page-height="122"
+           data-content-width="120" data-content-height="120"
+           data-margin-top="1" data-margin-right="1"
+           data-margin-bottom="1" data-margin-left="1">
+        <p class="body" data-source-anchor-id="p:body:citation">
+          citing body <sup data-footnote-id="f-long">1</sup>
+        </p>
+      </div>
+    </div>
+    <div id="container"></div>`;
+}
+
+async function paginateLongFootnote(
+  page: Page,
+  trailingParagraphs = '',
+  leadingContent = LONG_NOTE_WORDS,
+  extraCss = '',
+) {
+  const expectedText = `${leadingContent.replace(/<[^>]+>/g, ' ')} ${
+    trailingParagraphs.replace(/<[^>]+>/g, ' ')
+  }`.replace(/\s+/g, ' ').trim();
+  await page.setContent(longParagraphFootnoteHtml(
+    trailingParagraphs,
+    leadingContent,
+    extraCss,
+  ));
+  await page.addScriptTag({ path: path.join(__dirname, '../dist/pagination.bundle.js') });
+  return page.evaluate(({ expectedText }: { expectedText: string }) => {
+    const staging = document.getElementById('staging') as HTMLElement;
+    const container = document.getElementById('container') as HTMLElement;
+    const { PaginationEngine } = (window as any).DocxodusPagination;
+    const pagination = new PaginationEngine(staging, container, {
+      showPageNumbers: false,
+      layoutToken: { documentVersion: 1, rendererFingerprint: 'issue-489-evidence' },
+    }).paginate();
+    const boxes = Array.from(container.querySelectorAll<HTMLElement>('.page-box'));
+    const noteBands = boxes.map((box) => box.querySelector<HTMLElement>('.page-footnotes'));
+    const paragraphFragments = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-source-anchor-id="p:fn:long"]'),
+    );
+    const visibleNoteText = boxes.map((box) => {
+      const clone = box.querySelector<HTMLElement>('.page-footnotes')?.cloneNode(true) as
+        HTMLElement | undefined;
+      clone?.querySelectorAll('.footnote-number').forEach((number) => number.remove());
+      clone?.querySelectorAll('p').forEach((paragraph) => paragraph.after(' '));
+      return clone?.textContent ?? '';
+    }).join(' ').replace(/\s+/g, ' ').trim();
+    const clipped = noteBands.flatMap((band, pageIndex) => {
+      if (!band) return [];
+      const bandRect = band.getBoundingClientRect();
+      return Array.from(band.querySelectorAll<HTMLElement>('p'))
+        .filter((paragraph) => paragraph.getBoundingClientRect().bottom > bandRect.bottom + 1)
+        .map((paragraph) => ({
+          page: pageIndex + 1,
+          anchor: paragraph.dataset.sourceAnchorId,
+          paragraphBottom: paragraph.getBoundingClientRect().bottom,
+          bandBottom: bandRect.bottom,
+        }));
+    });
+    const pageMapFragments = pagination.pageMap.fragments
+      .filter((fragment: any) => fragment.anchorId === 'p:fn:long');
+    return {
+      totalPages: pagination.totalPages,
+      notePages: noteBands.filter(Boolean).length,
+      paragraphFragments: paragraphFragments.length,
+      pageMapFragments: pageMapFragments.map((fragment: any) => ({
+        fragmentId: fragment.fragmentId,
+        fragmentIndex: fragment.fragmentIndex,
+        pageNumber: fragment.pageNumber,
+        story: fragment.story,
+        geometry: fragment.geometry,
+      })),
+      bareIds: paragraphFragments.filter((paragraph) => paragraph.id === 'source-long').length,
+      bareAnchors: paragraphFragments.filter((paragraph) =>
+        paragraph.dataset.anchor === 'long-unid').length,
+      visibleNoteText,
+      expectedText,
+      clipped,
+      firstPageText: noteBands[0]?.textContent?.replace(/\s+/g, ' ').trim() ?? '',
+      pagesText: noteBands.map((band) => band?.textContent?.replace(/\s+/g, ' ').trim() ?? ''),
+    };
+  }, { expectedText });
+}
+
+type LongFootnoteResult = Awaited<ReturnType<typeof paginateLongFootnote>>;
+
+function describeFailure(error: unknown): { name?: string; message: string; stack?: string } {
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message, stack: error.stack };
+  }
+  return { message: String(error) };
+}
+
+async function attachLongFootnoteEvidence(
+  page: Page,
+  testInfo: TestInfo,
+  scenario: string,
+  result: LongFootnoteResult | undefined,
+  failure: ReturnType<typeof describeFailure> | undefined,
+): Promise<void> {
+  const captureWarnings: string[] = [];
+  let html: Buffer | undefined;
+  let screenshot: Buffer | undefined;
+  try {
+    html = Buffer.from(await page.content());
+  } catch (error) {
+    captureWarnings.push(`HTML capture failed: ${describeFailure(error).message}`);
+  }
+  try {
+    const container = page.locator('#container');
+    if (await container.count()) screenshot = await container.screenshot();
+  } catch (error) {
+    captureWarnings.push(`screenshot capture failed: ${describeFailure(error).message}`);
+  }
+
+  await testInfo.attach(`${scenario}.json`, {
+    body: Buffer.from(JSON.stringify({ result, failure, captureWarnings }, null, 2)),
+    contentType: 'application/json',
+  });
+  if (html) {
+    await testInfo.attach(`${scenario}.html`, { body: html, contentType: 'text/html' });
+  }
+  if (screenshot) {
+    await testInfo.attach(`${scenario}.png`, { body: screenshot, contentType: 'image/png' });
+  }
+}
+
+async function withLongFootnoteEvidence(
+  page: Page,
+  testInfo: TestInfo,
+  scenario: string,
+  paginate: () => Promise<LongFootnoteResult>,
+  verify: (result: LongFootnoteResult) => void | Promise<void>,
+): Promise<void> {
+  let result: LongFootnoteResult | undefined;
+  let failure: ReturnType<typeof describeFailure> | undefined;
+  try {
+    result = await paginate();
+    await verify(result);
+  } catch (error) {
+    failure = describeFailure(error);
+    throw error;
+  } finally {
+    await attachLongFootnoteEvidence(page, testInfo, scenario, result, failure);
+  }
+}
+
 /**
  * Geometry of every rendered page. `usedPct` is BODY + NOTES against the content box: notes
  * legitimately consume page height, so body extent alone understates how full a page is — the
@@ -144,7 +330,7 @@ const MEASURE_NOTES = () => {
   };
 };
 
-async function paginate(page: any, html: string) {
+async function paginate(page: Page, html: string) {
   await page.setContent(html);
   await page.addScriptTag({ path: path.join(__dirname, '../dist/pagination.bundle.js') });
   return page.evaluate(
@@ -247,5 +433,90 @@ test.describe('Paginated footnote layout', () => {
     expect(result.clipped, `notes rendered outside their visible band: ${JSON.stringify(result.clipped)}`)
       .toEqual([]);
     expect(result.noteOnlyPages).toBeGreaterThan(0);
+  });
+
+  test('splits one long footnote paragraph across as many note bands as needed', async ({
+    page,
+  }, testInfo) => {
+    await withLongFootnoteEvidence(
+      page,
+      testInfo,
+      'issue-489-long-footnote',
+      () => paginateLongFootnote(page),
+      (result) => {
+        expect(result.totalPages).toBeGreaterThan(2);
+        expect(result.notePages).toBe(result.totalPages);
+        expect(result.paragraphFragments).toBeGreaterThan(2);
+        expect(result.pageMapFragments.length).toBe(result.paragraphFragments);
+        expect(new Set(result.pageMapFragments.map((fragment: any) => fragment.pageNumber)).size)
+          .toBeGreaterThan(2);
+        expect(result.pageMapFragments.map((fragment: any) => fragment.fragmentIndex))
+          .toEqual(result.pageMapFragments.map((_: any, index: number) => index));
+        expect(new Set(result.pageMapFragments.map((fragment: any) => fragment.fragmentId)).size)
+          .toBe(result.pageMapFragments.length);
+        expect(result.pageMapFragments.every((fragment: any) =>
+          fragment.story === 'footnote'
+          && fragment.geometry.x >= 0
+          && fragment.geometry.y >= 0
+          && fragment.geometry.width > 0
+          && fragment.geometry.height > 0)).toBe(true);
+        expect(result.bareIds).toBe(1);
+        expect(result.bareAnchors).toBe(1);
+        expect(result.visibleNoteText).toBe(LONG_NOTE_WORDS);
+        expect(result.clipped).toEqual([]);
+        expect(result.firstPageText).toContain('word-0');
+      },
+    );
+  });
+
+  test('keeps a long leading paragraph with its citation while later note paragraphs continue', async ({
+    page,
+  }, testInfo) => {
+    const trailing = `
+      <p data-source-anchor-id="p:fn:after-one">after-one</p>
+      <p data-source-anchor-id="p:fn:after-two">after-two</p>`;
+    await withLongFootnoteEvidence(
+      page,
+      testInfo,
+      'issue-489-leading-paragraph-with-siblings',
+      () => paginateLongFootnote(page, trailing),
+      (result) => {
+        expect(result.firstPageText).toContain('word-0');
+        expect(result.pagesText.some((text: string) => text.includes('after-one'))).toBe(true);
+        expect(result.pagesText.some((text: string) => text.includes('after-two'))).toBe(true);
+        expect(result.visibleNoteText).toBe(`${LONG_NOTE_WORDS} after-one after-two`);
+        expect(result.clipped).toEqual([]);
+      },
+    );
+  });
+
+  test('an indivisible oversized note paragraph does not swallow later siblings', async ({
+    page,
+  }, testInfo) => {
+    const trailing = `
+      <p data-source-anchor-id="p:fn:after-one">after-one</p>
+      <p data-source-anchor-id="p:fn:after-two">after-two</p>`;
+    await withLongFootnoteEvidence(
+      page,
+      testInfo,
+      'issue-489-indivisible-leading-paragraph',
+      () => paginateLongFootnote(
+        page,
+        trailing,
+        '<span class="unsafe-note-box">oversized-unsafe</span>',
+        '.unsafe-note-box { display: inline-block; height: 150pt; width: 10pt; }',
+      ),
+      (result) => {
+        expect(result.totalPages).toBeGreaterThan(1);
+        expect(result.firstPageText).toContain('oversized-unsafe');
+        expect(result.firstPageText).not.toContain('after-one');
+        expect(result.pagesText.slice(1).some((text: string) =>
+          text.includes('after-one'))).toBe(true);
+        expect(result.pagesText.slice(1).some((text: string) =>
+          text.includes('after-two'))).toBe(true);
+        expect(result.pageMapFragments).toHaveLength(1);
+        expect(result.expectedText).toBe('oversized-unsafe after-one after-two');
+      },
+    );
   });
 });

--- a/npm/tests/pagination-footnote-layout.spec.ts
+++ b/npm/tests/pagination-footnote-layout.spec.ts
@@ -90,6 +90,9 @@ function longParagraphFootnoteHtml(
   trailingParagraphs = '',
   leadingContent = LONG_NOTE_WORDS,
   extraCss = '',
+  itemAttributes = '',
+  contentAttributes = '',
+  separatorStories = '',
 ): string {
   return `
     <style>
@@ -107,15 +110,21 @@ function longParagraphFootnoteHtml(
     </style>
     <div id="staging">
       <div id="pagination-footnote-registry">
+        ${separatorStories}
         <div class="footnote-item" data-footnote-id="f-long"
-             data-source-anchor-id="fn:fn:f-long">
+             data-source-anchor-id="fn:fn:f-long" ${itemAttributes}>
           <span class="footnote-number">1</span>
-          <span class="footnote-content">
+          <span class="footnote-content" ${contentAttributes}>
             <p id="source-long" data-anchor="long-unid"
                data-source-anchor-id="p:fn:long">${leadingContent}</p>
             ${trailingParagraphs}
           </span>
         </div>
+      </div>
+      <div id="pagination-comment-margin-registry">
+        <aside data-comment-id="7" data-source-anchor-id="cmt:fn:seven">
+          <p>margin-comment-seven</p>
+        </aside>
       </div>
       <div data-section-index="0"
            data-page-width="122" data-page-height="122"
@@ -130,11 +139,176 @@ function longParagraphFootnoteHtml(
     <div id="container"></div>`;
 }
 
+function continuationThenNewNoteHtml(): string {
+  const longWords = Array.from({ length: 140 }, (_, index) => `first-${index}`).join(' ');
+  return `
+    <style>
+      #staging { font: 12pt/12pt Arial; }
+      .body { height: 20pt; margin: 0; }
+      .page-footnotes { font: 10pt/10pt Arial; }
+      .page-footnotes hr { height: 1px; margin: 0 0 3pt; border: 0; }
+      .footnote-item, .footnote-content p, .footnote-continuation p { margin: 0; }
+    </style>
+    <div id="staging">
+      <div id="pagination-footnote-registry">
+        <div class="footnote-item" data-footnote-id="f1">
+          <span class="footnote-number">1</span>
+          <span class="footnote-content"><p>${longWords}</p></span>
+        </div>
+        <div class="footnote-item" data-footnote-id="f2">
+          <span class="footnote-number">2</span>
+          <span class="footnote-content"><p>second-note-alpha second-note-omega</p></span>
+        </div>
+      </div>
+      <div data-section-index="0"
+           data-page-width="122" data-page-height="122"
+           data-content-width="120" data-content-height="120"
+           data-margin-top="1" data-margin-right="1"
+           data-margin-bottom="1" data-margin-left="1">
+        <p class="body">cite first <sup data-footnote-id="f1">1</sup></p>
+        <p class="body">body after first A</p>
+        <p class="body">cite second <sup data-footnote-id="f2">2</sup></p>
+        <p class="body">body after second B</p>
+      </div>
+    </div>
+    <div id="container"></div>`;
+}
+
+function noPrefixFitsCitationBandHtml(): string {
+  return `
+    <style>
+      #staging { font: 12pt/12pt Arial; }
+      .body { height: 95pt; margin: 0; }
+      .page-footnotes { font: 10pt/10pt Arial; }
+      .page-footnotes hr { height: 1px; margin: 0 0 3pt; border: 0; }
+      .footnote-item { margin: 0; }
+      .footnote-content p, .footnote-continuation p {
+        display: block; height: 40pt; line-height: 40pt; margin: 0;
+      }
+    </style>
+    <div id="staging">
+      <div id="pagination-footnote-registry">
+        <div class="footnote-item" data-footnote-id="fresh">
+          <span class="footnote-number">1</span>
+          <span class="footnote-content"><p>fresh-band-safe tail-safe</p></span>
+        </div>
+      </div>
+      <div data-section-index="0"
+           data-page-width="122" data-page-height="122"
+           data-content-width="120" data-content-height="120"
+           data-margin-top="1" data-margin-right="1"
+           data-margin-bottom="1" data-margin-left="1">
+        <p class="body">citation <sup data-footnote-id="fresh">1</sup></p>
+      </div>
+    </div>
+    <div id="container"></div>`;
+}
+
+function indivisibleFitsFreshBandHtml(): string {
+  return `
+    <style>
+      #staging { font: 12pt/12pt Arial; }
+      .body { height: 95pt; margin: 0; }
+      .page-footnotes { font: 10pt/10pt Arial; }
+      .page-footnotes hr { height: 1px; margin: 0 0 3pt; border: 0; }
+      .footnote-item, .footnote-content p, .footnote-continuation p { margin: 0; }
+      .unsafe-fresh-band { display: inline-block; height: 45pt; width: 20pt; }
+    </style>
+    <div id="staging">
+      <div id="pagination-footnote-registry">
+        <div class="footnote-item" data-footnote-id="unsafe-fresh">
+          <span class="footnote-number">1</span>
+          <span class="footnote-content">
+            <p><span class="unsafe-fresh-band">indivisible-safe</span></p>
+            <p>later-safe-sibling</p>
+          </span>
+        </div>
+      </div>
+      <div data-section-index="0"
+           data-page-width="122" data-page-height="122"
+           data-content-width="120" data-content-height="120"
+           data-margin-top="1" data-margin-right="1"
+           data-margin-bottom="1" data-margin-left="1">
+        <p class="body">citation <sup data-footnote-id="unsafe-fresh">1</sup></p>
+      </div>
+    </div>
+    <div id="container"></div>`;
+}
+
+async function paginateScenario(page: Page, html: string) {
+  await page.setContent(html);
+  await page.addScriptTag({ path: path.join(__dirname, '../dist/pagination.bundle.js') });
+  return page.evaluate(() => {
+    const staging = document.getElementById('staging') as HTMLElement;
+    const container = document.getElementById('container') as HTMLElement;
+    const { PaginationEngine } = (window as any).DocxodusPagination;
+    const result = new PaginationEngine(staging, container, {
+      showPageNumbers: false,
+      checkCancellation: (() => {
+        let checkpoints = 0;
+        return () => {
+          if (++checkpoints > 50_000) throw new Error('pagination did not make forward progress');
+        };
+      })(),
+    }).paginate();
+    const boxes = Array.from(container.querySelectorAll<HTMLElement>('.page-box'));
+    const normalized = (value: string | null | undefined) =>
+      (value ?? '').replace(/\s+/g, ' ').trim();
+    const clipped: Array<{ page: number; text: string }> = [];
+    const overlaps: number[] = [];
+    boxes.forEach((box, index) => {
+      const band = box.querySelector<HTMLElement>('.page-footnotes');
+      const content = box.querySelector<HTMLElement>('.page-content');
+      if (!band) return;
+      const bandRect = band.getBoundingClientRect();
+      for (const element of Array.from(band.querySelectorAll<HTMLElement>('p, .footnote-item'))) {
+        if (element.getBoundingClientRect().bottom > bandRect.bottom + 1) {
+          clipped.push({ page: index + 1, text: normalized(element.textContent) });
+        }
+      }
+      const body = content ? Array.from(content.children) as HTMLElement[] : [];
+      const bodyBottom = body.at(-1)?.getBoundingClientRect().bottom;
+      if (bodyBottom !== undefined && bodyBottom > bandRect.top + 1) overlaps.push(index + 1);
+    });
+    return {
+      totalPages: result.totalPages,
+      bodyByPage: boxes.map((box) => Array.from(
+        box.querySelector<HTMLElement>('.page-content')?.children ?? [],
+        (element) => normalized(element.textContent),
+      )),
+      noteTextByPage: boxes.map((box) => {
+        const clone = box.querySelector<HTMLElement>('.page-footnotes')?.cloneNode(true) as
+          HTMLElement | undefined;
+        clone?.querySelectorAll('.footnote-number').forEach((number) => number.remove());
+        return normalized(clone?.textContent);
+      }),
+      notePages: boxes.map((box, index) =>
+        box.querySelector('.page-footnotes') ? index + 1 : 0).filter(Boolean),
+      f1Parts: container.querySelectorAll('.page-footnotes [data-footnote-id="f1"]').length,
+      f2Parts: container.querySelectorAll('.page-footnotes [data-footnote-id="f2"]').length,
+      freshPages: Array.from(container.querySelectorAll<HTMLElement>(
+        '.page-footnotes [data-footnote-id="fresh"]',
+      ))
+        .map((element) => Number(element.closest<HTMLElement>('.page-box')?.dataset.pageNumber)),
+      unsafeFreshPages: Array.from(container.querySelectorAll<HTMLElement>(
+        '.page-footnotes [data-footnote-id="unsafe-fresh"]',
+      )).map((element) => Number(element.closest<HTMLElement>('.page-box')?.dataset.pageNumber)),
+      numberText: Array.from(container.querySelectorAll<HTMLElement>('.footnote-number'))
+        .map((number) => normalized(number.textContent)),
+      clipped,
+      overlaps,
+    };
+  });
+}
+
 async function paginateLongFootnote(
   page: Page,
   trailingParagraphs = '',
   leadingContent = LONG_NOTE_WORDS,
   extraCss = '',
+  itemAttributes = '',
+  contentAttributes = '',
+  separatorStories = '',
 ) {
   const expectedText = `${leadingContent.replace(/<[^>]+>/g, ' ')} ${
     trailingParagraphs.replace(/<[^>]+>/g, ' ')
@@ -143,6 +317,9 @@ async function paginateLongFootnote(
     trailingParagraphs,
     leadingContent,
     extraCss,
+    itemAttributes,
+    contentAttributes,
+    separatorStories,
   ));
   await page.addScriptTag({ path: path.join(__dirname, '../dist/pagination.bundle.js') });
   return page.evaluate(({ expectedText }: { expectedText: string }) => {
@@ -162,6 +339,7 @@ async function paginateLongFootnote(
       const clone = box.querySelector<HTMLElement>('.page-footnotes')?.cloneNode(true) as
         HTMLElement | undefined;
       clone?.querySelectorAll('.footnote-number').forEach((number) => number.remove());
+      clone?.querySelectorAll('[data-footnote-separator]').forEach((separator) => separator.remove());
       clone?.querySelectorAll('p').forEach((paragraph) => paragraph.after(' '));
       return clone?.textContent ?? '';
     }).join(' ').replace(/\s+/g, ' ').trim();
@@ -179,6 +357,16 @@ async function paginateLongFootnote(
     });
     const pageMapFragments = pagination.pageMap.fragments
       .filter((fragment: any) => fragment.anchorId === 'p:fn:long');
+    const pageNumberFor = (element: Element) => Number(
+      element.closest<HTMLElement>('.page-box')?.dataset.pageNumber ?? '0',
+    );
+    const links = Array.from(container.querySelectorAll<HTMLAnchorElement>('[data-case="link"]'));
+    const clusterParts = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-cluster-part]'),
+    );
+    const continuationShells = Array.from(
+      container.querySelectorAll<HTMLElement>('.footnote-continuation'),
+    );
     return {
       totalPages: pagination.totalPages,
       notePages: noteBands.filter(Boolean).length,
@@ -198,6 +386,93 @@ async function paginateLongFootnote(
       clipped,
       firstPageText: noteBands[0]?.textContent?.replace(/\s+/g, ' ').trim() ?? '',
       pagesText: noteBands.map((band) => band?.textContent?.replace(/\s+/g, ' ').trim() ?? ''),
+      separatorCount: container.querySelectorAll(
+        '.page-footnotes > [data-footnote-separator]',
+      ).length,
+      separatorKinds: noteBands.map((band) =>
+        band?.firstElementChild?.getAttribute('data-footnote-separator') ?? ''),
+      separatorText: noteBands.map((band) =>
+        band?.firstElementChild?.textContent?.replace(/\s+/g, ' ').trim() ?? ''),
+      separatorFirst: noteBands.every((band) => !band ||
+        Boolean(band.firstElementChild?.hasAttribute('data-footnote-separator'))),
+      separatorIdentityCount: container.querySelectorAll(
+        '.page-footnotes #separator-source, .page-footnotes [data-anchor="separator-anchor"], ' +
+        '.page-footnotes [data-source-anchor-id="p:separator-source"]',
+      ).length,
+      separatorLocalLinks: container.querySelectorAll(
+        '.page-footnotes [data-footnote-separator] a[href^="#"]',
+      ).length,
+      separatorExternalLinks: Array.from(container.querySelectorAll<HTMLAnchorElement>(
+        '.page-footnotes [data-footnote-separator] a[href^="https://"]',
+      )).map((link) => link.href),
+      numberCount: container.querySelectorAll('.page-footnotes .footnote-number').length,
+      continuationFootnoteIds: Array.from(
+        container.querySelectorAll<HTMLElement>('.footnote-continuation'),
+      ).map((wrapper) => wrapper.dataset.footnoteId ?? ''),
+      continuationShells: continuationShells.map((wrapper) => {
+        const content = wrapper.querySelector<HTMLElement>(':scope > .footnote-content');
+        const firstParagraph = content?.querySelector<HTMLElement>(
+          'p:not(.footnote-continuation-position-sentinel)',
+        );
+        const style = firstParagraph ? getComputedStyle(firstParagraph) : null;
+        return {
+          isItem: wrapper.classList.contains('footnote-item'),
+          hasDirectContent: Boolean(content),
+          shellToken: wrapper.dataset.shellToken ?? '',
+          contentToken: content?.dataset.contentToken ?? '',
+          direction: getComputedStyle(wrapper).direction,
+          lang: wrapper.lang,
+          color: style?.color ?? '',
+          display: style?.display ?? '',
+          marginLeft: style?.marginLeft ?? '',
+          sentinelCount: content?.querySelectorAll(
+            ':scope > .footnote-continuation-position-sentinel',
+          ).length ?? 0,
+          duplicateIds: wrapper.querySelectorAll('#source-note-content').length
+            + (wrapper.id === 'source-note-item' ? 1 : 0),
+          duplicateAnchors: wrapper.querySelectorAll('[data-anchor="source-content-anchor"]').length
+            + (wrapper.dataset.anchor === 'source-item-anchor' ? 1 : 0),
+        };
+      }),
+      listMarkerPages: Array.from(
+        container.querySelectorAll<HTMLElement>('[data-list-marker]'),
+      ).map(pageNumberFor),
+      bookmarkTargetCount: container.querySelectorAll('#note-bookmark').length,
+      inlineAnchorCount: container.querySelectorAll('[data-anchor="inline-note-anchor"]').length,
+      fieldCount: container.querySelectorAll('[data-field="PAGE"]').length,
+      linkHrefs: links.map((link) => link.getAttribute('href')),
+      linkText: links.map((link) => link.textContent ?? '').join(''),
+      commentText: Array.from(
+        container.querySelectorAll<HTMLElement>('[data-comment-id="7"]'),
+      ).map((comment) => comment.textContent ?? '').join(''),
+      commentPageMapFragments: pagination.pageMap.fragments.filter(
+        (fragment: any) => fragment.anchorId === 'cmt:fn:seven',
+      ).length,
+      commentMarkerCount: container.querySelectorAll('a[data-comment-id="7"]').length,
+      marginCommentCount: container.querySelectorAll(
+        '.page-comment-margin > [data-comment-id="7"]',
+      ).length,
+      marginCommentText: Array.from(container.querySelectorAll<HTMLElement>(
+        '.page-comment-margin > [data-comment-id="7"]',
+      )).map((comment) => comment.textContent?.replace(/\s+/g, ' ').trim() ?? '').join(' '),
+      richPayloadText: Array.from(
+        container.querySelectorAll<HTMLElement>('[data-case="rich-payload"]'),
+      ).map((fragment) => fragment.textContent ?? '').join(''),
+      richPayloadFragments: container.querySelectorAll('[data-case="rich-payload"]').length,
+      crossRunFragments: Array.from(container.querySelectorAll<HTMLElement>(
+        '[data-case="cross-run"]',
+      )).map((fragment) => fragment.textContent ?? ''),
+      cjkFragments: Array.from(container.querySelectorAll<HTMLElement>(
+        '[data-case="cjk"]',
+      )).map((fragment) => fragment.textContent ?? ''),
+      clusterPartCounts: ['left', 'right'].map((part) =>
+        clusterParts.filter((element) => element.dataset.clusterPart === part).length),
+      clusterPages: clusterParts.map(pageNumberFor),
+      tableText: container.querySelector<HTMLElement>('[data-case="note-table"]')?.textContent
+        ?.replace(/\s+/g, ' ').trim() ?? '',
+      tablePageMapFragments: pagination.pageMap.fragments.filter(
+        (fragment: any) => fragment.anchorId === 'tbl:fn:tail-table',
+      ).length,
     };
   }, { expectedText });
 }
@@ -518,5 +793,277 @@ test.describe('Paginated footnote layout', () => {
         expect(result.expectedText).toBe('oversized-unsafe after-one after-two');
       },
     );
+  });
+
+  test('drains an older continuation before admitting later body and note payloads', async ({
+    page,
+  }) => {
+    const result = await paginateScenario(page, continuationThenNewNoteHtml());
+    expect(result.totalPages).toBeGreaterThan(3);
+    expect(result.bodyByPage.flat()).toEqual([
+      'cite first 1',
+      'body after first A',
+      'cite second 2',
+      'body after second B',
+    ]);
+    const noteText = result.noteTextByPage.join(' ');
+    for (const token of ['first-0', 'first-70', 'first-139', 'second-note-alpha', 'second-note-omega']) {
+      expect(noteText.match(new RegExp(`\\b${token}\\b`, 'g'))).toHaveLength(1);
+    }
+    expect(result.f1Parts).toBeGreaterThan(2);
+    expect(result.f2Parts).toBe(1);
+    expect(result.numberText).toEqual(['1', '2']);
+    expect(result.clipped).toEqual([]);
+    expect(result.overlaps).toEqual([]);
+  });
+
+  test('defers a splittable paragraph when no safe prefix fits the citation band', async ({
+    page,
+  }) => {
+    const result = await paginateScenario(page, noPrefixFitsCitationBandHtml());
+    expect(result.totalPages).toBe(2);
+    expect(result.bodyByPage).toEqual([['citation 1'], []]);
+    expect(result.noteTextByPage[0]).toBe('');
+    expect(result.noteTextByPage[1]).toContain('fresh-band-safe tail-safe');
+    expect(result.freshPages).toEqual([2]);
+    expect(result.numberText).toEqual(['1']);
+    expect(result.clipped).toEqual([]);
+    expect(result.overlaps).toEqual([]);
+  });
+
+  test('defers indivisible content that fits a fresh band instead of clipping the residual band', async ({
+    page,
+  }) => {
+    const result = await paginateScenario(page, indivisibleFitsFreshBandHtml());
+    expect(result.totalPages).toBe(2);
+    expect(result.noteTextByPage[0]).toBe('');
+    expect(result.noteTextByPage[1]).toContain('indivisible-safe later-safe-sibling');
+    expect(result.unsafeFreshPages).toEqual([2]);
+    expect(result.numberText).toEqual(['1']);
+    expect(result.clipped).toEqual([]);
+    expect(result.overlaps).toEqual([]);
+  });
+
+  test('preserves Unicode clusters and semantic inline/table content across a long note', async ({
+    page,
+  }, testInfo) => {
+    const linkText = Array.from({ length: 45 }, (_, index) => `linked-${index} `).join('');
+    const cjk = '漢字仮名交じり文。'.repeat(24);
+    const payload = `• A\u00a0B C\u2060D e\u0301 👨‍👩‍👧‍👦 שלום 42 [7] ` +
+      `LatinCrossRunBoundary ${linkText}${cjk}`;
+    const leading = `<span data-case="rich-payload" data-anchor="inline-note-anchor">` +
+      `<span data-list-marker="true">• </span>` +
+      `<a id="note-bookmark"></a>` +
+      `<span>A\u00a0B C\u2060D e\u0301 </span>` +
+      `<span data-cluster-part="left">👨</span><span data-cluster-part="right">‍👩‍👧‍👦</span>` +
+      `<b dir="rtl"> שלום </b>` +
+      `<span data-field="PAGE">42</span> ` +
+      `<a id="comment-ref-7" href="#comment-7" data-comment-id="7" ` +
+      `>[7]</a> ` +
+      `<span data-case="cross-run"><span>LatinCross</span><span>RunBoundary</span></span> ` +
+      `<a data-case="link" href="https://example.test/note">${linkText}</a>` +
+      `<span data-case="cjk">${cjk}</span></span>`;
+    const trailing = `<table data-case="note-table" data-source-anchor-id="tbl:fn:tail-table">` +
+      `<tbody><tr><td>tail-table-cell</td></tr></tbody></table>`;
+
+    await withLongFootnoteEvidence(
+      page,
+      testInfo,
+      'issue-489-rich-lossless-continuation',
+      () => paginateLongFootnote(page, trailing, leading),
+      (result) => {
+        expect(result.totalPages).toBeGreaterThan(3);
+        expect(result.richPayloadFragments).toBeGreaterThan(2);
+        expect(result.richPayloadText).toBe(payload);
+        expect(result.crossRunFragments).toEqual(['LatinCrossRunBoundary']);
+        expect(result.cjkFragments.join('')).toBe(cjk);
+        expect(result.cjkFragments.every((fragment: string) =>
+          !fragment.startsWith('。') && !/[「『（［｛]$/.test(fragment))).toBe(true);
+        expect(result.clusterPartCounts).toEqual([1, 1]);
+        expect(result.listMarkerPages).toHaveLength(1);
+        expect(result.bookmarkTargetCount).toBe(1);
+        expect(result.inlineAnchorCount).toBe(1);
+        expect(result.fieldCount).toBe(1);
+        expect(result.commentMarkerCount).toBe(1);
+        expect(result.marginCommentCount).toBe(1);
+        expect(result.marginCommentText).toBe('margin-comment-seven');
+        expect(result.commentText).toContain('[7]');
+        expect(result.commentText).toContain('margin-comment-seven');
+        expect(result.commentPageMapFragments).toBe(1);
+        expect(result.linkHrefs.length).toBeGreaterThan(1);
+        expect(result.linkHrefs.every((href: string | null) =>
+          href === 'https://example.test/note')).toBe(true);
+        expect(result.linkText).toBe(linkText);
+        expect(result.tableText).toBe('tail-table-cell');
+        expect(result.tablePageMapFragments).toBe(1);
+        expect(result.numberCount).toBe(1);
+        expect(result.separatorCount).toBe(result.notePages);
+        expect(result.continuationFootnoteIds.every((id: string) => id === 'f-long')).toBe(true);
+        expect(result.clipped).toEqual([]);
+      },
+    );
+  });
+
+  test('continues inside the source note/content shells without duplicating their identities', async ({
+    page,
+  }, testInfo) => {
+    const trailing = `<p data-source-anchor-id="p:fn:styled-tail">${LONG_NOTE_WORDS}</p>`;
+    await withLongFootnoteEvidence(
+      page,
+      testInfo,
+      'issue-489-continuation-shell-inheritance',
+      () => paginateLongFootnote(
+        page,
+        trailing,
+        'short first paragraph',
+        `[data-shell-token="kept"] > [data-content-token="kept"] { color: rgb(1, 2, 3); }
+         [data-content-token="kept"] p:not(:first-of-type) { margin-left: 19px; }`,
+        `id="source-note-item" data-anchor="source-item-anchor"
+         data-shell-token="kept" dir="rtl" lang="ar"`,
+        `id="source-note-content" data-anchor="source-content-anchor"
+         data-content-token="kept"`,
+      ),
+      (result) => {
+        expect(result.continuationShells.length).toBeGreaterThan(2);
+        expect(result.continuationShells.every((shell: any) =>
+          shell.isItem
+          && shell.hasDirectContent
+          && shell.shellToken === 'kept'
+          && shell.contentToken === 'kept'
+          && shell.direction === 'rtl'
+          && shell.lang === 'ar'
+          && shell.color === 'rgb(1, 2, 3)'
+          && shell.display === 'block'
+          && shell.marginLeft === '19px'
+          && shell.sentinelCount === 1
+          && shell.duplicateIds === 0
+          && shell.duplicateAnchors === 0)).toBe(true);
+        expect(result.visibleNoteText).toBe(`short first paragraph ${LONG_NOTE_WORDS}`);
+        expect(result.clipped).toEqual([]);
+      },
+    );
+  });
+
+  test('selects and sanitizes authored normal and continuation separator stories', async ({
+    page,
+  }, testInfo) => {
+    const separatorStories = `
+      <div data-footnote-separator="normal" id="separator-source"
+           data-anchor="separator-anchor" data-source-anchor-id="p:separator-source">
+        <span>NORMAL-STORY</span><a href="#separator-source">local</a>
+        <a href="https://example.test/separator">external</a>
+        <span data-footnote-id="not-a-definition">nested-semantic</span>
+      </div>
+      <div data-footnote-separator="continuation" id="separator-source"
+           data-anchor="separator-anchor" data-source-anchor-id="p:separator-source">
+        <span>CONTINUATION-STORY</span><a href="#separator-source">local</a>
+        <a href="https://example.test/separator">external</a>
+      </div>`;
+    await withLongFootnoteEvidence(
+      page,
+      testInfo,
+      'issue-489-custom-footnote-separators',
+      () => paginateLongFootnote(page, '', LONG_NOTE_WORDS, '', '', '', separatorStories),
+      (result) => {
+        expect(result.notePages).toBeGreaterThan(2);
+        expect(result.separatorCount).toBe(result.notePages);
+        expect(result.separatorKinds).toEqual([
+          'normal',
+          ...Array.from({ length: result.notePages - 1 }, () => 'continuation'),
+        ]);
+        expect(result.separatorText[0]).toContain('NORMAL-STORY');
+        expect(result.separatorText.slice(1).every((text: string) =>
+          text.includes('CONTINUATION-STORY') && !text.includes('NORMAL-STORY'))).toBe(true);
+        expect(result.separatorFirst).toBe(true);
+        expect(result.separatorIdentityCount).toBe(0);
+        expect(result.separatorLocalLinks).toBe(0);
+        expect(result.separatorExternalLinks).toHaveLength(result.notePages);
+        expect(result.visibleNoteText).toBe(LONG_NOTE_WORDS);
+        expect(result.clipped).toEqual([]);
+      },
+    );
+  });
+
+  test('checks the prospective page cap before appending a continuation page', async ({ page }) => {
+    await page.setContent(longParagraphFootnoteHtml());
+    await page.addScriptTag({ path: path.join(__dirname, '../dist/pagination.bundle.js') });
+    const result = await page.evaluate(() => {
+      const staging = document.getElementById('staging') as HTMLElement;
+      const container = document.getElementById('container') as HTMLElement;
+      const { PaginationEngine } = (window as any).DocxodusPagination;
+      const checks: number[] = [];
+      let message = '';
+      try {
+        new PaginationEngine(staging, container, {
+          showPageNumbers: false,
+          checkPageCount: (count: number) => {
+            checks.push(count);
+            if (count > 1) throw new Error('finalPages limit 1');
+          },
+        }).paginate();
+      } catch (error) {
+        message = String(error);
+      }
+      return {
+        checks,
+        message,
+        pages: container.querySelectorAll('.page-box').length,
+      };
+    });
+
+    expect(result.message).toContain('finalPages limit 1');
+    expect(result.checks).toEqual([1, 2]);
+    expect(result.pages).toBe(1);
+  });
+
+  test('charges the next page before cloning an adversarial continuation tail', async ({ page }) => {
+    const tail = Array.from({ length: 1_200 }, (_, index) =>
+      `<p style="height:0;line-height:0;margin:0">tail-${index}</p>`).join('');
+    await page.setContent(longParagraphFootnoteHtml(tail));
+    await page.addScriptTag({ path: path.join(__dirname, '../dist/pagination.bundle.js') });
+    const result = await page.evaluate(() => {
+      const staging = document.getElementById('staging') as HTMLElement;
+      const container = document.getElementById('container') as HTMLElement;
+      const { PaginationEngine } = (window as any).DocxodusPagination;
+      const originalCloneNode = Node.prototype.cloneNode;
+      let cloneCalls = 0;
+      Node.prototype.cloneNode = function patchedCloneNode(deep?: boolean) {
+        cloneCalls++;
+        return originalCloneNode.call(this, deep);
+      };
+      const admissions: Array<{ page: number; cloneCalls: number }> = [];
+      let message = '';
+      try {
+        new PaginationEngine(staging, container, {
+          showPageNumbers: false,
+          checkPageCount: (prospectivePage: number) => {
+            admissions.push({ page: prospectivePage, cloneCalls });
+            if (prospectivePage === 2) throw new Error('finalPages adversarial cap');
+          },
+          checkCancellation: (() => {
+            let checks = 0;
+            return () => {
+              if (++checks > 50_000) throw new Error('unbounded continuation work');
+            };
+          })(),
+        }).paginate();
+      } catch (error) {
+        message = String(error);
+      } finally {
+        Node.prototype.cloneNode = originalCloneNode;
+      }
+      return {
+        admissions,
+        message,
+        pages: container.querySelectorAll('.page-box').length,
+      };
+    });
+
+    expect(result.message).toContain('finalPages adversarial cap');
+    expect(result.admissions.map((entry) => entry.page)).toEqual([1, 2]);
+    // Page-one materialization may clone the visible head, but the 1,200-node
+    // tail must not be partitioned/recloned before page two is admitted.
+    expect(result.admissions[1].cloneCalls - result.admissions[0].cloneCalls).toBeLessThan(250);
+    expect(result.pages).toBe(1);
   });
 });

--- a/npm/tests/pagination-keep-with-next.spec.ts
+++ b/npm/tests/pagination-keep-with-next.spec.ts
@@ -116,13 +116,19 @@ test.describe('Pagination keep-with-next chains', () => {
 
     expect(result.content).toEqual([
       ['lead1'],
-      [],
       ['heading', 'body'],
+      [],
     ]);
     // The note is 3 x 30pt against a 60pt band (60% of a 100pt body), and the band carries
     // the separator: one paragraph measures 40.5pt and two measure 70.5pt, so exactly one
     // paragraph fits per page and the tail needs a third note area. The chain placement is
     // what this test pins; the note simply keeps flowing under it rather than being clipped.
+    //
+    // The carried tail is partitioned to its own band before the page's body is filled, so
+    // page two reserves the one paragraph it can show (40.5pt) rather than the whole 70.5pt
+    // remainder. The chain therefore fits under it, which is what "a page whose notes are
+    // capped still fills its remaining body space" requires: reserving the unshowable
+    // remainder used to leave that page's body empty for no visible gain.
     expect(result.footnotePages).toEqual([true, true, true]);
   });
 

--- a/npm/tests/standalone-export.spec.ts
+++ b/npm/tests/standalone-export.spec.ts
@@ -667,7 +667,7 @@ test('PaginationEngine uses the element realm and applies scale exactly once', a
     </style><div id="staging">
       <div id="pagination-footnote-registry"><div class="footnote-item" data-footnote-id="realm-note">
         <span class="footnote-number">1</span><span class="footnote-content"><p>${
-          Array.from({ length: 240 }, (_, index) => `realm-${index}`).join(' ')
+          Array.from({ length: 900 }, (_, index) => `realm-${index}`).join(' ')
         }</p></span></div></div>
       <section data-section-index="0" data-page-width="612"
       data-page-height="792" data-content-width="468" data-content-height="648"
@@ -719,7 +719,10 @@ test('PaginationEngine uses the element realm and applies scale exactly once', a
   expect(Number(result.zoom)).toBeCloseTo(0.8, 5);
   expect(result.transform).toBe('');
   expect(result.secondCall).toContain('one-shot');
+  // The note must outrun one 60%-of-648pt band, or "continues in the foreign
+  // realm" is not what this asserts: 240 words measured ~230pt and fitted a
+  // single band, so the split it claimed to prove never happened.
   expect(result.notePages).toBeGreaterThan(1);
   expect(result.noteText).toContain('realm-0');
-  expect(result.noteText).toContain('realm-239');
+  expect(result.noteText).toContain('realm-899');
 });

--- a/npm/tests/standalone-export.spec.ts
+++ b/npm/tests/standalone-export.spec.ts
@@ -416,6 +416,88 @@ test.describe('standalone paginated HTML', () => {
     expect(linkAudit.fragmentsResolve).toBe(true);
   });
 
+  test('exports a converter-produced multi-page footnote losslessly and deterministically', async ({
+    page,
+    context,
+  }) => {
+    const source = generateFootnoteDocx(1, 1, 1, 600, {
+      normalText: 'NORMAL-SEPARATOR-STORY',
+      continuationText: 'CONTINUATION-SEPARATOR-STORY',
+    });
+    const first = await convert(page, source);
+    const second = await convert(page, source);
+
+    expect(first.pageCount).toBeGreaterThan(2);
+    expect(second.html).toBe(first.html);
+    expect(canonical(second.pageMap)).toBe(canonical(first.pageMap));
+    expect(second.renderReport.bindings).toEqual(first.renderReport.bindings);
+    expect(first.renderReport.pages).toEqual(first.pageMap.pages);
+
+    const audit = await page.evaluate((html) => {
+      const parsed = new DOMParser().parseFromString(html, 'text/html');
+      const ids = Array.from(parsed.querySelectorAll<HTMLElement>('[id]'), (element) => element.id);
+      const noteBands = Array.from(parsed.querySelectorAll<HTMLElement>('.page-footnotes'));
+      return {
+        notePages: noteBands.length,
+        noteText: noteBands.map((band) => band.textContent ?? '').join(' ')
+          .replace(/\s+/g, ' ').trim(),
+        separators: parsed.querySelectorAll(
+          '.page-footnotes > [data-footnote-separator]',
+        ).length,
+        separatorKinds: noteBands.map((band) =>
+          band.firstElementChild?.getAttribute('data-footnote-separator') ?? ''),
+        separatorText: noteBands.map((band) =>
+          band.firstElementChild?.textContent?.replace(/\s+/g, ' ').trim() ?? ''),
+        numbers: parsed.querySelectorAll('.page-footnotes .footnote-number').length,
+        uniqueIds: new Set(ids).size === ids.length,
+        continuationIds: Array.from(
+          parsed.querySelectorAll<HTMLElement>('.footnote-continuation'),
+          (element) => element.dataset.footnoteId,
+        ),
+      };
+    }, first.html);
+    expect(audit.notePages).toBe(first.pageCount);
+    expect(audit.separators).toBe(audit.notePages);
+    expect(audit.separatorKinds).toEqual([
+      'normal',
+      ...Array.from({ length: audit.notePages - 1 }, () => 'continuation'),
+    ]);
+    expect(audit.separatorText[0]).toContain('NORMAL-SEPARATOR-STORY');
+    expect(audit.separatorText.slice(1).every((text) =>
+      text.includes('CONTINUATION-SEPARATOR-STORY')
+      && !text.includes('NORMAL-SEPARATOR-STORY'))).toBe(true);
+    expect(audit.numbers).toBe(1);
+    expect(audit.uniqueIds).toBe(true);
+    expect(audit.continuationIds.length).toBeGreaterThan(1);
+    expect(audit.continuationIds.every((id) => id === '1')).toBe(true);
+    for (const index of [1, 2, 150, 300, 450, 599, 600]) {
+      const token = `footnote-1-1-${index}`;
+      expect(audit.noteText.match(new RegExp(`\\b${token}\\b`, 'g'))).toHaveLength(1);
+    }
+
+    const fragments = first.pageMap.fragments as Array<{
+      story?: string;
+      anchorId?: string;
+      pageNumber?: number;
+      fragmentIndex?: number;
+    }>;
+    const paragraphFragments = fragments.filter((fragment) =>
+      fragment.story === 'footnote' && fragment.anchorId?.startsWith('p:fn:'));
+    expect(paragraphFragments.length).toBeGreaterThan(2);
+    expect(new Set(paragraphFragments.map((fragment) => fragment.pageNumber)).size)
+      .toBeGreaterThan(2);
+    expect(paragraphFragments.map((fragment) => fragment.fragmentIndex))
+      .toEqual(paragraphFragments.map((_, index) => index));
+
+    const offline = await context.newPage();
+    const requests: string[] = [];
+    offline.on('request', (request) => requests.push(request.url()));
+    await offline.setContent(first.html, { waitUntil: 'load' });
+    expect(await offline.locator('.page-box').count()).toBe(first.pageCount);
+    expect(requests).toEqual([]);
+    await offline.close();
+  });
+
   test('applies each review profile exactly once and proves already-applied input', async ({ page }) => {
     const source = generateTrackedRevisionDocx();
     const sourceDigest = digest(source);
@@ -579,33 +661,53 @@ test('PaginationEngine uses the element realm and applies scale exactly once', a
     const loaded = new Promise<void>((resolve) => frame.addEventListener('load', () => resolve(), { once: true }));
     frame.srcdoc = `<!doctype html><style>
       body{margin:0}.page-box{box-sizing:border-box;background:white}.page-container{display:flex}
-      table{border-collapse:collapse}td{height:20pt}
-    </style><div id="staging"><section data-section-index="0" data-page-width="612"
+      table{border-collapse:collapse}td{height:20pt}.body{height:20pt;margin:0}
+      .page-footnotes{font:10pt/10pt Arial}.page-footnotes hr{height:1px;margin:0 0 3pt;border:0}
+      .footnote-item,.footnote-content p,.footnote-continuation p{margin:0}
+    </style><div id="staging">
+      <div id="pagination-footnote-registry"><div class="footnote-item" data-footnote-id="realm-note">
+        <span class="footnote-number">1</span><span class="footnote-content"><p>${
+          Array.from({ length: 240 }, (_, index) => `realm-${index}`).join(' ')
+        }</p></span></div></div>
+      <section data-section-index="0" data-page-width="612"
       data-page-height="792" data-content-width="468" data-content-height="648"
       data-margin-top="72" data-margin-right="72" data-margin-bottom="72" data-margin-left="72">
+      <p class="body">foreign realm note <sup data-footnote-id="realm-note">1</sup></p>
       <div><table><tbody>${'<tr><td>row</td></tr>'.repeat(45)}</tbody></table></div>
     </section></div><div id="pages" class="page-container"></div>`;
     document.body.appendChild(frame);
     await loaded;
     try {
       const foreign = frame.contentDocument!;
-      const engine = new (window as any).DocxodusPagination.PaginationEngine(
-        foreign.getElementById('staging'),
-        foreign.getElementById('pages'),
-        { scale: 0.8, showPageNumbers: false, pageGap: 0 },
-      );
-      const pagination = engine.paginate();
-      let secondCall = '';
-      try { engine.paginate(); } catch (error) { secondCall = String(error); }
-      const first = foreign.querySelector<HTMLElement>('.page-box')!;
-      return {
-        pages: pagination.totalPages,
-        width: first.getBoundingClientRect().width,
-        authoredWidth: first.style.width,
-        zoom: first.style.zoom,
-        transform: first.style.transform,
-        secondCall,
-      };
+      const hostCreateElement = document.createElement;
+      document.createElement = (() => {
+        throw new Error('host document.createElement must not be used');
+      }) as typeof document.createElement;
+      try {
+        const engine = new (window as any).DocxodusPagination.PaginationEngine(
+          foreign.getElementById('staging'),
+          foreign.getElementById('pages'),
+          { scale: 0.8, showPageNumbers: false, pageGap: 0 },
+        );
+        const pagination = engine.paginate();
+        let secondCall = '';
+        try { engine.paginate(); } catch (error) { secondCall = String(error); }
+        const first = foreign.querySelector<HTMLElement>('.page-box')!;
+        const noteText = Array.from(foreign.querySelectorAll<HTMLElement>('.page-footnotes'))
+          .map((band) => band.textContent ?? '').join(' ').replace(/\s+/g, ' ').trim();
+        return {
+          pages: pagination.totalPages,
+          width: first.getBoundingClientRect().width,
+          authoredWidth: first.style.width,
+          zoom: first.style.zoom,
+          transform: first.style.transform,
+          secondCall,
+          notePages: foreign.querySelectorAll('.page-footnotes').length,
+          noteText,
+        };
+      } finally {
+        document.createElement = hostCreateElement;
+      }
     } finally {
       frame.remove();
     }
@@ -617,4 +719,7 @@ test('PaginationEngine uses the element realm and applies scale exactly once', a
   expect(Number(result.zoom)).toBeCloseTo(0.8, 5);
   expect(result.transform).toBe('');
   expect(result.secondCall).toContain('one-shot');
+  expect(result.notePages).toBeGreaterThan(1);
+  expect(result.noteText).toContain('realm-0');
+  expect(result.noteText).toContain('realm-239');
 });


### PR DESCRIPTION
Closes #489.

## What changed

- Reuses the conservative DOM Range paragraph fragmenter for long footnotes.
- Measures initial and continuation fragments in their exact rendered wrapper context.
- Preserves canonical PageMap anchors and contiguous fragment indices across pages.
- Keeps the bounded fallback for unsafe/indivisible content while allowing later siblings to continue.
- Uploads the Playwright HTML report and raw test evidence on every CI run.

## Root cause and impact

Whole-paragraph continuation left an ordinary footnote paragraph taller than the note band clipped on every attempt. Its invisible tail never received a later page or PageMap fragment. Long text-only footnotes now drain across as many note bands as necessary without duplicating editable DOM identity.

## Validation

- TypeScript typecheck and pagination bundle build
- Focused footnote/PageMap suite: 16/16
- Adjacent pagination regression suite: 25/25
- Final artifact suite: 4/4
- `git diff --check`