### PR TITLE
Add generated PDF fidelity ratchet

### DIFF
--- a/.github/workflows/visual-parity.yml
+++ b/.github/workflows/visual-parity.yml
@@ -28,6 +28,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: visual-parity-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   visual-parity:
     runs-on: ubuntu-latest
@@ -108,8 +112,25 @@ jobs:
       # fails at start, with this same guidance, when they drift.
       - name: Install pinned LibreOffice 25.8.7.3 (reference-version contract)
         run: |
-          curl -sSL -o /tmp/libreoffice.tar.gz \
+          curl -fsS --retry 3 --proto '=https' --tlsv1.2 --max-filesize 300000000 \
+            -o /tmp/libreoffice.tar.gz \
             "https://downloadarchive.documentfoundation.org/libreoffice/old/25.8.7.3/deb/x86_64/LibreOffice_25.8.7.3_Linux_x86-64_deb.tar.gz"
+          curl -fsS --retry 3 --proto '=https' --tlsv1.2 --max-filesize 1048576 \
+            -o /tmp/libreoffice.tar.gz.asc \
+            "https://downloadarchive.documentfoundation.org/libreoffice/old/25.8.7.3/deb/x86_64/LibreOffice_25.8.7.3_Linux_x86-64_deb.tar.gz.asc"
+          curl -fsS --retry 3 --proto '=https' --tlsv1.2 --max-filesize 1048576 \
+            -o /tmp/libreoffice-signing-key.asc \
+            "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xC2839ECAD9408FBE9531C3E9F434A1EFAFEEAEA3"
+          libreoffice_gnupg_home="$(mktemp -d)"
+          chmod 700 "$libreoffice_gnupg_home"
+          gpg --batch --homedir "$libreoffice_gnupg_home" \
+            --import /tmp/libreoffice-signing-key.asc
+          libreoffice_key_fingerprint="$(gpg --batch --homedir "$libreoffice_gnupg_home" \
+            --with-colons --fingerprint C2839ECAD9408FBE9531C3E9F434A1EFAFEEAEA3 \
+            | awk -F: '$1 == "fpr" { print $10; exit }')"
+          test "$libreoffice_key_fingerprint" = "C2839ECAD9408FBE9531C3E9F434A1EFAFEEAEA3"
+          gpg --batch --homedir "$libreoffice_gnupg_home" \
+            --verify /tmp/libreoffice.tar.gz.asc /tmp/libreoffice.tar.gz
           tar -xzf /tmp/libreoffice.tar.gz -C /tmp
           sudo dpkg -i /tmp/LibreOffice_*_Linux_x86-64_deb/DEBS/*.deb
           sudo rm -f /opt/libreoffice25.8/share/fonts/truetype/Carlito*.ttf \

--- a/.github/workflows/visual-parity.yml
+++ b/.github/workflows/visual-parity.yml
@@ -1,10 +1,15 @@
 name: LibreOffice visual parity
 
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       filter:
-        description: Optional comma-separated corpus case IDs
+        description: Optional comma-separated browser-page corpus case IDs
+        required: false
+        type: string
+      pdf_filter:
+        description: Optional comma-separated generated-PDF corpus case IDs
         required: false
         type: string
       strict:
@@ -26,11 +31,54 @@ permissions:
 jobs:
   visual-parity:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # The browser-page benchmark and the generated-PDF benchmark each traverse the full corpus.
+    # Keep one bounded job so they share the exact reference environment, with enough time for
+    # the second benchmark to finish and publish its own failure evidence.
+    timeout-minutes: 90
 
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+
+      # Create a portable, viewable artifact before any tool install or build can fail. The
+      # generated-PDF runner replaces the pending page and adds its reports as it progresses;
+      # if setup fails first, reviewers still receive the commit/run context instead of an empty
+      # artifact upload.
+      - name: Initialize generated-PDF parity artifacts
+        env:
+          DOCXODUS_GENERATED_PDF_PARITY_OUTPUT: ${{ runner.temp }}/docxodus-generated-pdf-parity
+          DOCXODUS_CI_COMMIT: ${{ github.sha }}
+          DOCXODUS_CI_EVENT: ${{ github.event_name }}
+          DOCXODUS_CI_REF: ${{ github.ref }}
+          DOCXODUS_CI_REPOSITORY: ${{ github.repository }}
+          DOCXODUS_CI_RUN_ATTEMPT: ${{ github.run_attempt }}
+          DOCXODUS_CI_RUN_ID: ${{ github.run_id }}
+        run: |
+          mkdir -p "$DOCXODUS_GENERATED_PDF_PARITY_OUTPUT"
+          node --input-type=module <<'NODE'
+          import { writeFileSync } from 'node:fs';
+          import { join } from 'node:path';
+
+          const output = process.env.DOCXODUS_GENERATED_PDF_PARITY_OUTPUT;
+          const context = {
+            schemaVersion: 1,
+            status: 'pending',
+            createdAt: new Date().toISOString(),
+            repository: process.env.DOCXODUS_CI_REPOSITORY,
+            commit: process.env.DOCXODUS_CI_COMMIT,
+            ref: process.env.DOCXODUS_CI_REF,
+            event: process.env.DOCXODUS_CI_EVENT,
+            runId: process.env.DOCXODUS_CI_RUN_ID,
+            runAttempt: process.env.DOCXODUS_CI_RUN_ATTEMPT,
+            runner: { os: process.platform, architecture: process.arch },
+          };
+          writeFileSync(join(output, 'ci-context.json'), `${JSON.stringify(context, null, 2)}\n`);
+          writeFileSync(join(output, 'index.html'), `<!doctype html>
+          <meta charset="utf-8"><title>Docxodus generated-PDF parity</title>
+          <h1>Generated-PDF parity evidence</h1>
+          <p>The test has not completed. If no other files are present, CI failed during setup or build.</p>
+          <p><a href="ci-context.json">CI run context</a></p>\n`);
+          NODE
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -77,13 +125,21 @@ jobs:
       - name: Build npm package
         run: cd npm && npm run build
 
+      # Build the supported Node/PDF surface the generated-PDF benchmark invokes. A normal
+      # install retains @playwright/browser-chromium's exact package-owned browser revision.
+      - name: Install Node export companion dependencies
+        run: cd npm-export && npm ci
+
+      - name: Build Node export companion
+        run: cd npm-export && npm run build
+
       - name: Install Chromium
         run: cd npm && npx playwright install --with-deps chromium
 
       # The regression ratchet (issue #395) compares this run against the committed record and
-      # fails when any case got worse. A scheduled run has no `inputs`, so the expression falls
-      # through to '1' — the weekly run is the one that most needs the gate, because nobody is
-      # watching it. Refresh the record deliberately in the PR that changes rendering.
+      # fails when any case got worse. Pull-request and scheduled runs have no `inputs`, so the
+      # expression falls through to '1'. Refresh the record deliberately in the PR that changes
+      # rendering; conversion, page-count, geometry, and semantic contracts remain unconditional.
       - name: Compare stratified corpus with LibreOffice
         env:
           DOCXODUS_VISUAL_PARITY_OUTPUT: ${{ runner.temp }}/docxodus-visual-parity
@@ -92,6 +148,17 @@ jobs:
           DOCXODUS_VISUAL_PARITY_RATCHET: ${{ github.event_name == 'workflow_dispatch' && !inputs.ratchet && '0' || '1' }}
         run: cd npm && npm run test:visual-parity
 
+      # Run even when the older browser-page benchmark found a regression: the delivered-PDF
+      # evidence is independently useful, and the job still retains the earlier failing status.
+      - name: Compare generated PDFs with LibreOffice PDFs
+        if: ${{ !cancelled() }}
+        env:
+          DOCXODUS_GENERATED_PDF_PARITY_OUTPUT: ${{ runner.temp }}/docxodus-generated-pdf-parity
+          DOCXODUS_GENERATED_PDF_PARITY_FILTER: ${{ inputs.pdf_filter }}
+          DOCXODUS_VISUAL_PARITY_STRICT: ${{ inputs.strict && '1' || '0' }}
+          DOCXODUS_VISUAL_PARITY_RATCHET: ${{ github.event_name == 'workflow_dispatch' && !inputs.ratchet && '0' || '1' }}
+        run: cd npm && npm run test:generated-pdf-parity
+
       - name: Upload visual comparison report
         uses: actions/upload-artifact@v7
         if: always()
@@ -99,4 +166,15 @@ jobs:
           name: libreoffice-visual-parity
           path: ${{ runner.temp }}/docxodus-visual-parity/
           if-no-files-found: warn
+          retention-days: 14
+
+      - name: Upload generated-PDF comparison report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: generated-pdf-visual-parity
+          path: ${{ runner.temp }}/docxodus-generated-pdf-parity/
+          # The initialization step guarantees an index and context file. Treat their absence as
+          # an infrastructure defect instead of quietly publishing an empty artifact.
+          if-no-files-found: error
           retention-days: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Generated-PDF visual-fidelity ratchet (#443).** A compact, provenance- and hash-pinned legal
+  document corpus now runs through the supported Node export API and LibreOffice, rasterizes both
+  PDFs under one Poppler contract, and gates page counts, physical boxes, searchable text,
+  hyperlink targets, SSIM, and directional ink precision/recall/F1 independently. CI always
+  uploads an incremental HTML evidence viewer with PDFs, page rasters, overlays, metrics, hashes,
+  environment fingerprints, and retained failure reports; the reviewable numbers-only baseline
+  prevents regressions without committing generated artifacts.
+- **Verified font runtime and deterministic embedding (#442).** Browser and Node export now resolve
+  configured font faces against the shared substitution contract, verify exact file bytes and
+  embedding permissions, and carry canonical evidence through offline HTML, PDF, render reports,
+  and renderer fingerprints. Resource limits, path redaction, ambiguity rejection, corrupt-font
+  policy, and package-boundary checks keep the runtime fail-closed and publishable.
 - **Deterministic print-readiness barrier (#441).** Browser and Node PDF export now coordinate
   explicit font loading, parallel image decoding, chart/SVG completion signals, paginator-ready
   diagnostics, and a mutation/resize-observed page-tree quiet interval under one deadline. Two

--- a/Docxodus.Tests/HtmlConversionOpsTests.cs
+++ b/Docxodus.Tests/HtmlConversionOpsTests.cs
@@ -2007,7 +2007,14 @@ public class HtmlConversionOpsTests
                    DocumentFormat.OpenXml.WordprocessingDocumentType.Document))
         {
             var main = doc.AddMainDocumentPart();
-            main.Document = new Wp.Document(new Wp.Body(new Wp.Paragraph()));
+            // Word commonly serializes a visually empty paragraph as an explicit run with an
+            // empty w:t (for example, the spacer rows in VP004's signature table). It still
+            // needs the same paragraph-mark line box as a structurally empty w:p.
+            main.Document = new Wp.Document(new Wp.Body(new Wp.Paragraph(
+                new Wp.Run(new Wp.Text(string.Empty)
+                {
+                    Space = DocumentFormat.OpenXml.SpaceProcessingModeValues.Preserve,
+                }))));
             main.AddNewPart<StyleDefinitionsPart>().Styles = new Wp.Styles(
                 new Wp.DocDefaults(
                     new Wp.RunPropertiesDefault(
@@ -2027,12 +2034,14 @@ public class HtmlConversionOpsTests
             new HtmlConversionOptions { FabricateCssClasses = false });
         var root = System.Xml.Linq.XElement.Parse(html);
         var paragraph = root.Descendants().Single(e => e.Name.LocalName == "p");
-        var placeholder = paragraph.Elements().Single(e => e.Name.LocalName == "span");
+        var placeholder = paragraph.Elements().Single(e =>
+            e.Name.LocalName == "span" && e.Value == "\u00A0");
 
         Assert.Contains("--docx-auto-line-spacing: 1.079", (string?)paragraph.Attribute("style"));
         Assert.Contains("line-height: normal", (string?)paragraph.Attribute("style"));
         Assert.Contains("line-height: calc(1lh * var(--docx-auto-line-spacing))",
             (string?)placeholder.Attribute("style"));
+        Assert.Equal("\u00A0", placeholder.Value);
     }
 
     // Error contract: an unresolvable anchor maps to JSON null; good anchors in the

--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -7943,9 +7943,14 @@ namespace Docxodus
                 // W.yearShort
                 if (element.Name == W.p)
                 {
-                    // Translate empty paragraphs to paragraphs having one run with
-                    // a normal space. A non-breaking space, i.e., \x00A0, is not
-                    // required if we use appropriate CSS.
+                    // Translate empty paragraphs to paragraphs having one run with a
+                    // non-breaking space. A normal space is eligible for the converter's
+                    // leading/trailing-whitespace suppression and can arrive in the browser as
+                    // an empty span. That removes the paragraph-mark line box entirely, leaves
+                    // a canonical paragraph anchor with zero geometry, and makes the strict
+                    // PageMap fail otherwise-valid documents (notably signature-table spacers).
+                    // NBSP is confined to this synthesized empty-paragraph placeholder; ordinary
+                    // run whitespace still uses pre-wrap without layout-changing substitution.
                     bool hasContent = element
                         .Elements()
                         .Where(e => e.Name != W.pPr)
@@ -7963,7 +7968,7 @@ namespace Docxodus
                             e.Name == W.separator ||
                             e.Name == W.softHyphen ||
                             e.Name == W.sym ||
-                            e.Name == W.t ||
+                            (e.Name == W.t && e.Value.Length != 0) ||
                             e.Name == W.tab ||
                             e.Name == W.yearLong ||
                             e.Name == W.yearShort
@@ -7975,7 +7980,7 @@ namespace Docxodus
                             element.Nodes().Select(n => InsertAppropriateNonbreakingSpacesTransform(n)),
                             new XElement(W.r,
                                 element.Elements(W.pPr).Elements(W.rPr),
-                                new XElement(W.t, " ")));
+                                new XElement(W.t, "\u00A0")));
                 }
 
                 return new XElement(element.Name,

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -17,6 +17,8 @@
         "@types/node": "^20.10.0",
         "@types/react": "^19.2.7",
         "esbuild": "^0.28.1",
+        "pdf-lib": "1.17.1",
+        "pdfjs-dist": "6.2.108",
         "typescript": "^5.3.0"
       },
       "peerDependencies": {
@@ -500,6 +502,288 @@
         "node": ">=18"
       }
     },
+    "node_modules/@napi-rs/canvas": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.6.tgz",
+      "integrity": "sha512-Ud4d0jLr9vSaakvfOTIjgP3hoY8kMIYgHC4mtE4L0bP3St9lf6TyCVsInvFIOEofzcUeMfDydHDy8Fs2WuWz+A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "1.0.6",
+        "@napi-rs/canvas-darwin-arm64": "1.0.6",
+        "@napi-rs/canvas-darwin-x64": "1.0.6",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.6",
+        "@napi-rs/canvas-linux-arm64-gnu": "1.0.6",
+        "@napi-rs/canvas-linux-arm64-musl": "1.0.6",
+        "@napi-rs/canvas-linux-riscv64-gnu": "1.0.6",
+        "@napi-rs/canvas-linux-x64-gnu": "1.0.6",
+        "@napi-rs/canvas-linux-x64-musl": "1.0.6",
+        "@napi-rs/canvas-win32-arm64-msvc": "1.0.6",
+        "@napi-rs/canvas-win32-x64-msvc": "1.0.6"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.6.tgz",
+      "integrity": "sha512-CZUmZEyN/cmSN1OhRJ44vBE6xyb5ekBbsIF8dqNgizbnAiHSFNi8eAA4oyyIAe5KzJ72K16OKC2lAynZLhv32Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.6.tgz",
+      "integrity": "sha512-FGJsIngRfS9LDaX4t/lFthqn2Km6b61ONzjJFC6+yuabL1NgaK7x0fwrj8276OQFkjCvSpJZ7+CeZWgcy03F2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.6.tgz",
+      "integrity": "sha512-wLDrtfX9V4bu6O55/WwGvPVCjfunL2bEm59lzIFk9ZQOt7oJrPzdx/ytZiQr6bMZ9XOFwvXujszYtpoCK7yUbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.6.tgz",
+      "integrity": "sha512-8TllEP/9UPDVxrBN/tnbGBsxxwG8Eo2tgyW8wDy+Gi9rm9si2I6MsDv9MlfI3a7JOuzkBcurHYDHZxwLgzAIdA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.6.tgz",
+      "integrity": "sha512-YF15AKoGrgU7aoA03CR+cATCRPQcVt6L14Lb/a9hqK7pT7/DhIkqh4qyl+a2GLfqx++yIIJfBuZ3sHM3zlXM1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.6.tgz",
+      "integrity": "sha512-zXeVWNFpj720HZln0bfAs+1/nP3Wy6Z5hUw60UJu+cvgips5jZtuX2+EjDHFk98q3BY35GaE1TQLwE9S244vPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.6.tgz",
+      "integrity": "sha512-kvy1Ypq4ODEI2WRNGvs588qTMcWCjlEIuZRyW8JXpiBnMUirgxQukIDFVDQEcrLlHP5cqZ9cvvfOkBJ7koOktA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.6.tgz",
+      "integrity": "sha512-czHnfLgSCl48iluS6bNrytGYhsbSTUuIvMucAwO0mPEj1uhkHk6SUiRI0xoqv0PSFzpGFfSnQvFpm7vV+tDO+A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.6.tgz",
+      "integrity": "sha512-afsg6GyfUx8qZzjsywjimXUEWcSWETY5F80hmMb2FWVSXkRbor8IpftY2gXnasq+Y42Xug/76qTHwqvti7HRTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.6.tgz",
+      "integrity": "sha512-byzha357piy0wgK6IZOQtU4plpt94f6CxHFS7LhJpWYrDWWT/AitQNxRMfCNNaQHZXUB3BwNhQSfH2RpiZ0WaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.6.tgz",
+      "integrity": "sha512-gWLOgKGZz3hZhzg49q2PJIURwy2pCWh1zvNFXmLO1yineOPhEpoL3EV6/VIjOiKa1l2P6ieP12Eo385u1MLLVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.57.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
@@ -606,6 +890,39 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "6.2.108",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.2.108.tgz",
+      "integrity": "sha512-YxFb+SQcodN2rnX9Tn3dHYlqfb7NjlzzfONPpJd+AKoKtUjEdevTfbC07d5TcczzOK6261auRkP/M8OBHs9vFQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^1.0.0"
+      }
+    },
     "node_modules/playwright": {
       "version": "1.57.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
@@ -643,6 +960,13 @@
       "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
       "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
       "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/npm/package.json
+++ b/npm/package.json
@@ -67,6 +67,7 @@
     "test": "playwright test",
     "test:arcade:libreoffice": "npm run pretest && DOCXODUS_LO_PARITY=1 playwright test demo-arcade-libreoffice.spec.ts --project=chromium",
     "test:visual-parity": "npm run pretest && DOCXODUS_VISUAL_PARITY=1 playwright test visual-parity.spec.ts visual-parity-reductions.spec.ts --project=chromium --reporter=line",
+    "test:generated-pdf-parity": "npm run pretest && DOCXODUS_VISUAL_PARITY=1 DOCXODUS_GENERATED_PDF_PARITY=1 playwright test generated-pdf-parity.spec.ts --project=chromium --reporter=line",
     "capture:word-reference": "mkdir -p dist/wasm && playwright test word-reference-capture.spec.ts --project=chromium --reporter=line",
     "test:ui": "playwright test --ui",
     "demo": "npm run build && npm run demo:serve",
@@ -120,6 +121,8 @@
     "@types/node": "^20.10.0",
     "@types/react": "^19.2.7",
     "esbuild": "^0.28.1",
+    "pdf-lib": "1.17.1",
+    "pdfjs-dist": "6.2.108",
     "typescript": "^5.3.0"
   },
   "dependencies": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -67,7 +67,7 @@
     "test": "playwright test",
     "test:arcade:libreoffice": "npm run pretest && DOCXODUS_LO_PARITY=1 playwright test demo-arcade-libreoffice.spec.ts --project=chromium",
     "test:visual-parity": "npm run pretest && DOCXODUS_VISUAL_PARITY=1 playwright test visual-parity.spec.ts visual-parity-reductions.spec.ts --project=chromium --reporter=line",
-    "test:generated-pdf-parity": "npm run pretest && DOCXODUS_VISUAL_PARITY=1 DOCXODUS_GENERATED_PDF_PARITY=1 playwright test generated-pdf-parity.spec.ts --project=chromium --reporter=line",
+    "test:generated-pdf-parity": "npm run build && npm --prefix ../npm-export run build && npm run pretest && DOCXODUS_VISUAL_PARITY=1 DOCXODUS_GENERATED_PDF_PARITY=1 playwright test generated-pdf-parity.spec.ts --project=chromium --reporter=line",
     "capture:word-reference": "mkdir -p dist/wasm && playwright test word-reference-capture.spec.ts --project=chromium --reporter=line",
     "test:ui": "playwright test --ui",
     "demo": "npm run build && npm run demo:serve",

--- a/npm/tests/docx-footnote-fixture.ts
+++ b/npm/tests/docx-footnote-fixture.ts
@@ -29,16 +29,31 @@ function bodyParagraph(index: number, noteId: number | null): string {
     `<w:r><w:t xml:space="preserve">Body line ${index + 1}</w:t></w:r>${citation}</w:p>`;
 }
 
-function footnote(id: number, paragraphCount: number, wordsPerParagraph: number): string {
-  const paragraphs = Array.from({ length: paragraphCount }, (_, index) =>
-    `<w:p><w:pPr><w:pStyle w:val="FootnoteText"/></w:pPr>` +
+function footnote(
+  id: number,
+  paragraphCount: number,
+  wordCounts: number | readonly number[],
+): string {
+  const paragraphWordCounts = Array.isArray(wordCounts) ? wordCounts : undefined;
+  const wordsPerParagraph = typeof wordCounts === 'number' ? wordCounts : 0;
+  const effectiveParagraphCount = paragraphWordCounts?.length ?? paragraphCount;
+  const paragraphs = Array.from({ length: effectiveParagraphCount }, (_, index) => {
+    const requestedWords = paragraphWordCounts?.[index];
+    const text = requestedWords === undefined
+      ? wordsPerParagraph > 0
+        ? Array.from({ length: wordsPerParagraph }, (_, wordIndex) =>
+          `footnote-${id}-${index + 1}-${wordIndex + 1}`).join(' ')
+        : `Footnote ${id} paragraph ${index + 1} text.`
+      : `Footnote ${id} paragraph ${index + 1} text.${
+        ' continuation'.repeat(Math.max(0, requestedWords - 5))}`;
+    return (
+      `<w:p><w:pPr><w:pStyle w:val="FootnoteText"/></w:pPr>` +
       (index === 0
         ? `<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r>`
         : '') +
-      `<w:r><w:t xml:space="preserve"> ${wordsPerParagraph > 0
-        ? Array.from({ length: wordsPerParagraph }, (_, wordIndex) =>
-          `footnote-${id}-${index + 1}-${wordIndex + 1}`).join(' ')
-        : `Footnote ${id} paragraph ${index + 1} text.`}</w:t></w:r></w:p>`)
+      `<w:r><w:t xml:space="preserve"> ${text}</w:t></w:r></w:p>`
+    );
+  })
     .join('');
   return `<w:footnote w:id="${id}">${paragraphs}</w:footnote>`;
 }
@@ -48,14 +63,14 @@ function footnote(id: number, paragraphCount: number, wordsPerParagraph: number)
  * @param bodyLines total body paragraphs — few enough to keep everything on one page, so the
  *   note area's position is determined purely by the page geometry, not by flow pressure.
  * @param paragraphsPerNote paragraphs emitted inside each note.
- * @param wordsPerParagraph when positive, emits this many uniquely numbered words in each note
- *   paragraph so one real converter paragraph can be made taller than a note band.
+ * @param wordCounts either a shared exact word count for every note paragraph, or per-paragraph
+ *   word counts for constructing notes with uneven continuation pressure.
  */
 export function generateFootnoteDocx(
   noteCount = 1,
   bodyLines = 5,
   paragraphsPerNote = 1,
-  wordsPerParagraph = 0,
+  wordCounts: number | readonly number[] = 0,
   separatorStories: {
     normalText?: string;
     continuationText?: string;
@@ -124,7 +139,7 @@ export function generateFootnoteDocx(
   <w:footnote w:type="continuationSeparator" w:id="0">${separatorRun(
     'continuationSeparator', separatorStories.continuationText,
   )}</w:footnote>
-  ${noteIds.map((id) => footnote(id, paragraphsPerNote, wordsPerParagraph)).join('\n  ')}
+  ${noteIds.map((id) => footnote(id, paragraphsPerNote, wordCounts)).join('\n  ')}
 </w:footnotes>`),
     },
     {

--- a/npm/tests/generated-pdf-parity-ratchet.spec.ts
+++ b/npm/tests/generated-pdf-parity-ratchet.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PDF_PARITY_CORPUS } from './visual-parity/pdf-corpus.js';
+import {
+  RATCHET_SCHEMA_VERSION,
+  RATCHET_TOLERANCE,
+  compareToRecord,
+  readRecord,
+  type RatchetRecord,
+  type RatchetSummary,
+} from './visual-parity/ratchet.js';
+
+/**
+ * Pure checks for #443's committed generated-PDF record. These run on ordinary PRs without
+ * LibreOffice, Poppler, or Chromium so a corpus/disposition change cannot silently escape the
+ * scheduled release ratchet.
+ */
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const recordFile = resolve(__dirname, 'visual-parity/generated-pdf-ratchet.json');
+
+function measuredSummary(record: RatchetRecord): RatchetSummary {
+  return {
+    gitCommit: record.sourceCommit,
+    workingTreeDirty: false,
+    environment: {
+      chromium: record.environment.chromium,
+      libreoffice: record.environment.libreoffice,
+      pdftoppm: record.environment.poppler,
+      fontContract: { sha256: record.environment.fontContractSha256 },
+    },
+    cases: record.cases.map((entry) => ({
+      id: entry.id,
+      disposition: { kind: entry.disposition },
+      docxodusPages: entry.pages.docxodus,
+      libreofficePages: entry.pages.libreoffice,
+      severity: entry.severity,
+      pages: Array.from({ length: entry.pages.docxodus }, () => ({
+        ssim: entry.ssim,
+        tolerantInkF1: entry.worstInkF1,
+      })),
+      physicalGeometryPassed: true,
+      semanticChecksPassed: true,
+    })),
+  };
+}
+
+test.describe('the committed generated-PDF parity ratchet', () => {
+  test('is current-schema, complete, successful, and numbers-only', () => {
+    const record = readRecord(recordFile);
+    expect(record, `${recordFile} must exist`).not.toBeNull();
+    expect(record!.schemaVersion).toBe(RATCHET_SCHEMA_VERSION);
+    expect(record!.tolerance).toEqual(RATCHET_TOLERANCE);
+    expect(record!.sourceCommit).toMatch(/^[0-9a-f]{40}$/);
+    expect(record!.cases.map((entry) => entry.id).sort())
+      .toEqual(PDF_PARITY_CORPUS.cases.map((entry) => entry.id).sort());
+
+    for (const entry of record!.cases) {
+      expect(Object.keys(entry).sort()).toEqual(
+        ['disposition', 'id', 'pages', 'severity', 'ssim', 'worstInkF1']);
+      expect(entry.pages.docxodus).toBeGreaterThan(0);
+      expect(entry.pages.libreoffice).toBe(entry.pages.docxodus);
+      expect(entry.ssim).toBeGreaterThanOrEqual(0);
+      expect(entry.ssim).toBeLessThanOrEqual(1);
+      expect(entry.worstInkF1).toBeGreaterThanOrEqual(0);
+      expect(entry.worstInkF1).toBeLessThanOrEqual(1);
+    }
+
+    const serialized = readFileSync(recordFile, 'utf8');
+    expect(serialized).not.toContain('.png');
+    expect(serialized).not.toContain('.pdf');
+    expect(serialized.match(/[0-9a-f]{64}/g) ?? [])
+      .toEqual([record!.environment.fontContractSha256]);
+  });
+
+  test('agrees with the corpus about every reviewable disposition', () => {
+    const record = readRecord(recordFile)!;
+    for (const entry of record.cases) {
+      const corpusEntry = PDF_PARITY_CORPUS.cases.find((candidate) => candidate.id === entry.id)!;
+      expect(entry.disposition, `${entry.id} disposition drifted from pdf-corpus.ts`)
+        .toBe(corpusEntry.disposition.kind);
+    }
+  });
+
+  test('rejects physical-geometry failure even for an already-severe raster baseline', () => {
+    const record = readRecord(recordFile)!;
+    const summary = measuredSummary(record);
+    const severe = summary.cases.find((entry) => entry.severity === 'severe')!;
+    severe.physicalGeometryPassed = false;
+
+    const comparison = compareToRecord(record, summary);
+    expect(comparison.status).toBe('regressed');
+    expect(comparison.findings).toContainEqual(expect.objectContaining({
+      caseId: severe.id,
+      signal: 'physicalGeometry',
+    }));
+  });
+
+  test('rejects semantic failure even for an already-severe raster baseline', () => {
+    const record = readRecord(recordFile)!;
+    const summary = measuredSummary(record);
+    const severe = summary.cases.find((entry) => entry.severity === 'severe')!;
+    severe.semanticChecksPassed = false;
+
+    const comparison = compareToRecord(record, summary);
+    expect(comparison.status).toBe('regressed');
+    expect(comparison.findings).toContainEqual(expect.objectContaining({
+      caseId: severe.id,
+      signal: 'semantics',
+    }));
+  });
+});

--- a/npm/tests/generated-pdf-parity-ratchet.spec.ts
+++ b/npm/tests/generated-pdf-parity-ratchet.spec.ts
@@ -74,6 +74,23 @@ test.describe('the committed generated-PDF parity ratchet', () => {
       .toEqual([record!.environment.fontContractSha256]);
   });
 
+  test('the public generated-PDF command owns both builds before it launches Playwright', () => {
+    const packageJson = JSON.parse(readFileSync(resolve(__dirname, '../package.json'), 'utf8')) as {
+      scripts: Record<string, string>;
+    };
+    const command = packageJson.scripts['test:generated-pdf-parity'];
+    expect(command).toContain('npm run build');
+    expect(command).toContain('npm --prefix ../npm-export run build');
+    expect(command).toContain('npm run pretest');
+    expect(command).toContain('playwright test generated-pdf-parity.spec.ts');
+    expect(command.indexOf('npm run build')).toBeLessThan(
+      command.indexOf('npm --prefix ../npm-export run build'),
+    );
+    expect(command.indexOf('npm --prefix ../npm-export run build')).toBeLessThan(
+      command.indexOf('playwright test generated-pdf-parity.spec.ts'),
+    );
+  });
+
   test('agrees with the corpus about every reviewable disposition', () => {
     const record = readRecord(recordFile)!;
     for (const entry of record.cases) {

--- a/npm/tests/generated-pdf-parity.spec.ts
+++ b/npm/tests/generated-pdf-parity.spec.ts
@@ -1,0 +1,935 @@
+import { expect, test, type Page } from '@playwright/test';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import {
+  GATING_DISPOSITION_KINDS,
+  type VisualDisposition,
+} from './visual-parity/corpus.js';
+import {
+  PDF_PARITY_CORPUS,
+  REQUIRED_PDF_PARITY_CATEGORIES,
+  type PdfLinkExpectation,
+  type PdfParityCorpusEntry,
+} from './visual-parity/pdf-corpus.js';
+import {
+  compareImages,
+  VISUAL_THRESHOLDS,
+  type PageMetrics,
+  type VisualSeverity,
+} from './visual-parity/metrics.js';
+import {
+  PDF_RASTER_CONTRACT,
+  PDF_RASTER_CONTRACT_SHA256,
+  inspectPdf,
+  rasterizePdf,
+  sha256File,
+  type PdfBox,
+  type PdfInspection,
+} from './visual-parity/pdf.js';
+import { decodePng, encodePng } from './visual-parity/png.js';
+import {
+  FONT_CONTRACT_FILE,
+  assertFontContract,
+  fontContractReport,
+} from './visual-parity/font-contract.js';
+import {
+  assertLibreOfficeContract,
+  popplerVersionOutput,
+} from './visual-parity/environment-contract.js';
+import {
+  assertRecordUpdateProvenance,
+  buildRecord,
+  compareToRecord,
+  readRecord,
+  serializeRecord,
+} from './visual-parity/ratchet.js';
+
+test.skip(process.env.DOCXODUS_GENERATED_PDF_PARITY !== '1',
+  'set DOCXODUS_GENERATED_PDF_PARITY=1 on a host with LibreOffice and Poppler');
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '../..');
+const severityOrder: readonly VisualSeverity[] = ['close', 'minor', 'major', 'severe'];
+const GENERATED_PDF_RATCHET_RECORD_FILE = resolve(
+  __dirname,
+  'visual-parity/generated-pdf-ratchet.json',
+);
+const PHYSICAL_GEOMETRY_TOLERANCE_POINTS = 0.5;
+const BOOTSTRAP_ARTIFACTS = new Set(['ci-context.json', 'index.html']);
+
+interface ExportModule {
+  convertDocxToPdf(document: Uint8Array, options: Record<string, unknown>): Promise<{
+    pdf: Uint8Array;
+    pageCount: number;
+    pageMap: unknown;
+    renderReport: {
+      status: 'complete';
+      environment: { rendererFingerprint: string; verification: string };
+      bindings: { pdfDigest?: string };
+      source: { rawPackageBytesDigest: string };
+      options: { reviewProfile: string; commentProfile: string };
+      [key: string]: unknown;
+    };
+    rendererFingerprint: string;
+    warnings: unknown[];
+  }>;
+}
+
+interface GeometryDelta {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  maximumAbsoluteDelta: number;
+}
+
+interface PageGeometryComparison {
+  page: number;
+  candidate: { mediaBox: PdfBox; cropBox: PdfBox };
+  reference: { mediaBox: PdfBox; cropBox: PdfBox };
+  mediaBoxDelta: GeometryDelta;
+  cropBoxDelta: GeometryDelta;
+  passed: boolean;
+}
+
+interface TextExtractorEvidence {
+  characterCount: number;
+  sha256: string;
+  requiredText: string[];
+  missingRequiredText: string[];
+  forbiddenText: string[];
+  observedForbiddenText: string[];
+  passed: boolean;
+}
+
+interface LinkEvidence {
+  expected: PdfLinkExpectation[];
+  observed: Array<{ kind: string; value?: string; unsafeValue?: string }>;
+  missing: PdfLinkExpectation[];
+  unsupportedAnnotations: number;
+  passed: boolean;
+}
+
+interface SemanticEvidence {
+  candidate: {
+    pdfjs: TextExtractorEvidence;
+    pdftotext: TextExtractorEvidence;
+    links: LinkEvidence;
+  };
+  reference: {
+    pdfjs: TextExtractorEvidence;
+    pdftotext: TextExtractorEvidence;
+  };
+  passed: boolean;
+}
+
+interface PdfParityPageResult extends PageMetrics {
+  page: number;
+  physicalGeometry: PageGeometryComparison;
+  environmentFingerprint: string;
+  rendererFingerprint: string;
+  artifacts: { candidate: string; reference: string; overlay: string };
+  artifactSha256: { candidate: string; reference: string; overlay: string };
+}
+
+interface PdfParityCaseResult {
+  id: string;
+  path: string;
+  categories: readonly string[];
+  rationale: string;
+  disposition: VisualDisposition;
+  profiles: PdfParityCorpusEntry['profiles'];
+  provenance: PdfParityCorpusEntry['source']['provenance'];
+  sourceSha256: string;
+  sourceGitBlob: string;
+  referenceSourceSha256: string;
+  docxodusPages: number;
+  libreofficePages: number;
+  pageCountDelta: number;
+  physicalGeometryPassed: boolean;
+  semanticChecksPassed: boolean;
+  severity: VisualSeverity;
+  rendererFingerprint?: string;
+  environmentFingerprint?: string;
+  artifacts: Record<string, string>;
+  artifactSha256: Record<string, string>;
+  semantic?: SemanticEvidence;
+  pages: PdfParityPageResult[];
+  error?: string;
+}
+
+interface RunState {
+  schemaVersion: 1;
+  status: 'running' | 'passed' | 'failed';
+  phase: string;
+  startedAt: string;
+  updatedAt: string;
+  outputRoot: string;
+  casesCompleted: number;
+  casesSelected: number;
+  failure?: { phase: string; message: string };
+}
+
+function sha256(bytes: Uint8Array | string): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function commandVersion(command: string, args: string[]): string {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (result.error) return String(result.error);
+  return `${result.stdout ?? ''}\n${result.stderr ?? ''}`.trim();
+}
+
+function executableEvidence(command: string, versionArgs: string[]): Record<string, string> {
+  const path = execFileSync('which', [command], { encoding: 'utf8' }).trim();
+  const resolvedPath = realpathSync(path);
+  return {
+    command,
+    executable: basename(resolvedPath),
+    executableSha256: sha256File(resolvedPath),
+    version: commandVersion(command, versionArgs),
+  };
+}
+
+function writeJsonAtomic(path: string, value: unknown): void {
+  const temporary = `${path}.tmp`;
+  writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`);
+  renameSync(temporary, path);
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function writeViewer(outputRoot: string, state: RunState, cases: PdfParityCaseResult[]): void {
+  const caseSections = cases.map((entry) => {
+    const pageRows = entry.pages.map((page) => `
+      <tr><th>Page ${page.page}</th>
+        <td><a href="${escapeHtml(page.artifacts.candidate)}"><img src="${escapeHtml(page.artifacts.candidate)}" alt="Docxodus page ${page.page}"></a></td>
+        <td><a href="${escapeHtml(page.artifacts.reference)}"><img src="${escapeHtml(page.artifacts.reference)}" alt="Reference page ${page.page}"></a></td>
+        <td><a href="${escapeHtml(page.artifacts.overlay)}"><img src="${escapeHtml(page.artifacts.overlay)}" alt="Difference overlay ${page.page}"></a></td>
+      </tr>`).join('');
+    const links = Object.entries(entry.artifacts)
+      .map(([label, path]) => `<li><a href="${escapeHtml(path)}">${escapeHtml(label)}</a></li>`)
+      .join('');
+    return `<section>
+      <h2>${escapeHtml(entry.id)} — ${escapeHtml(entry.severity)}</h2>
+      <p>${escapeHtml(entry.rationale)}</p>
+      ${entry.error ? `<p class="failure"><strong>Failure:</strong> ${escapeHtml(entry.error)}</p>` : ''}
+      <ul>${links}</ul>
+      ${pageRows ? `<table><thead><tr><th></th><th>Docxodus PDF</th><th>LibreOffice PDF</th><th>Overlay</th></tr></thead><tbody>${pageRows}</tbody></table>` : ''}
+    </section>`;
+  }).join('\n');
+  const failureLink = existsSync(join(outputRoot, 'failure.json'))
+    ? '<li><a href="failure.json">Failure details</a></li>'
+    : '';
+  const summaryLink = existsSync(join(outputRoot, 'summary.json'))
+    ? '<li><a href="summary.json">Complete summary</a></li>'
+    : '<li><a href="summary.partial.json">Partial summary</a></li>';
+  const ciLink = existsSync(join(outputRoot, 'ci-context.json'))
+    ? '<li><a href="ci-context.json">CI context</a></li>'
+    : '';
+  writeFileSync(join(outputRoot, 'index.html'), `<!doctype html>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Docxodus generated-PDF parity evidence</title>
+<style>
+body{font:15px/1.45 system-ui;margin:2rem;max-width:110rem}table{border-collapse:collapse;width:100%}th,td{border:1px solid #bbb;padding:.5rem;vertical-align:top}img{display:block;width:100%;min-width:14rem;height:auto}.failure{color:#a00}code{word-break:break-all}section{margin:2rem 0 4rem}
+</style>
+<h1>Docxodus generated-PDF parity evidence</h1>
+<p>Status: <strong>${escapeHtml(state.status)}</strong>; phase: <code>${escapeHtml(state.phase)}</code>; ${state.casesCompleted}/${state.casesSelected} cases materialized.</p>
+<ul><li><a href="run.json">Run state</a></li>${summaryLink}${failureLink}${ciLink}</ul>
+${caseSections || '<p>No case artifacts have materialized yet. Inspect the run/failure context above.</p>'}
+`);
+}
+
+function initializeOutputRoot(): string {
+  const outputRoot = resolve(process.env.DOCXODUS_GENERATED_PDF_PARITY_OUTPUT
+    ?? join(tmpdir(), 'docxodus-generated-pdf-parity'));
+  const relativeToRepo = relative(repoRoot, outputRoot);
+  if (relativeToRepo === '' || (!relativeToRepo.startsWith('..') && !isAbsolute(relativeToRepo))) {
+    throw new Error(`Generated-PDF parity artifacts must stay outside the repository: ${outputRoot}`);
+  }
+  mkdirSync(outputRoot, { recursive: true, mode: 0o700 });
+  const unexpected = readdirSync(outputRoot).filter((name) => !BOOTSTRAP_ARTIFACTS.has(name));
+  if (unexpected.length) {
+    throw new Error(`Generated-PDF parity output contains stale artifacts: ${unexpected.join(', ')}`);
+  }
+  return outputRoot;
+}
+
+function selectedCorpus(): PdfParityCorpusEntry[] {
+  const filter = process.env.DOCXODUS_GENERATED_PDF_PARITY_FILTER;
+  if (!filter) return [...PDF_PARITY_CORPUS.cases];
+  const requested = new Set(filter.split(',').map((value) => value.trim()).filter(Boolean));
+  const selected = PDF_PARITY_CORPUS.cases.filter((entry) => requested.has(entry.id));
+  const unknown = [...requested].filter((id) => !PDF_PARITY_CORPUS.cases.some((entry) => entry.id === id));
+  if (unknown.length) throw new Error(`Unknown generated-PDF parity case(s): ${unknown.join(', ')}`);
+  if (!selected.length) throw new Error('Generated-PDF parity filter selected no cases.');
+  return selected;
+}
+
+function assertPinnedSource(entry: PdfParityCorpusEntry): Uint8Array {
+  const path = resolve(repoRoot, entry.source.path);
+  if (!existsSync(path) || !lstatSync(path).isFile() || lstatSync(path).isSymbolicLink()) {
+    throw new Error(`${entry.id} source must be a tracked regular file: ${entry.source.path}`);
+  }
+  execFileSync('git', ['ls-files', '--error-unmatch', entry.source.path], {
+    cwd: repoRoot,
+    stdio: 'pipe',
+  });
+  const bytes = new Uint8Array(readFileSync(path));
+  const digest = sha256(bytes);
+  if (digest !== entry.source.sha256) {
+    throw new Error(`${entry.id} source SHA-256 changed (${digest} != ${entry.source.sha256}).`);
+  }
+  const blob = execFileSync('git', ['hash-object', entry.source.path], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  }).trim();
+  if (blob !== entry.source.gitBlob) {
+    throw new Error(`${entry.id} source Git blob changed (${blob} != ${entry.source.gitBlob}).`);
+  }
+  return bytes;
+}
+
+function libreofficeEnv(work: string): NodeJS.ProcessEnv {
+  const runtimeDir = join(work, 'runtime');
+  const homeDir = join(work, 'home');
+  for (const directory of [runtimeDir, homeDir]) {
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+  }
+  return {
+    ...process.env,
+    HOME: homeDir,
+    XDG_RUNTIME_DIR: runtimeDir,
+    LANG: 'C.UTF-8',
+    LC_ALL: 'C.UTF-8',
+    TZ: 'UTC',
+    FONTCONFIG_FILE: FONT_CONTRACT_FILE,
+  };
+}
+
+async function ensureWasmBridge(page: Page): Promise<void> {
+  if (page.url().endsWith('/test-harness.html')) return;
+  await page.goto('/test-harness.html');
+  await page.waitForFunction(() => (window as any).DocxodusReady === true, { timeout: 90_000 });
+}
+
+async function referenceSource(
+  page: Page,
+  entry: PdfParityCorpusEntry,
+  source: Uint8Array,
+  caseOutput: string,
+): Promise<{ path: string; sha256: string }> {
+  if (entry.profiles.reference.revisionProjection === 'source') {
+    const path = join(caseOutput, 'reference-source.docx');
+    writeFileSync(path, source);
+    return { path, sha256: sha256(source) };
+  }
+  await ensureWasmBridge(page);
+  const accepted = await page.evaluate((input) => {
+    const bytes = (window as any).Docxodus.DocxDiffBridge.AcceptRevisions(new Uint8Array(input));
+    return Array.from(bytes as Uint8Array);
+  }, Array.from(source));
+  if (!accepted.length) throw new Error(`${entry.id}: final-view reference projection returned no bytes.`);
+  const bytes = new Uint8Array(accepted);
+  const path = join(caseOutput, 'reference-source.docx');
+  writeFileSync(path, bytes);
+  return { path, sha256: sha256(bytes) };
+}
+
+function renderReferencePdf(sourcePath: string, work: string, destination: string): Uint8Array {
+  const pdfDirectory = join(work, 'reference-pdf');
+  const profileDirectory = join(work, 'libreoffice-profile');
+  mkdirSync(pdfDirectory, { recursive: true, mode: 0o700 });
+  mkdirSync(profileDirectory, { recursive: true, mode: 0o700 });
+  execFileSync('libreoffice', [
+    `-env:UserInstallation=${pathToFileURL(profileDirectory).href}`,
+    '--headless', '--nologo', '--nodefault', '--nofirststartwizard', '--norestore',
+    '--convert-to', 'pdf:writer_pdf_Export', '--outdir', pdfDirectory, sourcePath,
+  ], {
+    env: libreofficeEnv(work),
+    stdio: 'pipe',
+    timeout: 120_000,
+  });
+  const produced = join(pdfDirectory, `${basename(sourcePath).replace(/\.docx$/i, '')}.pdf`);
+  if (!existsSync(produced)) throw new Error(`LibreOffice did not produce ${produced}.`);
+  const bytes = new Uint8Array(readFileSync(produced));
+  writeFileSync(destination, bytes);
+  return bytes;
+}
+
+function normalizeText(value: string): string {
+  return value.normalize('NFC').replace(/\s+/g, ' ').trim();
+}
+
+function textEvidence(text: string, entry: PdfParityCorpusEntry): TextExtractorEvidence {
+  const normalized = normalizeText(text);
+  const requiredText = entry.semantics.requiredText.map(normalizeText);
+  const forbiddenText = (entry.semantics.forbiddenText ?? []).map(normalizeText);
+  const missingRequiredText = requiredText.filter((fragment) => !normalized.includes(fragment));
+  const observedForbiddenText = forbiddenText.filter((fragment) => normalized.includes(fragment));
+  return {
+    characterCount: normalized.length,
+    sha256: sha256(normalized),
+    requiredText,
+    missingRequiredText,
+    forbiddenText,
+    observedForbiddenText,
+    passed: normalized.length > 0
+      && missingRequiredText.length === 0
+      && observedForbiddenText.length === 0,
+  };
+}
+
+function popplerText(path: string): string {
+  return execFileSync('pdftotext', ['-enc', 'UTF-8', '-nopgbrk', path, '-'], {
+    encoding: 'utf8',
+    env: { ...process.env, LANG: 'C.UTF-8', LC_ALL: 'C.UTF-8', TZ: 'UTC' },
+    timeout: 120_000,
+  });
+}
+
+function canonicalUrl(value: string): string {
+  try {
+    return new URL(value).href;
+  } catch {
+    return value;
+  }
+}
+
+function linkEvidence(inspection: PdfInspection, entry: PdfParityCorpusEntry): LinkEvidence {
+  const expected = [...(entry.semantics.links ?? [])];
+  const observed = inspection.pages.flatMap((page) => page.hyperlinks.map((annotation) => ({
+    kind: annotation.target.kind,
+    ...(annotation.target.kind === 'unsupported' ? {} : { value: annotation.target.value }),
+    ...(annotation.target.kind === 'url' && annotation.target.unsafeValue
+      ? { unsafeValue: annotation.target.unsafeValue }
+      : {}),
+  })));
+  const missing = expected.filter((link) => {
+    if (link.kind === 'external') {
+      return !observed.some((target) => target.kind === 'url'
+        && [target.value, target.unsafeValue].filter((value): value is string => Boolean(value))
+          .some((value) => canonicalUrl(value) === canonicalUrl(link.exactTarget)));
+    }
+    return !observed.some((target) => target.kind === 'destination'
+      && target.value === link.anchor);
+  });
+  const unsupportedAnnotations = observed.filter((target) => target.kind === 'unsupported').length;
+  return {
+    expected,
+    observed,
+    missing,
+    unsupportedAnnotations,
+    passed: missing.length === 0 && unsupportedAnnotations === 0,
+  };
+}
+
+function semanticEvidence(
+  candidatePath: string,
+  candidateInspection: PdfInspection,
+  referencePath: string,
+  referenceInspection: PdfInspection,
+  entry: PdfParityCorpusEntry,
+): SemanticEvidence {
+  const candidatePdfjs = textEvidence(candidateInspection.searchableText, entry);
+  const candidatePoppler = textEvidence(popplerText(candidatePath), entry);
+  const candidateLinks = linkEvidence(candidateInspection, entry);
+  const referencePdfjs = textEvidence(referenceInspection.searchableText, entry);
+  const referencePoppler = textEvidence(popplerText(referencePath), entry);
+  return {
+    candidate: {
+      pdfjs: candidatePdfjs,
+      pdftotext: candidatePoppler,
+      links: candidateLinks,
+    },
+    reference: {
+      pdfjs: referencePdfjs,
+      pdftotext: referencePoppler,
+    },
+    passed: candidatePdfjs.passed
+      && candidatePoppler.passed
+      && candidateLinks.passed
+      && referencePdfjs.passed
+      && referencePoppler.passed,
+  };
+}
+
+function boxDelta(candidate: PdfBox, reference: PdfBox): GeometryDelta {
+  const delta = {
+    x: candidate.x - reference.x,
+    y: candidate.y - reference.y,
+    width: candidate.width - reference.width,
+    height: candidate.height - reference.height,
+  };
+  return {
+    ...delta,
+    maximumAbsoluteDelta: Math.max(...Object.values(delta).map(Math.abs)),
+  };
+}
+
+function compareGeometry(
+  candidate: PdfInspection,
+  reference: PdfInspection,
+): PageGeometryComparison[] {
+  const count = Math.min(candidate.pages.length, reference.pages.length);
+  return Array.from({ length: count }, (_, index) => {
+    const candidatePage = candidate.pages[index];
+    const referencePage = reference.pages[index];
+    const mediaBoxDelta = boxDelta(candidatePage.mediaBox, referencePage.mediaBox);
+    const cropBoxDelta = boxDelta(candidatePage.cropBox, referencePage.cropBox);
+    return {
+      page: index + 1,
+      candidate: { mediaBox: candidatePage.mediaBox, cropBox: candidatePage.cropBox },
+      reference: { mediaBox: referencePage.mediaBox, cropBox: referencePage.cropBox },
+      mediaBoxDelta,
+      cropBoxDelta,
+      passed: mediaBoxDelta.maximumAbsoluteDelta <= PHYSICAL_GEOMETRY_TOLERANCE_POINTS
+        && cropBoxDelta.maximumAbsoluteDelta <= PHYSICAL_GEOMETRY_TOLERANCE_POINTS,
+    };
+  });
+}
+
+function worse(left: VisualSeverity, right: VisualSeverity): VisualSeverity {
+  return severityOrder.indexOf(left) >= severityOrder.indexOf(right) ? left : right;
+}
+
+function hasHardParityFailure(result: PdfParityCaseResult): boolean {
+  return result.error !== undefined
+    || result.pageCountDelta !== 0
+    || !result.physicalGeometryPassed
+    || !result.semanticChecksPassed;
+}
+
+function gatesStrictRasterRun(result: PdfParityCaseResult): boolean {
+  return result.severity === 'severe'
+    && GATING_DISPOSITION_KINDS.includes(result.disposition.kind);
+}
+
+function summarizeCases(cases: PdfParityCaseResult[]) {
+  const pages = cases.flatMap((entry) => entry.pages);
+  return {
+    cases: cases.length,
+    pagesCompared: pages.length,
+    pageCountMismatches: cases.filter((entry) => entry.pageCountDelta !== 0).length,
+    physicalGeometryFailures: cases.filter((entry) => !entry.physicalGeometryPassed).length,
+    semanticFailures: cases.filter((entry) => !entry.semanticChecksPassed).length,
+    errors: cases.filter((entry) => entry.error !== undefined).length,
+    severityCounts: Object.fromEntries(severityOrder.map((level) => [
+      level,
+      cases.filter((entry) => entry.severity === level).length,
+    ])),
+    hardGatingCases: cases.filter(hasHardParityFailure).map((entry) => entry.id),
+    strictRasterGatingCases: cases.filter(gatesStrictRasterRun).map((entry) => entry.id),
+    meanSsim: pages.reduce((sum, page) => sum + page.ssim, 0) / Math.max(1, pages.length),
+    meanInkPrecision: pages.reduce((sum, page) => sum + page.tolerantInkPrecision, 0)
+      / Math.max(1, pages.length),
+    meanInkRecall: pages.reduce((sum, page) => sum + page.tolerantInkRecall, 0)
+      / Math.max(1, pages.length),
+    meanInkF1: pages.reduce((sum, page) => sum + page.tolerantInkF1, 0)
+      / Math.max(1, pages.length),
+  };
+}
+
+test('supported generated PDFs match reference PDFs through the fidelity ratchet', async ({ page, browserName }) => {
+  test.setTimeout(30 * 60 * 1000);
+
+  const outputRoot = initializeOutputRoot();
+  const corpus = selectedCorpus();
+  const startedAt = new Date().toISOString();
+  const cases: PdfParityCaseResult[] = [];
+  let phase = 'artifact-initialization';
+  let environment: Record<string, unknown> = {};
+  const state: RunState = {
+    schemaVersion: 1,
+    status: 'running',
+    phase,
+    startedAt,
+    updatedAt: startedAt,
+    outputRoot,
+    casesCompleted: 0,
+    casesSelected: corpus.length,
+  };
+
+  const persist = (complete = false): void => {
+    state.phase = phase;
+    state.updatedAt = new Date().toISOString();
+    state.casesCompleted = cases.length;
+    writeJsonAtomic(join(outputRoot, 'run.json'), state);
+    const summary = {
+      schemaVersion: 1,
+      measurementPipeline: 'generated-pdf-v1',
+      generatedAt: state.updatedAt,
+      gitCommit: commandVersion('git', ['rev-parse', 'HEAD']),
+      workingTreeDirty: commandVersion('git', ['status', '--porcelain']).length > 0,
+      rasterContract: {
+        ...PDF_RASTER_CONTRACT,
+        sha256: PDF_RASTER_CONTRACT_SHA256,
+      },
+      physicalGeometryTolerancePoints: PHYSICAL_GEOMETRY_TOLERANCE_POINTS,
+      thresholds: VISUAL_THRESHOLDS,
+      environment,
+      coverage: Object.fromEntries(REQUIRED_PDF_PARITY_CATEGORIES.map((category) => [
+        category,
+        PDF_PARITY_CORPUS.cases.filter((entry) =>
+          (entry.categories as readonly string[]).includes(category))
+          .map((entry) => entry.id),
+      ])),
+      aggregate: summarizeCases(cases),
+      cases,
+    };
+    writeJsonAtomic(join(outputRoot, complete ? 'summary.json' : 'summary.partial.json'), summary);
+    writeViewer(outputRoot, state, cases);
+  };
+
+  persist();
+  try {
+    phase = 'environment-preflight';
+    assertFontContract();
+    const fontContract = fontContractReport(repoRoot);
+    const libreofficeVersion = assertLibreOfficeContract();
+    const poppler = popplerVersionOutput();
+    const pdftotext = commandVersion('pdftotext', ['-v']);
+    const exportEntry = resolve(repoRoot, 'npm-export/dist/index.js');
+    if (!existsSync(exportEntry)) {
+      throw new Error(`Build @docxodus/export before the benchmark: missing ${exportEntry}`);
+    }
+    const exporter = await import(pathToFileURL(exportEntry).href) as ExportModule;
+    if (typeof exporter.convertDocxToPdf !== 'function') {
+      throw new Error('The supported @docxodus/export entry point does not export convertDocxToPdf.');
+    }
+    const playwrightCoreEntry = resolve(repoRoot, 'npm-export/node_modules/playwright-core/index.mjs');
+    const exporterPlaywright = await import(pathToFileURL(playwrightCoreEntry).href) as {
+      chromium: { executablePath(): string; launch(options: Record<string, unknown>): Promise<{
+        version(): string;
+        close(): Promise<void>;
+      }> };
+    };
+    const chromiumExecutablePath = exporterPlaywright.chromium.executablePath();
+    const chromiumProbe = await exporterPlaywright.chromium.launch({ headless: true });
+    const chromiumVersion = chromiumProbe.version();
+    await chromiumProbe.close();
+    environment = {
+      browserName,
+      chromium: chromiumVersion,
+      chromiumExecutable: {
+        executable: basename(chromiumExecutablePath),
+        sha256: sha256File(chromiumExecutablePath),
+      },
+      node: process.version,
+      libreoffice: libreofficeVersion,
+      pdftoppm: poppler,
+      pdftotext,
+      tools: {
+        libreoffice: executableEvidence('libreoffice', ['--version']),
+        pdftoppm: executableEvidence('pdftoppm', ['-v']),
+        pdftotext: executableEvidence('pdftotext', ['-v']),
+      },
+      fontContract,
+      locale: 'C.UTF-8',
+      timezone: 'UTC',
+      rasterContractSha256: PDF_RASTER_CONTRACT_SHA256,
+    };
+    persist();
+
+    for (const [caseIndex, entry] of corpus.entries()) {
+      phase = `case:${entry.id}`;
+      const caseOutput = join(outputRoot, entry.id);
+      mkdirSync(caseOutput, { recursive: true, mode: 0o700 });
+      const work = mkdtempSync(join(tmpdir(), `docxodus-generated-pdf-${entry.id}-`));
+      const artifacts: Record<string, string> = {
+        source: `${entry.id}/source.docx`,
+        referenceSource: `${entry.id}/reference-source.docx`,
+        metrics: `${entry.id}/metrics.json`,
+      };
+      let sourceSha256 = entry.source.sha256;
+      let referenceSourceSha256 = entry.source.sha256;
+      let docxodusPages = 0;
+      let libreofficePages = 0;
+      try {
+        const source = assertPinnedSource(entry);
+        sourceSha256 = sha256(source);
+        writeFileSync(join(caseOutput, 'source.docx'), source);
+        const projectedReference = await referenceSource(page, entry, source, caseOutput);
+        referenceSourceSha256 = projectedReference.sha256;
+
+        const candidate = await exporter.convertDocxToPdf(source, {
+          ...entry.profiles.candidate,
+          browserExecutablePath: chromiumExecutablePath,
+          expectedSourceDigest: sourceSha256,
+          unsupportedContent: 'warn',
+          timeoutMs: 120_000,
+        });
+        docxodusPages = candidate.pageCount;
+        const candidatePdfPath = join(caseOutput, 'docxodus.pdf');
+        writeFileSync(candidatePdfPath, candidate.pdf);
+        writeJsonAtomic(join(caseOutput, 'render-report.json'), candidate.renderReport);
+        writeJsonAtomic(join(caseOutput, 'page-map.json'), candidate.pageMap);
+        artifacts.candidatePdf = `${entry.id}/docxodus.pdf`;
+        artifacts.renderReport = `${entry.id}/render-report.json`;
+        artifacts.pageMap = `${entry.id}/page-map.json`;
+
+        if (candidate.renderReport.source.rawPackageBytesDigest !== sourceSha256) {
+          throw new Error(`${entry.id}: render report source digest does not bind the pinned source.`);
+        }
+        if (candidate.renderReport.options.reviewProfile !== entry.profiles.candidate.reviewProfile
+          || candidate.renderReport.options.commentProfile !== entry.profiles.candidate.commentProfile) {
+          throw new Error(`${entry.id}: render report profile differs from the corpus contract.`);
+        }
+        if (candidate.renderReport.bindings.pdfDigest !== sha256(candidate.pdf)) {
+          throw new Error(`${entry.id}: render report PDF digest does not bind the returned artifact.`);
+        }
+
+        const referencePdfPath = join(caseOutput, 'reference.pdf');
+        const referencePdf = renderReferencePdf(projectedReference.path, work, referencePdfPath);
+        artifacts.referencePdf = `${entry.id}/reference.pdf`;
+
+        const candidateInspection = await inspectPdf(candidate.pdf);
+        const referenceInspection = await inspectPdf(referencePdf);
+        docxodusPages = candidateInspection.pageCount;
+        libreofficePages = referenceInspection.pageCount;
+        writeJsonAtomic(join(caseOutput, 'candidate-inspection.json'), candidateInspection);
+        writeJsonAtomic(join(caseOutput, 'reference-inspection.json'), referenceInspection);
+        artifacts.candidateInspection = `${entry.id}/candidate-inspection.json`;
+        artifacts.referenceInspection = `${entry.id}/reference-inspection.json`;
+
+        const semantic = semanticEvidence(
+          candidatePdfPath,
+          candidateInspection,
+          referencePdfPath,
+          referenceInspection,
+          entry,
+        );
+        writeJsonAtomic(join(caseOutput, 'semantic.json'), semantic);
+        artifacts.semantic = `${entry.id}/semantic.json`;
+
+        const geometry = compareGeometry(candidateInspection, referenceInspection);
+        const physicalGeometryPassed = candidateInspection.pageCount === referenceInspection.pageCount
+          && geometry.every((pageGeometry) => pageGeometry.passed);
+        writeJsonAtomic(join(caseOutput, 'physical-geometry.json'), {
+          tolerancePoints: PHYSICAL_GEOMETRY_TOLERANCE_POINTS,
+          pageCountDelta: candidateInspection.pageCount - referenceInspection.pageCount,
+          passed: physicalGeometryPassed,
+          pages: geometry,
+        });
+        artifacts.physicalGeometry = `${entry.id}/physical-geometry.json`;
+
+        const candidateRaster = rasterizePdf(candidatePdfPath, join(caseOutput, 'docxodus'));
+        const referenceRaster = rasterizePdf(referencePdfPath, join(caseOutput, 'libreoffice'));
+        if (candidateRaster.contractSha256 !== referenceRaster.contractSha256
+          || candidateRaster.contractSha256 !== PDF_RASTER_CONTRACT_SHA256) {
+          throw new Error(`${entry.id}: candidate/reference raster contracts differ.`);
+        }
+
+        const environmentFingerprint = sha256(JSON.stringify({
+          schemaVersion: 1,
+          externalEnvironment: environment,
+          rendererFingerprint: candidate.rendererFingerprint,
+          sourceSha256,
+          referenceSourceSha256,
+          rasterContractSha256: PDF_RASTER_CONTRACT_SHA256,
+        }));
+        const comparablePages = Math.min(candidateRaster.pages.length, referenceRaster.pages.length);
+        let severity: VisualSeverity = candidateRaster.pages.length === referenceRaster.pages.length
+          && physicalGeometryPassed
+          && semantic.passed
+          ? 'close'
+          : 'severe';
+        const pages: PdfParityPageResult[] = [];
+        for (let index = 0; index < comparablePages; index++) {
+          const candidatePage = candidateRaster.pages[index];
+          const referencePage = referenceRaster.pages[index];
+          const comparison = compareImages(
+            decodePng(readFileSync(candidatePage.path)),
+            decodePng(readFileSync(referencePage.path)),
+          );
+          const overlayPath = join(caseOutput, `overlay-${index + 1}.png`);
+          writeFileSync(overlayPath, encodePng(comparison.overlay));
+          severity = worse(severity, comparison.metrics.severity);
+          pages.push({
+            page: index + 1,
+            ...comparison.metrics,
+            physicalGeometry: geometry[index],
+            environmentFingerprint,
+            rendererFingerprint: candidate.rendererFingerprint,
+            artifacts: {
+              candidate: relative(outputRoot, candidatePage.path),
+              reference: relative(outputRoot, referencePage.path),
+              overlay: relative(outputRoot, overlayPath),
+            },
+            artifactSha256: {
+              candidate: candidatePage.sha256,
+              reference: referencePage.sha256,
+              overlay: sha256File(overlayPath),
+            },
+          });
+        }
+
+        const result: PdfParityCaseResult = {
+          id: entry.id,
+          path: entry.source.path,
+          categories: entry.categories,
+          rationale: entry.rationale,
+          disposition: entry.disposition,
+          profiles: entry.profiles,
+          provenance: entry.source.provenance,
+          sourceSha256,
+          sourceGitBlob: entry.source.gitBlob,
+          referenceSourceSha256,
+          docxodusPages: candidateRaster.pages.length,
+          libreofficePages: referenceRaster.pages.length,
+          pageCountDelta: candidateRaster.pages.length - referenceRaster.pages.length,
+          physicalGeometryPassed,
+          semanticChecksPassed: semantic.passed,
+          severity,
+          rendererFingerprint: candidate.rendererFingerprint,
+          environmentFingerprint,
+          artifacts,
+          artifactSha256: {
+            source: sourceSha256,
+            referenceSource: referenceSourceSha256,
+            candidatePdf: candidateRaster.pdfSha256,
+            referencePdf: referenceRaster.pdfSha256,
+          },
+          semantic,
+          pages,
+        };
+        cases.push(result);
+        writeJsonAtomic(join(caseOutput, 'metrics.json'), result);
+        console.log(`[${caseIndex + 1}/${corpus.length}] ${entry.id}: `
+          + `${result.docxodusPages}/${result.libreofficePages} pages, ${result.severity} `
+          + `(${result.disposition.kind}), semantics ${semantic.passed ? 'pass' : 'FAIL'}, `
+          + `geometry ${physicalGeometryPassed ? 'pass' : 'FAIL'}`);
+      } catch (error) {
+        const failedReport = error && typeof error === 'object'
+          && 'report' in error ? (error as { report?: unknown }).report : undefined;
+        if (failedReport !== undefined) {
+          writeJsonAtomic(join(caseOutput, 'failed-render-report.json'), failedReport);
+          artifacts.failedRenderReport = `${entry.id}/failed-render-report.json`;
+        }
+        const result: PdfParityCaseResult = {
+          id: entry.id,
+          path: entry.source.path,
+          categories: entry.categories,
+          rationale: entry.rationale,
+          disposition: entry.disposition,
+          profiles: entry.profiles,
+          provenance: entry.source.provenance,
+          sourceSha256,
+          sourceGitBlob: entry.source.gitBlob,
+          referenceSourceSha256,
+          docxodusPages,
+          libreofficePages,
+          pageCountDelta: docxodusPages - libreofficePages,
+          physicalGeometryPassed: false,
+          semanticChecksPassed: false,
+          severity: 'severe',
+          artifacts,
+          artifactSha256: {},
+          pages: [],
+          error: error instanceof Error ? error.message : String(error),
+        };
+        cases.push(result);
+        writeJsonAtomic(join(caseOutput, 'metrics.json'), result);
+        console.error(`[${caseIndex + 1}/${corpus.length}] ${entry.id}: ERROR ${result.error}`);
+      } finally {
+        rmSync(work, { recursive: true, force: true });
+      }
+      persist();
+    }
+
+    phase = 'summary';
+    persist(true);
+    const summaryPath = join(outputRoot, 'summary.json');
+    const summary = JSON.parse(readFileSync(summaryPath, 'utf8'));
+
+    phase = 'hard-gate';
+    expect(cases.filter(hasHardParityFailure).map((entry) => ({
+      id: entry.id,
+      pageCountDelta: entry.pageCountDelta,
+      physicalGeometryPassed: entry.physicalGeometryPassed,
+      semanticChecksPassed: entry.semanticChecksPassed,
+      error: entry.error,
+    })), 'generated-PDF conversion, page-count, physical-geometry, and semantic contracts '
+      + 'are unconditional; raster severity and disposition cannot waive them').toEqual([]);
+
+    phase = 'ratchet';
+    const complete = !process.env.DOCXODUS_GENERATED_PDF_PARITY_FILTER;
+    if (process.env.DOCXODUS_GENERATED_PDF_PARITY_UPDATE_RECORD === '1') {
+      if (!complete) {
+        throw new Error('Refusing to write a partial generated-PDF ratchet record; unset the filter.');
+      }
+      assertRecordUpdateProvenance(summary);
+      const record = buildRecord(summary, new Date().toISOString().slice(0, 10));
+      record.description = 'Generated-PDF visual-fidelity regression ratchet (issue #443). '
+        + 'Numbers only; complete PDFs, rasters, semantic evidence, geometry, hashes, and '
+        + 'fingerprints live in the uploaded artifact. See npm/tests/visual-parity/README.md.';
+      writeFileSync(GENERATED_PDF_RATCHET_RECORD_FILE, serializeRecord(record));
+      console.log(`Generated-PDF ratchet record refreshed: ${GENERATED_PDF_RATCHET_RECORD_FILE}`);
+    } else if (process.env.DOCXODUS_VISUAL_PARITY_RATCHET !== '0') {
+      const record = readRecord(GENERATED_PDF_RATCHET_RECORD_FILE);
+      if (!record) {
+        throw new Error('Generated-PDF ratchet record is missing. Run a complete benchmark with '
+          + 'DOCXODUS_GENERATED_PDF_PARITY_UPDATE_RECORD=1 and commit the numbers-only record.');
+      }
+      const comparison = compareToRecord(record, summary, { expectComplete: complete });
+      writeJsonAtomic(join(outputRoot, 'ratchet-comparison.json'), comparison);
+      console.log(`Generated-PDF ratchet [${comparison.status}]: ${comparison.message}`);
+      expect(comparison.status, comparison.message).toBe('ok');
+    }
+
+    phase = 'strict-gate';
+    if (process.env.DOCXODUS_VISUAL_PARITY_STRICT === '1') {
+      expect(cases.filter(gatesStrictRasterRun).map((entry) => ({
+        id: entry.id,
+        severity: entry.severity,
+        disposition: entry.disposition.kind,
+      })), 'strict generated-PDF parity additionally rejects renderer-owned severe raster '
+        + 'differences').toEqual([]);
+    }
+
+    phase = 'complete';
+    state.status = 'passed';
+    persist(true);
+    console.log(`Generated-PDF parity viewer: ${join(outputRoot, 'index.html')}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.stack ?? error.message : String(error);
+    state.status = 'failed';
+    state.failure = { phase, message };
+    writeJsonAtomic(join(outputRoot, 'failure.json'), {
+      schemaVersion: 1,
+      failedAt: new Date().toISOString(),
+      phase,
+      message,
+      remediation: 'Open index.html, inspect the retained per-case PDFs/rasters/reports, and rerun '
+        + 'the documented generated-PDF parity command after addressing the named phase.',
+      environment,
+    });
+    persist(cases.length === corpus.length);
+    throw error;
+  }
+});

--- a/npm/tests/generated-pdf-parity.spec.ts
+++ b/npm/tests/generated-pdf-parity.spec.ts
@@ -265,13 +265,16 @@ ${caseSections || '<p>No case artifacts have materialized yet. Inspect the run/f
 `);
 }
 
-function initializeOutputRoot(): string {
-  const outputRoot = resolve(process.env.DOCXODUS_GENERATED_PDF_PARITY_OUTPUT
+function initializeOutputRoot(retry: number): string {
+  const configuredOutputRoot = resolve(process.env.DOCXODUS_GENERATED_PDF_PARITY_OUTPUT
     ?? join(tmpdir(), 'docxodus-generated-pdf-parity'));
-  const relativeToRepo = relative(repoRoot, outputRoot);
+  const relativeToRepo = relative(repoRoot, configuredOutputRoot);
   if (relativeToRepo === '' || (!relativeToRepo.startsWith('..') && !isAbsolute(relativeToRepo))) {
-    throw new Error(`Generated-PDF parity artifacts must stay outside the repository: ${outputRoot}`);
+    throw new Error(`Generated-PDF parity artifacts must stay outside the repository: ${configuredOutputRoot}`);
   }
+  const outputRoot = retry === 0
+    ? configuredOutputRoot
+    : join(configuredOutputRoot, `retry-${retry}`);
   mkdirSync(outputRoot, { recursive: true, mode: 0o700 });
   const unexpected = readdirSync(outputRoot).filter((name) => !BOOTSTRAP_ARTIFACTS.has(name));
   if (unexpected.length) {
@@ -555,10 +558,10 @@ function summarizeCases(cases: PdfParityCaseResult[]) {
   };
 }
 
-test('supported generated PDFs match reference PDFs through the fidelity ratchet', async ({ page, browserName }) => {
+test('supported generated PDFs match reference PDFs through the fidelity ratchet', async ({ page, browserName }, testInfo) => {
   test.setTimeout(30 * 60 * 1000);
 
-  const outputRoot = initializeOutputRoot();
+  const outputRoot = initializeOutputRoot(testInfo.retry);
   const corpus = selectedCorpus();
   const startedAt = new Date().toISOString();
   // Capture the source identity before any benchmark-owned write. Record updates intentionally

--- a/npm/tests/generated-pdf-parity.spec.ts
+++ b/npm/tests/generated-pdf-parity.spec.ts
@@ -1,20 +1,18 @@
 import { expect, test, type Page } from '@playwright/test';
-import { execFileSync, spawnSync } from 'node:child_process';
-import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { createHash, randomUUID } from 'node:crypto';
 import {
   existsSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
-  readdirSync,
-  realpathSync,
   renameSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { basename, dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import {
   GATING_DISPOSITION_KINDS,
@@ -23,7 +21,6 @@ import {
 import {
   PDF_PARITY_CORPUS,
   REQUIRED_PDF_PARITY_CATEGORIES,
-  type PdfLinkExpectation,
   type PdfParityCorpusEntry,
 } from './visual-parity/pdf-corpus.js';
 import {
@@ -35,6 +32,7 @@ import {
 import {
   PDF_RASTER_CONTRACT,
   PDF_RASTER_CONTRACT_SHA256,
+  PDF_PARITY_LIMITS,
   inspectPdf,
   rasterizePdf,
   sha256File,
@@ -44,12 +42,10 @@ import {
 import { decodePng, encodePng } from './visual-parity/png.js';
 import {
   FONT_CONTRACT_FILE,
-  assertFontContract,
   fontContractReport,
 } from './visual-parity/font-contract.js';
 import {
   assertLibreOfficeContract,
-  popplerVersionOutput,
 } from './visual-parity/environment-contract.js';
 import {
   assertRecordUpdateProvenance,
@@ -58,6 +54,27 @@ import {
   readRecord,
   serializeRecord,
 } from './visual-parity/ratchet.js';
+import {
+  assertSafeCaseId,
+  prepareExternalOutputRoot,
+  resolveTrackedRegularFile,
+} from './visual-parity/benchmark-paths.js';
+import {
+  commandVersion,
+  pinExecutable,
+  resolveExecutable,
+} from './visual-parity/toolchain.js';
+import {
+  assertBuildOwningLifecycle,
+  captureGeneratedPdfBuildEvidence,
+} from './visual-parity/build-provenance.js';
+import { assertSupportedPdfResult } from './visual-parity/pdf-result.js';
+import { exactLinkEvidence, type LinkEvidence } from './visual-parity/pdf-links.js';
+
+assertBuildOwningLifecycle(
+  process.env.DOCXODUS_GENERATED_PDF_PARITY === '1',
+  process.env.npm_lifecycle_event,
+);
 
 test.skip(process.env.DOCXODUS_GENERATED_PDF_PARITY !== '1',
   'set DOCXODUS_GENERATED_PDF_PARITY=1 on a host with LibreOffice and Poppler');
@@ -117,14 +134,6 @@ interface TextExtractorEvidence {
   passed: boolean;
 }
 
-interface LinkEvidence {
-  expected: PdfLinkExpectation[];
-  observed: Array<{ kind: string; value?: string; unsafeValue?: string }>;
-  missing: PdfLinkExpectation[];
-  unsupportedAnnotations: number;
-  passed: boolean;
-}
-
 interface SemanticEvidence {
   candidate: {
     pdfjs: TextExtractorEvidence;
@@ -163,6 +172,8 @@ interface PdfParityCaseResult {
   pageCountDelta: number;
   physicalGeometryPassed: boolean;
   semanticChecksPassed: boolean;
+  vectorContentPassed: boolean;
+  vectorPathOperations?: { candidate: number; reference: number };
   severity: VisualSeverity;
   rendererFingerprint?: string;
   environmentFingerprint?: string;
@@ -189,29 +200,13 @@ function sha256(bytes: Uint8Array | string): string {
   return createHash('sha256').update(bytes).digest('hex');
 }
 
-function commandVersion(command: string, args: string[]): string {
-  const result = spawnSync(command, args, {
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-  if (result.error) return String(result.error);
-  return `${result.stdout ?? ''}\n${result.stderr ?? ''}`.trim();
-}
-
-function executableEvidence(command: string, versionArgs: string[]): Record<string, string> {
-  const path = execFileSync('which', [command], { encoding: 'utf8' }).trim();
-  const resolvedPath = realpathSync(path);
-  return {
-    command,
-    executable: basename(resolvedPath),
-    executableSha256: sha256File(resolvedPath),
-    version: commandVersion(command, versionArgs),
-  };
-}
-
 function writeJsonAtomic(path: string, value: unknown): void {
-  const temporary = `${path}.tmp`;
-  writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`);
+  writeTextAtomic(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeTextAtomic(path: string, value: string): void {
+  const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  writeFileSync(temporary, value, { flag: 'wx', mode: 0o600 });
   renameSync(temporary, path);
 }
 
@@ -252,7 +247,7 @@ function writeViewer(outputRoot: string, state: RunState, cases: PdfParityCaseRe
   const ciLink = existsSync(join(outputRoot, 'ci-context.json'))
     ? '<li><a href="ci-context.json">CI context</a></li>'
     : '';
-  writeFileSync(join(outputRoot, 'index.html'), `<!doctype html>
+  writeTextAtomic(join(outputRoot, 'index.html'), `<!doctype html>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Docxodus generated-PDF parity evidence</title>
 <style>
@@ -268,19 +263,7 @@ ${caseSections || '<p>No case artifacts have materialized yet. Inspect the run/f
 function initializeOutputRoot(retry: number): string {
   const configuredOutputRoot = resolve(process.env.DOCXODUS_GENERATED_PDF_PARITY_OUTPUT
     ?? join(tmpdir(), 'docxodus-generated-pdf-parity'));
-  const relativeToRepo = relative(repoRoot, configuredOutputRoot);
-  if (relativeToRepo === '' || (!relativeToRepo.startsWith('..') && !isAbsolute(relativeToRepo))) {
-    throw new Error(`Generated-PDF parity artifacts must stay outside the repository: ${configuredOutputRoot}`);
-  }
-  const outputRoot = retry === 0
-    ? configuredOutputRoot
-    : join(configuredOutputRoot, `retry-${retry}`);
-  mkdirSync(outputRoot, { recursive: true, mode: 0o700 });
-  const unexpected = readdirSync(outputRoot).filter((name) => !BOOTSTRAP_ARTIFACTS.has(name));
-  if (unexpected.length) {
-    throw new Error(`Generated-PDF parity output contains stale artifacts: ${unexpected.join(', ')}`);
-  }
-  return outputRoot;
+  return prepareExternalOutputRoot(repoRoot, configuredOutputRoot, retry, BOOTSTRAP_ARTIFACTS);
 }
 
 function selectedCorpus(): PdfParityCorpusEntry[] {
@@ -294,12 +277,10 @@ function selectedCorpus(): PdfParityCorpusEntry[] {
   return selected;
 }
 
-function assertPinnedSource(entry: PdfParityCorpusEntry): Uint8Array {
-  const path = resolve(repoRoot, entry.source.path);
-  if (!existsSync(path) || !lstatSync(path).isFile() || lstatSync(path).isSymbolicLink()) {
-    throw new Error(`${entry.id} source must be a tracked regular file: ${entry.source.path}`);
-  }
-  execFileSync('git', ['ls-files', '--error-unmatch', entry.source.path], {
+function assertPinnedSource(entry: PdfParityCorpusEntry, gitExecutable: string): Uint8Array {
+  assertSafeCaseId(entry.id);
+  const path = resolveTrackedRegularFile(repoRoot, entry.source.path);
+  execFileSync(gitExecutable, ['ls-files', '--error-unmatch', entry.source.path], {
     cwd: repoRoot,
     stdio: 'pipe',
   });
@@ -308,12 +289,20 @@ function assertPinnedSource(entry: PdfParityCorpusEntry): Uint8Array {
   if (digest !== entry.source.sha256) {
     throw new Error(`${entry.id} source SHA-256 changed (${digest} != ${entry.source.sha256}).`);
   }
-  const blob = execFileSync('git', ['hash-object', entry.source.path], {
+  const blob = execFileSync(gitExecutable, ['hash-object', entry.source.path], {
     cwd: repoRoot,
     encoding: 'utf8',
   }).trim();
   if (blob !== entry.source.gitBlob) {
     throw new Error(`${entry.id} source Git blob changed (${blob} != ${entry.source.gitBlob}).`);
+  }
+  const headBlob = execFileSync(gitExecutable, ['rev-parse', `HEAD:${entry.source.path}`], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+  if (headBlob !== entry.source.gitBlob) {
+    throw new Error(`${entry.id} manifest does not bind the fixture at HEAD (${headBlob} != ${entry.source.gitBlob}).`);
   }
   return bytes;
 }
@@ -364,12 +353,17 @@ async function referenceSource(
   return { path, sha256: sha256(bytes) };
 }
 
-function renderReferencePdf(sourcePath: string, work: string, destination: string): Uint8Array {
+function renderReferencePdf(
+  libreofficeExecutable: string,
+  sourcePath: string,
+  work: string,
+  destination: string,
+): Uint8Array {
   const pdfDirectory = join(work, 'reference-pdf');
   const profileDirectory = join(work, 'libreoffice-profile');
   mkdirSync(pdfDirectory, { recursive: true, mode: 0o700 });
   mkdirSync(profileDirectory, { recursive: true, mode: 0o700 });
-  execFileSync('libreoffice', [
+  execFileSync(libreofficeExecutable, [
     `-env:UserInstallation=${pathToFileURL(profileDirectory).href}`,
     '--headless', '--nologo', '--nodefault', '--nofirststartwizard', '--norestore',
     '--convert-to', 'pdf:writer_pdf_Export', '--outdir', pdfDirectory, sourcePath,
@@ -380,6 +374,11 @@ function renderReferencePdf(sourcePath: string, work: string, destination: strin
   });
   const produced = join(pdfDirectory, `${basename(sourcePath).replace(/\.docx$/i, '')}.pdf`);
   if (!existsSync(produced)) throw new Error(`LibreOffice did not produce ${produced}.`);
+  const producedMetadata = lstatSync(produced);
+  if (!producedMetadata.isFile() || producedMetadata.isSymbolicLink()
+    || producedMetadata.size > PDF_PARITY_LIMITS.maximumPdfBytes) {
+    throw new Error(`LibreOffice PDF is not a bounded regular non-symlink file: ${produced}`);
+  }
   const bytes = new Uint8Array(readFileSync(produced));
   writeFileSync(destination, bytes);
   return bytes;
@@ -408,51 +407,17 @@ function textEvidence(text: string, entry: PdfParityCorpusEntry): TextExtractorE
   };
 }
 
-function popplerText(path: string): string {
-  return execFileSync('pdftotext', ['-enc', 'UTF-8', '-nopgbrk', path, '-'], {
+function popplerText(pdftotextExecutable: string, path: string): string {
+  return execFileSync(pdftotextExecutable, ['-enc', 'UTF-8', '-nopgbrk', path, '-'], {
     encoding: 'utf8',
     env: { ...process.env, LANG: 'C.UTF-8', LC_ALL: 'C.UTF-8', TZ: 'UTC' },
     timeout: 120_000,
+    maxBuffer: 6 * 1024 * 1024,
   });
-}
-
-function canonicalUrl(value: string): string {
-  try {
-    return new URL(value).href;
-  } catch {
-    return value;
-  }
-}
-
-function linkEvidence(inspection: PdfInspection, entry: PdfParityCorpusEntry): LinkEvidence {
-  const expected = [...(entry.semantics.links ?? [])];
-  const observed = inspection.pages.flatMap((page) => page.hyperlinks.map((annotation) => ({
-    kind: annotation.target.kind,
-    ...(annotation.target.kind === 'unsupported' ? {} : { value: annotation.target.value }),
-    ...(annotation.target.kind === 'url' && annotation.target.unsafeValue
-      ? { unsafeValue: annotation.target.unsafeValue }
-      : {}),
-  })));
-  const missing = expected.filter((link) => {
-    if (link.kind === 'external') {
-      return !observed.some((target) => target.kind === 'url'
-        && [target.value, target.unsafeValue].filter((value): value is string => Boolean(value))
-          .some((value) => canonicalUrl(value) === canonicalUrl(link.exactTarget)));
-    }
-    return !observed.some((target) => target.kind === 'destination'
-      && target.value === link.anchor);
-  });
-  const unsupportedAnnotations = observed.filter((target) => target.kind === 'unsupported').length;
-  return {
-    expected,
-    observed,
-    missing,
-    unsupportedAnnotations,
-    passed: missing.length === 0 && unsupportedAnnotations === 0,
-  };
 }
 
 function semanticEvidence(
+  pdftotextExecutable: string,
   candidatePath: string,
   candidateInspection: PdfInspection,
   referencePath: string,
@@ -460,10 +425,10 @@ function semanticEvidence(
   entry: PdfParityCorpusEntry,
 ): SemanticEvidence {
   const candidatePdfjs = textEvidence(candidateInspection.searchableText, entry);
-  const candidatePoppler = textEvidence(popplerText(candidatePath), entry);
-  const candidateLinks = linkEvidence(candidateInspection, entry);
+  const candidatePoppler = textEvidence(popplerText(pdftotextExecutable, candidatePath), entry);
+  const candidateLinks = exactLinkEvidence(candidateInspection, entry);
   const referencePdfjs = textEvidence(referenceInspection.searchableText, entry);
-  const referencePoppler = textEvidence(popplerText(referencePath), entry);
+  const referencePoppler = textEvidence(popplerText(pdftotextExecutable, referencePath), entry);
   return {
     candidate: {
       pdfjs: candidatePdfjs,
@@ -525,7 +490,8 @@ function hasHardParityFailure(result: PdfParityCaseResult): boolean {
   return result.error !== undefined
     || result.pageCountDelta !== 0
     || !result.physicalGeometryPassed
-    || !result.semanticChecksPassed;
+    || !result.semanticChecksPassed
+    || !result.vectorContentPassed;
 }
 
 function gatesStrictRasterRun(result: PdfParityCaseResult): boolean {
@@ -541,6 +507,7 @@ function summarizeCases(cases: PdfParityCaseResult[]) {
     pageCountMismatches: cases.filter((entry) => entry.pageCountDelta !== 0).length,
     physicalGeometryFailures: cases.filter((entry) => !entry.physicalGeometryPassed).length,
     semanticFailures: cases.filter((entry) => !entry.semanticChecksPassed).length,
+    vectorFailures: cases.filter((entry) => !entry.vectorContentPassed).length,
     errors: cases.filter((entry) => entry.error !== undefined).length,
     severityCounts: Object.fromEntries(severityOrder.map((level) => [
       level,
@@ -567,8 +534,11 @@ test('supported generated PDFs match reference PDFs through the fidelity ratchet
   // Capture the source identity before any benchmark-owned write. Record updates intentionally
   // dirty the repository at the end of a successful run; recomputing status while writing the
   // final artifact would therefore mislabel a verified clean source as dirty.
-  const sourceCommit = commandVersion('git', ['rev-parse', 'HEAD']);
-  const sourceWorkingTreeDirty = commandVersion('git', ['status', '--porcelain']).length > 0;
+  const git = pinExecutable('git', ['--version']);
+  const sourceCommit = commandVersion(git.path, ['rev-parse', 'HEAD']);
+  const sourceTree = commandVersion(git.path, ['rev-parse', 'HEAD^{tree}']);
+  const sourceWorkingTreeStatus = commandVersion(git.path, ['status', '--porcelain']);
+  const sourceWorkingTreeDirty = sourceWorkingTreeStatus.length > 0;
   const cases: PdfParityCaseResult[] = [];
   let phase = 'artifact-initialization';
   let environment: Record<string, unknown> = {};
@@ -593,6 +563,7 @@ test('supported generated PDFs match reference PDFs through the fidelity ratchet
       measurementPipeline: 'generated-pdf-v1',
       generatedAt: state.updatedAt,
       gitCommit: sourceCommit,
+      gitTree: sourceTree,
       workingTreeDirty: sourceWorkingTreeDirty,
       rasterContract: {
         ...PDF_RASTER_CONTRACT,
@@ -617,28 +588,37 @@ test('supported generated PDFs match reference PDFs through the fidelity ratchet
   persist();
   try {
     phase = 'environment-preflight';
-    assertFontContract();
-    const fontContract = fontContractReport(repoRoot);
-    const libreofficeVersion = assertLibreOfficeContract();
-    const poppler = popplerVersionOutput();
-    const pdftotext = commandVersion('pdftotext', ['-v']);
-    const exportEntry = resolve(repoRoot, 'npm-export/dist/index.js');
-    if (!existsSync(exportEntry)) {
-      throw new Error(`Build @docxodus/export before the benchmark: missing ${exportEntry}`);
-    }
+    const tools = {
+      fcMatch: pinExecutable('fc-match', ['--version']),
+      libreoffice: pinExecutable('libreoffice', ['--version']),
+      pdftoppm: pinExecutable('pdftoppm', ['-v']),
+      pdftotext: pinExecutable('pdftotext', ['-v']),
+    };
+    const fontContract = fontContractReport(repoRoot, tools.fcMatch.path);
+    const libreofficeVersion = assertLibreOfficeContract(tools.libreoffice.evidence.version);
+    const poppler = tools.pdftoppm.evidence.version.split('\n')[0].trim();
+    const pdftotext = tools.pdftotext.evidence.version;
+    const build = captureGeneratedPdfBuildEvidence(repoRoot);
+    const exportEntry = resolveTrackedRegularFile(repoRoot, 'npm-export/dist/index.js');
     const exporter = await import(pathToFileURL(exportEntry).href) as ExportModule;
     if (typeof exporter.convertDocxToPdf !== 'function') {
       throw new Error('The supported @docxodus/export entry point does not export convertDocxToPdf.');
     }
-    const playwrightCoreEntry = resolve(repoRoot, 'npm-export/node_modules/playwright-core/index.mjs');
+    const playwrightCoreEntry = resolveTrackedRegularFile(
+      repoRoot,
+      'npm-export/node_modules/playwright-core/index.mjs',
+    );
     const exporterPlaywright = await import(pathToFileURL(playwrightCoreEntry).href) as {
       chromium: { executablePath(): string; launch(options: Record<string, unknown>): Promise<{
         version(): string;
         close(): Promise<void>;
       }> };
     };
-    const chromiumExecutablePath = exporterPlaywright.chromium.executablePath();
-    const chromiumProbe = await exporterPlaywright.chromium.launch({ headless: true });
+    const chromiumExecutablePath = resolveExecutable(exporterPlaywright.chromium.executablePath());
+    const chromiumProbe = await exporterPlaywright.chromium.launch({
+      headless: true,
+      executablePath: chromiumExecutablePath,
+    });
     const chromiumVersion = chromiumProbe.version();
     await chromiumProbe.close();
     environment = {
@@ -649,13 +629,21 @@ test('supported generated PDFs match reference PDFs through the fidelity ratchet
         sha256: sha256File(chromiumExecutablePath),
       },
       node: process.version,
+      source: { commit: sourceCommit, tree: sourceTree, workingTreeDirty: sourceWorkingTreeDirty },
+      build,
+      moduleEntries: {
+        exporter: sha256File(exportEntry),
+        playwrightCore: sha256File(playwrightCoreEntry),
+      },
       libreoffice: libreofficeVersion,
       pdftoppm: poppler,
       pdftotext,
       tools: {
-        libreoffice: executableEvidence('libreoffice', ['--version']),
-        pdftoppm: executableEvidence('pdftoppm', ['-v']),
-        pdftotext: executableEvidence('pdftotext', ['-v']),
+        git: git.evidence,
+        fcMatch: tools.fcMatch.evidence,
+        libreoffice: tools.libreoffice.evidence,
+        pdftoppm: tools.pdftoppm.evidence,
+        pdftotext: tools.pdftotext.evidence,
       },
       fontContract,
       locale: 'C.UTF-8',
@@ -666,6 +654,7 @@ test('supported generated PDFs match reference PDFs through the fidelity ratchet
 
     for (const [caseIndex, entry] of corpus.entries()) {
       phase = `case:${entry.id}`;
+      assertSafeCaseId(entry.id);
       const caseOutput = join(outputRoot, entry.id);
       mkdirSync(caseOutput, { recursive: true, mode: 0o700 });
       const work = mkdtempSync(join(tmpdir(), `docxodus-generated-pdf-${entry.id}-`));
@@ -679,7 +668,7 @@ test('supported generated PDFs match reference PDFs through the fidelity ratchet
       let docxodusPages = 0;
       let libreofficePages = 0;
       try {
-        const source = assertPinnedSource(entry);
+        const source = assertPinnedSource(entry, git.path);
         sourceSha256 = sha256(source);
         writeFileSync(join(caseOutput, 'source.docx'), source);
         const projectedReference = await referenceSource(page, entry, source, caseOutput);
@@ -687,12 +676,16 @@ test('supported generated PDFs match reference PDFs through the fidelity ratchet
 
         const candidate = await exporter.convertDocxToPdf(source, {
           ...entry.profiles.candidate,
-          browserExecutablePath: chromiumExecutablePath,
           expectedSourceDigest: sourceSha256,
           unsupportedContent: 'warn',
           timeoutMs: 120_000,
         });
-        docxodusPages = candidate.pageCount;
+        const verifiedCandidate = assertSupportedPdfResult(candidate, {
+          sourceSha256,
+          reviewProfile: entry.profiles.candidate.reviewProfile,
+          commentProfile: entry.profiles.candidate.commentProfile,
+        });
+        docxodusPages = verifiedCandidate.pageCount;
         const candidatePdfPath = join(caseOutput, 'docxodus.pdf');
         writeFileSync(candidatePdfPath, candidate.pdf);
         writeJsonAtomic(join(caseOutput, 'render-report.json'), candidate.renderReport);
@@ -713,11 +706,27 @@ test('supported generated PDFs match reference PDFs through the fidelity ratchet
         }
 
         const referencePdfPath = join(caseOutput, 'reference.pdf');
-        const referencePdf = renderReferencePdf(projectedReference.path, work, referencePdfPath);
+        const referencePdf = renderReferencePdf(
+          tools.libreoffice.path,
+          projectedReference.path,
+          work,
+          referencePdfPath,
+        );
         artifacts.referencePdf = `${entry.id}/reference.pdf`;
 
         const candidateInspection = await inspectPdf(candidate.pdf);
         const referenceInspection = await inspectPdf(referencePdf);
+        if (candidateInspection.pageCount !== verifiedCandidate.pageCount) {
+          throw new Error(`${entry.id}: export API and independent PDF parser disagree on page count.`);
+        }
+        for (const [pageIndex, pageMapPage] of verifiedCandidate.pages.entries()) {
+          const pdfPage = candidateInspection.pages[pageIndex];
+          if (!pdfPage
+            || Math.abs(pageMapPage.width - pdfPage.mediaBox.width) > PHYSICAL_GEOMETRY_TOLERANCE_POINTS
+            || Math.abs(pageMapPage.height - pdfPage.mediaBox.height) > PHYSICAL_GEOMETRY_TOLERANCE_POINTS) {
+            throw new Error(`${entry.id}: PageMap page ${pageIndex + 1} does not bind the PDF MediaBox.`);
+          }
+        }
         docxodusPages = candidateInspection.pageCount;
         libreofficePages = referenceInspection.pageCount;
         writeJsonAtomic(join(caseOutput, 'candidate-inspection.json'), candidateInspection);
@@ -726,6 +735,7 @@ test('supported generated PDFs match reference PDFs through the fidelity ratchet
         artifacts.referenceInspection = `${entry.id}/reference-inspection.json`;
 
         const semantic = semanticEvidence(
+          tools.pdftotext.path,
           candidatePdfPath,
           candidateInspection,
           referencePdfPath,
@@ -734,6 +744,15 @@ test('supported generated PDFs match reference PDFs through the fidelity ratchet
         );
         writeJsonAtomic(join(caseOutput, 'semantic.json'), semantic);
         artifacts.semantic = `${entry.id}/semantic.json`;
+        const vectorContentPassed = !(entry.categories as readonly string[]).includes('charts')
+          || candidateInspection.vectorPathOperations > 0;
+        writeJsonAtomic(join(caseOutput, 'vector-content.json'), {
+          required: (entry.categories as readonly string[]).includes('charts'),
+          passed: vectorContentPassed,
+          candidateConstructPathOperations: candidateInspection.vectorPathOperations,
+          referenceConstructPathOperations: referenceInspection.vectorPathOperations,
+        });
+        artifacts.vectorContent = `${entry.id}/vector-content.json`;
 
         const geometry = compareGeometry(candidateInspection, referenceInspection);
         const physicalGeometryPassed = candidateInspection.pageCount === referenceInspection.pageCount
@@ -746,11 +765,19 @@ test('supported generated PDFs match reference PDFs through the fidelity ratchet
         });
         artifacts.physicalGeometry = `${entry.id}/physical-geometry.json`;
 
-        const candidateRaster = rasterizePdf(candidatePdfPath, join(caseOutput, 'docxodus'));
-        const referenceRaster = rasterizePdf(referencePdfPath, join(caseOutput, 'libreoffice'));
+        const candidateRaster = rasterizePdf(candidatePdfPath, join(caseOutput, 'docxodus'), {
+          executablePath: tools.pdftoppm.path,
+        });
+        const referenceRaster = rasterizePdf(referencePdfPath, join(caseOutput, 'libreoffice'), {
+          executablePath: tools.pdftoppm.path,
+        });
         if (candidateRaster.contractSha256 !== referenceRaster.contractSha256
           || candidateRaster.contractSha256 !== PDF_RASTER_CONTRACT_SHA256) {
           throw new Error(`${entry.id}: candidate/reference raster contracts differ.`);
+        }
+        if (candidateRaster.pages.length !== candidateInspection.pageCount
+          || referenceRaster.pages.length !== referenceInspection.pageCount) {
+          throw new Error(`${entry.id}: PDF parser and rasterizer disagree on page count.`);
         }
 
         const environmentFingerprint = sha256(JSON.stringify({
@@ -813,6 +840,11 @@ test('supported generated PDFs match reference PDFs through the fidelity ratchet
           pageCountDelta: candidateRaster.pages.length - referenceRaster.pages.length,
           physicalGeometryPassed,
           semanticChecksPassed: semantic.passed,
+          vectorContentPassed,
+          vectorPathOperations: {
+            candidate: candidateInspection.vectorPathOperations,
+            reference: referenceInspection.vectorPathOperations,
+          },
           severity,
           rendererFingerprint: candidate.rendererFingerprint,
           environmentFingerprint,
@@ -855,6 +887,7 @@ test('supported generated PDFs match reference PDFs through the fidelity ratchet
           pageCountDelta: docxodusPages - libreofficePages,
           physicalGeometryPassed: false,
           semanticChecksPassed: false,
+          vectorContentPassed: false,
           severity: 'severe',
           artifacts,
           artifactSha256: {},
@@ -881,42 +914,26 @@ test('supported generated PDFs match reference PDFs through the fidelity ratchet
       pageCountDelta: entry.pageCountDelta,
       physicalGeometryPassed: entry.physicalGeometryPassed,
       semanticChecksPassed: entry.semanticChecksPassed,
+      vectorContentPassed: entry.vectorContentPassed,
       error: entry.error,
-    })), 'generated-PDF conversion, page-count, physical-geometry, and semantic contracts '
+    })), 'generated-PDF conversion, page-count, physical-geometry, semantic, and chart-vector contracts '
       + 'are unconditional; raster severity and disposition cannot waive them').toEqual([]);
 
-    phase = 'ratchet';
+    phase = 'ratchet-comparison';
     const complete = !process.env.DOCXODUS_GENERATED_PDF_PARITY_FILTER;
-    if (process.env.DOCXODUS_GENERATED_PDF_PARITY_UPDATE_RECORD === '1') {
-      if (!complete) {
-        throw new Error('Refusing to write a partial generated-PDF ratchet record; unset the filter.');
-      }
-      assertRecordUpdateProvenance(summary);
-      const finalSourceCommit = commandVersion('git', ['rev-parse', 'HEAD']);
-      const finalSourceWorkingTreeDirty = commandVersion('git', ['status', '--porcelain']).length > 0;
-      assertRecordUpdateProvenance({
-        ...summary,
-        gitCommit: finalSourceCommit,
-        workingTreeDirty: finalSourceWorkingTreeDirty,
-      });
-      if (finalSourceCommit !== summary.gitCommit) {
-        throw new Error('Refusing to refresh a parity ratchet after HEAD changed during the benchmark.');
-      }
-      const record = buildRecord(summary, new Date().toISOString().slice(0, 10));
-      record.description = 'Generated-PDF visual-fidelity regression ratchet (issue #443). '
-        + 'Numbers only; complete PDFs, rasters, semantic evidence, geometry, hashes, and '
-        + 'fingerprints live in the uploaded artifact. See npm/tests/visual-parity/README.md.';
-      writeFileSync(GENERATED_PDF_RATCHET_RECORD_FILE, serializeRecord(record));
-      console.log(`Generated-PDF ratchet record refreshed: ${GENERATED_PDF_RATCHET_RECORD_FILE}`);
-    } else if (process.env.DOCXODUS_VISUAL_PARITY_RATCHET !== '0') {
-      const record = readRecord(GENERATED_PDF_RATCHET_RECORD_FILE);
-      if (!record) {
-        throw new Error('Generated-PDF ratchet record is missing. Run a complete benchmark with '
-          + 'DOCXODUS_GENERATED_PDF_PARITY_UPDATE_RECORD=1 and commit the numbers-only record.');
-      }
-      const comparison = compareToRecord(record, summary, { expectComplete: complete });
-      writeJsonAtomic(join(outputRoot, 'ratchet-comparison.json'), comparison);
-      console.log(`Generated-PDF ratchet [${comparison.status}]: ${comparison.message}`);
+    const updateRecord = process.env.DOCXODUS_GENERATED_PDF_PARITY_UPDATE_RECORD === '1';
+    if (updateRecord && !complete) {
+      throw new Error('Refusing to write a partial generated-PDF ratchet record; unset the filter.');
+    }
+    const existingRecord = readRecord(GENERATED_PDF_RATCHET_RECORD_FILE);
+    if (!existingRecord) {
+      throw new Error('Generated-PDF ratchet record is missing. Run a complete benchmark with '
+        + 'DOCXODUS_GENERATED_PDF_PARITY_UPDATE_RECORD=1 and commit the numbers-only record.');
+    }
+    const comparison = compareToRecord(existingRecord, summary, { expectComplete: complete });
+    writeJsonAtomic(join(outputRoot, 'ratchet-comparison.json'), comparison);
+    console.log(`Generated-PDF ratchet [${comparison.status}]: ${comparison.message}`);
+    if (!updateRecord && process.env.DOCXODUS_VISUAL_PARITY_RATCHET !== '0') {
       expect(comparison.status, comparison.message).toBe('ok');
     }
 
@@ -928,6 +945,45 @@ test('supported generated PDFs match reference PDFs through the fidelity ratchet
         disposition: entry.disposition.kind,
       })), 'strict generated-PDF parity additionally rejects renderer-owned severe raster '
         + 'differences').toEqual([]);
+    }
+
+    phase = 'evidence-stability';
+    const finalSourceCommit = commandVersion(git.path, ['rev-parse', 'HEAD']);
+    const finalSourceTree = commandVersion(git.path, ['rev-parse', 'HEAD^{tree}']);
+    const finalWorkingTreeStatus = commandVersion(git.path, ['status', '--porcelain']);
+    if (finalSourceCommit !== sourceCommit || finalSourceTree !== sourceTree
+      || finalWorkingTreeStatus !== sourceWorkingTreeStatus) {
+      throw new Error('Source commit, tree, or working-tree state changed during the benchmark.');
+    }
+    if (JSON.stringify(captureGeneratedPdfBuildEvidence(repoRoot)) !== JSON.stringify(build)
+      || JSON.stringify(fontContractReport(repoRoot, tools.fcMatch.path)) !== JSON.stringify(fontContract)
+      || sha256File(exportEntry) !== (environment.moduleEntries as Record<string, string>).exporter
+      || sha256File(playwrightCoreEntry)
+        !== (environment.moduleEntries as Record<string, string>).playwrightCore
+      || sha256File(chromiumExecutablePath)
+        !== (environment.chromiumExecutable as Record<string, string>).sha256) {
+      throw new Error('The built exporter, browser assets, module entries, or Chromium changed during the run.');
+    }
+    for (const tool of [git, tools.fcMatch, tools.libreoffice, tools.pdftoppm, tools.pdftotext]) {
+      if (sha256File(tool.path) !== tool.evidence.executableSha256) {
+        throw new Error(`Pinned executable changed during the run: ${tool.evidence.command}`);
+      }
+    }
+
+    if (updateRecord) {
+      phase = 'record-update';
+      assertRecordUpdateProvenance(summary);
+      assertRecordUpdateProvenance({
+        ...summary,
+        gitCommit: finalSourceCommit,
+        workingTreeDirty: finalWorkingTreeStatus.length > 0,
+      });
+      const record = buildRecord(summary, new Date().toISOString().slice(0, 10));
+      record.description = 'Generated-PDF visual-fidelity regression ratchet (issue #443). '
+        + 'Numbers only; complete PDFs, rasters, semantic evidence, geometry, hashes, and '
+        + 'fingerprints live in the uploaded artifact. See npm/tests/visual-parity/README.md.';
+      writeTextAtomic(GENERATED_PDF_RATCHET_RECORD_FILE, serializeRecord(record));
+      console.log(`Generated-PDF ratchet record refreshed: ${GENERATED_PDF_RATCHET_RECORD_FILE}`);
     }
 
     phase = 'complete';

--- a/npm/tests/generated-pdf-parity.spec.ts
+++ b/npm/tests/generated-pdf-parity.spec.ts
@@ -561,6 +561,11 @@ test('supported generated PDFs match reference PDFs through the fidelity ratchet
   const outputRoot = initializeOutputRoot();
   const corpus = selectedCorpus();
   const startedAt = new Date().toISOString();
+  // Capture the source identity before any benchmark-owned write. Record updates intentionally
+  // dirty the repository at the end of a successful run; recomputing status while writing the
+  // final artifact would therefore mislabel a verified clean source as dirty.
+  const sourceCommit = commandVersion('git', ['rev-parse', 'HEAD']);
+  const sourceWorkingTreeDirty = commandVersion('git', ['status', '--porcelain']).length > 0;
   const cases: PdfParityCaseResult[] = [];
   let phase = 'artifact-initialization';
   let environment: Record<string, unknown> = {};
@@ -584,8 +589,8 @@ test('supported generated PDFs match reference PDFs through the fidelity ratchet
       schemaVersion: 1,
       measurementPipeline: 'generated-pdf-v1',
       generatedAt: state.updatedAt,
-      gitCommit: commandVersion('git', ['rev-parse', 'HEAD']),
-      workingTreeDirty: commandVersion('git', ['status', '--porcelain']).length > 0,
+      gitCommit: sourceCommit,
+      workingTreeDirty: sourceWorkingTreeDirty,
       rasterContract: {
         ...PDF_RASTER_CONTRACT,
         sha256: PDF_RASTER_CONTRACT_SHA256,
@@ -884,6 +889,16 @@ test('supported generated PDFs match reference PDFs through the fidelity ratchet
         throw new Error('Refusing to write a partial generated-PDF ratchet record; unset the filter.');
       }
       assertRecordUpdateProvenance(summary);
+      const finalSourceCommit = commandVersion('git', ['rev-parse', 'HEAD']);
+      const finalSourceWorkingTreeDirty = commandVersion('git', ['status', '--porcelain']).length > 0;
+      assertRecordUpdateProvenance({
+        ...summary,
+        gitCommit: finalSourceCommit,
+        workingTreeDirty: finalSourceWorkingTreeDirty,
+      });
+      if (finalSourceCommit !== summary.gitCommit) {
+        throw new Error('Refusing to refresh a parity ratchet after HEAD changed during the benchmark.');
+      }
       const record = buildRecord(summary, new Date().toISOString().slice(0, 10));
       record.description = 'Generated-PDF visual-fidelity regression ratchet (issue #443). '
         + 'Numbers only; complete PDFs, rasters, semantic evidence, geometry, hashes, and '

--- a/npm/tests/standalone-export.spec.ts
+++ b/npm/tests/standalone-export.spec.ts
@@ -962,55 +962,57 @@ test.describe('standalone paginated HTML', () => {
     });
   });
 
-  test('fails closed before PageMap publication when a long footnote paragraph clips', async ({
+  test('publishes complete PageMaps when long footnote paragraphs continue', async ({
     page,
   }, testInfo) => {
     const cases = [
       {
         id: 'single-oversized-paragraph',
-        // Issue #489 case C: the whole-child splitter consumes this one paragraph even though
-        // it is taller than the maximum note band.
+        // Issue #489 case C: one paragraph is taller than the maximum note band and must
+        // continue across pages without clipping.
         source: generateFootnoteDocx(1, 2, 1, [700]),
       },
       {
         id: 'oversized-leading-paragraph-with-tail',
-        // Issue #489 case C2: the oversized leading paragraph must not permit the otherwise
-        // splittable tail to disappear behind the clipped note band.
+        // Issue #489 case C2: the long leader and its tail must all survive continuation.
         source: generateFootnoteDocx(1, 2, 3, [700, 8, 8]),
       },
     ];
-    const evidence: Array<{ id: string; sourceSha256: string; failure: unknown }> = [];
+    const evidence: Array<{
+      id: string;
+      sourceSha256: string;
+      pageMap: BrowserExportResult['pageMap'];
+      renderReport: BrowserExportResult['renderReport'];
+    }> = [];
 
     for (const entry of cases) {
-      const failure = await page.evaluate(async ({ bytes }) =>
-        (window as any).DocxodusStandalone.convertFailure(bytes, {
-          reviewProfile: 'final',
-          commentProfile: 'hidden',
-        }), { bytes: Array.from(entry.source) });
+      const result = await convert(page, entry.source, false, { commentProfile: 'hidden' });
+      const footnotePages = new Set(result.pageMap.fragments
+        .filter((fragment: any) => fragment.story === 'footnote')
+        .map((fragment: any) => fragment.pageNumber));
 
-      expect(failure.unexpectedSuccess, entry.id).toBeUndefined();
-      expect(failure.code, entry.id).toBe('pagination_failure');
-      expect(failure.phase, entry.id).toBe('running_story_placement');
-      expect(failure.report, entry.id).toEqual(expect.objectContaining({
-        status: 'failed',
-        source: expect.objectContaining({ rawPackageBytesDigest: digest(entry.source) }),
-        failure: expect.objectContaining({
-          code: 'pagination_failure',
-          phase: 'running_story_placement',
-          message: expect.stringContaining('footnote continuation is clipped'),
-          remediation: expect.stringContaining('issue #489'),
-        }),
-        unavailable: expect.arrayContaining([
-          expect.objectContaining({ field: 'bindings.pageMapDigest' }),
-          expect.objectContaining({ field: 'bindings.htmlDigest' }),
-        ]),
+      expect(result.pageCount, entry.id).toBeGreaterThan(2);
+      expect(footnotePages.size, `${entry.id} must continue its note across pages`)
+        .toBeGreaterThan(1);
+      expect(result.renderReport.status, entry.id).toBe('complete');
+      expect(result.renderReport.source.rawPackageBytesDigest, entry.id).toBe(digest(entry.source));
+      expect(result.renderReport.readiness, entry.id).toContainEqual(expect.objectContaining({
+        phase: 'running_story_placement',
+        status: 'complete',
+        pending: [],
       }));
-      expect(failure.report.bindings, `${entry.id} must not publish artifact bindings`).toBeUndefined();
-      expect(failure.pageMap, `${entry.id} must not publish an incomplete PageMap`).toBeUndefined();
-      evidence.push({ id: entry.id, sourceSha256: digest(entry.source), failure });
+      expect(result.renderReport.bindings.htmlDigest, entry.id).toBe(digest(result.html));
+      expect(result.renderReport.bindings.pageMapDigest, entry.id)
+        .toBe(digest(canonical(result.pageMap)));
+      evidence.push({
+        id: entry.id,
+        sourceSha256: digest(entry.source),
+        pageMap: result.pageMap,
+        renderReport: result.renderReport,
+      });
     }
 
-    await testInfo.attach('long-footnote-fail-closed.json', {
+    await testInfo.attach('long-footnote-continuation-exports.json', {
       body: Buffer.from(`${JSON.stringify(evidence, null, 2)}\n`),
       contentType: 'application/json',
     });

--- a/npm/tests/standalone-export.spec.ts
+++ b/npm/tests/standalone-export.spec.ts
@@ -961,6 +961,60 @@ test.describe('standalone paginated HTML', () => {
       contentType: 'application/json',
     });
   });
+
+  test('fails closed before PageMap publication when a long footnote paragraph clips', async ({
+    page,
+  }, testInfo) => {
+    const cases = [
+      {
+        id: 'single-oversized-paragraph',
+        // Issue #489 case C: the whole-child splitter consumes this one paragraph even though
+        // it is taller than the maximum note band.
+        source: generateFootnoteDocx(1, 2, 1, [700]),
+      },
+      {
+        id: 'oversized-leading-paragraph-with-tail',
+        // Issue #489 case C2: the oversized leading paragraph must not permit the otherwise
+        // splittable tail to disappear behind the clipped note band.
+        source: generateFootnoteDocx(1, 2, 3, [700, 8, 8]),
+      },
+    ];
+    const evidence: Array<{ id: string; sourceSha256: string; failure: unknown }> = [];
+
+    for (const entry of cases) {
+      const failure = await page.evaluate(async ({ bytes }) =>
+        (window as any).DocxodusStandalone.convertFailure(bytes, {
+          reviewProfile: 'final',
+          commentProfile: 'hidden',
+        }), { bytes: Array.from(entry.source) });
+
+      expect(failure.unexpectedSuccess, entry.id).toBeUndefined();
+      expect(failure.code, entry.id).toBe('pagination_failure');
+      expect(failure.phase, entry.id).toBe('running_story_placement');
+      expect(failure.report, entry.id).toEqual(expect.objectContaining({
+        status: 'failed',
+        source: expect.objectContaining({ rawPackageBytesDigest: digest(entry.source) }),
+        failure: expect.objectContaining({
+          code: 'pagination_failure',
+          phase: 'running_story_placement',
+          message: expect.stringContaining('footnote continuation is clipped'),
+          remediation: expect.stringContaining('issue #489'),
+        }),
+        unavailable: expect.arrayContaining([
+          expect.objectContaining({ field: 'bindings.pageMapDigest' }),
+          expect.objectContaining({ field: 'bindings.htmlDigest' }),
+        ]),
+      }));
+      expect(failure.report.bindings, `${entry.id} must not publish artifact bindings`).toBeUndefined();
+      expect(failure.pageMap, `${entry.id} must not publish an incomplete PageMap`).toBeUndefined();
+      evidence.push({ id: entry.id, sourceSha256: digest(entry.source), failure });
+    }
+
+    await testInfo.attach('long-footnote-fail-closed.json', {
+      body: Buffer.from(`${JSON.stringify(evidence, null, 2)}\n`),
+      contentType: 'application/json',
+    });
+  });
 });
 
 test('PaginationEngine uses the element realm and applies scale exactly once', async ({ page }) => {

--- a/npm/tests/visual-parity-benchmark-paths.spec.ts
+++ b/npm/tests/visual-parity-benchmark-paths.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  assertSafeCaseId,
+  prepareExternalOutputRoot,
+  resolveTrackedRegularFile,
+} from './visual-parity/benchmark-paths.js';
+
+test.describe('generated-PDF benchmark path confinement', () => {
+  const work = join(tmpdir(), `docxodus-benchmark-paths-${process.pid}`);
+  const repository = join(work, 'repository');
+  const outside = join(work, 'outside');
+
+  test.beforeEach(() => {
+    rmSync(work, { recursive: true, force: true });
+    mkdirSync(repository, { recursive: true });
+    mkdirSync(outside, { recursive: true });
+  });
+  test.afterEach(() => rmSync(work, { recursive: true, force: true }));
+
+  test('rejects traversal identifiers and repository-relative path escapes', () => {
+    expect(() => assertSafeCaseId('pdf-legal-contract')).not.toThrow();
+    for (const id of ['../escape', 'nested/case', '', '-leading', 'trailing-']) {
+      expect(() => assertSafeCaseId(id)).toThrow(/unsafe/);
+    }
+    expect(() => resolveTrackedRegularFile(repository, '../outside/file.docx')).toThrow();
+    expect(() => resolveTrackedRegularFile(repository, 'nested\\file.docx')).toThrow();
+  });
+
+  test('accepts a regular tracked file and rejects a symlinked artifact root', () => {
+    writeFileSync(join(repository, 'fixture.docx'), 'fixture');
+    expect(resolveTrackedRegularFile(repository, 'fixture.docx')).toBe(join(repository, 'fixture.docx'));
+    if (process.platform === 'win32') return;
+    const linked = join(outside, 'linked-root');
+    symlinkSync(repository, linked, 'dir');
+    expect(() => prepareExternalOutputRoot(repository, linked, 0, new Set()))
+      .toThrow(/non-symlink|inside the repository/);
+  });
+
+  test('separates retries and rejects symlink bootstrap artifacts', () => {
+    const root = join(outside, 'artifacts');
+    const first = prepareExternalOutputRoot(repository, root, 0, new Set());
+    expect(first).toBe(root);
+    expect(prepareExternalOutputRoot(repository, root, 1, new Set())).toBe(join(root, 'retry-1'));
+    if (process.platform === 'win32') return;
+    const bootstrap = join(root, 'ci-context.json');
+    symlinkSync(join(repository, 'missing'), bootstrap);
+    expect(() => prepareExternalOutputRoot(repository, root, 0, new Set(['ci-context.json'])))
+      .toThrow(/unsafe/);
+  });
+});

--- a/npm/tests/visual-parity-build-provenance.spec.ts
+++ b/npm/tests/visual-parity-build-provenance.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test';
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  assertBuildOwningLifecycle,
+  javascriptGraphEvidence,
+} from './visual-parity/build-provenance.js';
+
+test.describe('generated-PDF build provenance', () => {
+  const work = join(tmpdir(), `docxodus-build-evidence-${process.pid}`);
+  test.beforeEach(() => {
+    rmSync(work, { recursive: true, force: true });
+    mkdirSync(join(work, 'nested'), { recursive: true });
+    writeFileSync(join(work, 'index.js'), 'export const value = 1;\n');
+    writeFileSync(join(work, 'nested/module.js'), 'export const sibling = 2;\n');
+    writeFileSync(join(work, 'index.js.map'), 'ignored source map');
+  });
+  test.afterEach(() => rmSync(work, { recursive: true, force: true }));
+
+  test('is stable but detects tampering in an imported sibling module', () => {
+    const first = javascriptGraphEvidence(work);
+    expect(first).toMatchObject({ files: 2, sha256: expect.stringMatching(/^[0-9a-f]{64}$/) });
+    expect(javascriptGraphEvidence(work)).toEqual(first);
+    writeFileSync(join(work, 'nested/module.js'), 'export const sibling = 3;\n');
+    expect(javascriptGraphEvidence(work).sha256).not.toBe(first.sha256);
+  });
+
+  test('rejects symlinks in the emitted module graph', () => {
+    if (process.platform === 'win32') return;
+    symlinkSync(join(work, 'index.js'), join(work, 'linked.js'));
+    expect(() => javascriptGraphEvidence(work)).toThrow(/symlink/);
+  });
+
+  test('rejects an active direct Playwright invocation that skipped the owned builds', () => {
+    expect(() => assertBuildOwningLifecycle(false, undefined)).not.toThrow();
+    expect(() => assertBuildOwningLifecycle(true, 'test:generated-pdf-parity')).not.toThrow();
+    expect(() => assertBuildOwningLifecycle(true, undefined)).toThrow(/direct Playwright/);
+  });
+});

--- a/npm/tests/visual-parity-metrics.spec.ts
+++ b/npm/tests/visual-parity-metrics.spec.ts
@@ -26,6 +26,19 @@ test.describe('visual parity metrics', () => {
     expect(encodePng(decoded)).toEqual(encoded);
   });
 
+  test('PNG decoding rejects corrupt chunks and trailing bytes', () => {
+    const encoded = encodePng(image(2, 2));
+    const corruptHeader = Buffer.from(encoded);
+    corruptHeader[16] ^= 1;
+    expect(() => decodePng(corruptHeader)).toThrow(/CRC/);
+    expect(() => decodePng(Buffer.concat([encoded, Buffer.from([0])]))).toThrow(/trailing bytes/);
+  });
+
+  test('PNG dimensions are bounded before allocation or inflation', () => {
+    expect(() => encodePng({ width: 4_000_001, height: 1, data: new Uint8Array() }))
+      .toThrow(/pixel limit/);
+  });
+
   test('identical pages are exact, structurally identical, and close', () => {
     const original = image(32, 32, { x: 8, y: 8, width: 10, height: 12 });
     const comparison = compareImages(original, original);

--- a/npm/tests/visual-parity-metrics.spec.ts
+++ b/npm/tests/visual-parity-metrics.spec.ts
@@ -34,6 +34,8 @@ test.describe('visual parity metrics', () => {
     expect(result.exactDiffPixelRatio).toBe(0);
     expect(result.perceptualDiffPixelRatio).toBe(0);
     expect(result.ssim).toBeCloseTo(1, 10);
+    expect(result.tolerantInkPrecision).toBeCloseTo(1, 10);
+    expect(result.tolerantInkRecall).toBeCloseTo(1, 10);
     expect(result.tolerantInkF1).toBeCloseTo(1, 10);
     expect(result.severity).toBe('close');
     expect(comparison.overlay.data[0]).toBe(255);
@@ -65,7 +67,22 @@ test.describe('visual parity metrics', () => {
     const blank = image(32, 32);
     const content = image(32, 32, { x: 8, y: 8, width: 12, height: 12 });
     const result = compareImages(blank, content).metrics;
+    expect(result.tolerantInkPrecision).toBe(0);
+    expect(result.tolerantInkRecall).toBe(0);
     expect(result.tolerantInkF1).toBe(0);
     expect(result.severity).toBe('severe');
+  });
+
+  test('ink precision and recall retain their Docxodus/reference direction', () => {
+    const smallDocxodus = image(32, 32, { x: 10, y: 10, width: 4, height: 4 });
+    const largeReference = image(32, 32, { x: 8, y: 8, width: 12, height: 12 });
+    const docxodusSubset = compareImages(smallDocxodus, largeReference).metrics;
+    expect(docxodusSubset.tolerantInkPrecision).toBe(1);
+    expect(docxodusSubset.tolerantInkRecall).toBeLessThan(1);
+
+    const docxodusSuperset = compareImages(largeReference, smallDocxodus).metrics;
+    expect(docxodusSuperset.tolerantInkPrecision).toBeLessThan(1);
+    expect(docxodusSuperset.tolerantInkRecall).toBe(1);
+    expect(docxodusSuperset.tolerantInkF1).toBeCloseTo(docxodusSubset.tolerantInkF1, 10);
   });
 });

--- a/npm/tests/visual-parity-pdf-corpus.spec.ts
+++ b/npm/tests/visual-parity-pdf-corpus.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from "@playwright/test";
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
-import { lstatSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { inflateRawSync } from "node:zlib";
-import { dirname, isAbsolute, relative, resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   PDF_PARITY_CORPUS,
@@ -12,12 +12,18 @@ import {
   type PdfLinkExpectation,
   type PdfParityCorpusEntry,
 } from "./visual-parity/pdf-corpus.js";
+import {
+  assertSafeCaseId,
+  resolveTrackedRegularFile,
+} from "./visual-parity/benchmark-paths.js";
+import { pinExecutable } from "./visual-parity/toolchain.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "../..");
 const sha256Pattern = /^[0-9a-f]{64}$/;
 const gitObjectPattern = /^[0-9a-f]{40}$/;
 const pdfCases: readonly PdfParityCorpusEntry[] = PDF_PARITY_CORPUS.cases;
+const git = pinExecutable("git", ["--version"]);
 
 function sha256(bytes: Uint8Array): string {
   return createHash("sha256").update(bytes).digest("hex");
@@ -102,7 +108,8 @@ function byId(id: string): PdfParityCorpusEntry {
 }
 
 function sourceParts(id: string): Map<string, Buffer> {
-  return zipParts(resolve(repoRoot, byId(id).source.path));
+  const entry = byId(id);
+  return zipParts(resolveTrackedRegularFile(repoRoot, entry.source.path));
 }
 
 function packageText(parts: Map<string, Buffer>): string {
@@ -128,6 +135,7 @@ test.describe("versioned generated-PDF corpus", () => {
     expect(REQUIRED_PDF_PARITY_CATEGORIES.filter((category) => !covered.has(category))).toEqual([]);
 
     for (const entry of pdfCases) {
+      assertSafeCaseId(entry.id);
       expect(entry.rationale.trim(), `${entry.id} corpus rationale`).not.toBe("");
       expect(entry.disposition.rationale.trim(), `${entry.id} disposition rationale`).not.toBe("");
       expect(entry.semantics.requiredText.length, `${entry.id} searchable text contract`).toBeGreaterThan(0);
@@ -147,41 +155,46 @@ test.describe("versioned generated-PDF corpus", () => {
       sourceText: "EricWhite.com",
       relationshipId: "rId4",
       exactTarget: "http://www.ericwhite.com",
+      expectedPdfTarget: "http://www.ericwhite.com/",
+      expectedPdfAnnotations: 1,
     }]);
   });
 
   test("pins every tracked fixture and generator to exact repository bytes", () => {
     const checkedGenerators = new Set<string>();
     for (const entry of pdfCases) {
-      expect(isAbsolute(entry.source.path), `${entry.id} path must be repository-relative`).toBe(false);
-      const path = resolve(repoRoot, entry.source.path);
-      const relativePath = relative(repoRoot, path);
-      expect(relativePath.startsWith(".."), `${entry.id} path escapes the repository`).toBe(false);
-      expect(lstatSync(path).isFile(), `${entry.id} must name a regular file`).toBe(true);
-      expect(lstatSync(path).isSymbolicLink(), `${entry.id} must not name a symlink`).toBe(false);
-      execFileSync("git", ["ls-files", "--error-unmatch", entry.source.path], {
+      const path = resolveTrackedRegularFile(repoRoot, entry.source.path);
+      execFileSync(git.path, ["ls-files", "--error-unmatch", entry.source.path], {
         cwd: repoRoot,
         stdio: "pipe",
       });
       expect(sha256(readFileSync(path)), `${entry.id} fixture SHA-256`).toBe(entry.source.sha256);
-      expect(execFileSync("git", ["hash-object", entry.source.path], {
+      expect(execFileSync(git.path, ["hash-object", entry.source.path], {
         cwd: repoRoot,
         encoding: "utf8",
       }).trim(), `${entry.id} fixture Git blob`).toBe(entry.source.gitBlob);
+      expect(execFileSync(git.path, ["rev-parse", `HEAD:${entry.source.path}`], {
+        cwd: repoRoot,
+        encoding: "utf8",
+      }).trim(), `${entry.id} fixture blob at HEAD`).toBe(entry.source.gitBlob);
 
       const generator = entry.source.provenance.generator;
       if (!generator || checkedGenerators.has(generator.path)) continue;
       checkedGenerators.add(generator.path);
-      const generatorPath = resolve(repoRoot, generator.path);
-      execFileSync("git", ["ls-files", "--error-unmatch", generator.path], {
+      const generatorPath = resolveTrackedRegularFile(repoRoot, generator.path);
+      execFileSync(git.path, ["ls-files", "--error-unmatch", generator.path], {
         cwd: repoRoot,
         stdio: "pipe",
       });
       expect(sha256(readFileSync(generatorPath)), `${generator.path} SHA-256`).toBe(generator.sha256);
-      expect(execFileSync("git", ["hash-object", generator.path], {
+      expect(execFileSync(git.path, ["hash-object", generator.path], {
         cwd: repoRoot,
         encoding: "utf8",
       }).trim(), `${generator.path} Git blob`).toBe(generator.gitBlob);
+      expect(execFileSync(git.path, ["rev-parse", `HEAD:${generator.path}`], {
+        cwd: repoRoot,
+        encoding: "utf8",
+      }).trim(), `${generator.path} blob at HEAD`).toBe(generator.gitBlob);
       expect(generator.rationale.trim()).not.toBe("");
     }
   });

--- a/npm/tests/visual-parity-pdf-corpus.spec.ts
+++ b/npm/tests/visual-parity-pdf-corpus.spec.ts
@@ -1,0 +1,278 @@
+import { test, expect } from "@playwright/test";
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { lstatSync, readFileSync } from "node:fs";
+import { inflateRawSync } from "node:zlib";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  PDF_PARITY_CORPUS,
+  PDF_PARITY_CORPUS_SCHEMA_VERSION,
+  REQUIRED_PDF_PARITY_CATEGORIES,
+  type PdfLinkExpectation,
+  type PdfParityCorpusEntry,
+} from "./visual-parity/pdf-corpus.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../..");
+const sha256Pattern = /^[0-9a-f]{64}$/;
+const gitObjectPattern = /^[0-9a-f]{40}$/;
+const pdfCases: readonly PdfParityCorpusEntry[] = PDF_PARITY_CORPUS.cases;
+
+function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+/** Minimal read-only ZIP reader for fixture-shape assertions; DOCX uses stored or deflated parts. */
+function zipParts(path: string): Map<string, Buffer> {
+  const bytes = readFileSync(path);
+  const minimumEocd = 22;
+  const earliestEocd = Math.max(0, bytes.length - 65_557);
+  let eocd = -1;
+  for (let offset = bytes.length - minimumEocd; offset >= earliestEocd; offset--) {
+    if (bytes.readUInt32LE(offset) === 0x06054b50) {
+      eocd = offset;
+      break;
+    }
+  }
+  if (eocd < 0) throw new Error(`${path} has no ZIP end-of-central-directory record`);
+
+  const count = bytes.readUInt16LE(eocd + 10);
+  let cursor = bytes.readUInt32LE(eocd + 16);
+  const parts = new Map<string, Buffer>();
+  for (let index = 0; index < count; index++) {
+    if (bytes.readUInt32LE(cursor) !== 0x02014b50) {
+      throw new Error(`${path} has an invalid central-directory record at ${cursor}`);
+    }
+    const method = bytes.readUInt16LE(cursor + 10);
+    const compressedSize = bytes.readUInt32LE(cursor + 20);
+    const nameLength = bytes.readUInt16LE(cursor + 28);
+    const extraLength = bytes.readUInt16LE(cursor + 30);
+    const commentLength = bytes.readUInt16LE(cursor + 32);
+    const localOffset = bytes.readUInt32LE(cursor + 42);
+    const name = bytes.subarray(cursor + 46, cursor + 46 + nameLength).toString("utf8");
+
+    if (bytes.readUInt32LE(localOffset) !== 0x04034b50) {
+      throw new Error(`${path}:${name} has an invalid local-file record`);
+    }
+    const localNameLength = bytes.readUInt16LE(localOffset + 26);
+    const localExtraLength = bytes.readUInt16LE(localOffset + 28);
+    const dataStart = localOffset + 30 + localNameLength + localExtraLength;
+    const compressed = bytes.subarray(dataStart, dataStart + compressedSize);
+    if (!name.endsWith("/")) {
+      if (method === 0) parts.set(name, Buffer.from(compressed));
+      else if (method === 8) parts.set(name, inflateRawSync(compressed));
+      else throw new Error(`${path}:${name} uses unsupported ZIP compression method ${method}`);
+    }
+    cursor += 46 + nameLength + extraLength + commentLength;
+  }
+  return parts;
+}
+
+function xml(parts: Map<string, Buffer>, name: string): string {
+  const part = parts.get(name);
+  if (!part) throw new Error(`DOCX is missing ${name}`);
+  return part.toString("utf8");
+}
+
+function occurrences(value: string, pattern: RegExp): number {
+  return value.match(pattern)?.length ?? 0;
+}
+
+function regexEscape(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function decodedText(xmlFragment: string): string {
+  return xmlFragment
+    .replace(/<[^>]+>/g, "")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function byId(id: string): PdfParityCorpusEntry {
+  const entry = pdfCases.find((candidate) => candidate.id === id);
+  if (!entry) throw new Error(`Missing PDF corpus case ${id}`);
+  return entry;
+}
+
+function sourceParts(id: string): Map<string, Buffer> {
+  return zipParts(resolve(repoRoot, byId(id).source.path));
+}
+
+function packageText(parts: Map<string, Buffer>): string {
+  return [...parts]
+    .filter(([name]) => name.startsWith("word/") && name.endsWith(".xml"))
+    .map(([, bytes]) => decodedText(bytes.toString("utf8")))
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+test.describe("versioned generated-PDF corpus", () => {
+  test("is complete, compact, explicitly profiled, and semantically inspectable", () => {
+    expect(PDF_PARITY_CORPUS.schemaVersion).toBe(PDF_PARITY_CORPUS_SCHEMA_VERSION);
+    expect(pdfCases.length).toBeLessThanOrEqual(10);
+
+    const ids = pdfCases.map((entry) => entry.id);
+    const paths = pdfCases.map((entry) => entry.source.path);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(new Set(paths).size).toBe(paths.length);
+
+    const covered = new Set(pdfCases.flatMap((entry) => entry.categories));
+    expect(REQUIRED_PDF_PARITY_CATEGORIES.filter((category) => !covered.has(category))).toEqual([]);
+
+    for (const entry of pdfCases) {
+      expect(entry.rationale.trim(), `${entry.id} corpus rationale`).not.toBe("");
+      expect(entry.disposition.rationale.trim(), `${entry.id} disposition rationale`).not.toBe("");
+      expect(entry.semantics.requiredText.length, `${entry.id} searchable text contract`).toBeGreaterThan(0);
+      expect(entry.profiles.candidate).toEqual({ reviewProfile: "final", commentProfile: "hidden" });
+      expect(entry.profiles.reference.commentProjection).toBe("hidden");
+      expect(entry.profiles.rationale.trim(), `${entry.id} profile rationale`).not.toBe("");
+      expect(entry.source.sha256).toMatch(sha256Pattern);
+      expect(entry.source.gitBlob).toMatch(gitObjectPattern);
+      expect(entry.source.provenance.introducedBy).toMatch(gitObjectPattern);
+      expect(entry.source.provenance.rationale.trim(), `${entry.id} provenance rationale`).not.toBe("");
+    }
+
+    const links = pdfCases.flatMap((entry) => entry.semantics.links ?? []);
+    expect(links.filter((link) => link.kind === "internal")).toHaveLength(11);
+    expect(links.filter((link) => link.kind === "external")).toEqual([{
+      kind: "external",
+      sourceText: "EricWhite.com",
+      relationshipId: "rId4",
+      exactTarget: "http://www.ericwhite.com",
+    }]);
+  });
+
+  test("pins every tracked fixture and generator to exact repository bytes", () => {
+    const checkedGenerators = new Set<string>();
+    for (const entry of pdfCases) {
+      expect(isAbsolute(entry.source.path), `${entry.id} path must be repository-relative`).toBe(false);
+      const path = resolve(repoRoot, entry.source.path);
+      const relativePath = relative(repoRoot, path);
+      expect(relativePath.startsWith(".."), `${entry.id} path escapes the repository`).toBe(false);
+      expect(lstatSync(path).isFile(), `${entry.id} must name a regular file`).toBe(true);
+      expect(lstatSync(path).isSymbolicLink(), `${entry.id} must not name a symlink`).toBe(false);
+      execFileSync("git", ["ls-files", "--error-unmatch", entry.source.path], {
+        cwd: repoRoot,
+        stdio: "pipe",
+      });
+      expect(sha256(readFileSync(path)), `${entry.id} fixture SHA-256`).toBe(entry.source.sha256);
+      expect(execFileSync("git", ["hash-object", entry.source.path], {
+        cwd: repoRoot,
+        encoding: "utf8",
+      }).trim(), `${entry.id} fixture Git blob`).toBe(entry.source.gitBlob);
+
+      const generator = entry.source.provenance.generator;
+      if (!generator || checkedGenerators.has(generator.path)) continue;
+      checkedGenerators.add(generator.path);
+      const generatorPath = resolve(repoRoot, generator.path);
+      execFileSync("git", ["ls-files", "--error-unmatch", generator.path], {
+        cwd: repoRoot,
+        stdio: "pipe",
+      });
+      expect(sha256(readFileSync(generatorPath)), `${generator.path} SHA-256`).toBe(generator.sha256);
+      expect(execFileSync("git", ["hash-object", generator.path], {
+        cwd: repoRoot,
+        encoding: "utf8",
+      }).trim(), `${generator.path} Git blob`).toBe(generator.gitBlob);
+      expect(generator.rationale.trim()).not.toBe("");
+    }
+  });
+
+  test("binds every strict text token to content in its pinned source package", () => {
+    for (const entry of pdfCases) {
+      const text = packageText(sourceParts(entry.id));
+      for (const required of entry.semantics.requiredText) {
+        expect(text, `${entry.id} required text ${JSON.stringify(required)}`).toContain(required);
+      }
+      for (const hidden of entry.semantics.forbiddenText ?? []) {
+        expect(text, `${entry.id} hidden/final-view text ${JSON.stringify(hidden)}`).toContain(hidden);
+      }
+    }
+  });
+
+  test("the pinned packages contain every claimed high-risk document shape", () => {
+    const legal = sourceParts("pdf-legal-contract");
+    expect(xml(legal, "word/document.xml")).toContain("<w:tbl>");
+
+    const columns = sourceParts("pdf-two-column-section");
+    expect(xml(columns, "word/document.xml")).toMatch(/<w:cols\b[^>]*w:num="2"/);
+
+    const footnote = sourceParts("pdf-footnote");
+    expect(xml(footnote, "word/document.xml")).toContain("<w:footnoteReference");
+    expect(xml(footnote, "word/footnotes.xml")).toContain("This is a test.");
+
+    const endnote = sourceParts("pdf-endnote-table");
+    expect(xml(endnote, "word/document.xml")).toContain("<w:endnoteReference");
+    expect(xml(endnote, "word/endnotes.xml")).toContain("<w:tbl>");
+
+    const mixed = sourceParts("pdf-mixed-orientation-running-stories");
+    const mixedDocument = xml(mixed, "word/document.xml");
+    const pageSizes = mixedDocument.match(/<w:pgSz\b[^>]*\/>/g) ?? [];
+    expect(pageSizes.some((tag) => /w:orient="landscape"/.test(tag))).toBe(true);
+    expect(pageSizes.some((tag) => !/w:orient=/.test(tag))).toBe(true);
+    expect(occurrences(mixedDocument, /<w:headerReference\b/g)).toBeGreaterThan(0);
+    expect(occurrences(mixedDocument, /<w:footerReference\b/g)).toBeGreaterThan(0);
+    expect([...mixed.keys()].some((name) => /^word\/header\d+\.xml$/.test(name))).toBe(true);
+    expect([...mixed.keys()].some((name) => /^word\/footer\d+\.xml$/.test(name))).toBe(true);
+
+    const image = sourceParts("pdf-raster-image");
+    expect(xml(image, "word/document.xml")).toContain("<w:drawing>");
+    expect([...image.keys()].some((name) => name.startsWith("word/media/"))).toBe(true);
+
+    const chart = sourceParts("pdf-chart");
+    expect(xml(chart, "word/document.xml")).toContain("<c:chart");
+    expect([...chart.keys()].some((name) => /^word\/charts\/chart\d+\.xml$/.test(name))).toBe(true);
+
+    const revisions = sourceParts("pdf-final-revisions");
+    expect(xml(revisions, "word/document.xml")).toContain("<w:del ");
+    expect(xml(revisions, "word/document.xml")).toContain("powerful");
+    expect(byId("pdf-final-revisions").profiles.reference.revisionProjection).toBe("accepted");
+
+    const comments = sourceParts("pdf-hidden-comments");
+    expect(occurrences(xml(comments, "word/document.xml"), /<w:commentReference\b/g)).toBe(10);
+    expect(occurrences(xml(comments, "word/comments.xml"), /<w:comment\b/g)).toBe(10);
+    expect(occurrences(xml(comments, "word/commentsExtended.xml"), /<w15:commentEx\b/g)).toBe(10);
+    expect(byId("pdf-hidden-comments").profiles.candidate.commentProfile).toBe("hidden");
+  });
+
+  test("pins exact internal destinations and the external URI", () => {
+    const checkLink = (link: PdfLinkExpectation, document: string, relationships: string): void => {
+      if (link.kind === "external") {
+        expect(document).toMatch(new RegExp(
+          `<w:hyperlink\\b[^>]*r:id="${regexEscape(link.relationshipId)}"[^>]*>[\\s\\S]*?${regexEscape(link.sourceText)}[\\s\\S]*?</w:hyperlink>`,
+        ));
+        expect(relationships).toMatch(new RegExp(
+          `<Relationship\\b(?=[^>]*\\bId="${regexEscape(link.relationshipId)}")(?=[^>]*\\bTarget="${regexEscape(link.exactTarget)}")(?=[^>]*\\bTargetMode="External")[^>]*/>`,
+        ));
+        return;
+      }
+
+      const hyperlink = document.match(new RegExp(
+        `<w:hyperlink\\b[^>]*w:anchor="${regexEscape(link.anchor)}"[^>]*>([\\s\\S]*?)</w:hyperlink>`,
+      ));
+      expect(hyperlink, `missing hyperlink to ${link.anchor}`).not.toBeNull();
+      expect(decodedText(hyperlink![1])).toContain(link.sourceText);
+      const bookmark = document.match(new RegExp(
+        `<w:bookmarkStart\\b[^>]*w:name="${regexEscape(link.anchor)}"[^>]*/>([\\s\\S]*?)<w:bookmarkEnd\\b`,
+      ));
+      expect(bookmark, `missing bookmark ${link.anchor}`).not.toBeNull();
+      expect(decodedText(bookmark![1])).toContain(link.destinationText);
+    };
+
+    for (const entry of pdfCases) {
+      if (!entry.semantics.links?.length) continue;
+      const parts = sourceParts(entry.id);
+      const document = xml(parts, "word/document.xml");
+      const relationships = xml(parts, "word/_rels/document.xml.rels");
+      for (const link of entry.semantics.links) checkLink(link, document, relationships);
+    }
+  });
+});

--- a/npm/tests/visual-parity-pdf-links.spec.ts
+++ b/npm/tests/visual-parity-pdf-links.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from '@playwright/test';
+import type { PdfInspection } from './visual-parity/pdf.js';
+import { exactLinkEvidence } from './visual-parity/pdf-links.js';
+
+const semantics = {
+  requiredText: ['TOC', 'Target'],
+  links: [{
+    kind: 'internal' as const,
+    sourceText: 'TOC Entry',
+    anchor: '_Target',
+    destinationText: 'Target Heading',
+    expectedPdfAnnotations: 1,
+  }],
+};
+
+function inspection(): PdfInspection {
+  return {
+    pdfSha256: 'a'.repeat(64),
+    pageCount: 2,
+    searchableText: 'TOC Entry\nTarget Heading',
+    linkAnnotations: 1,
+    vectorPathOperations: 0,
+    marked: false,
+    semantics: {} as PdfInspection['semantics'],
+    pages: [
+      {
+        pageNumber: 1, userUnit: 1, rotation: 0,
+        mediaBox: { x: 0, y: 0, width: 612, height: 792 },
+        cropBox: { x: 0, y: 0, width: 612, height: 792 },
+        text: 'TOC Entry', textSha256: 'b'.repeat(64), constructPathOperations: 0,
+        hyperlinks: [{
+          rectangle: [1, 2, 3, 4],
+          target: { kind: 'destination', value: '_Target', namedDestination: '_Target', pageNumber: 2 },
+        }],
+      },
+      {
+        pageNumber: 2, userUnit: 1, rotation: 0,
+        mediaBox: { x: 0, y: 0, width: 612, height: 792 },
+        cropBox: { x: 0, y: 0, width: 612, height: 792 },
+        text: 'Target Heading', textSha256: 'c'.repeat(64), constructPathOperations: 0,
+        hyperlinks: [],
+      },
+    ],
+  };
+}
+
+test.describe('exact PDF hyperlink evidence', () => {
+  test('binds source label, exact target, destination page text, rectangle, and cardinality', () => {
+    expect(exactLinkEvidence(inspection(), { semantics })).toMatchObject({
+      passed: true,
+      unexpectedLogicalLinks: 0,
+      missingOrMismatched: [],
+    });
+  });
+
+  test('rejects swapped/wrong targets, wrong destination text, missing rectangles, and extras', () => {
+    const mutations = [
+      (value: PdfInspection) => { (value.pages[0].hyperlinks[0].target as any).namedDestination = '_Wrong'; },
+      (value: PdfInspection) => { value.pages[1].text = 'Wrong page'; },
+      (value: PdfInspection) => { delete (value.pages[0].hyperlinks[0] as any).rectangle; },
+      (value: PdfInspection) => { value.pages[0].hyperlinks.push(value.pages[0].hyperlinks[0]); },
+    ];
+    for (const mutate of mutations) {
+      const value = inspection();
+      mutate(value);
+      expect(exactLinkEvidence(value, { semantics }).passed).toBe(false);
+    }
+  });
+
+  test('requires the source URI representation instead of a canonicalized equivalent', () => {
+    const value = inspection();
+    value.pages[0].hyperlinks = [{
+      rectangle: [1, 2, 3, 4],
+      target: { kind: 'url', value: 'http://example.invalid/', unsafeValue: 'http://example.invalid/' },
+    }];
+    const external = {
+      requiredText: ['Example'],
+      links: [{
+        kind: 'external' as const,
+        sourceText: 'TOC Entry',
+        relationshipId: 'rId1',
+        exactTarget: 'http://example.invalid',
+        expectedPdfTarget: 'http://example.invalid',
+        expectedPdfAnnotations: 1,
+      }],
+    };
+    expect(exactLinkEvidence(value, { semantics: external }).passed).toBe(false);
+  });
+});

--- a/npm/tests/visual-parity-pdf-result.spec.ts
+++ b/npm/tests/visual-parity-pdf-result.spec.ts
@@ -1,0 +1,77 @@
+import { createHash } from 'node:crypto';
+import { expect, test } from '@playwright/test';
+import { canonicalJson } from './visual-parity/canonical-json.js';
+import { assertSupportedPdfResult } from './visual-parity/pdf-result.js';
+
+const sha256 = (value: Uint8Array | string): string =>
+  createHash('sha256').update(value).digest('hex');
+
+function validResult(): Record<string, any> {
+  const pdf = new Uint8Array(32).fill(1);
+  const fingerprint = 'a'.repeat(64);
+  const pageMap = {
+    schemaVersion: 1,
+    mode: 'paginated',
+    availability: 'available',
+    documentVersion: 0,
+    rendererFingerprint: fingerprint,
+    pages: [{ pageNumber: 1, pageInSection: 1, width: 612, height: 792, sectionIndex: 0, pageName: 'page-1' }],
+    fragments: [{
+      fragmentId: 'p1-f0-body:document:p1',
+      anchorId: 'body:document:p1',
+      fragmentIndex: 0,
+      pageNumber: 1,
+      geometry: { x: 1, y: 2, width: 3, height: 4 },
+      story: 'body',
+      inTableCell: false,
+    }],
+  };
+  return {
+    pdf,
+    pageCount: 1,
+    pageMap,
+    rendererFingerprint: fingerprint,
+    warnings: [],
+    renderReport: {
+      status: 'complete',
+      source: { rawPackageBytesDigest: 'b'.repeat(64) },
+      options: { reviewProfile: 'final', commentProfile: 'hidden' },
+      environment: { rendererFingerprint: fingerprint, verification: 'nodeVerified', fidelityTier: 'releaseBaselined' },
+      pages: pageMap.pages,
+      warnings: [],
+      bindings: { pdfDigest: sha256(pdf), pageMapDigest: sha256(canonicalJson(pageMap)) },
+    },
+  };
+}
+
+const expectation = {
+  sourceSha256: 'b'.repeat(64),
+  reviewProfile: 'final',
+  commentProfile: 'hidden',
+};
+
+test.describe('supported generated-PDF result verification', () => {
+  test('accepts a fully bound result', () => {
+    expect(assertSupportedPdfResult(validResult(), expectation)).toMatchObject({
+      pageCount: 1,
+      rendererFingerprint: 'a'.repeat(64),
+    });
+  });
+
+  test('rejects independent count, fingerprint, PageMap, and report drift', () => {
+    const mutations = [
+      (value: Record<string, any>) => { value.pageCount = 2; },
+      (value: Record<string, any>) => { value.pageMap.rendererFingerprint = 'c'.repeat(64); },
+      (value: Record<string, any>) => { value.pageMap.pages[0].width = Number.POSITIVE_INFINITY; },
+      (value: Record<string, any>) => { value.pageMap.fragments[0].pageNumber = 2; },
+      (value: Record<string, any>) => { value.renderReport.environment.verification = 'browserObserved'; },
+      (value: Record<string, any>) => { value.renderReport.bindings.pdfDigest = 'd'.repeat(64); },
+      (value: Record<string, any>) => { value.warnings.push({ code: 'unexpected' }); },
+    ];
+    for (const mutate of mutations) {
+      const value = validResult();
+      mutate(value);
+      expect(() => assertSupportedPdfResult(value, expectation)).toThrow();
+    }
+  });
+});

--- a/npm/tests/visual-parity-pdf.spec.ts
+++ b/npm/tests/visual-parity-pdf.spec.ts
@@ -1,0 +1,142 @@
+import { expect, test } from '@playwright/test';
+import {
+  PDFDocument,
+  PDFName,
+  PDFString,
+  StandardFonts,
+} from 'pdf-lib';
+import {
+  PDF_RASTER_CONTRACT,
+  PDF_RASTER_CONTRACT_SHA256,
+  inspectPdf,
+  popplerRasterArguments,
+} from './visual-parity/pdf.js';
+
+async function semanticFixture(): Promise<Uint8Array> {
+  const pdf = await PDFDocument.create();
+  const font = await pdf.embedFont(StandardFonts.Helvetica);
+  const first = pdf.addPage([612, 792]);
+  first.setCropBox(10, 20, 580, 740);
+  first.drawText('SELECTABLE ALPHA', { x: 72, y: 700, size: 12, font });
+  const uri = pdf.context.register(pdf.context.obj({
+    Type: PDFName.of('Annot'),
+    Subtype: PDFName.of('Link'),
+    Rect: [72, 675, 240, 695],
+    Border: [0, 0, 0],
+    A: {
+      Type: PDFName.of('Action'),
+      S: PDFName.of('URI'),
+      URI: PDFString.of('https://example.invalid/contract'),
+    },
+  }));
+
+  const second = pdf.addPage([792, 612]);
+  second.drawText('SELECTABLE OMEGA', { x: 72, y: 520, size: 12, font });
+  const internal = pdf.context.register(pdf.context.obj({
+    Type: PDFName.of('Annot'),
+    Subtype: PDFName.of('Link'),
+    Rect: [72, 640, 240, 660],
+    Border: [0, 0, 0],
+    Dest: [second.ref, PDFName.of('Fit')],
+  }));
+  first.node.set(PDFName.of('Annots'), pdf.context.obj([uri, internal]));
+  return new Uint8Array(await pdf.save({ useObjectStreams: false }));
+}
+
+test.describe('generated-PDF visual parity helpers', () => {
+  test('one frozen Poppler argument contract fixes DPI, RGB PNG, antialiasing, and MediaBox', () => {
+    expect(Object.isFrozen(PDF_RASTER_CONTRACT)).toBe(true);
+    expect(PDF_RASTER_CONTRACT).toMatchObject({
+      tool: 'pdftoppm',
+      dpi: 96,
+      format: 'png',
+      colorModel: 'rgb',
+      pageBox: 'media',
+      fontAntialiasing: true,
+      vectorAntialiasing: true,
+      thinLineMode: 'none',
+    });
+    expect(PDF_RASTER_CONTRACT_SHA256).toMatch(/^[0-9a-f]{64}$/);
+
+    const args = popplerRasterArguments('/tmp/source.pdf', '/tmp/pages/render');
+    expect(Object.isFrozen(args)).toBe(true);
+    expect(args).toEqual([
+      '-r', '96',
+      '-png',
+      '-freetype', 'yes',
+      '-thinlinemode', 'none',
+      '-aa', 'yes',
+      '-aaVector', 'yes',
+      '-forcenum',
+      '-q',
+      '/tmp/source.pdf',
+      '/tmp/pages/render',
+    ]);
+    expect(args).not.toContain('-gray');
+    expect(args).not.toContain('-mono');
+    expect(args).not.toContain('-cropbox');
+  });
+
+  test('inspects actual per-page boxes, selectable text, exact link targets, and hashes', async () => {
+    const bytes = await semanticFixture();
+    const inspection = await inspectPdf(bytes, {
+      requireSelectableText: true,
+      requiredText: ['SELECTABLE ALPHA', 'SELECTABLE OMEGA'],
+      forbiddenText: ['REDACTED SECRET'],
+      requiredHyperlinkTargets: [
+        { kind: 'url', value: 'https://example.invalid/contract', representation: 'source' },
+        { kind: 'destination', pageNumber: 2 },
+      ],
+    });
+
+    expect(inspection.pdfSha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(inspection.pageCount).toBe(2);
+    expect(inspection.pages.map((page) => page.mediaBox)).toEqual([
+      { x: 0, y: 0, width: 612, height: 792 },
+      { x: 0, y: 0, width: 792, height: 612 },
+    ]);
+    expect(inspection.pages[0].cropBox).toEqual({ x: 10, y: 20, width: 580, height: 740 });
+    expect(inspection.pages[1].cropBox).toEqual({ x: 0, y: 0, width: 792, height: 612 });
+    expect(inspection.pages.every((page) => /^[0-9a-f]{64}$/.test(page.textSha256))).toBe(true);
+    expect(inspection.linkAnnotations).toBe(2);
+    expect(inspection.pages[0].hyperlinks[0].target).toEqual({
+      kind: 'url',
+      value: 'https://example.invalid/contract',
+      unsafeValue: 'https://example.invalid/contract',
+    });
+    expect(inspection.pages[0].hyperlinks[1].target).toMatchObject({
+      kind: 'destination',
+      pageNumber: 2,
+    });
+    expect(inspection.semantics).toMatchObject({
+      passed: true,
+      selectableText: { status: 'verified', missingFragments: [] },
+      hyperlinks: {
+        status: 'verified',
+        annotationCount: 2,
+        supportedCount: 2,
+        unsupportedCount: 0,
+        missingTargets: [],
+      },
+    });
+  });
+
+  test('reports missing text and hyperlink expectations independently of raster metrics', async () => {
+    const inspection = await inspectPdf(await semanticFixture(), {
+      requiredText: ['NOT PRESENT'],
+      forbiddenText: ['SELECTABLE ALPHA'],
+      requiredHyperlinkTargets: [{ kind: 'url', value: 'https://missing.invalid/' }],
+    });
+
+    expect(inspection.semantics.passed).toBe(false);
+    expect(inspection.semantics.selectableText).toMatchObject({
+      status: 'failed',
+      missingFragments: ['NOT PRESENT'],
+      presentForbiddenFragments: ['SELECTABLE ALPHA'],
+    });
+    expect(inspection.semantics.hyperlinks).toMatchObject({
+      status: 'failed',
+      missingTargets: [{ kind: 'url', value: 'https://missing.invalid/' }],
+    });
+  });
+});

--- a/npm/tests/visual-parity-pdf.spec.ts
+++ b/npm/tests/visual-parity-pdf.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test';
 import {
   PDFDocument,
   PDFName,
+  PDFNumber,
   PDFString,
   StandardFonts,
 } from 'pdf-lib';
@@ -67,6 +68,8 @@ test.describe('generated-PDF visual parity helpers', () => {
       '-thinlinemode', 'none',
       '-aa', 'yes',
       '-aaVector', 'yes',
+      '-f', '1',
+      '-l', '33',
       '-forcenum',
       '-q',
       '/tmp/source.pdf',
@@ -75,6 +78,33 @@ test.describe('generated-PDF visual parity helpers', () => {
     expect(args).not.toContain('-gray');
     expect(args).not.toContain('-mono');
     expect(args).not.toContain('-cropbox');
+  });
+
+  test('applies UserUnit and page rotation without discarding nonzero box origins', async () => {
+    const pdf = await PDFDocument.create();
+    const rotated90 = pdf.addPage([100, 200]);
+    rotated90.setMediaBox(10, 20, 30, 40);
+    rotated90.setCropBox(12, 22, 20, 30);
+    rotated90.node.set(PDFName.of('UserUnit'), PDFNumber.of(2));
+    rotated90.node.set(PDFName.of('Rotate'), PDFNumber.of(90));
+    const rotated270 = pdf.addPage([100, 200]);
+    rotated270.setMediaBox(5, 7, 20, 30);
+    rotated270.node.set(PDFName.of('UserUnit'), PDFNumber.of(3));
+    rotated270.node.set(PDFName.of('Rotate'), PDFNumber.of(270));
+
+    const inspection = await inspectPdf(new Uint8Array(await pdf.save({ useObjectStreams: false })));
+
+    expect(inspection.pages[0]).toMatchObject({
+      userUnit: 2,
+      rotation: 90,
+      mediaBox: { x: 20, y: 40, width: 80, height: 60 },
+      cropBox: { x: 24, y: 44, width: 60, height: 40 },
+    });
+    expect(inspection.pages[1]).toMatchObject({
+      userUnit: 3,
+      rotation: 270,
+      mediaBox: { x: 15, y: 21, width: 90, height: 60 },
+    });
   });
 
   test('inspects actual per-page boxes, selectable text, exact link targets, and hashes', async () => {

--- a/npm/tests/visual-parity-ratchet.spec.ts
+++ b/npm/tests/visual-parity-ratchet.spec.ts
@@ -16,6 +16,7 @@ import {
   RATCHET_RECORD_FILE,
   RATCHET_SCHEMA_VERSION,
   RATCHET_TOLERANCE,
+  assertRecordUpdateProvenance,
   buildRecord,
   chromiumFingerprint,
   compareToRecord,
@@ -298,6 +299,19 @@ test.describe('visual parity ratchet', () => {
     expect(serializeRecord(BASELINE_RECORD).endsWith('\n')).toBe(true);
     // Sorted by id so corpus reordering cannot churn the committed diff.
     expect(BASELINE_RECORD.cases.map(entry => entry.id)).toEqual(['multi-section', 'shape']);
+  });
+
+  test('record refresh requires an exact clean source commit', () => {
+    const clean = {
+      ...BASELINE_SUMMARY,
+      gitCommit: 'a'.repeat(40),
+      workingTreeDirty: false,
+    };
+    expect(() => assertRecordUpdateProvenance(clean)).not.toThrow();
+    expect(() => assertRecordUpdateProvenance({ ...clean, workingTreeDirty: true }))
+      .toThrow(/dirty or unverified worktree/);
+    expect(() => assertRecordUpdateProvenance({ ...clean, gitCommit: 'deadbeef' }))
+      .toThrow(/40-character source commit/);
   });
 });
 

--- a/npm/tests/visual-parity-ratchet.spec.ts
+++ b/npm/tests/visual-parity-ratchet.spec.ts
@@ -364,6 +364,18 @@ test.describe('LibreOffice reference-version contract', () => {
   test('the declared build belongs to the declared minor', () => {
     expect(LIBREOFFICE_CONTRACT.build.startsWith(`${LIBREOFFICE_CONTRACT.version}.`)).toBe(true);
     expect(LIBREOFFICE_CONTRACT.archiveUrl).toContain(LIBREOFFICE_CONTRACT.build);
+    expect(LIBREOFFICE_CONTRACT.archiveSignatureUrl).toBe(`${LIBREOFFICE_CONTRACT.archiveUrl}.asc`);
+    expect(LIBREOFFICE_CONTRACT.signingKeyFingerprint).toMatch(/^[0-9A-F]{40}$/);
+  });
+
+  test('CI verifies the detached signature and exact signing-key fingerprint before extraction', () => {
+    const workflow = readFileSync(resolve(__dirname, '../../.github/workflows/visual-parity.yml'), 'utf8');
+    expect(workflow).toContain(LIBREOFFICE_CONTRACT.archiveSignatureUrl);
+    expect(workflow).toContain(LIBREOFFICE_CONTRACT.signingKeyFingerprint);
+    expect(workflow).toContain('--verify /tmp/libreoffice.tar.gz.asc /tmp/libreoffice.tar.gz');
+    expect(workflow.indexOf('--verify /tmp/libreoffice.tar.gz.asc'))
+      .toBeLessThan(workflow.indexOf('tar -xzf /tmp/libreoffice.tar.gz'));
+    expect(workflow).toContain('cancel-in-progress: true');
   });
 });
 

--- a/npm/tests/visual-parity-toolchain.spec.ts
+++ b/npm/tests/visual-parity-toolchain.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@playwright/test';
+import { realpathSync } from 'node:fs';
+import { basename, dirname } from 'node:path';
+import {
+  commandVersion,
+  pinExecutable,
+  resolveExecutable,
+} from './visual-parity/toolchain.js';
+
+test.describe('visual-parity executable evidence', () => {
+  test('resolves, invokes, and hashes the same absolute executable', () => {
+    const resolved = resolveExecutable(basename(process.execPath), dirname(process.execPath));
+    expect(resolved).toBe(realpathSync(process.execPath));
+    expect(commandVersion(resolved, ['--version'])).toMatch(/^v\d+/);
+    const pinned = pinExecutable(
+      basename(process.execPath),
+      ['--version'],
+      dirname(process.execPath),
+    );
+    expect(pinned.path).toBe(realpathSync(process.execPath));
+    expect(pinned.evidence).toMatchObject({
+      command: basename(process.execPath),
+      executable: basename(process.execPath),
+      executableSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+      version: expect.stringMatching(/^v\d+/),
+    });
+  });
+
+  test('rejects unresolved and relative version probes', () => {
+    expect(() => resolveExecutable('definitely-not-a-docxodus-tool', '')).toThrow(/not found/);
+    expect(() => commandVersion('node', ['--version'])).toThrow(/absolute/);
+  });
+});

--- a/npm/tests/visual-parity.spec.ts
+++ b/npm/tests/visual-parity.spec.ts
@@ -348,7 +348,7 @@ function summarizeCases(cases: CaseResult[]) {
   };
 }
 
-test('stratified tracked corpus matches LibreOffice at pixel level', async ({ page, browserName }) => {
+test('stratified tracked corpus matches LibreOffice at pixel level', async ({ page, browserName }, testInfo) => {
   test.setTimeout(20 * 60 * 1000);
   assertTrackedCorpus(VISUAL_PARITY_CORPUS);
   const fontContract = fontContractReport(repoRoot); // throws if the host misses the contract
@@ -356,13 +356,16 @@ test('stratified tracked corpus matches LibreOffice at pixel level', async ({ pa
   // rather than after twenty minutes at the ratchet's fingerprint check.
   const libreofficeVersion = assertLibreOfficeContract();
   const corpus = selectedCorpus();
-  const outputRoot = resolve(process.env.DOCXODUS_VISUAL_PARITY_OUTPUT ??
+  const configuredOutputRoot = resolve(process.env.DOCXODUS_VISUAL_PARITY_OUTPUT ??
     join(tmpdir(), 'docxodus-visual-parity'));
-  const outputRelativeToRepo = relative(repoRoot, outputRoot);
+  const outputRelativeToRepo = relative(repoRoot, configuredOutputRoot);
   if (outputRelativeToRepo === '' ||
       (!outputRelativeToRepo.startsWith('..') && !isAbsolute(outputRelativeToRepo))) {
-    throw new Error(`Visual parity artifacts must stay outside the repository: ${outputRoot}`);
+    throw new Error(`Visual parity artifacts must stay outside the repository: ${configuredOutputRoot}`);
   }
+  const outputRoot = testInfo.retry === 0
+    ? configuredOutputRoot
+    : join(configuredOutputRoot, `retry-${testInfo.retry}`);
   if (existsSync(outputRoot) && readdirSync(outputRoot).length) {
     throw new Error(`Visual parity output must be empty to prevent stale artifacts: ${outputRoot}`);
   }

--- a/npm/tests/visual-parity.spec.ts
+++ b/npm/tests/visual-parity.spec.ts
@@ -40,6 +40,7 @@ import {
 import { decodePng, encodePng } from './visual-parity/png.js';
 import {
   RATCHET_RECORD_FILE,
+  assertRecordUpdateProvenance,
   buildRecord,
   compareToRecord,
   readRecord,
@@ -501,6 +502,7 @@ test('stratified tracked corpus matches LibreOffice at pixel level', async ({ pa
       throw new Error('Refusing to write a partial ratchet record: unset ' +
         'DOCXODUS_VISUAL_PARITY_FILTER so every case is measured in the same run.');
     }
+    assertRecordUpdateProvenance(summary);
     const record = buildRecord(summary, new Date().toISOString().slice(0, 10));
     writeFileSync(RATCHET_RECORD_FILE, serializeRecord(record));
     console.log(`Ratchet record refreshed: ${RATCHET_RECORD_FILE}`);

--- a/npm/tests/visual-parity/README.md
+++ b/npm/tests/visual-parity/README.md
@@ -381,6 +381,10 @@ explicitly cancelled. Both failures still contribute to the job result. A timeou
 currently active case, but the initialized viewer and every previously finalized case remain in the
 artifact.
 
+Playwright retries write to `retry-N/` subdirectories beneath the configured artifact root. The
+first attempt remains available through the root viewer, and a retry cannot replace the original
+failure with a stale-output error.
+
 ## Triage rules
 
 LibreOffice is a comparison implementation, not an oracle. Start with severe cases, inspect the two

--- a/npm/tests/visual-parity/README.md
+++ b/npm/tests/visual-parity/README.md
@@ -141,14 +141,18 @@ declared once in `environment-contract.ts` and enforced twice:
   can never be misread as a renderer regression, and can never refresh the record.
 
 CI installs the contract build from the TDF archive rather than `ubuntu-latest` apt (which
-carries whatever the runner image's Ubuntu shipped — 24.2 on 24.04). The pure spec
+carries whatever the runner image's Ubuntu shipped — 24.2 on 24.04). Before extraction, CI
+verifies the archive's detached TDF signature and requires the exact pinned issuer fingerprint
+`C2839ECAD9408FBE9531C3E9F434A1EFAFEEAEA3`. The pure spec
 `visual-parity-ratchet.spec.ts` proves the failure message and asserts the declared version,
 the committed record's fingerprint, and the CI pin cannot drift apart, on every pull request,
 without LibreOffice installed.
 
-The repository currently contains no TDF-published checksum for that archive, so the workflow does
-not pretend to verify one. A checksum must be added only from an authoritative TDF checksum source
-and reviewed with the version bump; it must never be inferred from a locally downloaded archive.
+The 25.8 line is archived and no longer receives security updates. It is retained only because a
+visual ratchet must hold its reference renderer constant; CI uses it in a dedicated, read-only job
+against repository-pinned fixtures, with no untrusted document input. A future reference-version
+bump must update the archive URL, detached signature, key fingerprint, and measured records in one
+reviewed change.
 
 ## Required tools and version identity
 
@@ -188,8 +192,8 @@ Every paired page reports:
 - ink precision, recall, and F1 after a two-pixel dilation, which tolerate glyph antialiasing
   without tolerating missing, extra, or displaced layout;
 - raster width/height deltas and the bounded alignment offset; and
-- for the generated-PDF path, MediaBox/CropBox origins and dimensions in PDF points before either
-  artifact is rasterized.
+- for the generated-PDF path, inherited `UserUnit`/`Rotate` plus scaled, orientation-aware
+  MediaBox/CropBox origins and dimensions in physical PDF points before either artifact is rasterized.
 
 Severity is assigned by the worst signal:
 
@@ -201,8 +205,9 @@ Severity is assigned by the worst signal:
 | severe | below major | below major | above major | > 1 px |
 
 A page-count mismatch is always severe. The generated-PDF path unconditionally fails conversion,
-page-count, MediaBox/CropBox, selectable-text, and hyperlink-contract errors; raster similarity or a
-reviewed disposition cannot excuse a broken hard signal. `DOCXODUS_VISUAL_PARITY_STRICT=1`
+API/report/PageMap/PDF binding, page-count, MediaBox/CropBox, selectable-text, exact logical-link,
+and chart-vector errors; raster similarity or a reviewed disposition cannot excuse a broken hard
+signal. `DOCXODUS_VISUAL_PARITY_STRICT=1`
 additionally turns renderer-attributable severe raster cases into a failing gate (see the disposition
 contract below). This keeps the baseline useful while known environment deltas and reference
 deviations are tracked without waiving PDF correctness. Independently of strict mode, every run
@@ -255,12 +260,26 @@ DOCXODUS_VISUAL_PARITY_UPDATE_RECORD=1 \
 npm run test:visual-parity
 ```
 
+The generated-PDF record is distinct and uses its own complete run:
+
+```bash
+DOCXODUS_GENERATED_PDF_PARITY_OUTPUT="$(mktemp -d)" \
+DOCXODUS_GENERATED_PDF_PARITY_UPDATE_RECORD=1 \
+  npm --prefix npm run test:generated-pdf-parity
+```
+
 The update path refuses a filtered run and any dirty or unverified worktree. Commit the
 implementation first, then generate the record from that exact clean commit so `sourceCommit`
 identifies reproducible source rather than merely the base of local edits. A passing run still lists
 every improvement it measured, so a stale record announces itself. Set
 `DOCXODUS_VISUAL_PARITY_RATCHET=0` to observe without gating; the comparison is reported either
 way. A filtered run compares only the cases it measured.
+
+`sourceCommit` identifies the historical implementation that actually produced the stored numbers;
+it is not rewritten to a rebased commit by analogy. Each current run separately records `gitCommit`
+and `gitTree`, builds both packages itself, and compares the resulting PDFs to that historical
+ratchet. Refresh `sourceCommit` only through the complete clean update command above, after every
+hard/strict/evidence gate has passed.
 
 The comparison layer (`ratchet.ts`) is pure, and `visual-parity-ratchet.spec.ts` exercises it on
 **every** pull request — no LibreOffice, no renderer. That is what keeps "a deliberately introduced
@@ -323,15 +342,17 @@ failure message — but TDF-packaged builds bundle their own Caladea/Carlito/Lib
 under `share/fonts/truetype/`, which silently override the font contract inside LibreOffice
 only. Remove the bundled duplicates so both engines resolve the same system fonts (the wrapping
 probe fails naming the family if you forget — see the issue-#400 baseline entry).
+Verify the adjacent `.asc` signature with the exact key fingerprint printed by the failure message
+before extracting or installing the archive.
 
-Install and build the exact locked packages from the repository root. The companion's normal
-install fetches its pinned Chromium revision; do not use `--ignore-scripts` for this benchmark.
+Install the exact locked packages from the repository root. The companion's normal install fetches
+its pinned Chromium revision; do not use `--ignore-scripts` for this benchmark. The public PDF gate
+rebuilds both packages itself, in npm-then-exporter order, so a clean source commit cannot be paired
+with stale ignored `dist` bytes.
 
 ```bash
 npm --prefix npm ci
-npm --prefix npm run build
 npm --prefix npm-export ci
-npm --prefix npm-export run build
 npm --prefix npm exec -- playwright install --with-deps chromium
 ```
 
@@ -366,7 +387,9 @@ Open `index.html` first. It links the run context and summary, both original PDF
 rasters, red perceptual-difference overlays, physical geometry, selectable-text/link evidence, and
 per-case metrics. Artifact paths inside JSON are relative to the output root so the downloaded
 directory remains portable. Source, PDF, raster, and overlay evidence carries SHA-256 digests, and
-the summary records the source commit and whether the worktree was dirty.
+the summary records the source commit and tree, whether the worktree was dirty, the bounded built
+exporter graph, asset manifest, module entries, exact executable hashes, and package lock hashes.
+Those executable and build identities are rechecked after the run before a record can be updated.
 
 The generated-PDF runner writes progress incrementally. A failed case retains all PDFs and page
 evidence produced before the failure and receives structured failure evidence rather than being

--- a/npm/tests/visual-parity/README.md
+++ b/npm/tests/visual-parity/README.md
@@ -1,11 +1,16 @@
-# LibreOffice pixel-parity benchmark
+# PDF visual-fidelity benchmark
 
 This opt-in benchmark renders a small, stratified set of repository-tracked DOCX fixtures through
-Docxodus and LibreOffice, rasterizes every page at 96 DPI, and writes page images, heatmaps, and
-machine-readable metrics outside the repository.
+Docxodus and LibreOffice. The release-gating path tests the artifact users receive: it invokes the
+supported `@docxodus/export` API, writes a Docxodus PDF, writes the LibreOffice reference PDF, and
+rasterizes both PDFs through the same Poppler command at 96 DPI before computing page metrics.
+It also checks physical PDF geometry, selectable text, and supported link annotations independently
+of the raster comparison.
 
-It extends the single-frame arcade interoperability test into a document-wide diagnostic. It is not
-part of the normal browser suite because LibreOffice and Poppler are host tools.
+The earlier browser-page-to-LibreOffice benchmark remains available as a separate diagnostic and
+keeps its existing ratchet history. The generated-PDF run has a distinct pipeline identity and
+artifact root so a PDF regression cannot be confused with movement in browser screenshot capture.
+Neither run is part of the normal browser suite because LibreOffice and Poppler are host tools.
 
 The initial measured findings and prioritized renderer gaps are recorded in [BASELINE.md](BASELINE.md).
 
@@ -18,16 +23,48 @@ and untracked files are rejected before either renderer starts. The benchmark re
 fixtures in place. It does not copy a third-party corpus or any ignored/untracked harness into the
 repository.
 
-Generated PNGs, overlays, and JSON must be written outside the checkout. The runner rejects an
-output directory inside the repository, even if that directory is ignored, and rejects a non-empty
-output directory so stale pages cannot contaminate a rerun.
+Generated PDFs, PNGs, overlays, and JSON must be written outside the checkout. The runners reject
+an output directory inside the repository, even if that directory is ignored. A local run starts
+with a new empty directory so stale pages cannot contaminate it. CI initializes only the generated-
+PDF root with a recognized `ci-context.json` and pending `index.html`; the generated-PDF runner owns
+the remaining contents and replaces the pending viewer as evidence becomes available.
+
+## PDF-to-PDF measurement flow
+
+For every selected corpus entry, the generated-PDF runner performs one ordered, bounded flow:
+
+1. Verify that the fixture is a regular Git-tracked file whose worktree bytes equal `HEAD`.
+2. Convert those bytes with the public `@docxodus/export` API and its package-owned pinned Chromium,
+   requesting the explicit revision and comment profiles declared by the case.
+3. Export the same comparison fixture to a reference PDF with the contracted LibreOffice build and
+   a fresh user profile.
+4. Preserve both original PDFs and record their SHA-256 digests. PDF byte identity is diagnostic,
+   not a cross-run promise, because Chromium records volatile PDF metadata.
+5. Parse both PDFs before rasterization. Page count and every MediaBox/CropBox origin and physical
+   dimension are recorded in points and remain hard signals separate from image similarity.
+6. Rasterize both PDFs with the same `pdftoppm` executable, DPI, page-box choice, antialiasing, and
+   color-mode argument vector. The complete argument contract and Poppler version are recorded in
+   the report; no engine receives a renderer-specific raster option.
+7. Compare paired pages for SSIM, perceptual color difference, tolerant ink precision/recall/F1,
+   and a reviewable overlay. Each PDF, page raster, and overlay carries a SHA-256 digest.
+8. Extract selectable text and link annotations independently of the raster. Expected visible and
+   hidden text follows the case's revision/comment profile; supported external targets must match,
+   and every internal destination must resolve to a page in the generated PDF.
+
+A page-count mismatch, out-of-contract physical page, semantic extraction failure, unresolved link,
+or conversion error is severe regardless of a visually white or similar page. Pixel severity and
+the reviewed disposition contract below decide whether a remaining visual difference gates strict
+mode.
 
 ## Deterministic rendering contract
 
-- Docxodus uses Chromium at device scale 1 and pagination scale 1: one CSS pixel equals one 96-DPI
-  raster pixel.
-- LibreOffice exports PDF from a fresh per-document user profile. Poppler rasterizes the PDF at
-  exactly 96 DPI.
+- The generated-PDF run uses the supported Node API and the exact Chromium revision owned by
+  `@docxodus/export`; its render report records the production renderer/font fingerprint. The
+  separate browser-page benchmark continues to use Chromium at device scale 1 and pagination
+  scale 1.
+- LibreOffice exports PDF from a fresh per-document user profile. The generated and reference PDFs
+  are rasterized by the same Poppler executable at exactly 96 DPI and under one recorded color and
+  antialiasing contract.
 - Both processes use `C.UTF-8`, UTC, and the **font-substitution contract** below instead of the
   host's default fontconfig, so line wraps cannot drift with whatever fonts a host happens to
   carry. The summary records the Chromium, LibreOffice, and Poppler versions plus every contract
@@ -36,10 +73,14 @@ output directory so stale pages cannot contaminate a rerun.
   rendered. LibreOffice's headless PDF filter follows the file's saved redline-display state and
   provides no final-view switch, so manifest cases marked `revisionMode: 'accepted'` are accepted
   once into a temporary DOCX outside the checkout; both engines then render those identical bytes.
-  Comments and Docxodus annotations are disabled; headers, footers, footnotes, and endnotes are
-  enabled.
-- Chromium waits for `document.fonts.ready`, every image load, and two animation frames. Animations,
-  transitions, carets, page shadows, page labels, and page gaps are disabled.
+  Each generated-PDF case records its explicit revision/comment profile. The older browser-page
+  diagnostic keeps comments and Docxodus annotations disabled. Headers, footers, footnotes, and
+  endnotes remain enabled.
+- Generated PDF printing crosses the production readiness barriers for fonts, images, charts/SVG,
+  pagination, running stories, and stable page geometry, then repeats them after reopening the exact
+  serialized standalone document. The browser-page diagnostic separately waits for
+  `document.fonts.ready`, every image load, and two animation frames. Animations, transitions,
+  carets, page shadows, page labels, and page gaps are disabled in diagnostic capture.
 - Pages are paired by one-based page index. Page count and page dimensions remain independent hard
   signals. A bounded translation search of only ±2 pixels normalizes raster-origin rounding; the
   chosen offset is always reported.
@@ -105,6 +146,31 @@ carries whatever the runner image's Ubuntu shipped — 24.2 on 24.04). The pure 
 the committed record's fingerprint, and the CI pin cannot drift apart, on every pull request,
 without LibreOffice installed.
 
+The repository currently contains no TDF-published checksum for that archive, so the workflow does
+not pretend to verify one. A checksum must be added only from an authoritative TDF checksum source
+and reviewed with the version bump; it must never be inferred from a locally downloaded archive.
+
+## Required tools and version identity
+
+The measurement surface intentionally names every external component:
+
+| Component | Contract used by CI |
+|---|---|
+| Node.js | 22; the export package itself requires at least 22.13 |
+| .NET / WASM tools | .NET 10.0.x plus the `wasm-tools` workload |
+| Docxodus Chromium | `@playwright/browser-chromium` 1.57.0 from `npm-export/package-lock.json` |
+| PDF parsing | `pdf-lib` 1.17.1 and `pdfjs-dist` 6.2.108 |
+| LibreOffice | exact known-good build 25.8.7.3; accepted fingerprint 25.8 |
+| Poppler | `pdftoppm` and `pdftotext` from the same `poppler-utils` install |
+| Font discovery | Fontconfig `fc-match` plus Carlito, Caladea, and Liberation contract fonts |
+
+`npm ci` makes JavaScript package versions exact through the committed lockfiles. Poppler comes from
+the CI runner's apt repository, so its major/minor is part of the ratchet environment fingerprint;
+a runner-image change fails as `environment-changed` instead of being attributed to Docxodus.
+Reproducing an existing recorded number requires the Poppler fingerprint in `ratchet.json`, not
+merely any `pdftoppm` binary. Reports retain the full version banners and measurement arguments so
+an artifact can be recreated without guessing which tools were used.
+
 Known cross-version rendering differences the corpus is sensitive to (each new finding joins
 `KNOWN_LIBREOFFICE_VERSION_DIFFERENCES` so the failure message teaches it):
 
@@ -119,9 +185,11 @@ Every paired page reports:
 - exact RGB diff ratio (diagnostic only; antialiasing makes it unsuitable as a gate);
 - CIE Lab ΔE76 mean and the ratio above ΔE 2.3, a conventional just-noticeable threshold;
 - block SSIM over 8×8 luminance windows;
-- ink F1 after a two-pixel dilation, which tolerates glyph antialiasing without tolerating displaced
-  layout;
-- page width/height deltas and the bounded alignment offset.
+- ink precision, recall, and F1 after a two-pixel dilation, which tolerate glyph antialiasing
+  without tolerating missing, extra, or displaced layout;
+- raster width/height deltas and the bounded alignment offset; and
+- for the generated-PDF path, MediaBox/CropBox origins and dimensions in PDF points before either
+  artifact is rasterized.
 
 Severity is assigned by the worst signal:
 
@@ -132,10 +200,13 @@ Severity is assigned by the worst signal:
 | major | ≥ 0.85 | ≥ 0.75 | ≤ 0.15 | ≤ 1 px |
 | severe | below major | below major | above major | > 1 px |
 
-A page-count mismatch is always severe. `DOCXODUS_VISUAL_PARITY_STRICT=1` turns renderer-attributable
-severe cases into a failing gate (see the disposition contract below). This keeps the baseline useful
-while known environment deltas and reference deviations are tracked without blocking. Independently
-of strict mode, every run compares itself against the committed regression record described next.
+A page-count mismatch is always severe. The generated-PDF path unconditionally fails conversion,
+page-count, MediaBox/CropBox, selectable-text, and hyperlink-contract errors; raster similarity or a
+reviewed disposition cannot excuse a broken hard signal. `DOCXODUS_VISUAL_PARITY_STRICT=1`
+additionally turns renderer-attributable severe raster cases into a failing gate (see the disposition
+contract below). This keeps the baseline useful while known environment deltas and reference
+deviations are tracked without waiving PDF correctness. Independently of strict mode, every run
+compares itself against the committed regression record described next.
 
 ## Regression ratchet
 
@@ -156,6 +227,8 @@ artifact expired in 14 days and nothing compared one run to the next.
 | mean SSIM | falls more than `tolerance.ssim` (0.0005) below the record |
 | worst ink F1 | falls more than `tolerance.inkF1` (0.001) below the record |
 | conversion | the case errors where the record has none |
+| physical geometry | a generated PDF fails the absolute MediaBox/CropBox contract |
+| semantics | generated-PDF selectable text or supported hyperlink targets fail |
 | coverage | a recorded case is missing, or a measured case is unrecorded |
 
 The tolerances are tight because within one environment the benchmark is *deterministic* — two
@@ -182,8 +255,10 @@ DOCXODUS_VISUAL_PARITY_UPDATE_RECORD=1 \
 npm run test:visual-parity
 ```
 
-The update path refuses a filtered run, so a partial record cannot be committed. A passing run
-still lists every improvement it measured, so a stale record announces itself. Set
+The update path refuses a filtered run and any dirty or unverified worktree. Commit the
+implementation first, then generate the record from that exact clean commit so `sourceCommit`
+identifies reproducible source rather than merely the base of local edits. A passing run still lists
+every improvement it measured, so a stale record announces itself. Set
 `DOCXODUS_VISUAL_PARITY_RATCHET=0` to observe without gating; the comparison is reported either
 way. A filtered run compares only the cases it measured.
 
@@ -240,7 +315,8 @@ contract above; a bare `libreoffice-core` install fails every case with "source 
 be loaded", and an out-of-contract version fails at run start with install guidance),
 `poppler-utils` (`pdftoppm`/`pdftotext`), the contract fonts (`fonts-crosextra-carlito`,
 `fonts-crosextra-caladea`, `fonts-liberation2` — the run fails with install instructions when
-missing), Chromium installed for Playwright, and the repository's npm dependencies.
+missing), Fontconfig (`fc-match`), .NET 10 with the `wasm-tools` workload, and the repository's two
+npm package dependency sets.
 
 When your distro does not package the contract minor, use the TDF archive build named in the
 failure message — but TDF-packaged builds bundle their own Caladea/Carlito/Liberation copies
@@ -248,25 +324,62 @@ under `share/fonts/truetype/`, which silently override the font contract inside 
 only. Remove the bundled duplicates so both engines resolve the same system fonts (the wrapping
 probe fails naming the family if you forget — see the issue-#400 baseline entry).
 
+Install and build the exact locked packages from the repository root. The companion's normal
+install fetches its pinned Chromium revision; do not use `--ignore-scripts` for this benchmark.
+
 ```bash
-cd npm
-npm run build
-DOCXODUS_VISUAL_PARITY_OUTPUT=/tmp/docxodus-visual-parity npm run test:visual-parity
+npm --prefix npm ci
+npm --prefix npm run build
+npm --prefix npm-export ci
+npm --prefix npm-export run build
+npm --prefix npm exec -- playwright install --with-deps chromium
+```
+
+Run the PDF release gate into a fresh directory:
+
+```bash
+DOCXODUS_PARITY_OUTPUT="$(mktemp -d)"
+DOCXODUS_GENERATED_PDF_PARITY_OUTPUT="$DOCXODUS_PARITY_OUTPUT" \
+  npm --prefix npm run test:generated-pdf-parity
+echo "Artifact viewer: $DOCXODUS_PARITY_OUTPUT/index.html"
+```
+
+The older browser-page diagnostic remains independently reproducible:
+
+```bash
+DOCXODUS_BROWSER_PARITY_OUTPUT="$(mktemp -d)"
+DOCXODUS_VISUAL_PARITY_OUTPUT="$DOCXODUS_BROWSER_PARITY_OUTPUT" \
+  npm --prefix npm run test:visual-parity
 ```
 
 Run selected manifest IDs:
 
 ```bash
-DOCXODUS_VISUAL_PARITY_FILTER=text-formatting,merged-table \
-DOCXODUS_VISUAL_PARITY_OUTPUT=/tmp/docxodus-visual-parity \
-npm run test:visual-parity
+DOCXODUS_GENERATED_PDF_PARITY_FILTER=pdf-footnote,pdf-chart \
+DOCXODUS_GENERATED_PDF_PARITY_OUTPUT="$(mktemp -d)" \
+  npm --prefix npm run test:generated-pdf-parity
 ```
 
-The output contains `summary.json` plus one directory per case. Each case contains the two engine
-PNGs, a red perceptual-difference heatmap, and `metrics.json`. Artifact paths inside JSON are relative
-to the output root so an uploaded report remains portable. Every artifact also carries a SHA-256
-digest, and the summary records whether the source worktree was dirty, so repeated runs can be
-compared without trusting filenames or silently mixing source states.
+## Artifacts and failure retention
+
+Open `index.html` first. It links the run context and summary, both original PDFs, side-by-side page
+rasters, red perceptual-difference overlays, physical geometry, selectable-text/link evidence, and
+per-case metrics. Artifact paths inside JSON are relative to the output root so the downloaded
+directory remains portable. Source, PDF, raster, and overlay evidence carries SHA-256 digests, and
+the summary records the source commit and whether the worktree was dirty.
+
+The generated-PDF runner writes progress incrementally. A failed case retains all PDFs and page
+evidence produced before the failure and receives structured failure evidence rather than being
+deleted. Pull-request, manual, and scheduled CI create `ci-context.json` and a pending viewer before installing external tools, so even
+an apt, LibreOffice, npm, build, or run-start failure leaves a viewable artifact that names the
+commit and workflow run. `.github/workflows/visual-parity.yml` uploads this root with `if: always()`,
+retains it for 14 days, and treats a missing artifact root as an error. The browser-page report is
+uploaded separately, also on failure; one benchmark cannot suppress the other's evidence.
+
+The generated-PDF test runs even when the preceding browser-page benchmark fails, unless the job was
+explicitly cancelled. Both failures still contribute to the job result. A timeout may interrupt the
+currently active case, but the initialized viewer and every previously finalized case remain in the
+artifact.
 
 ## Triage rules
 

--- a/npm/tests/visual-parity/benchmark-paths.ts
+++ b/npm/tests/visual-parity/benchmark-paths.ts
@@ -1,0 +1,104 @@
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  realpathSync,
+} from 'node:fs';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
+
+function isInside(parent: string, candidate: string): boolean {
+  const difference = relative(parent, candidate);
+  return difference === '' || (!difference.startsWith('..') && !isAbsolute(difference));
+}
+
+function nearestExistingAncestor(path: string): string {
+  let current = path;
+  while (!existsSync(current)) {
+    const parent = dirname(current);
+    if (parent === current) throw new Error(`No existing ancestor for ${path}`);
+    current = parent;
+  }
+  return current;
+}
+
+function assertRegularDirectory(path: string, label: string): void {
+  const metadata = lstatSync(path);
+  if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+    throw new Error(`${label} must be a non-symlink directory: ${path}`);
+  }
+}
+
+/** Prepare a canonical artifact directory that cannot resolve into the source repository. */
+export function prepareExternalOutputRoot(
+  repositoryRoot: string,
+  requestedRoot: string,
+  retry: number,
+  allowedBootstrapArtifacts: ReadonlySet<string>,
+): string {
+  if (!Number.isSafeInteger(retry) || retry < 0) throw new Error('Retry index must be non-negative.');
+  const canonicalRepository = realpathSync(repositoryRoot);
+  const configured = resolve(requestedRoot);
+  if (isInside(canonicalRepository, configured)) {
+    throw new Error(`Generated-PDF parity artifacts must stay outside the repository: ${configured}`);
+  }
+  const ancestor = realpathSync(nearestExistingAncestor(configured));
+  if (isInside(canonicalRepository, ancestor)) {
+    throw new Error(`Generated-PDF parity artifact ancestor resolves inside the repository: ${ancestor}`);
+  }
+  mkdirSync(configured, { recursive: true, mode: 0o700 });
+  assertRegularDirectory(configured, 'Configured artifact root');
+  const canonicalConfigured = realpathSync(configured);
+  if (isInside(canonicalRepository, canonicalConfigured)) {
+    throw new Error(`Generated-PDF parity artifact root resolves inside the repository: ${configured}`);
+  }
+
+  const output = retry === 0 ? canonicalConfigured : join(canonicalConfigured, `retry-${retry}`);
+  mkdirSync(output, { recursive: true, mode: 0o700 });
+  assertRegularDirectory(output, 'Attempt artifact root');
+  const canonicalOutput = realpathSync(output);
+  if (!isInside(canonicalConfigured, canonicalOutput)
+    || isInside(canonicalRepository, canonicalOutput)) {
+    throw new Error(`Generated-PDF parity retry root escaped its configured root: ${output}`);
+  }
+  const unexpected: string[] = [];
+  for (const name of readdirSync(canonicalOutput)) {
+    const path = join(canonicalOutput, name);
+    const metadata = lstatSync(path);
+    if (!allowedBootstrapArtifacts.has(name)
+      || !metadata.isFile() || metadata.isSymbolicLink()) unexpected.push(name);
+  }
+  if (unexpected.length > 0) {
+    throw new Error(`Generated-PDF parity output contains stale or unsafe artifacts: ${unexpected.join(', ')}`);
+  }
+  return canonicalOutput;
+}
+
+export function assertSafeCaseId(id: string): void {
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/.test(id)) {
+    throw new Error(`Generated-PDF parity case has an unsafe artifact identifier: ${id}`);
+  }
+}
+
+/** Resolve a portable repository-relative path and reject traversal, symlink, and escape cases. */
+export function resolveTrackedRegularFile(repositoryRoot: string, repositoryPath: string): string {
+  if (!repositoryPath || isAbsolute(repositoryPath) || repositoryPath.includes('\\')
+    || repositoryPath.includes('\0')
+    || repositoryPath.split('/').some((segment) => segment === '' || segment === '.' || segment === '..')) {
+    throw new Error(`Tracked path is not a canonical repository-relative path: ${repositoryPath}`);
+  }
+  const canonicalRepository = realpathSync(repositoryRoot);
+  const lexical = resolve(canonicalRepository, repositoryPath);
+  if (!isInside(canonicalRepository, lexical)) {
+    throw new Error(`Tracked path escapes the repository: ${repositoryPath}`);
+  }
+  const metadata = lstatSync(lexical);
+  if (!metadata.isFile() || metadata.isSymbolicLink()) {
+    throw new Error(`Tracked path must be a regular non-symlink file: ${repositoryPath}`);
+  }
+  const canonical = realpathSync(lexical);
+  if (!isInside(canonicalRepository, canonical)) {
+    throw new Error(`Tracked path resolves outside the repository: ${repositoryPath}`);
+  }
+  return canonical;
+}

--- a/npm/tests/visual-parity/build-provenance.ts
+++ b/npm/tests/visual-parity/build-provenance.ts
@@ -1,0 +1,110 @@
+import { createHash } from 'node:crypto';
+import {
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+} from 'node:fs';
+import { extname, join, relative, resolve, sep } from 'node:path';
+
+const MAXIMUM_GRAPH_FILES = 512;
+const MAXIMUM_GRAPH_BYTES = 32 * 1024 * 1024;
+const MAXIMUM_EVIDENCE_FILE_BYTES = 64 * 1024 * 1024;
+
+export interface FileDigestEvidence {
+  bytes: number;
+  sha256: string;
+}
+
+export interface JavaScriptGraphEvidence extends FileDigestEvidence {
+  files: number;
+}
+
+export interface GeneratedPdfBuildEvidence {
+  schemaVersion: 1;
+  exporterJavaScript: JavaScriptGraphEvidence;
+  exporterEntry: FileDigestEvidence;
+  docxodusRuntimeEntry: FileDigestEvidence;
+  exportAssetManifest: FileDigestEvidence;
+  npmLock: FileDigestEvidence;
+  exporterLock: FileDigestEvidence;
+}
+
+export function assertBuildOwningLifecycle(active: boolean, lifecycleEvent: string | undefined): void {
+  if (active && lifecycleEvent !== 'test:generated-pdf-parity') {
+    throw new Error('Run generated-PDF parity through `npm run test:generated-pdf-parity`; '
+      + 'direct Playwright invocation does not own the required npm and exporter builds.');
+  }
+}
+
+function digest(bytes: Uint8Array | string): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function regularFileEvidence(path: string): FileDigestEvidence {
+  const metadata = lstatSync(path);
+  if (!metadata.isFile() || metadata.isSymbolicLink()) {
+    throw new Error(`Build evidence requires a regular non-symlink file: ${path}`);
+  }
+  if (metadata.size > MAXIMUM_EVIDENCE_FILE_BYTES) {
+    throw new Error(`Build-evidence file exceeds ${MAXIMUM_EVIDENCE_FILE_BYTES} bytes: ${path}`);
+  }
+  const bytes = readFileSync(path);
+  return { bytes: bytes.byteLength, sha256: digest(bytes) };
+}
+
+/** Digest every emitted JavaScript module, including siblings imported by dist/index.js. */
+export function javascriptGraphEvidence(root: string): JavaScriptGraphEvidence {
+  const lexicalRoot = resolve(root);
+  const rootMetadata = lstatSync(lexicalRoot);
+  if (!rootMetadata.isDirectory() || rootMetadata.isSymbolicLink()) {
+    throw new Error(`Exporter build graph root must be a non-symlink directory: ${lexicalRoot}`);
+  }
+  const canonicalRoot = realpathSync(lexicalRoot);
+  const files: string[] = [];
+  const visit = (directory: string): void => {
+    for (const name of readdirSync(directory).sort()) {
+      const path = join(directory, name);
+      const metadata = lstatSync(path);
+      if (metadata.isSymbolicLink()) throw new Error(`Build graph rejects symlinks: ${path}`);
+      if (metadata.isDirectory()) {
+        visit(path);
+      } else if (metadata.isFile() && extname(name) === '.js') {
+        files.push(path);
+        if (files.length > MAXIMUM_GRAPH_FILES) {
+          throw new Error(`Build graph exceeds ${MAXIMUM_GRAPH_FILES} JavaScript files.`);
+        }
+      } else if (!metadata.isFile()) {
+        throw new Error(`Build graph rejects special filesystem entries: ${path}`);
+      }
+    }
+  };
+  visit(canonicalRoot);
+  if (files.length === 0) throw new Error(`Build graph contains no JavaScript: ${canonicalRoot}`);
+  const graph = createHash('sha256');
+  let bytes = 0;
+  for (const path of files) {
+    const content = readFileSync(path);
+    bytes += content.byteLength;
+    if (bytes > MAXIMUM_GRAPH_BYTES) {
+      throw new Error(`Build graph exceeds ${MAXIMUM_GRAPH_BYTES} JavaScript bytes.`);
+    }
+    const name = relative(canonicalRoot, path).split(sep).join('/');
+    graph.update(name).update('\0').update(String(content.byteLength)).update('\0')
+      .update(digest(content)).update('\n');
+  }
+  return { files: files.length, bytes, sha256: graph.digest('hex') };
+}
+
+export function captureGeneratedPdfBuildEvidence(repositoryRoot: string): GeneratedPdfBuildEvidence {
+  const exporterDist = resolve(repositoryRoot, 'npm-export/dist');
+  return {
+    schemaVersion: 1,
+    exporterJavaScript: javascriptGraphEvidence(exporterDist),
+    exporterEntry: regularFileEvidence(join(exporterDist, 'index.js')),
+    docxodusRuntimeEntry: regularFileEvidence(resolve(repositoryRoot, 'npm/dist/export-browser.js')),
+    exportAssetManifest: regularFileEvidence(resolve(repositoryRoot, 'npm/dist/export-assets.json')),
+    npmLock: regularFileEvidence(resolve(repositoryRoot, 'npm/package-lock.json')),
+    exporterLock: regularFileEvidence(resolve(repositoryRoot, 'npm-export/package-lock.json')),
+  };
+}

--- a/npm/tests/visual-parity/canonical-json.ts
+++ b/npm/tests/visual-parity/canonical-json.ts
@@ -1,0 +1,44 @@
+function assertWellFormedUnicode(value: string): void {
+  for (let index = 0; index < value.length; index++) {
+    const unit = value.charCodeAt(index);
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(++index);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        throw new TypeError('Canonical JSON rejects unpaired UTF-16 surrogates');
+      }
+    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
+      throw new TypeError('Canonical JSON rejects unpaired UTF-16 surrogates');
+    }
+  }
+}
+
+function canonicalValue(value: unknown): unknown {
+  if (value === null || typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    assertWellFormedUnicode(value);
+    return value;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new TypeError('Canonical JSON rejects non-finite numbers');
+    return Object.is(value, -0) ? 0 : value;
+  }
+  if (Array.isArray(value)) return value.map(canonicalValue);
+  if (typeof value === 'object') {
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new TypeError('Canonical JSON supports only plain objects');
+    }
+    const source = value as Record<string, unknown>;
+    const result: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+    for (const key of Object.keys(source).sort()) {
+      assertWellFormedUnicode(key);
+      if (source[key] !== undefined) result[key] = canonicalValue(source[key]);
+    }
+    return result;
+  }
+  throw new TypeError(`Canonical JSON rejects ${typeof value} values`);
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalValue(value));
+}

--- a/npm/tests/visual-parity/corpus.ts
+++ b/npm/tests/visual-parity/corpus.ts
@@ -160,8 +160,12 @@ export const VISUAL_PARITY_CORPUS: VisualCorpusEntry[] = [
     categories: ['headers-footers', 'images', 'multi-section'],
     rationale: 'Default/first/even running stories, embedded images, and section inheritance.',
     disposition: {
-      kind: 'environment',
-      rationale: 'Close since PR #372 and issue #377; the residual is substituted-font line metrics.',
+      kind: 'reference-deviation',
+      rationale: 'Section 2 sets titlePg but omits first-page header and footer references. ' +
+        'WordprocessingML therefore inherits the previous section\'s first-page stories. ' +
+        'Docxodus follows that rule; LibreOffice instead renders the odd-page stories on page 4.',
+      reference: 'https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oi29500/' +
+        'bce5f993-d683-4aa7-825e-bce25c64e8b8',
     },
   },
   {

--- a/npm/tests/visual-parity/environment-contract.ts
+++ b/npm/tests/visual-parity/environment-contract.ts
@@ -34,6 +34,15 @@ export const LIBREOFFICE_CONTRACT = {
   archiveUrl:
     'https://downloadarchive.documentfoundation.org/libreoffice/old/25.8.7.3/deb/x86_64/' +
     'LibreOffice_25.8.7.3_Linux_x86-64_deb.tar.gz',
+  /** Detached signature published beside the archived binary. */
+  archiveSignatureUrl:
+    'https://downloadarchive.documentfoundation.org/libreoffice/old/25.8.7.3/deb/x86_64/' +
+    'LibreOffice_25.8.7.3_Linux_x86-64_deb.tar.gz.asc',
+  /** Issuer fingerprint embedded in that signature; the workflow rejects every other key. */
+  signingKeyFingerprint: 'C2839ECAD9408FBE9531C3E9F434A1EFAFEEAEA3',
+  signingKeyUrl:
+    'https://keyserver.ubuntu.com/pks/lookup?op=get&search=' +
+    '0xC2839ECAD9408FBE9531C3E9F434A1EFAFEEAEA3',
 } as const;
 
 /**
@@ -93,6 +102,8 @@ export function checkLibreOfficeContract(versionOutput: string): LibreOfficeCont
       `LibreOffice ${LIBREOFFICE_CONTRACT.version}; known cross-version differences:\n${differences}\n` +
       `Install LibreOffice ${LIBREOFFICE_CONTRACT.build}, e.g. the TDF build:\n` +
       `  ${LIBREOFFICE_CONTRACT.archiveUrl}\n` +
+      `Verify ${LIBREOFFICE_CONTRACT.archiveSignatureUrl} with signing key ` +
+      `${LIBREOFFICE_CONTRACT.signingKeyFingerprint} before installation.\n` +
       `After a TDF install, REMOVE its bundled Carlito/Caladea/Liberation fonts ` +
       `(share/fonts/truetype/) — they silently override the font-substitution contract inside ` +
       `LibreOffice only (see README).\n` +
@@ -103,8 +114,8 @@ export function checkLibreOfficeContract(versionOutput: string): LibreOfficeCont
 }
 
 /** `libreoffice --version` from the host, empty string when the binary is missing entirely. */
-export function libreofficeVersionOutput(): string {
-  return versionBanner('libreoffice', ['--version']);
+export function libreofficeVersionOutput(executable = 'libreoffice'): string {
+  return versionBanner(executable, ['--version']);
 }
 
 /**
@@ -112,8 +123,8 @@ export function libreofficeVersionOutput(): string {
  * host's LibreOffice is out of contract, returns the full version string for the report when in
  * contract (or when drift is deliberately allowed).
  */
-export function assertLibreOfficeContract(): string {
-  const check = checkLibreOfficeContract(libreofficeVersionOutput());
+export function assertLibreOfficeContract(versionOutput = libreofficeVersionOutput()): string {
+  const check = checkLibreOfficeContract(versionOutput);
   if (check.ok) return check.version;
   if (process.env[LIBREOFFICE_DRIFT_ENV] === '1') {
     console.warn(`[visual-parity] ${LIBREOFFICE_DRIFT_ENV}=1: measuring OUT-OF-CONTRACT ` +
@@ -127,9 +138,9 @@ export function assertLibreOfficeContract(): string {
 /** Poppler is fingerprinted (not install-asserted): pdftoppm's rasterizer is part of what the
  * recorded numbers were measured through, so a distro bump must surface as environment drift
  * rather than as a silent shift attributed to the renderer. */
-export function popplerVersionOutput(): string {
+export function popplerVersionOutput(executable = 'pdftoppm'): string {
   // pdftoppm prints its version banner on stderr with exit code 0.
-  return versionBanner('pdftoppm', ['-v']).split('\n')[0].trim();
+  return versionBanner(executable, ['-v']).split('\n')[0].trim();
 }
 
 export { popplerFingerprint };

--- a/npm/tests/visual-parity/font-contract.ts
+++ b/npm/tests/visual-parity/font-contract.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { readFileSync } from 'node:fs';
-import { dirname, relative, resolve } from 'node:path';
+import { lstatSync, readFileSync, realpathSync } from 'node:fs';
+import { basename, dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   FONT_SUBSTITUTION_CONTRACT,
@@ -42,24 +42,33 @@ export interface ResolvedFont {
   substitute: string;
   resolvedFamily: string;
   file: string;
+  fileSha256: string;
   fontVersion: string;
   metricCompatible: boolean;
 }
 
 /** What each declared family resolves to under the contract, per fc-match. */
-export function resolveContractFonts(): ResolvedFont[] {
+export function resolveContractFonts(fcMatchExecutable = 'fc-match'): ResolvedFont[] {
   return FONT_CONTRACT.map(entry => {
-    const out = execFileSync('fc-match', ['-f', '%{family}\t%{file}\t%{fontversion}', entry.family], {
+    const out = execFileSync(fcMatchExecutable, ['-f', '%{family}\t%{file}\t%{fontversion}', entry.family], {
       encoding: 'utf8',
       env: { ...process.env, FONTCONFIG_FILE: FONT_CONTRACT_FILE },
+      timeout: 15_000,
+      maxBuffer: 1024 * 1024,
     });
     const [resolvedFamily = '', file = '', fontVersion = ''] = out.split('\t');
+    const resolvedFile = realpathSync(file);
+    const metadata = lstatSync(resolvedFile);
+    if (!metadata.isFile() || metadata.isSymbolicLink()) {
+      throw new Error(`fc-match returned a non-regular font file for ${entry.family}`);
+    }
     return {
       family: entry.family,
       substitute: entry.substitute,
       // fc-match may report a family list; the substitute must be one of its names.
       resolvedFamily,
-      file,
+      file: basename(resolvedFile),
+      fileSha256: createHash('sha256').update(readFileSync(resolvedFile)).digest('hex'),
       fontVersion,
       metricCompatible: entry.metricCompatible,
     };
@@ -70,10 +79,10 @@ export function resolveContractFonts(): ResolvedFont[] {
  * Fails clearly when the host cannot satisfy the contract, naming the packages to install.
  * Returns the resolutions for the report on success.
  */
-export function assertFontContract(): ResolvedFont[] {
+export function assertFontContract(fcMatchExecutable = 'fc-match'): ResolvedFont[] {
   let resolved: ResolvedFont[];
   try {
-    resolved = resolveContractFonts();
+    resolved = resolveContractFonts(fcMatchExecutable);
   } catch (error) {
     throw new Error(`fc-match is unavailable; the font contract cannot be verified: ${error}`);
   }
@@ -90,11 +99,11 @@ export function assertFontContract(): ResolvedFont[] {
 }
 
 /** The report block `summary.json` records for the environment. */
-export function fontContractReport(repoRoot: string) {
+export function fontContractReport(repoRoot: string, fcMatchExecutable = 'fc-match') {
   return {
     file: relative(repoRoot, FONT_CONTRACT_FILE),
     sha256: createHash('sha256').update(readFileSync(FONT_CONTRACT_FILE)).digest('hex'),
-    families: assertFontContract(),
+    families: assertFontContract(fcMatchExecutable),
   };
 }
 

--- a/npm/tests/visual-parity/generated-pdf-ratchet.json
+++ b/npm/tests/visual-parity/generated-pdf-ratchet.json
@@ -1,0 +1,128 @@
+{
+  "schemaVersion": 2,
+  "description": "Generated-PDF visual-fidelity regression ratchet (issue #443). Numbers only; complete PDFs, rasters, semantic evidence, geometry, hashes, and fingerprints live in the uploaded artifact. See npm/tests/visual-parity/README.md.",
+  "recordedAt": "2026-08-16",
+  "sourceCommit": "14765be7870dffd346c210a351e3e1d2a066e15c",
+  "environment": {
+    "libreoffice": "25.8",
+    "chromium": "143",
+    "poppler": "25.03",
+    "fontContractSha256": "65e32c507ebaa14eef364f04036f26c6853ab900779889d29b2f3d427c9937db"
+  },
+  "tolerance": {
+    "ssim": 0.0005,
+    "inkF1": 0.001
+  },
+  "cases": [
+    {
+      "id": "pdf-chart",
+      "disposition": "environment",
+      "pages": {
+        "docxodus": 1,
+        "libreoffice": 1
+      },
+      "severity": "minor",
+      "ssim": 0.97896,
+      "worstInkF1": 1
+    },
+    {
+      "id": "pdf-endnote-table",
+      "disposition": "unattributed",
+      "pages": {
+        "docxodus": 1,
+        "libreoffice": 1
+      },
+      "severity": "severe",
+      "ssim": 0.83263,
+      "worstInkF1": 0.92519
+    },
+    {
+      "id": "pdf-external-hyperlink",
+      "disposition": "unattributed",
+      "pages": {
+        "docxodus": 1,
+        "libreoffice": 1
+      },
+      "severity": "close",
+      "ssim": 0.99875,
+      "worstInkF1": 1
+    },
+    {
+      "id": "pdf-final-revisions",
+      "disposition": "environment",
+      "pages": {
+        "docxodus": 1,
+        "libreoffice": 1
+      },
+      "severity": "major",
+      "ssim": 0.94936,
+      "worstInkF1": 0.83804
+    },
+    {
+      "id": "pdf-footnote",
+      "disposition": "environment",
+      "pages": {
+        "docxodus": 1,
+        "libreoffice": 1
+      },
+      "severity": "close",
+      "ssim": 0.99563,
+      "worstInkF1": 0.99031
+    },
+    {
+      "id": "pdf-hidden-comments",
+      "disposition": "unattributed",
+      "pages": {
+        "docxodus": 1,
+        "libreoffice": 1
+      },
+      "severity": "minor",
+      "ssim": 0.97934,
+      "worstInkF1": 1
+    },
+    {
+      "id": "pdf-legal-contract",
+      "disposition": "renderer-bug",
+      "pages": {
+        "docxodus": 3,
+        "libreoffice": 3
+      },
+      "severity": "severe",
+      "ssim": 0.72192,
+      "worstInkF1": 0.64058
+    },
+    {
+      "id": "pdf-mixed-orientation-running-stories",
+      "disposition": "environment",
+      "pages": {
+        "docxodus": 6,
+        "libreoffice": 6
+      },
+      "severity": "close",
+      "ssim": 0.99986,
+      "worstInkF1": 1
+    },
+    {
+      "id": "pdf-raster-image",
+      "disposition": "environment",
+      "pages": {
+        "docxodus": 1,
+        "libreoffice": 1
+      },
+      "severity": "major",
+      "ssim": 0.93775,
+      "worstInkF1": 0.8797
+    },
+    {
+      "id": "pdf-two-column-section",
+      "disposition": "renderer-bug",
+      "pages": {
+        "docxodus": 1,
+        "libreoffice": 1
+      },
+      "severity": "severe",
+      "ssim": 0.71808,
+      "worstInkF1": 0.46279
+    }
+  ]
+}

--- a/npm/tests/visual-parity/generated-pdf-ratchet.json
+++ b/npm/tests/visual-parity/generated-pdf-ratchet.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "description": "Generated-PDF visual-fidelity regression ratchet (issue #443). Numbers only; complete PDFs, rasters, semantic evidence, geometry, hashes, and fingerprints live in the uploaded artifact. See npm/tests/visual-parity/README.md.",
   "recordedAt": "2026-08-16",
-  "sourceCommit": "14765be7870dffd346c210a351e3e1d2a066e15c",
+  "sourceCommit": "ab1b4177b965aca10c611dffdd4b6409e63f2118",
   "environment": {
     "libreoffice": "25.8",
     "chromium": "143",

--- a/npm/tests/visual-parity/generated-pdf-ratchet.json
+++ b/npm/tests/visual-parity/generated-pdf-ratchet.json
@@ -2,11 +2,11 @@
   "schemaVersion": 2,
   "description": "Generated-PDF visual-fidelity regression ratchet (issue #443). Numbers only; complete PDFs, rasters, semantic evidence, geometry, hashes, and fingerprints live in the uploaded artifact. See npm/tests/visual-parity/README.md.",
   "recordedAt": "2026-08-16",
-  "sourceCommit": "6af5059593ed78c4daa48fa9e29dd7d3df80de72",
+  "sourceCommit": "de64978a8dd71776a59384aec209888e18c44512",
   "environment": {
     "libreoffice": "25.8",
     "chromium": "143",
-    "poppler": "25.03",
+    "poppler": "24.02",
     "fontContractSha256": "65e32c507ebaa14eef364f04036f26c6853ab900779889d29b2f3d427c9937db"
   },
   "tolerance": {
@@ -34,7 +34,7 @@
       },
       "severity": "severe",
       "ssim": 0.83263,
-      "worstInkF1": 0.92519
+      "worstInkF1": 0.92516
     },
     {
       "id": "pdf-external-hyperlink",

--- a/npm/tests/visual-parity/generated-pdf-ratchet.json
+++ b/npm/tests/visual-parity/generated-pdf-ratchet.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "description": "Generated-PDF visual-fidelity regression ratchet (issue #443). Numbers only; complete PDFs, rasters, semantic evidence, geometry, hashes, and fingerprints live in the uploaded artifact. See npm/tests/visual-parity/README.md.",
   "recordedAt": "2026-08-16",
-  "sourceCommit": "ab1b4177b965aca10c611dffdd4b6409e63f2118",
+  "sourceCommit": "6af5059593ed78c4daa48fa9e29dd7d3df80de72",
   "environment": {
     "libreoffice": "25.8",
     "chromium": "143",

--- a/npm/tests/visual-parity/metrics.ts
+++ b/npm/tests/visual-parity/metrics.ts
@@ -23,6 +23,10 @@ export interface PageMetrics {
   perceptualDiffPixelRatio: number;
   meanDeltaE76: number;
   ssim: number;
+  /** Fraction of Docxodus ink lying within the tolerance radius of reference ink. */
+  tolerantInkPrecision: number;
+  /** Fraction of reference ink lying within the tolerance radius of Docxodus ink. */
+  tolerantInkRecall: number;
   tolerantInkF1: number;
   severity: VisualSeverity;
 }
@@ -224,14 +228,20 @@ function dilate(mask: Uint8Array, width: number, height: number, radius: number)
   return out;
 }
 
-function inkF1(
+interface InkMetrics {
+  precision: number;
+  recall: number;
+  f1: number;
+}
+
+function inkMetrics(
   a: RgbaImage,
   b: RgbaImage,
   bgA: readonly number[],
   bgB: readonly number[],
   dx: number,
   dy: number,
-): number {
+): InkMetrics {
   const width = Math.max(a.width, b.width);
   const height = Math.max(a.height, b.height);
   const maskA = new Uint8Array(width * height);
@@ -255,7 +265,11 @@ function inkF1(
   }
   const precision = activeA ? matchedA / activeA : activeB ? 0 : 1;
   const recall = activeB ? matchedB / activeB : activeA ? 0 : 1;
-  return precision + recall ? 2 * precision * recall / (precision + recall) : 0;
+  return {
+    precision,
+    recall,
+    f1: precision + recall ? 2 * precision * recall / (precision + recall) : 0,
+  };
 }
 
 function severity(metrics: Omit<PageMetrics, 'severity'>): VisualSeverity {
@@ -310,6 +324,7 @@ export function compareImages(a: RgbaImage, b: RgbaImage): { metrics: PageMetric
   }
 
   const pixels = width * height;
+  const ink = inkMetrics(a, b, bgA, bgB, alignment.dx, alignment.dy);
   const withoutSeverity: Omit<PageMetrics, 'severity'> = {
     docxodus: { width: a.width, height: a.height, background: bgA },
     libreoffice: { width: b.width, height: b.height, background: bgB },
@@ -320,7 +335,9 @@ export function compareImages(a: RgbaImage, b: RgbaImage): { metrics: PageMetric
     perceptualDiffPixelRatio: pixels ? perceptuallyDifferent / pixels : 0,
     meanDeltaE76: pixels ? deltaTotal / pixels : 0,
     ssim: ssim(a, b, bgA, bgB, alignment.dx, alignment.dy),
-    tolerantInkF1: inkF1(a, b, bgA, bgB, alignment.dx, alignment.dy),
+    tolerantInkPrecision: ink.precision,
+    tolerantInkRecall: ink.recall,
+    tolerantInkF1: ink.f1,
   };
   return {
     metrics: { ...withoutSeverity, severity: severity(withoutSeverity) },

--- a/npm/tests/visual-parity/pdf-corpus.ts
+++ b/npm/tests/visual-parity/pdf-corpus.ts
@@ -1,0 +1,404 @@
+import type { CommentProfile, ReviewProfile } from "../../src/export-browser.js";
+import type { VisualDisposition } from "./corpus.js";
+
+/**
+ * The generated-PDF parity corpus is deliberately separate from the broader HTML-vs-LibreOffice
+ * visual corpus. Its entries are inputs to a strict release gate, so fixture identity, provenance,
+ * review/comment projection, searchable text, and link semantics are all reviewable data.
+ */
+export const PDF_PARITY_CORPUS_SCHEMA_VERSION = 1 as const;
+
+export const REQUIRED_PDF_PARITY_CATEGORIES = [
+  "legal-contract",
+  "tables",
+  "columns",
+  "footnotes",
+  "endnotes",
+  "headers-footers",
+  "images",
+  "charts",
+  "revisions",
+  "comments",
+  "mixed-orientation",
+  "internal-links",
+  "external-links",
+] as const;
+
+export type PdfParityCategory = typeof REQUIRED_PDF_PARITY_CATEGORIES[number];
+
+export interface TrackedGeneratorProvenance {
+  path: string;
+  sha256: string;
+  gitBlob: string;
+  rationale: string;
+}
+
+export interface TrackedFixtureSource {
+  kind: "tracked-fixture";
+  path: string;
+  /** Hash of the exact DOCX bytes. Unlike a comparison to HEAD, this survives fixture edits. */
+  sha256: string;
+  /** Git blob identity makes repository-history inspection direct without replacing SHA-256. */
+  gitBlob: string;
+  provenance: {
+    origin: "repository-authored" | "open-xml-powertools";
+    introducedBy: string;
+    rationale: string;
+    generator?: TrackedGeneratorProvenance;
+  };
+}
+
+export interface PdfParityProfileExpectation {
+  candidate: {
+    reviewProfile: ReviewProfile;
+    commentProfile: CommentProfile;
+  };
+  reference: {
+    /**
+     * LibreOffice follows saved redline state. Revision cases therefore accept a temporary copy
+     * for the reference only; the candidate must still receive the original bytes through the
+     * supported export API so its `final` projection is exercised.
+     */
+    revisionProjection: "source" | "accepted";
+    commentProjection: "hidden";
+  };
+  rationale: string;
+}
+
+export interface InternalPdfLinkExpectation {
+  kind: "internal";
+  sourceText: string;
+  anchor: string;
+  destinationText: string;
+}
+
+export interface ExternalPdfLinkExpectation {
+  kind: "external";
+  sourceText: string;
+  relationshipId: string;
+  exactTarget: string;
+}
+
+export type PdfLinkExpectation = InternalPdfLinkExpectation | ExternalPdfLinkExpectation;
+
+export interface PdfSemanticExpectation {
+  /** Tokens which must be present in independently extracted PDF text. */
+  requiredText: readonly string[];
+  /** Profile-hidden or final-view content which must not leak into extracted PDF text. */
+  forbiddenText?: readonly string[];
+  /** Exact targets to inspect independently of raster comparison. */
+  links?: readonly PdfLinkExpectation[];
+}
+
+export interface PdfParityCorpusEntry {
+  id: string;
+  categories: readonly PdfParityCategory[];
+  rationale: string;
+  source: TrackedFixtureSource;
+  profiles: PdfParityProfileExpectation;
+  semantics: PdfSemanticExpectation;
+  /** Attribution of the dominant raster residual; semantic failures always gate separately. */
+  disposition: VisualDisposition;
+}
+
+export interface PdfParityCorpusManifest {
+  schemaVersion: typeof PDF_PARITY_CORPUS_SCHEMA_VERSION;
+  rationale: string;
+  cases: readonly PdfParityCorpusEntry[];
+}
+
+const VP_GENERATOR = {
+  path: "TestFiles/VP/make-vp-fixtures.py",
+  sha256: "9f3d1cb820f50fa6b6b1d3cbb4252f818f13b282c28a2461022d8806241a368e",
+  gitBlob: "2b7ff34d3193c9857656db0cf523bc41bcebee13",
+  rationale: "Repository generator fixes ZIP timestamps and member order and emits byte-identical fixtures.",
+} as const satisfies TrackedGeneratorProvenance;
+
+const FINAL_HIDDEN_SOURCE = {
+  candidate: { reviewProfile: "final", commentProfile: "hidden" },
+  reference: { revisionProjection: "source", commentProjection: "hidden" },
+  rationale: "Compare the supported final/hidden export profile against the same source view.",
+} as const satisfies PdfParityProfileExpectation;
+
+const FINAL_HIDDEN_ACCEPTED_REFERENCE = {
+  candidate: { reviewProfile: "final", commentProfile: "hidden" },
+  reference: { revisionProjection: "accepted", commentProjection: "hidden" },
+  rationale: "The candidate receives original revision markup; only the reference copy is accepted to force the same final view.",
+} as const satisfies PdfParityProfileExpectation;
+
+const LEGAL_CONTRACT_INTERNAL_LINKS = [
+  ["1. Definitions", "_Toc400000001", "Definitions"],
+  ["2. Services", "_Toc400000002", "Services"],
+  ["2.1 Statements of Work", "_Toc400000003", "Statements of Work"],
+  ["2.2 Change Orders", "_Toc400000004", "Change Orders"],
+  ["3. Fees and Payment", "_Toc400000005", "Fees and Payment"],
+  ["3.1 Fees", "_Toc400000006", "Fees"],
+  ["3.2 Invoicing; Late Payment", "_Toc400000007", "Invoicing; Late Payment"],
+  ["4. Term and Termination", "_Toc400000008", "Term and Termination"],
+  ["5. Confidentiality", "_Toc400000009", "Confidentiality"],
+  ["6. Limitation of Liability", "_Toc400000010", "Limitation of Liability"],
+  ["7. General Provisions", "_Toc400000011", "General Provisions"],
+].map(([sourceText, anchor, destinationText]) => ({
+  kind: "internal" as const,
+  sourceText,
+  anchor,
+  destinationText,
+}));
+
+/**
+ * Ten cases / a small page set rather than the full diagnostic corpus. Several cases are
+ * intentionally multi-purpose: the legal agreement and the endnote exercise tables, while the
+ * mixed-section fixture covers both running stories and portrait/landscape transitions.
+ */
+export const PDF_PARITY_CORPUS = {
+  schemaVersion: PDF_PARITY_CORPUS_SCHEMA_VERSION,
+  rationale: "Compact, hash-pinned generated-PDF release corpus for issue #443.",
+  cases: [
+    {
+      id: "pdf-legal-contract",
+      categories: ["legal-contract", "tables", "internal-links"],
+      rationale: "Realistic three-page agreement with a signature table and eleven internal TOC destinations.",
+      source: {
+        kind: "tracked-fixture",
+        path: "TestFiles/VP/VP004-Legal-Contract.docx",
+        sha256: "5ad0115afae50d06da1fc7cb21aa61714026fa59b9fa67e454741622d2689346",
+        gitBlob: "0c805ef6ff5a7c3c5f2c456932dee05df5bed07d",
+        provenance: {
+          origin: "repository-authored",
+          introducedBy: "1d1332261891d16bed32480c4e77c4a1d1a1b3b7",
+          rationale: "Authored specifically for the visual-parity legal-document corpus in issue #400.",
+          generator: VP_GENERATOR,
+        },
+      },
+      profiles: FINAL_HIDDEN_SOURCE,
+      semantics: {
+        requiredText: ["MASTER SERVICES AGREEMENT", "Meridian Consulting Group LLC", "ATLAS MANUFACTURING CORPORATION"],
+        links: LEGAL_CONTRACT_INTERNAL_LINKS,
+      },
+      disposition: {
+        kind: "renderer-bug",
+        rationale: "The existing visual corpus attributes accumulated clause-position residuals to Docxodus; PDF output must not regress them.",
+        reference: "https://github.com/JSv4/Docxodus/issues/415",
+      },
+    },
+    {
+      id: "pdf-two-column-section",
+      categories: ["columns"],
+      rationale: "Continuous transition from a one-column title to a two-column body.",
+      source: {
+        kind: "tracked-fixture",
+        path: "TestFiles/VP/VP003-Two-Column-Section.docx",
+        sha256: "e51b73ae672efcf92d9312e14fade03ff95be2b89a1c06950d98e961e8a61600",
+        gitBlob: "2fca8bdfebcc2a1ba6a435876d1699e5f054529b",
+        provenance: {
+          origin: "repository-authored",
+          introducedBy: "1d1332261891d16bed32480c4e77c4a1d1a1b3b7",
+          rationale: "Authored specifically to isolate continuous-section column flow in issue #400.",
+          generator: VP_GENERATOR,
+        },
+      },
+      profiles: FINAL_HIDDEN_SOURCE,
+      semantics: { requiredText: ["The Docxodus Gazette", "A Two-Column Layout Exercise"] },
+      disposition: {
+        kind: "renderer-bug",
+        rationale: "Column fill and split geometry remain renderer-owned in the existing ratchet.",
+        reference: "https://github.com/JSv4/Docxodus/issues/413",
+      },
+    },
+    {
+      id: "pdf-footnote",
+      categories: ["footnotes"],
+      rationale: "Footnote reference, separator, note text, and bottom-of-page placement.",
+      source: {
+        kind: "tracked-fixture",
+        path: "TestFiles/CA/CA008-Footnote-Reference.docx",
+        sha256: "a3a43411bf1dfa9b8b3a0907a9966a9f856484564a3f4672fca6be1c2e5f4a81",
+        gitBlob: "ba2dcc3a3a5734a56c4a137f2436e10af26d59d9",
+        provenance: {
+          origin: "open-xml-powertools",
+          introducedBy: "7e8fb1dca18072c19414c7e99851c3d1e8ded95c",
+          rationale: "Tracked Open-Xml-PowerTools comparison fixture retained in the repository test corpus.",
+        },
+      },
+      profiles: FINAL_HIDDEN_SOURCE,
+      semantics: { requiredText: ["provides a way.", "This is a test."] },
+      disposition: {
+        kind: "environment",
+        rationale: "Placement is close; the known residual is shared substitute-font rasterization.",
+      },
+    },
+    {
+      id: "pdf-endnote-table",
+      categories: ["endnotes", "tables"],
+      rationale: "End-of-document note flow with a real table inside the endnote.",
+      source: {
+        kind: "tracked-fixture",
+        path: "TestFiles/WC/WC036-Endnote-With-Table-Before.docx",
+        sha256: "52dd6af5071df72afd7b3207076d23b119f5b43be30a72ab15bf00531fea62b1",
+        gitBlob: "18dc4e9db268909a79c58dda8aec403dd13dbf42",
+        provenance: {
+          origin: "open-xml-powertools",
+          introducedBy: "7e8fb1dca18072c19414c7e99851c3d1e8ded95c",
+          rationale: "Tracked Open-Xml-PowerTools comparison fixture retained in the repository test corpus.",
+        },
+      },
+      profiles: FINAL_HIDDEN_SOURCE,
+      semantics: { requiredText: ["Video provides a powerful way", "Aaa", "Iii"] },
+      disposition: {
+        kind: "unattributed",
+        rationale: "Endnote flow changed recently; keep the first generated-PDF baseline strict until its residual is re-triaged.",
+        reference: "https://github.com/JSv4/Docxodus/issues/414",
+      },
+    },
+    {
+      id: "pdf-mixed-orientation-running-stories",
+      categories: ["headers-footers", "mixed-orientation"],
+      rationale: "Landscape-to-portrait section transition with first/even/default headers and footers.",
+      source: {
+        kind: "tracked-fixture",
+        path: "TestFiles/DB001-Sections.docx",
+        sha256: "e4175a97187da72a48ee42efc74a16674f9767d687ade34cc6337ae999cd8479",
+        gitBlob: "46b4acc9c46829af19569ebc69ab2da97cc69c16",
+        provenance: {
+          origin: "open-xml-powertools",
+          introducedBy: "38d18c3d3422e47592db4fd96011b246e97097e0",
+          rationale: "Imported with the original Open-Xml-PowerTools section/running-story fixtures.",
+        },
+      },
+      profiles: FINAL_HIDDEN_SOURCE,
+      semantics: {
+        requiredText: ["This is a section that is in landscape mode.", "This is in the following section."],
+      },
+      disposition: {
+        kind: "environment",
+        rationale: "Page dimensions agree in the existing corpus; remaining deltas are shared-font line metrics.",
+      },
+    },
+    {
+      id: "pdf-raster-image",
+      categories: ["images"],
+      rationale: "Embedded PNG decode, physical sizing, placement, and surrounding selectable text.",
+      source: {
+        kind: "tracked-fixture",
+        path: "TestFiles/HC042-Image-Png.docx",
+        sha256: "c71ca76022a332a4f4aaf2b6db77937c8345b1c9765efed324c9749b9843fd05",
+        gitBlob: "b6e52cc56a868117d76b75a0c1ec3c741d89e871",
+        provenance: {
+          origin: "open-xml-powertools",
+          introducedBy: "38d18c3d3422e47592db4fd96011b246e97097e0",
+          rationale: "Imported with the original Open-Xml-PowerTools HTML conversion fixtures.",
+        },
+      },
+      profiles: FINAL_HIDDEN_SOURCE,
+      semantics: { requiredText: ["Video provides a powerful way to help you prove your point."] },
+      disposition: {
+        kind: "environment",
+        rationale: "The image extent is correct; the existing residual is surrounding text line-box behavior.",
+        reference: "https://github.com/JSv4/Docxodus/issues/404",
+      },
+    },
+    {
+      id: "pdf-chart",
+      categories: ["charts"],
+      rationale: "Cached-data clustered chart exercises SVG-to-PDF vector and label preservation.",
+      source: {
+        kind: "tracked-fixture",
+        path: "TestFiles/HC043-Chart.docx",
+        sha256: "fc56de3bbe6ab73d8cd289f9dd6c884d57fcf3e7160be5960796d1a5e809e248",
+        gitBlob: "a9221c7285d90f4cc3b9355d36445e9aae4c541f",
+        provenance: {
+          origin: "open-xml-powertools",
+          introducedBy: "38d18c3d3422e47592db4fd96011b246e97097e0",
+          rationale: "Imported with the original Open-Xml-PowerTools HTML conversion fixtures.",
+        },
+      },
+      profiles: FINAL_HIDDEN_SOURCE,
+      semantics: { requiredText: ["Series 1", "Category 1"] },
+      disposition: {
+        kind: "environment",
+        rationale: "The supported clustered chart is close; its remaining residual is label rasterization.",
+      },
+    },
+    {
+      id: "pdf-final-revisions",
+      categories: ["revisions"],
+      rationale: "The supported API must project a real deleted run to final view before PDF output.",
+      source: {
+        kind: "tracked-fixture",
+        path: "TestFiles/FA/RevTracking/001-DeletedRun.docx",
+        sha256: "b450ee098b2010955a6de2ed5ed0a86ee1d65a39e08f2c377eeee8040505778a",
+        gitBlob: "636af5ab41ded2fe1946ab6948864abb1612c615",
+        provenance: {
+          origin: "open-xml-powertools",
+          introducedBy: "135af9043c733a44cb262d8c75fe6aa91cf3697f",
+          rationale: "Added to Open-Xml-PowerTools for formatting/revision processing coverage.",
+        },
+      },
+      profiles: FINAL_HIDDEN_ACCEPTED_REFERENCE,
+      semantics: {
+        requiredText: ["Video provides a", "way to help you prove your point."],
+        forbiddenText: ["powerful"],
+      },
+      disposition: {
+        kind: "environment",
+        rationale: "With identical final-view content, the existing residual is heading/font rasterization rather than revision semantics.",
+        reference: "https://github.com/JSv4/Docxodus/issues/404",
+      },
+    },
+    {
+      id: "pdf-hidden-comments",
+      categories: ["comments"],
+      rationale: "Ten dense, overlapping, point, and threaded comments prove the explicit hidden profile does not leak note bodies.",
+      source: {
+        kind: "tracked-fixture",
+        path: "TestFiles/DD/DD002-DenseComments.docx",
+        sha256: "a4271f1e693994f5d7e6b05d843939f457726ccf8de561e6baf69deb33c3192c",
+        gitBlob: "c6834c45f95f81adaa34d46747338e5fe69053a8",
+        provenance: {
+          origin: "repository-authored",
+          introducedBy: "5418d00905082c2860d3798d41cd32e2adca6dc7",
+          rationale: "Authored for the repository's dense comment-range and threading regression suite.",
+        },
+      },
+      profiles: FINAL_HIDDEN_SOURCE,
+      semantics: {
+        requiredText: ["Master Agreement", "These recitals bind the parties named below"],
+        forbiddenText: ["scope of the recitals", "agree, keep it as drafted"],
+      },
+      disposition: {
+        kind: "unattributed",
+        rationale: "New PDF corpus case; strict until the first measured raster run is reviewed.",
+      },
+    },
+    {
+      id: "pdf-external-hyperlink",
+      categories: ["external-links"],
+      rationale: "One inert external relationship with an exact URI, validated independently from pixels.",
+      source: {
+        kind: "tracked-fixture",
+        path: "TestFiles/HC023-Hyperlink.docx",
+        sha256: "85de8c3dcc381f49df150b06398a06b030c9423380407983be29e3d666c12927",
+        gitBlob: "ba2b2449e8247e648f922ff2a2493f55aa37e654",
+        provenance: {
+          origin: "open-xml-powertools",
+          introducedBy: "38d18c3d3422e47592db4fd96011b246e97097e0",
+          rationale: "Imported with the original Open-Xml-PowerTools HTML conversion fixtures.",
+        },
+      },
+      profiles: FINAL_HIDDEN_SOURCE,
+      semantics: {
+        requiredText: ["Following is a hyperlink.", "EricWhite.com"],
+        links: [{
+          kind: "external",
+          sourceText: "EricWhite.com",
+          relationshipId: "rId4",
+          exactTarget: "http://www.ericwhite.com",
+        }],
+      },
+      disposition: {
+        kind: "unattributed",
+        rationale: "Semantic link preservation gates independently; raster residual starts strict until measured.",
+      },
+    },
+  ],
+} as const satisfies PdfParityCorpusManifest;

--- a/npm/tests/visual-parity/pdf-corpus.ts
+++ b/npm/tests/visual-parity/pdf-corpus.ts
@@ -70,6 +70,8 @@ export interface InternalPdfLinkExpectation {
   sourceText: string;
   anchor: string;
   destinationText: string;
+  /** Chromium emits one logical internal link as this exact consecutive annotation group. */
+  expectedPdfAnnotations: number;
 }
 
 export interface ExternalPdfLinkExpectation {
@@ -77,6 +79,9 @@ export interface ExternalPdfLinkExpectation {
   sourceText: string;
   relationshipId: string;
   exactTarget: string;
+  /** Exact URI representation delivered in the PDF after Chromium URL serialization. */
+  expectedPdfTarget: string;
+  expectedPdfAnnotations: number;
 }
 
 export type PdfLinkExpectation = InternalPdfLinkExpectation | ExternalPdfLinkExpectation;
@@ -143,6 +148,7 @@ const LEGAL_CONTRACT_INTERNAL_LINKS = [
   sourceText,
   anchor,
   destinationText,
+  expectedPdfAnnotations: 5,
 }));
 
 /**
@@ -393,6 +399,8 @@ export const PDF_PARITY_CORPUS = {
           sourceText: "EricWhite.com",
           relationshipId: "rId4",
           exactTarget: "http://www.ericwhite.com",
+          expectedPdfTarget: "http://www.ericwhite.com/",
+          expectedPdfAnnotations: 1,
         }],
       },
       disposition: {

--- a/npm/tests/visual-parity/pdf-links.ts
+++ b/npm/tests/visual-parity/pdf-links.ts
@@ -1,0 +1,146 @@
+import type { PdfLinkExpectation, PdfParityCorpusEntry } from './pdf-corpus.js';
+import type { PdfHyperlinkAnnotation, PdfInspection } from './pdf.js';
+
+export interface ObservedLinkEvidence {
+  annotationPage: number;
+  annotationCount: number;
+  rectangles: readonly (readonly number[])[];
+  kind: string;
+  value?: string;
+  unsafeValue?: string;
+  destinationPage?: number;
+  expectedSourceText?: string;
+  sourceTextPresent: boolean;
+  destinationTextPresent: boolean;
+  exactTargetPassed: boolean;
+  exactAnnotationCountPassed: boolean;
+}
+
+export interface LinkEvidence {
+  expected: readonly PdfLinkExpectation[];
+  observed: ObservedLinkEvidence[];
+  missingOrMismatched: readonly PdfLinkExpectation[];
+  unexpectedLogicalLinks: number;
+  unsupportedAnnotations: number;
+  passed: boolean;
+}
+
+interface LocatedAnnotation {
+  annotation: PdfHyperlinkAnnotation;
+  annotationPage: number;
+  pageText: string;
+}
+
+function normalized(value: string): string {
+  return value.normalize('NFC').replace(/\s+/g, ' ').trim();
+}
+
+function comparableText(value: string): string {
+  return normalized(value).toLocaleLowerCase('en-US');
+}
+
+function sourceRepresentation(annotation: PdfHyperlinkAnnotation): string | undefined {
+  return annotation.target.kind === 'url'
+    ? annotation.target.unsafeValue ?? annotation.target.value
+    : undefined;
+}
+
+function logicalTargetKey(annotation: PdfHyperlinkAnnotation, index: number): string {
+  const target = annotation.target;
+  if (target.kind === 'destination') {
+    return `destination\0${target.namedDestination ?? target.value}\0${target.pageNumber}`;
+  }
+  if (target.kind === 'url') return `url\0${sourceRepresentation(annotation) ?? ''}`;
+  return `unsupported\0${index}`;
+}
+
+function consecutiveGroups(annotations: readonly LocatedAnnotation[]): LocatedAnnotation[][] {
+  const groups: LocatedAnnotation[][] = [];
+  let previousKey: string | undefined;
+  annotations.forEach((item, index) => {
+    const key = logicalTargetKey(item.annotation, index);
+    if (key !== previousKey) groups.push([]);
+    groups[groups.length - 1].push(item);
+    previousKey = key;
+  });
+  return groups;
+}
+
+/**
+ * Bind logical links to the manifest in deterministic document order. Chromium currently emits
+ * several consecutive rectangles for one internal hyperlink, so the manifest pins both the
+ * logical target sequence and exact annotation multiplicity instead of mistaking those rectangles
+ * for unexpected links or silently accepting injected duplicates.
+ */
+export function exactLinkEvidence(
+  inspection: PdfInspection,
+  entry: Pick<PdfParityCorpusEntry, 'semantics'>,
+): LinkEvidence {
+  const expected = [...(entry.semantics.links ?? [])];
+  const annotations = inspection.pages.flatMap((page) => page.hyperlinks.map((annotation) => ({
+    annotation,
+    annotationPage: page.pageNumber,
+    pageText: comparableText(page.text),
+  })));
+  const groups = consecutiveGroups(annotations);
+  const missingOrMismatched: PdfLinkExpectation[] = [];
+  const observed = groups.map((group, index): ObservedLinkEvidence => {
+    const first = group[0];
+    const expectation = expected[index];
+    const target = first.annotation.target;
+    const destinationPage = target.kind === 'destination' ? target.pageNumber : undefined;
+    const destinationText = expectation?.kind === 'internal'
+      ? comparableText(inspection.pages[destinationPage === undefined ? -1 : destinationPage - 1]?.text ?? '')
+      : '';
+    const sourceTextPresent = expectation !== undefined
+      && first.pageText.includes(comparableText(expectation.sourceText));
+    const destinationTextPresent = expectation?.kind !== 'internal'
+      || destinationText.includes(comparableText(expectation.destinationText));
+    const exactTargetPassed = expectation?.kind === 'external'
+      ? target.kind === 'url' && sourceRepresentation(first.annotation) === expectation.expectedPdfTarget
+      : expectation?.kind === 'internal'
+        ? target.kind === 'destination'
+          && (target.namedDestination ?? target.value) === expectation.anchor
+          && destinationPage !== undefined
+        : false;
+    const exactAnnotationCountPassed = expectation !== undefined
+      && group.length === expectation.expectedPdfAnnotations;
+    const rectangles = group.flatMap((item) => item.annotation.rectangle ? [item.annotation.rectangle] : []);
+    const rectanglesPassed = rectangles.length === group.length
+      && rectangles.every((rectangle) => rectangle.length === 4 && rectangle.every(Number.isFinite));
+    const oneSourcePage = group.every((item) => item.annotationPage === first.annotationPage);
+    if (!expectation || !sourceTextPresent || !destinationTextPresent || !exactTargetPassed
+      || !exactAnnotationCountPassed || !rectanglesPassed || !oneSourcePage) {
+      if (expectation) missingOrMismatched.push(expectation);
+    }
+    return {
+      annotationPage: first.annotationPage,
+      annotationCount: group.length,
+      rectangles,
+      kind: target.kind,
+      ...(target.kind === 'unsupported' ? {} : { value: target.value }),
+      ...(target.kind === 'url' && target.unsafeValue ? { unsafeValue: target.unsafeValue } : {}),
+      ...(destinationPage === undefined ? {} : { destinationPage }),
+      ...(expectation === undefined ? {} : { expectedSourceText: expectation.sourceText }),
+      sourceTextPresent,
+      destinationTextPresent,
+      exactTargetPassed,
+      exactAnnotationCountPassed,
+    };
+  });
+  if (groups.length < expected.length) missingOrMismatched.push(...expected.slice(groups.length));
+  const unsupportedAnnotations = annotations
+    .filter((item) => item.annotation.target.kind === 'unsupported').length;
+  const exactContractRequired = expected.length > 0;
+  const unexpectedLogicalLinks = exactContractRequired ? Math.max(0, groups.length - expected.length) : 0;
+  return {
+    expected,
+    observed,
+    missingOrMismatched,
+    unexpectedLogicalLinks,
+    unsupportedAnnotations,
+    passed: unsupportedAnnotations === 0
+      && (!exactContractRequired
+        || (groups.length === expected.length && missingOrMismatched.length === 0)),
+  };
+}

--- a/npm/tests/visual-parity/pdf-result.ts
+++ b/npm/tests/visual-parity/pdf-result.ts
@@ -1,0 +1,150 @@
+import { createHash } from 'node:crypto';
+import { canonicalJson } from './canonical-json.js';
+import { PDF_PARITY_LIMITS } from './pdf.js';
+
+const DIGEST = /^[0-9a-f]{64}$/;
+const MAXIMUM_FRAGMENTS = 100_000;
+const MAXIMUM_FRAGMENT_STRING_CHARACTERS = 8_192;
+const MAXIMUM_TOTAL_FRAGMENT_STRING_CHARACTERS = 16 * 1024 * 1024;
+const PAGE_TOLERANCE = 0.1;
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function exactKeys(value: Record<string, unknown>, allowed: readonly string[]): boolean {
+  return Object.keys(value).every((key) => allowed.includes(key));
+}
+
+function sha256(value: Uint8Array | string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+export interface SupportedPdfResultExpectation {
+  sourceSha256: string;
+  reviewProfile: string;
+  commentProfile: string;
+  documentVersion?: number;
+}
+
+export interface VerifiedPdfResult {
+  pageCount: number;
+  rendererFingerprint: string;
+  pages: Array<{ pageNumber: number; width: number; height: number }>;
+}
+
+/** Independently validate the supported API envelope before any PDF parser overwrites its claims. */
+export function assertSupportedPdfResult(
+  candidate: unknown,
+  expected: SupportedPdfResultExpectation,
+): VerifiedPdfResult {
+  const result = record(candidate);
+  if (!result || !(result.pdf instanceof Uint8Array)
+    || result.pdf.byteLength < 16 || result.pdf.byteLength > PDF_PARITY_LIMITS.maximumPdfBytes
+    || !Number.isSafeInteger(result.pageCount) || (result.pageCount as number) < 1
+    || (result.pageCount as number) > PDF_PARITY_LIMITS.maximumPages
+    || typeof result.rendererFingerprint !== 'string' || !DIGEST.test(result.rendererFingerprint)
+    || !Array.isArray(result.warnings)) {
+    throw new Error('Supported PDF result has an invalid top-level envelope.');
+  }
+
+  const map = record(result.pageMap);
+  if (!map || !exactKeys(map, [
+    'schemaVersion', 'mode', 'availability', 'documentVersion', 'rendererFingerprint',
+    'pages', 'fragments',
+  ]) || map.schemaVersion !== 1 || map.mode !== 'paginated' || map.availability !== 'available'
+    || map.documentVersion !== (expected.documentVersion ?? 0)
+    || map.rendererFingerprint !== result.rendererFingerprint
+    || !Array.isArray(map.pages) || map.pages.length !== result.pageCount
+    || !Array.isArray(map.fragments) || map.fragments.length > MAXIMUM_FRAGMENTS) {
+    throw new Error('Supported PDF result has an invalid or inconsistent PageMap envelope.');
+  }
+
+  const pages: Array<{ pageNumber: number; width: number; height: number }> = [];
+  const pageSizes = new Map<number, { width: number; height: number }>();
+  for (let index = 0; index < map.pages.length; index++) {
+    const page = record(map.pages[index]);
+    if (!page || !exactKeys(page, [
+      'pageNumber', 'pageInSection', 'width', 'height', 'sectionIndex', 'pageName',
+    ]) || page.pageNumber !== index + 1
+      || !Number.isSafeInteger(page.pageInSection) || (page.pageInSection as number) < 1
+      || typeof page.width !== 'number' || !Number.isFinite(page.width) || page.width <= 0
+      || page.width > PDF_PARITY_LIMITS.maximumPhysicalPagePoints
+      || typeof page.height !== 'number' || !Number.isFinite(page.height) || page.height <= 0
+      || page.height > PDF_PARITY_LIMITS.maximumPhysicalPagePoints
+      || (page.sectionIndex !== undefined
+        && (!Number.isSafeInteger(page.sectionIndex) || (page.sectionIndex as number) < 0))
+      || typeof page.pageName !== 'string' || page.pageName.length < 1 || page.pageName.length > 512) {
+      throw new Error(`Supported PDF result has an invalid PageMap page at index ${index}.`);
+    }
+    const verified = {
+      pageNumber: page.pageNumber as number,
+      width: page.width,
+      height: page.height,
+    };
+    pages.push(verified);
+    pageSizes.set(verified.pageNumber, verified);
+  }
+
+  const fragmentIds = new Set<string>();
+  const nextFragmentIndex = new Map<string, number>();
+  let fragmentStringCharacters = 0;
+  for (const candidateFragment of map.fragments) {
+    const fragment = record(candidateFragment);
+    const geometry = fragment ? record(fragment.geometry) : undefined;
+    const page = fragment && Number.isSafeInteger(fragment.pageNumber)
+      ? pageSizes.get(fragment.pageNumber as number)
+      : undefined;
+    fragmentStringCharacters += typeof fragment?.fragmentId === 'string' ? fragment.fragmentId.length : 0;
+    fragmentStringCharacters += typeof fragment?.anchorId === 'string' ? fragment.anchorId.length : 0;
+    if (!fragment || !exactKeys(fragment, [
+      'fragmentId', 'anchorId', 'fragmentIndex', 'pageNumber', 'geometry', 'story', 'inTableCell',
+    ]) || typeof fragment.fragmentId !== 'string' || fragment.fragmentId.length < 1
+      || fragment.fragmentId.length > MAXIMUM_FRAGMENT_STRING_CHARACTERS
+      || fragmentIds.has(fragment.fragmentId)
+      || typeof fragment.anchorId !== 'string' || fragment.anchorId.length < 1
+      || fragment.anchorId.length > MAXIMUM_FRAGMENT_STRING_CHARACTERS
+      || fragmentStringCharacters > MAXIMUM_TOTAL_FRAGMENT_STRING_CHARACTERS
+      || !Number.isSafeInteger(fragment.fragmentIndex) || (fragment.fragmentIndex as number) < 0
+      || !page
+      || fragment.fragmentId !== `p${fragment.pageNumber}-f${fragment.fragmentIndex}-${fragment.anchorId}`
+      || !geometry || !exactKeys(geometry, ['x', 'y', 'width', 'height'])
+      || ![geometry.x, geometry.y, geometry.width, geometry.height].every((value) =>
+        typeof value === 'number' && Number.isFinite(value) && value >= 0)
+      || (geometry.x as number) + (geometry.width as number) > page.width + PAGE_TOLERANCE
+      || (geometry.y as number) + (geometry.height as number) > page.height + PAGE_TOLERANCE
+      || !['body', 'header', 'footer', 'footnote', 'endnote', 'comment']
+        .includes(String(fragment.story))
+      || typeof fragment.inTableCell !== 'boolean') {
+      throw new Error('Supported PDF result has an invalid PageMap fragment.');
+    }
+    const expectedIndex = nextFragmentIndex.get(fragment.anchorId) ?? 0;
+    if (fragment.fragmentIndex !== expectedIndex) {
+      throw new Error('Supported PDF result has a discontinuous PageMap fragment sequence.');
+    }
+    nextFragmentIndex.set(fragment.anchorId, expectedIndex + 1);
+    fragmentIds.add(fragment.fragmentId);
+  }
+
+  const report = record(result.renderReport);
+  const reportEnvironment = report ? record(report.environment) : undefined;
+  const reportBindings = report ? record(report.bindings) : undefined;
+  const reportSource = report ? record(report.source) : undefined;
+  const reportOptions = report ? record(report.options) : undefined;
+  if (!report || report.status !== 'complete'
+    || !reportEnvironment || reportEnvironment.rendererFingerprint !== result.rendererFingerprint
+    || reportEnvironment.verification !== 'nodeVerified'
+    || reportEnvironment.fidelityTier !== 'releaseBaselined'
+    || !reportBindings || reportBindings.pdfDigest !== sha256(result.pdf)
+    || reportBindings.pageMapDigest !== sha256(canonicalJson(map))
+    || !reportSource || reportSource.rawPackageBytesDigest !== expected.sourceSha256
+    || !reportOptions || reportOptions.reviewProfile !== expected.reviewProfile
+    || reportOptions.commentProfile !== expected.commentProfile
+    || canonicalJson(report.pages) !== canonicalJson(map.pages)
+    || canonicalJson(report.warnings) !== canonicalJson(result.warnings)) {
+    throw new Error('Supported PDF result is not bound to its report, PageMap, source, and profiles.');
+  }
+  return { pageCount: result.pageCount as number, rendererFingerprint: result.rendererFingerprint, pages };
+}

--- a/npm/tests/visual-parity/pdf.ts
+++ b/npm/tests/visual-parity/pdf.ts
@@ -2,13 +2,33 @@ import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import {
   existsSync,
+  lstatSync,
   readFileSync,
   readdirSync,
   statSync,
 } from 'node:fs';
 import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
-import { PDFDocument } from 'pdf-lib';
+import { PDFDocument, PDFName, PDFNumber } from 'pdf-lib';
+import type { PDFObject, PDFPage } from 'pdf-lib';
 import { getDocument, OPS, type PDFDocumentProxy } from 'pdfjs-dist/legacy/build/pdf.mjs';
+
+/**
+ * Resource ceilings for the fixed release corpus. These are deliberately far above its current
+ * largest artifacts while preventing a broken renderer/parser from turning CI into an unbounded
+ * PDF, raster, text, annotation, or operator-list expansion.
+ */
+export const PDF_PARITY_LIMITS = Object.freeze({
+  maximumPdfBytes: 32 * 1024 * 1024,
+  maximumPages: 32,
+  maximumRasterBytesPerPage: 16 * 1024 * 1024,
+  maximumTotalRasterBytes: 128 * 1024 * 1024,
+  maximumRasterPixelsPerPage: 4_000_000,
+  maximumTextCharacters: 5_000_000,
+  maximumAnnotationsPerPage: 4_096,
+  maximumOperatorEntriesPerPage: 1_000_000,
+  maximumPhysicalPagePoints: 14_400,
+  maximumHyperlinkTargetCharacters: 8_192,
+});
 
 /**
  * The one raster contract used for both the Docxodus PDF and its reference PDF.
@@ -30,6 +50,11 @@ export const PDF_RASTER_CONTRACT = Object.freeze({
   freeType: true as const,
   thinLineMode: 'none' as const,
   forcePageNumber: true as const,
+  maximumPages: PDF_PARITY_LIMITS.maximumPages,
+  maximumPdfBytes: PDF_PARITY_LIMITS.maximumPdfBytes,
+  maximumRasterBytesPerPage: PDF_PARITY_LIMITS.maximumRasterBytesPerPage,
+  maximumTotalRasterBytes: PDF_PARITY_LIMITS.maximumTotalRasterBytes,
+  maximumRasterPixelsPerPage: PDF_PARITY_LIMITS.maximumRasterPixelsPerPage,
 });
 
 function sha256(bytes: Uint8Array | string): string {
@@ -41,6 +66,7 @@ export const PDF_RASTER_CONTRACT_SHA256 = sha256(JSON.stringify(PDF_RASTER_CONTR
 export interface RasterArtifact {
   pageNumber: number;
   path: string;
+  bytes: number;
   sha256: string;
 }
 
@@ -54,6 +80,8 @@ export interface RasterizedPdf {
 export interface RasterizePdfOptions {
   env?: NodeJS.ProcessEnv;
   timeoutMs?: number;
+  /** Absolute executable already resolved and hashed by the benchmark preflight. */
+  executablePath?: string;
 }
 
 function escapedRegExp(value: string): string {
@@ -67,7 +95,18 @@ function numberedPngs(outputPrefix: string): Array<{ pageNumber: number; path: s
   return readdirSync(directory)
     .map((name) => ({ name, match: name.match(pattern) }))
     .filter((entry): entry is { name: string; match: RegExpMatchArray } => entry.match !== null)
-    .map((entry) => ({ pageNumber: Number(entry.match[1]), path: join(directory, entry.name) }))
+    .map((entry) => {
+      const pageNumber = Number(entry.match[1]);
+      const path = join(directory, entry.name);
+      if (!Number.isSafeInteger(pageNumber) || pageNumber < 1) {
+        throw new Error(`pdftoppm produced an invalid page number at ${path}`);
+      }
+      const metadata = lstatSync(path);
+      if (!metadata.isFile() || metadata.isSymbolicLink()) {
+        throw new Error(`pdftoppm raster output is not a regular non-symlink file: ${path}`);
+      }
+      return { pageNumber, path };
+    })
     .sort((left, right) => left.pageNumber - right.pageNumber);
 }
 
@@ -82,6 +121,8 @@ export function popplerRasterArguments(pdfPath: string, outputPrefix: string): r
     '-thinlinemode', PDF_RASTER_CONTRACT.thinLineMode,
     '-aa', PDF_RASTER_CONTRACT.fontAntialiasing ? 'yes' : 'no',
     '-aaVector', PDF_RASTER_CONTRACT.vectorAntialiasing ? 'yes' : 'no',
+    '-f', '1',
+    '-l', String(PDF_RASTER_CONTRACT.maximumPages + 1),
     '-forcenum',
     '-q',
     input,
@@ -104,17 +145,27 @@ export function rasterizePdf(
   }
   const resolvedPdf = resolve(pdfPath);
   const resolvedPrefix = resolve(outputPrefix);
-  if (!existsSync(resolvedPdf) || !statSync(resolvedPdf).isFile()) {
+  if (!existsSync(resolvedPdf) || !lstatSync(resolvedPdf).isFile()
+    || lstatSync(resolvedPdf).isSymbolicLink()) {
     throw new Error(`PDF raster input is not a regular file: ${resolvedPdf}`);
   }
-  if (!existsSync(dirname(resolvedPrefix)) || !statSync(dirname(resolvedPrefix)).isDirectory()) {
+  const pdfBytes = statSync(resolvedPdf).size;
+  if (pdfBytes > PDF_RASTER_CONTRACT.maximumPdfBytes) {
+    throw new Error(`PDF raster input exceeds ${PDF_RASTER_CONTRACT.maximumPdfBytes} bytes: ${pdfBytes}`);
+  }
+  if (!existsSync(dirname(resolvedPrefix)) || !lstatSync(dirname(resolvedPrefix)).isDirectory()
+    || lstatSync(dirname(resolvedPrefix)).isSymbolicLink()) {
     throw new Error(`PDF raster output directory does not exist: ${dirname(resolvedPrefix)}`);
   }
   if (numberedPngs(resolvedPrefix).length > 0) {
     throw new Error(`Refusing to mix stale raster pages for prefix: ${resolvedPrefix}`);
   }
 
-  execFileSync(PDF_RASTER_CONTRACT.tool, [...popplerRasterArguments(resolvedPdf, resolvedPrefix)], {
+  const executable = options.executablePath ?? PDF_RASTER_CONTRACT.tool;
+  if (options.executablePath !== undefined && !isAbsolute(options.executablePath)) {
+    throw new Error('The pinned pdftoppm executable path must be absolute.');
+  }
+  execFileSync(executable, [...popplerRasterArguments(resolvedPdf, resolvedPrefix)], {
     env: options.env,
     stdio: 'pipe',
     timeout: options.timeoutMs ?? 120_000,
@@ -123,9 +174,29 @@ export function rasterizePdf(
   if (pages.length === 0) {
     throw new Error(`pdftoppm produced no PNG pages for: ${resolvedPdf}`);
   }
+  if (pages.length > PDF_RASTER_CONTRACT.maximumPages) {
+    throw new Error(`pdftoppm produced more than ${PDF_RASTER_CONTRACT.maximumPages} pages.`);
+  }
+  let totalRasterBytes = 0;
   pages.forEach((page, index) => {
     if (page.pageNumber !== index + 1) {
       throw new Error(`pdftoppm produced a non-contiguous page sequence at ${page.path}`);
+    }
+    const size = statSync(page.path).size;
+    if (size > PDF_RASTER_CONTRACT.maximumRasterBytesPerPage) {
+      throw new Error(`Raster page exceeds ${PDF_RASTER_CONTRACT.maximumRasterBytesPerPage} bytes: ${page.path}`);
+    }
+    totalRasterBytes += size;
+    if (totalRasterBytes > PDF_RASTER_CONTRACT.maximumTotalRasterBytes) {
+      throw new Error(`Raster output exceeds ${PDF_RASTER_CONTRACT.maximumTotalRasterBytes} total bytes.`);
+    }
+    const header = readFileSync(page.path).subarray(0, 24);
+    const isPng = header.length === 24
+      && header.subarray(0, 8).equals(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]));
+    const width = isPng ? header.readUInt32BE(16) : 0;
+    const height = isPng ? header.readUInt32BE(20) : 0;
+    if (!width || !height || width * height > PDF_RASTER_CONTRACT.maximumRasterPixelsPerPage) {
+      throw new Error(`Raster page has invalid or excessive dimensions at ${page.path}: ${width}x${height}`);
     }
   });
   return {
@@ -134,6 +205,7 @@ export function rasterizePdf(
     contractSha256: PDF_RASTER_CONTRACT_SHA256,
     pages: pages.map((page) => ({
       ...page,
+      bytes: statSync(page.path).size,
       sha256: sha256(readFileSync(page.path)),
     })),
   };
@@ -156,8 +228,20 @@ export interface PdfHyperlinkAnnotation {
   rectangle?: readonly number[];
 }
 
+function annotationRectangle(value: unknown): readonly number[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.length !== 4
+    || !value.every((coordinate) => typeof coordinate === 'number'
+      && Number.isFinite(coordinate) && Math.abs(coordinate) <= 1_000_000)) {
+    throw new Error('PDF link annotation has an invalid or excessive rectangle.');
+  }
+  return Object.freeze([...value] as number[]);
+}
+
 export interface PdfPageInspection {
   pageNumber: number;
+  userUnit: number;
+  rotation: number;
   mediaBox: PdfBox;
   cropBox: PdfBox;
   text: string;
@@ -217,12 +301,51 @@ function pdfBox(box: { x: number; y: number; width: number; height: number }): P
   return { x: box.x, y: box.y, width: box.width, height: box.height };
 }
 
+function inheritedPageNumber(page: PDFPage, name: string): number | undefined {
+  const value = page.node.getInheritableAttribute(PDFName.of(name));
+  if (value === undefined) return undefined;
+  const resolved = page.node.context.lookup(value) as PDFObject | undefined;
+  if (!(resolved instanceof PDFNumber)) {
+    throw new Error(`PDF page attribute /${name} is not a number.`);
+  }
+  return resolved.asNumber();
+}
+
+/**
+ * Scale a page-space box and orient its dimensions. x/y deliberately remain the scaled raw PDF
+ * box origin: /Rotate changes the displayed axes but not the page dictionary's coordinate-space
+ * origin. Keeping rotation as a separate field avoids inventing a viewer-specific translation.
+ */
+function scaledOrientedPdfBox(
+  box: { x: number; y: number; width: number; height: number },
+  userUnit: number,
+  rotation: number,
+): PdfBox {
+  const swapsAxes = rotation === 90 || rotation === 270;
+  const physical = pdfBox({
+    x: box.x * userUnit,
+    y: box.y * userUnit,
+    width: (swapsAxes ? box.height : box.width) * userUnit,
+    height: (swapsAxes ? box.width : box.height) * userUnit,
+  });
+  if (!Object.values(physical).every(Number.isFinite)
+    || physical.width <= 0 || physical.height <= 0
+    || Math.abs(physical.x) > PDF_PARITY_LIMITS.maximumPhysicalPagePoints
+    || Math.abs(physical.y) > PDF_PARITY_LIMITS.maximumPhysicalPagePoints
+    || physical.width > PDF_PARITY_LIMITS.maximumPhysicalPagePoints
+    || physical.height > PDF_PARITY_LIMITS.maximumPhysicalPagePoints) {
+    throw new Error(`PDF page has invalid or excessive physical geometry: ${JSON.stringify(physical)}`);
+  }
+  return physical;
+}
+
 function destinationValue(value: unknown): string {
   if (typeof value === 'string') return value;
   try {
-    return JSON.stringify(value) ?? String(value);
+    const serialized = JSON.stringify(value) ?? String(value);
+    return serialized.slice(0, PDF_PARITY_LIMITS.maximumHyperlinkTargetCharacters);
   } catch {
-    return String(value);
+    return String(value).slice(0, PDF_PARITY_LIMITS.maximumHyperlinkTargetCharacters);
   }
 }
 
@@ -261,6 +384,20 @@ async function hyperlinkTarget(
   annotation: Record<string, unknown>,
 ): Promise<PdfHyperlinkTarget> {
   if (typeof annotation.url === 'string') {
+    if (annotation.url.length > PDF_PARITY_LIMITS.maximumHyperlinkTargetCharacters
+      || (typeof annotation.unsafeUrl === 'string'
+        && annotation.unsafeUrl.length > PDF_PARITY_LIMITS.maximumHyperlinkTargetCharacters)) {
+      return { kind: 'unsupported', reason: 'link target exceeds the inspection limit' };
+    }
+    let protocol: string;
+    try {
+      protocol = new URL(annotation.url).protocol.toLowerCase();
+    } catch {
+      return { kind: 'unsupported', reason: 'link target is not an absolute URL' };
+    }
+    if (!['http:', 'https:', 'mailto:'].includes(protocol)) {
+      return { kind: 'unsupported', reason: `link target uses disallowed protocol ${protocol}` };
+    }
     return {
       kind: 'url',
       value: annotation.url,
@@ -307,7 +444,8 @@ function semanticResult(
     || missingFragments.length > 0
     || presentForbiddenFragments.length > 0;
   const hyperlinksRequired = requiredTargets.length > 0;
-  const hyperlinksFailed = missingTargets.length > 0;
+  const hyperlinksFailed = missingTargets.length > 0
+    || (hyperlinksRequired && targets.some((target) => target.kind === 'unsupported'));
   return {
     passed: !textFailed && !hyperlinksFailed,
     selectableText: {
@@ -341,6 +479,9 @@ export async function inspectPdf(
   bytes: Uint8Array,
   expectations: PdfSemanticExpectations = {},
 ): Promise<PdfInspection> {
+  if (bytes.byteLength < 16 || bytes.byteLength > PDF_PARITY_LIMITS.maximumPdfBytes) {
+    throw new Error(`PDF inspection input must be 16..${PDF_PARITY_LIMITS.maximumPdfBytes} bytes.`);
+  }
   const owned = new Uint8Array(bytes);
   const geometryDocument = await PDFDocument.load(new Uint8Array(owned), {
     ignoreEncryption: false,
@@ -348,12 +489,19 @@ export async function inspectPdf(
     throwOnInvalidObject: true,
   });
   const geometryPages = geometryDocument.getPages();
+  if (geometryPages.length < 1 || geometryPages.length > PDF_PARITY_LIMITS.maximumPages) {
+    throw new Error(`PDF inspection page count must be 1..${PDF_PARITY_LIMITS.maximumPages}.`);
+  }
   const loading = getDocument({
     data: new Uint8Array(owned),
-    useSystemFonts: true,
+    useSystemFonts: false,
+    disableFontFace: true,
+    stopAtErrors: true,
+    maxImageSize: PDF_PARITY_LIMITS.maximumRasterPixelsPerPage,
+    canvasMaxAreaInBytes: PDF_PARITY_LIMITS.maximumRasterBytesPerPage,
   });
-  const pdf = await loading.promise;
   try {
+    const pdf = await loading.promise;
     if (pdf.numPages !== geometryPages.length) {
       throw new Error(
         `PDF parsers disagree on page count (${pdf.numPages} != ${geometryPages.length}).`,
@@ -362,28 +510,53 @@ export async function inspectPdf(
     const pages: PdfPageInspection[] = [];
     const allHyperlinks: PdfHyperlinkAnnotation[] = [];
     let vectorPathOperations = 0;
+    let totalTextCharacters = 0;
     for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber++) {
       const page = await pdf.getPage(pageNumber);
       const content = await page.getTextContent();
       const text = content.items.map((item) => 'str' in item ? item.str : '').join(' ');
+      totalTextCharacters += text.length;
+      if (totalTextCharacters > PDF_PARITY_LIMITS.maximumTextCharacters) {
+        throw new Error(`PDF selectable text exceeds ${PDF_PARITY_LIMITS.maximumTextCharacters} characters.`);
+      }
       const annotations = await page.getAnnotations();
+      if (annotations.length > PDF_PARITY_LIMITS.maximumAnnotationsPerPage) {
+        throw new Error(`PDF page ${pageNumber} exceeds the annotation limit.`);
+      }
       const linkAnnotations = annotations
         .filter((annotation) => annotation.subtype === 'Link')
       const hyperlinks = await Promise.all(linkAnnotations
-        .map(async (annotation): Promise<PdfHyperlinkAnnotation> => ({
-          target: await hyperlinkTarget(pdf, annotation as Record<string, unknown>),
-          ...(Array.isArray(annotation.rect)
-            ? { rectangle: Object.freeze(annotation.rect.map(Number)) }
-            : {}),
-        })));
+        .map(async (annotation): Promise<PdfHyperlinkAnnotation> => {
+          const rectangle = annotationRectangle(annotation.rect);
+          return {
+            target: await hyperlinkTarget(pdf, annotation as Record<string, unknown>),
+            ...(rectangle === undefined ? {} : { rectangle }),
+          };
+        }));
       const operations = await page.getOperatorList();
+      if (operations.fnArray.length > PDF_PARITY_LIMITS.maximumOperatorEntriesPerPage) {
+        throw new Error(`PDF page ${pageNumber} exceeds the operator-list limit.`);
+      }
       const pagePaths = operations.fnArray.filter((operation) => operation === OPS.constructPath).length;
+      const geometryPage = geometryPages[pageNumber - 1];
+      const userUnit = inheritedPageNumber(geometryPage, 'UserUnit') ?? 1;
+      if (!Number.isFinite(userUnit) || userUnit < 1 || userUnit > 75_000) {
+        throw new Error(`PDF page ${pageNumber} has invalid /UserUnit ${String(userUnit)}.`);
+      }
+      const rawRotation = inheritedPageNumber(geometryPage, 'Rotate') ?? 0;
+      if (!Number.isFinite(rawRotation) || !Number.isInteger(rawRotation)
+        || rawRotation % 90 !== 0) {
+        throw new Error(`PDF page ${pageNumber} has invalid /Rotate ${String(rawRotation)}.`);
+      }
+      const rotation = ((rawRotation % 360) + 360) % 360;
       vectorPathOperations += pagePaths;
       allHyperlinks.push(...hyperlinks);
       pages.push({
         pageNumber,
-        mediaBox: pdfBox(geometryPages[pageNumber - 1].getMediaBox()),
-        cropBox: pdfBox(geometryPages[pageNumber - 1].getCropBox()),
+        userUnit,
+        rotation,
+        mediaBox: scaledOrientedPdfBox(geometryPage.getMediaBox(), userUnit, rotation),
+        cropBox: scaledOrientedPdfBox(geometryPage.getCropBox(), userUnit, rotation),
         text,
         textSha256: sha256(text),
         hyperlinks,

--- a/npm/tests/visual-parity/pdf.ts
+++ b/npm/tests/visual-parity/pdf.ts
@@ -1,0 +1,412 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+} from 'node:fs';
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
+import { PDFDocument } from 'pdf-lib';
+import { getDocument, OPS, type PDFDocumentProxy } from 'pdfjs-dist/legacy/build/pdf.mjs';
+
+/**
+ * The one raster contract used for both the Docxodus PDF and its reference PDF.
+ *
+ * RGB is selected by deliberately omitting pdftoppm's `-mono` and `-gray`
+ * switches. MediaBox is selected by deliberately omitting `-cropbox`. Keeping
+ * those choices in this frozen, hashable record makes defaults that otherwise
+ * look accidental part of the reviewable comparison contract.
+ */
+export const PDF_RASTER_CONTRACT = Object.freeze({
+  schemaVersion: 1 as const,
+  tool: 'pdftoppm' as const,
+  dpi: 96 as const,
+  format: 'png' as const,
+  colorModel: 'rgb' as const,
+  pageBox: 'media' as const,
+  fontAntialiasing: true as const,
+  vectorAntialiasing: true as const,
+  freeType: true as const,
+  thinLineMode: 'none' as const,
+  forcePageNumber: true as const,
+});
+
+function sha256(bytes: Uint8Array | string): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+export const PDF_RASTER_CONTRACT_SHA256 = sha256(JSON.stringify(PDF_RASTER_CONTRACT));
+
+export interface RasterArtifact {
+  pageNumber: number;
+  path: string;
+  sha256: string;
+}
+
+export interface RasterizedPdf {
+  pdfPath: string;
+  pdfSha256: string;
+  contractSha256: string;
+  pages: RasterArtifact[];
+}
+
+export interface RasterizePdfOptions {
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+}
+
+function escapedRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function numberedPngs(outputPrefix: string): Array<{ pageNumber: number; path: string }> {
+  const directory = dirname(outputPrefix);
+  const prefix = basename(outputPrefix);
+  const pattern = new RegExp(`^${escapedRegExp(prefix)}-(\\d+)\\.png$`);
+  return readdirSync(directory)
+    .map((name) => ({ name, match: name.match(pattern) }))
+    .filter((entry): entry is { name: string; match: RegExpMatchArray } => entry.match !== null)
+    .map((entry) => ({ pageNumber: Number(entry.match[1]), path: join(directory, entry.name) }))
+    .sort((left, right) => left.pageNumber - right.pageNumber);
+}
+
+/** Builds the exact argument vector used for every PDF in the comparison. */
+export function popplerRasterArguments(pdfPath: string, outputPrefix: string): readonly string[] {
+  const input = resolve(pdfPath);
+  const output = resolve(outputPrefix);
+  return Object.freeze([
+    '-r', String(PDF_RASTER_CONTRACT.dpi),
+    '-png',
+    '-freetype', PDF_RASTER_CONTRACT.freeType ? 'yes' : 'no',
+    '-thinlinemode', PDF_RASTER_CONTRACT.thinLineMode,
+    '-aa', PDF_RASTER_CONTRACT.fontAntialiasing ? 'yes' : 'no',
+    '-aaVector', PDF_RASTER_CONTRACT.vectorAntialiasing ? 'yes' : 'no',
+    '-forcenum',
+    '-q',
+    input,
+    output,
+  ]);
+}
+
+/**
+ * Rasterizes one PDF without accepting pre-existing numbered outputs. The
+ * caller supplies a distinct prefix for each renderer, but this function owns
+ * the command contract and artifact hashing for both.
+ */
+export function rasterizePdf(
+  pdfPath: string,
+  outputPrefix: string,
+  options: RasterizePdfOptions = {},
+): RasterizedPdf {
+  if (!isAbsolute(pdfPath) || !isAbsolute(outputPrefix)) {
+    throw new Error('PDF raster inputs and output prefixes must be absolute paths.');
+  }
+  const resolvedPdf = resolve(pdfPath);
+  const resolvedPrefix = resolve(outputPrefix);
+  if (!existsSync(resolvedPdf) || !statSync(resolvedPdf).isFile()) {
+    throw new Error(`PDF raster input is not a regular file: ${resolvedPdf}`);
+  }
+  if (!existsSync(dirname(resolvedPrefix)) || !statSync(dirname(resolvedPrefix)).isDirectory()) {
+    throw new Error(`PDF raster output directory does not exist: ${dirname(resolvedPrefix)}`);
+  }
+  if (numberedPngs(resolvedPrefix).length > 0) {
+    throw new Error(`Refusing to mix stale raster pages for prefix: ${resolvedPrefix}`);
+  }
+
+  execFileSync(PDF_RASTER_CONTRACT.tool, [...popplerRasterArguments(resolvedPdf, resolvedPrefix)], {
+    env: options.env,
+    stdio: 'pipe',
+    timeout: options.timeoutMs ?? 120_000,
+  });
+  const pages = numberedPngs(resolvedPrefix);
+  if (pages.length === 0) {
+    throw new Error(`pdftoppm produced no PNG pages for: ${resolvedPdf}`);
+  }
+  pages.forEach((page, index) => {
+    if (page.pageNumber !== index + 1) {
+      throw new Error(`pdftoppm produced a non-contiguous page sequence at ${page.path}`);
+    }
+  });
+  return {
+    pdfPath: resolvedPdf,
+    pdfSha256: sha256(readFileSync(resolvedPdf)),
+    contractSha256: PDF_RASTER_CONTRACT_SHA256,
+    pages: pages.map((page) => ({
+      ...page,
+      sha256: sha256(readFileSync(page.path)),
+    })),
+  };
+}
+
+export interface PdfBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export type PdfHyperlinkTarget =
+  | { kind: 'url'; value: string; unsafeValue?: string }
+  | { kind: 'destination'; value: string; namedDestination?: string; pageNumber: number }
+  | { kind: 'unsupported'; value?: string; reason: string };
+
+export interface PdfHyperlinkAnnotation {
+  target: PdfHyperlinkTarget;
+  rectangle?: readonly number[];
+}
+
+export interface PdfPageInspection {
+  pageNumber: number;
+  mediaBox: PdfBox;
+  cropBox: PdfBox;
+  text: string;
+  textSha256: string;
+  hyperlinks: PdfHyperlinkAnnotation[];
+  constructPathOperations: number;
+}
+
+export interface PdfSemanticExpectations {
+  requireSelectableText?: boolean;
+  requiredText?: readonly string[];
+  forbiddenText?: readonly string[];
+  requiredHyperlinkTargets?: readonly PdfHyperlinkExpectation[];
+}
+
+export type PdfHyperlinkExpectation =
+  | { kind: 'url'; value: string; representation?: 'normalized' | 'source' }
+  | { kind: 'destination'; value?: string; pageNumber?: number };
+
+export type PdfSemanticStatus = 'observed' | 'verified' | 'failed';
+
+export interface PdfSemanticResult {
+  passed: boolean;
+  selectableText: {
+    status: PdfSemanticStatus;
+    characterCount: number;
+    sha256: string;
+    required: boolean;
+    requiredFragments: readonly string[];
+    missingFragments: readonly string[];
+    forbiddenFragments: readonly string[];
+    presentForbiddenFragments: readonly string[];
+  };
+  hyperlinks: {
+    status: PdfSemanticStatus;
+    annotationCount: number;
+    supportedCount: number;
+    unsupportedCount: number;
+    targets: readonly PdfHyperlinkTarget[];
+    requiredTargets: readonly PdfHyperlinkExpectation[];
+    missingTargets: readonly PdfHyperlinkExpectation[];
+  };
+}
+
+export interface PdfInspection {
+  pdfSha256: string;
+  pageCount: number;
+  searchableText: string;
+  linkAnnotations: number;
+  vectorPathOperations: number;
+  marked: boolean;
+  pages: PdfPageInspection[];
+  semantics: PdfSemanticResult;
+}
+
+function pdfBox(box: { x: number; y: number; width: number; height: number }): PdfBox {
+  return { x: box.x, y: box.y, width: box.width, height: box.height };
+}
+
+function destinationValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+async function resolvedDestination(
+  pdf: PDFDocumentProxy,
+  destination: unknown,
+): Promise<PdfHyperlinkTarget> {
+  const namedDestination = typeof destination === 'string' ? destination : undefined;
+  const explicit = namedDestination
+    ? await pdf.getDestination(namedDestination)
+    : Array.isArray(destination) ? destination : null;
+  const value = destinationValue(destination);
+  if (!explicit || explicit.length === 0) {
+    return { kind: 'unsupported', value, reason: 'destination did not resolve' };
+  }
+  const pageReference = explicit[0];
+  if (!pageReference || typeof pageReference !== 'object'
+    || !('num' in pageReference) || !('gen' in pageReference)) {
+    return { kind: 'unsupported', value, reason: 'destination has no page reference' };
+  }
+  try {
+    const pageNumber = await pdf.getPageIndex(pageReference as { num: number; gen: number }) + 1;
+    return {
+      kind: 'destination',
+      value,
+      ...(namedDestination ? { namedDestination } : {}),
+      pageNumber,
+    };
+  } catch {
+    return { kind: 'unsupported', value, reason: 'destination page is outside the document' };
+  }
+}
+
+async function hyperlinkTarget(
+  pdf: PDFDocumentProxy,
+  annotation: Record<string, unknown>,
+): Promise<PdfHyperlinkTarget> {
+  if (typeof annotation.url === 'string') {
+    return {
+      kind: 'url',
+      value: annotation.url,
+      ...(typeof annotation.unsafeUrl === 'string' ? { unsafeValue: annotation.unsafeUrl } : {}),
+    };
+  }
+  if (annotation.dest !== undefined && annotation.dest !== null) {
+    return resolvedDestination(pdf, annotation.dest);
+  }
+  return { kind: 'unsupported', reason: 'link annotation has no URI or destination' };
+}
+
+function targetMatches(target: PdfHyperlinkTarget, expected: PdfHyperlinkExpectation): boolean {
+  if (target.kind !== expected.kind) return false;
+  if (expected.kind === 'url') {
+    return target.kind === 'url'
+      && (expected.representation === 'source' ? target.unsafeValue : target.value) === expected.value;
+  }
+  return target.kind === 'destination'
+    && (expected.value === undefined || target.value === expected.value)
+    && (expected.pageNumber === undefined || target.pageNumber === expected.pageNumber);
+}
+
+function semanticResult(
+  searchableText: string,
+  hyperlinks: readonly PdfHyperlinkAnnotation[],
+  expectations: PdfSemanticExpectations,
+): PdfSemanticResult {
+  const requiredText = Object.freeze([...(expectations.requiredText ?? [])]);
+  const forbiddenText = Object.freeze([...(expectations.forbiddenText ?? [])]);
+  const requiredTargets = Object.freeze((expectations.requiredHyperlinkTargets ?? [])
+    .map((target) => Object.freeze({ ...target })));
+  const missingFragments = Object.freeze(requiredText.filter((fragment) => !searchableText.includes(fragment)));
+  const presentForbiddenFragments = Object.freeze(
+    forbiddenText.filter((fragment) => searchableText.includes(fragment)),
+  );
+  const targets = Object.freeze(hyperlinks.map((annotation) => annotation.target));
+  const missingTargets = Object.freeze(requiredTargets.filter((expected) =>
+    !targets.some((target) => targetMatches(target, expected))));
+  const textRequired = expectations.requireSelectableText === true
+    || requiredText.length > 0
+    || forbiddenText.length > 0;
+  const textFailed = (expectations.requireSelectableText === true && searchableText.length === 0)
+    || missingFragments.length > 0
+    || presentForbiddenFragments.length > 0;
+  const hyperlinksRequired = requiredTargets.length > 0;
+  const hyperlinksFailed = missingTargets.length > 0;
+  return {
+    passed: !textFailed && !hyperlinksFailed,
+    selectableText: {
+      status: textRequired ? textFailed ? 'failed' : 'verified' : 'observed',
+      characterCount: searchableText.length,
+      sha256: sha256(searchableText),
+      required: textRequired,
+      requiredFragments: requiredText,
+      missingFragments,
+      forbiddenFragments: forbiddenText,
+      presentForbiddenFragments,
+    },
+    hyperlinks: {
+      status: hyperlinksRequired ? hyperlinksFailed ? 'failed' : 'verified' : 'observed',
+      annotationCount: hyperlinks.length,
+      supportedCount: targets.filter((target) => target.kind !== 'unsupported').length,
+      unsupportedCount: targets.filter((target) => target.kind === 'unsupported').length,
+      targets,
+      requiredTargets,
+      missingTargets,
+    },
+  };
+}
+
+/**
+ * Inspects actual PDF bytes. pdf-lib owns physical page-box parsing, while the
+ * exact pdfjs-dist seam used by the Node export tests owns selectable text and
+ * hyperlink annotation semantics.
+ */
+export async function inspectPdf(
+  bytes: Uint8Array,
+  expectations: PdfSemanticExpectations = {},
+): Promise<PdfInspection> {
+  const owned = new Uint8Array(bytes);
+  const geometryDocument = await PDFDocument.load(new Uint8Array(owned), {
+    ignoreEncryption: false,
+    updateMetadata: false,
+    throwOnInvalidObject: true,
+  });
+  const geometryPages = geometryDocument.getPages();
+  const loading = getDocument({
+    data: new Uint8Array(owned),
+    useSystemFonts: true,
+  });
+  const pdf = await loading.promise;
+  try {
+    if (pdf.numPages !== geometryPages.length) {
+      throw new Error(
+        `PDF parsers disagree on page count (${pdf.numPages} != ${geometryPages.length}).`,
+      );
+    }
+    const pages: PdfPageInspection[] = [];
+    const allHyperlinks: PdfHyperlinkAnnotation[] = [];
+    let vectorPathOperations = 0;
+    for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber++) {
+      const page = await pdf.getPage(pageNumber);
+      const content = await page.getTextContent();
+      const text = content.items.map((item) => 'str' in item ? item.str : '').join(' ');
+      const annotations = await page.getAnnotations();
+      const linkAnnotations = annotations
+        .filter((annotation) => annotation.subtype === 'Link')
+      const hyperlinks = await Promise.all(linkAnnotations
+        .map(async (annotation): Promise<PdfHyperlinkAnnotation> => ({
+          target: await hyperlinkTarget(pdf, annotation as Record<string, unknown>),
+          ...(Array.isArray(annotation.rect)
+            ? { rectangle: Object.freeze(annotation.rect.map(Number)) }
+            : {}),
+        })));
+      const operations = await page.getOperatorList();
+      const pagePaths = operations.fnArray.filter((operation) => operation === OPS.constructPath).length;
+      vectorPathOperations += pagePaths;
+      allHyperlinks.push(...hyperlinks);
+      pages.push({
+        pageNumber,
+        mediaBox: pdfBox(geometryPages[pageNumber - 1].getMediaBox()),
+        cropBox: pdfBox(geometryPages[pageNumber - 1].getCropBox()),
+        text,
+        textSha256: sha256(text),
+        hyperlinks,
+        constructPathOperations: pagePaths,
+      });
+    }
+    const searchableText = pages.map((page) => page.text).join('\n').trim();
+    const markInfo = await pdf.getMarkInfo();
+    return {
+      pdfSha256: sha256(owned),
+      pageCount: pages.length,
+      searchableText,
+      linkAnnotations: allHyperlinks.length,
+      vectorPathOperations,
+      marked: markInfo?.Marked === true,
+      pages,
+      semantics: semanticResult(searchableText, allHyperlinks, expectations),
+    };
+  } finally {
+    await loading.destroy();
+  }
+}
+
+export function sha256File(path: string): string {
+  return sha256(readFileSync(path));
+}

--- a/npm/tests/visual-parity/png.ts
+++ b/npm/tests/visual-parity/png.ts
@@ -7,6 +7,8 @@ export interface RgbaImage {
 }
 
 const PNG_SIGNATURE = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+const MAXIMUM_PNG_INPUT_BYTES = 64 * 1024 * 1024;
+const MAXIMUM_PNG_PIXELS = 4_000_000;
 
 function paeth(a: number, b: number, c: number): number {
   const p = a + b - c;
@@ -19,9 +21,9 @@ function paeth(a: number, b: number, c: number): number {
 /** Decode the non-interlaced, 8-bit PNG formats emitted by Chromium and pdftoppm. */
 export function decodePng(input: Uint8Array): RgbaImage {
   const bytes = Buffer.from(input);
-  if (bytes.length < PNG_SIGNATURE.length ||
+  if (bytes.length < PNG_SIGNATURE.length || bytes.length > MAXIMUM_PNG_INPUT_BYTES ||
       !bytes.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE)) {
-    throw new Error('Not a PNG file');
+    throw new Error(`PNG input must be a valid file no larger than ${MAXIMUM_PNG_INPUT_BYTES} bytes`);
   }
 
   let width = 0;
@@ -32,31 +34,69 @@ export function decodePng(input: Uint8Array): RgbaImage {
   let palette: Buffer | undefined;
   let transparency: Buffer | undefined;
   const idat: Buffer[] = [];
+  let sawHeader = false;
+  let sawEnd = false;
+  let sawImageData = false;
+  let endedImageData = false;
+  let chunkCount = 0;
 
   for (let offset = PNG_SIGNATURE.length; offset + 12 <= bytes.length;) {
+    chunkCount++;
+    if (chunkCount > 100_000) throw new Error('PNG contains too many chunks');
     const length = bytes.readUInt32BE(offset);
     const type = bytes.toString('ascii', offset + 4, offset + 8);
+    const end = offset + 12 + length;
+    if (!Number.isSafeInteger(end) || end > bytes.length) {
+      throw new Error(`Truncated PNG ${type} chunk`);
+    }
     const data = bytes.subarray(offset + 8, offset + 8 + length);
-    if (offset + 12 + length > bytes.length) throw new Error(`Truncated PNG ${type} chunk`);
+    const expectedCrc = bytes.readUInt32BE(offset + 8 + length);
+    const actualCrc = crc32(bytes.subarray(offset + 4, offset + 8 + length));
+    if (actualCrc !== expectedCrc) throw new Error(`PNG ${type} chunk failed its CRC check`);
     if (type === 'IHDR') {
+      if (sawHeader || offset !== PNG_SIGNATURE.length || data.length !== 13) {
+        throw new Error('PNG must contain exactly one leading 13-byte IHDR chunk');
+      }
+      sawHeader = true;
       width = data.readUInt32BE(0);
       height = data.readUInt32BE(4);
       bitDepth = data[8];
       colorType = data[9];
+      if (data[10] !== 0 || data[11] !== 0) {
+        throw new Error('PNG uses an unsupported compression or filter method');
+      }
       interlace = data[12];
     } else if (type === 'PLTE') {
+      if (palette || sawImageData) throw new Error('PNG PLTE chunk is duplicate or out of order');
       palette = data;
     } else if (type === 'tRNS') {
+      if (transparency || sawImageData) throw new Error('PNG tRNS chunk is duplicate or out of order');
       transparency = data;
     } else if (type === 'IDAT') {
+      if (!sawHeader || sawEnd || endedImageData) throw new Error('PNG IDAT chunk is out of order');
+      sawImageData = true;
       idat.push(data);
     } else if (type === 'IEND') {
+      if (data.length !== 0) throw new Error('PNG IEND chunk must be empty');
+      sawEnd = true;
+      if (end !== bytes.length) throw new Error('PNG has trailing bytes after IEND');
       break;
+    } else {
+      if (sawImageData) endedImageData = true;
+      if (type[0] === type[0]?.toUpperCase()) {
+        throw new Error(`PNG contains unsupported critical chunk ${type}`);
+      }
     }
-    offset += length + 12;
+    offset = end;
   }
 
-  if (!width || !height || !idat.length) throw new Error('PNG is missing IHDR or IDAT data');
+  if (!sawHeader || !sawEnd || !width || !height || !idat.length) {
+    throw new Error('PNG is missing IHDR, IDAT, or IEND data');
+  }
+  const pixels = width * height;
+  if (!Number.isSafeInteger(pixels) || pixels > MAXIMUM_PNG_PIXELS) {
+    throw new Error(`PNG dimensions exceed the ${MAXIMUM_PNG_PIXELS}-pixel limit`);
+  }
   if (bitDepth !== 8 || interlace !== 0) {
     throw new Error(`Unsupported PNG format: bitDepth=${bitDepth}, interlace=${interlace}`);
   }
@@ -65,10 +105,18 @@ export function decodePng(input: Uint8Array): RgbaImage {
   const channels = channelsByType[colorType];
   if (!channels) throw new Error(`Unsupported PNG color type ${colorType}`);
   if (colorType === 3 && !palette) throw new Error('Indexed PNG is missing its palette');
+  if (palette && (palette.length === 0 || palette.length > 768 || palette.length % 3 !== 0)) {
+    throw new Error('PNG palette has an invalid length');
+  }
+  if (transparency && colorType === 3 && transparency.length > (palette?.length ?? 0) / 3) {
+    throw new Error('PNG transparency table exceeds its palette');
+  }
 
   const stride = width * channels;
-  const filtered = inflateSync(Buffer.concat(idat));
-  if (filtered.length !== (stride + 1) * height) {
+  const expectedFilteredBytes = (stride + 1) * height;
+  if (!Number.isSafeInteger(expectedFilteredBytes)) throw new Error('PNG payload size is unsafe');
+  const filtered = inflateSync(Buffer.concat(idat), { maxOutputLength: expectedFilteredBytes });
+  if (filtered.length !== expectedFilteredBytes) {
     throw new Error(`Unexpected PNG payload length ${filtered.length}`);
   }
 
@@ -157,7 +205,11 @@ function pngChunk(type: string, data: Uint8Array): Buffer {
 
 /** Encode an RGBA image as a deterministic, non-interlaced PNG. */
 export function encodePng(image: RgbaImage): Buffer {
-  if (image.data.length !== image.width * image.height * 4) {
+  const pixels = image.width * image.height;
+  if (!Number.isSafeInteger(pixels) || pixels < 1 || pixels > MAXIMUM_PNG_PIXELS) {
+    throw new Error(`RGBA dimensions exceed the ${MAXIMUM_PNG_PIXELS}-pixel limit`);
+  }
+  if (image.data.length !== pixels * 4) {
     throw new Error('RGBA buffer length does not match its dimensions');
   }
   const header = Buffer.alloc(13);

--- a/npm/tests/visual-parity/ratchet.json
+++ b/npm/tests/visual-parity/ratchet.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 2,
   "description": "Per-case visual-parity regression ratchet (issue #395). Numbers only. The scheduled run fails when any case gets worse than recorded beyond `tolerance`. Refresh this file deliberately in the PR that changes rendering, so improvements and accepted regressions are reviewed in the diff. See npm/tests/visual-parity/README.md.",
-  "recordedAt": "2026-08-13",
-  "sourceCommit": "a3d71c2ddcf6ff3775be752908654a24823caf8c",
+  "recordedAt": "2026-08-16",
+  "sourceCommit": "de64978a8dd71776a59384aec209888e18c44512",
   "environment": {
     "libreoffice": "25.8",
     "chromium": "143",
@@ -77,8 +77,8 @@
         "libreoffice": 1
       },
       "severity": "minor",
-      "ssim": 0.96026,
-      "worstInkF1": 0.99775
+      "ssim": 0.95942,
+      "worstInkF1": 0.99868
     },
     {
       "id": "footnote",
@@ -170,14 +170,14 @@
     },
     {
       "id": "running-content",
-      "disposition": "environment",
+      "disposition": "reference-deviation",
       "pages": {
         "docxodus": 5,
         "libreoffice": 5
       },
-      "severity": "close",
-      "ssim": 0.99927,
-      "worstInkF1": 0.96486
+      "severity": "severe",
+      "ssim": 0.99868,
+      "worstInkF1": 0.10495
     },
     {
       "id": "shape",

--- a/npm/tests/visual-parity/ratchet.ts
+++ b/npm/tests/visual-parity/ratchet.ts
@@ -110,10 +110,14 @@ export interface RatchetSummaryCase {
   severity: VisualSeverity;
   pages: { ssim: number; tolerantInkF1: number }[];
   error?: string;
+  /** Generated-PDF hard signals. Browser-page summaries omit these fields. */
+  physicalGeometryPassed?: boolean;
+  semanticChecksPassed?: boolean;
 }
 
 export interface RatchetSummary {
   gitCommit?: string;
+  workingTreeDirty?: boolean;
   environment: {
     chromium?: string;
     libreoffice?: string;
@@ -136,7 +140,8 @@ export interface RatchetOptions {
 export interface RatchetFinding {
   caseId: string;
   /** The signal that moved, so the failure names both the case and what got worse. */
-  signal: 'severity' | 'ssim' | 'inkF1' | 'pages' | 'error' | 'missing' | 'unrecorded';
+  signal: 'severity' | 'ssim' | 'inkF1' | 'pages' | 'error' | 'physicalGeometry'
+    | 'semantics' | 'missing' | 'unrecorded';
   recorded: string;
   measured: string;
   detail: string;
@@ -231,6 +236,21 @@ export function buildRecord(summary: RatchetSummary, recordedAt: string): Ratche
     tolerance: { ssim: RATCHET_TOLERANCE.ssim, inkF1: RATCHET_TOLERANCE.inkF1 },
     cases: [...summary.cases].sort((a, b) => a.id.localeCompare(b.id)).map(recordCase),
   };
+}
+
+/**
+ * A committed record must identify the exact clean tree that produced it. Keeping this check
+ * outside `buildRecord` preserves that function as a pure formatter for synthetic unit tests,
+ * while both benchmark update paths call it before writing repository state.
+ */
+export function assertRecordUpdateProvenance(summary: RatchetSummary): void {
+  if (summary.workingTreeDirty !== false) {
+    throw new Error('Refusing to refresh a parity ratchet from a dirty or unverified worktree; '
+      + 'commit the implementation and rerun the complete benchmark.');
+  }
+  if (!/^[0-9a-f]{40}$/.test(summary.gitCommit ?? '')) {
+    throw new Error('Refusing to refresh a parity ratchet without the exact 40-character source commit.');
+  }
 }
 
 /** Stable, human-readable serialization; the record is reviewed as a diff. */
@@ -384,6 +404,26 @@ function compareCase(
       detail: `${recorded.id}: page count changed from ` +
         `${recorded.pages.docxodus}/${recorded.pages.libreoffice} (Docxodus/LibreOffice) to ` +
         `${measured.docxodusPages}/${measured.libreofficePages}`,
+    });
+  }
+
+  if (measured.physicalGeometryPassed === false) {
+    findings.push({
+      caseId: recorded.id,
+      signal: 'physicalGeometry',
+      recorded: 'passed',
+      measured: 'failed',
+      detail: `${recorded.id}: physical PDF geometry failed its absolute contract`,
+    });
+  }
+
+  if (measured.semanticChecksPassed === false) {
+    findings.push({
+      caseId: recorded.id,
+      signal: 'semantics',
+      recorded: 'passed',
+      measured: 'failed',
+      detail: `${recorded.id}: selectable-text or hyperlink semantics failed`,
     });
   }
 

--- a/npm/tests/visual-parity/toolchain.ts
+++ b/npm/tests/visual-parity/toolchain.ts
@@ -1,0 +1,81 @@
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  accessSync,
+  constants,
+  lstatSync,
+  readFileSync,
+  realpathSync,
+} from 'node:fs';
+import { delimiter } from 'node:path';
+import { basename, isAbsolute, resolve } from 'node:path';
+
+const VERSION_TIMEOUT_MS = 15_000;
+const VERSION_OUTPUT_BYTES = 1024 * 1024;
+
+/** Resolve one executable once so its invocation, version, and digest cannot observe different PATH entries. */
+export function resolveExecutable(command: string, pathValue = process.env.PATH ?? ''): string {
+  if (!command || command.includes('\0')) throw new Error('Executable name must be non-empty.');
+  const candidates = isAbsolute(command)
+    ? [command]
+    : pathValue.split(delimiter).map((directory) => resolve(directory || '.', command));
+  for (const candidate of candidates) {
+    try {
+      accessSync(candidate, constants.X_OK);
+      const resolved = realpathSync(candidate);
+      const metadata = lstatSync(resolved);
+      if (metadata.isFile() && !metadata.isSymbolicLink()) return resolved;
+    } catch {
+      // Keep looking. The final error names the requested command without leaking every PATH entry.
+    }
+  }
+  throw new Error(`Required executable was not found as a regular file: ${command}`);
+}
+
+/** A bounded, successful version probe for an already-resolved executable. */
+export function commandVersion(executable: string, args: readonly string[]): string {
+  if (!isAbsolute(executable)) {
+    throw new Error(`Version probes require an absolute executable path: ${executable}`);
+  }
+  const result = spawnSync(executable, [...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: VERSION_TIMEOUT_MS,
+    maxBuffer: VERSION_OUTPUT_BYTES,
+  });
+  if (result.error) throw result.error;
+  if (result.signal) throw new Error(`${basename(executable)} version probe ended with ${result.signal}.`);
+  if (result.status !== 0) {
+    throw new Error(`${basename(executable)} version probe exited with status ${String(result.status)}.`);
+  }
+  return `${result.stdout ?? ''}\n${result.stderr ?? ''}`.trim();
+}
+
+export interface ExecutableEvidence {
+  command: string;
+  executable: string;
+  executableSha256: string;
+  version: string;
+}
+
+export interface PinnedExecutable {
+  path: string;
+  evidence: ExecutableEvidence;
+}
+
+export function pinExecutable(
+  command: string,
+  versionArgs: readonly string[],
+  pathValue = process.env.PATH ?? '',
+): PinnedExecutable {
+  const resolvedPath = resolveExecutable(command, pathValue);
+  return {
+    path: resolvedPath,
+    evidence: {
+      command,
+      executable: basename(resolvedPath),
+      executableSha256: createHash('sha256').update(readFileSync(resolvedPath)).digest('hex'),
+      version: commandVersion(resolvedPath, versionArgs),
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- add a provenance- and hash-pinned 10-document generated-PDF corpus spanning legal contracts, tables, columns, notes, running stories, images, charts, revisions, comments, mixed orientation, and links
- compare supported `@docxodus/export` PDFs with LibreOffice PDFs through one frozen Poppler raster contract
- gate conversion, page count, MediaBox/CropBox geometry, selectable text, exact hyperlink targets, SSIM, and directional ink metrics independently
- bind ratchet refreshes to an unchanged clean source commit and reject dirty, partial, or moving-HEAD updates
- publish an incremental, self-contained HTML evidence viewer from CI even when setup or a test phase fails
- retain #441's delayed-pagination regression coverage and fail closed for #489's C/C2 oversized-footnote cases

## Stack

- Based on #506 / issue #442
- Uses the corrected #493 package-preflight and raw-source identity contract

## Validation

- npm build and pretest; package boundary: 175 files
- `@docxodus/export` typecheck/build; package boundary: 51 files
- focused parity/provenance/PDF helpers: 49 passed
- print-readiness and standalone export: 13 passed
- focused .NET HTML conversion: 63 passed
- clean-source ratchet refresh: 10 cases / 17 pages, zero conversion, page-count, geometry, or semantic failures
- final non-update release gate: ratchet `ok`, no findings, no environment drift

## Artifacts

The final local viewer is `/tmp/docxodus-443-release-artifacts/index.html` (166 linked files, including both PDFs, rasters, overlays, inspections, semantic/link evidence, PageMaps, render reports, fingerprints, and hashes). CI uploads the equivalent `generated-pdf-visual-parity` viewer with `if: always()`.

Closes #443