### PR TITLE
Sweep every real redline fixture through the reversibility proof

### DIFF
--- a/Docxodus.Tests/RedlineReversibilityFixtureSweepTests.cs
+++ b/Docxodus.Tests/RedlineReversibilityFixtureSweepTests.cs
@@ -1,0 +1,519 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Text;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Docxodus.Verification;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+/// <summary>
+/// Fixture-scale evidence for the redline reversibility proof (#464), complementing the
+/// scenario-focused cases in <see cref="RedlineReversibilityProofTests"/>.
+///
+/// Two corpora, two claims:
+///
+/// 1. Word-authored redlines — every complete triple in <c>TestFiles/RP</c>
+///    (<c>{stem}.docx</c> + <c>{stem}-Accepted.docx</c> + <c>{stem}-Rejected.docx</c>, the
+///    long-standing RevisionProcessor oracle corpus). The proof's selective resolver must
+///    accept every revision to the accepted oracle and reject every revision to the rejected
+///    oracle at the story-text level, and each triple pins whether the far stronger
+///    normalized whole-package equivalence also holds per direction. A guard test keeps the
+///    pinned list in lock-step with the fixture directory so a new triple cannot be added
+///    without being swept.
+///
+/// 2. Engine-generated redlines — the WCB comparison corpus (real Word documents under
+///    <c>TestFiles/WC</c>, <c>CA</c>, <c>RC</c>). For each before/after pair the redline is
+///    <c>DocxDiff.Compare(left, right)</c> and the proof must complete both paths, classify
+///    every revision as generated, and recover <c>right</c> on accept / <c>left</c> on
+///    reject at the story-text level. Pairs where that does not currently hold are pinned as
+///    explicit known gaps with their exact failure signature, so the gap is visible here and
+///    this file must be updated when it is fixed.
+///
+/// "Story text" means the concatenated <c>w:t</c> runs of the body plus every header,
+/// footer, footnotes and endnotes part — presence of a story part counts, so an output that
+/// grows an empty footnotes part the expected document never had does not pass.
+/// </summary>
+public class RedlineReversibilityFixtureSweepTests
+{
+    private static readonly string TestFilesDir = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "../../../../TestFiles"));
+
+    // ------------------------------------------------------------------
+    // 1. Word-authored redlines: TestFiles/RP triples.
+    // ------------------------------------------------------------------
+
+    // Columns: fixture stem, accept path fully equivalent (normalized whole package),
+    // reject path fully equivalent. Story-text equality with the oracle documents is
+    // asserted unconditionally for every row; the booleans pin only the stronger
+    // package-level claim per direction.
+    [Theory]
+    [InlineData("RP002-Deleted-Text", true, true)]
+    [InlineData("RP003-Inserted-Text", true, true)]
+    [InlineData("RP004-Deleted-Text-in-CC", true, true)]
+    [InlineData("RP005-Deleted-Paragraph-Mark", false, true)]
+    [InlineData("RP006-Inserted-Paragraph-Mark", true, false)]
+    [InlineData("RP007-Multiple-Deleted-Para-Mark", false, true)]
+    [InlineData("RP008-Multiple-Inserted-Para-Mark", true, false)]
+    [InlineData("RP009-Deleted-Table-Row", true, true)]
+    [InlineData("RP010-Inserted-Table-Row", true, true)]
+    [InlineData("RP011-Multiple-Deleted-Rows", true, true)]
+    [InlineData("RP012-Multiple-Inserted-Rows", true, true)]
+    [InlineData("RP013-Deleted-Math-Control-Char", true, true)]
+    [InlineData("RP014-Inserted-Math-Control-Char", true, true)]
+    [InlineData("RP015-MoveFrom-MoveTo", false, false)]
+    [InlineData("RP016-Deleted-CC", false, false)]
+    [InlineData("RP017-Inserted-CC", true, true)]
+    [InlineData("RP019-Deleted-Field-Code", false, false)]
+    [InlineData("RP020-Inserted-Field-Code", true, false)]
+    [InlineData("RP021-Inserted-Numbering-Properties", true, false)]
+    [InlineData("RP022-NumberingChange", true, false)]
+    [InlineData("RP023-NumberingChange", false, false)]
+    [InlineData("RP024-ParagraphMark-rPr-Change", false, false)]
+    [InlineData("RP025-Paragraph-Props-Change", false, false)]
+    [InlineData("RP026-NumberingChange", false, false)]
+    [InlineData("RP027-Change-Section", true, false)]
+    [InlineData("RP028-Table-Grid-Change", true, false)]
+    [InlineData("RP029-Table-Row-Props-Change", true, false)]
+    [InlineData("RP030-Table-Row-Props-Change", true, false)]
+    [InlineData("RP031-Table-Prop-Change", true, false)]
+    [InlineData("RP032-Table-Prop-Change", true, false)]
+    [InlineData("RP033-Table-Prop-Ex-Change", true, false)]
+    [InlineData("RP034-Deleted-Cells", false, false)]
+    [InlineData("RP035-Inserted-Cells", false, false)]
+    [InlineData("RP036-Vert-Merged-Cells", true, false)]
+    [InlineData("RP037-Changed-Style-Para-Props", true, false)]
+    [InlineData("RP038-Inserted-Paras-at-End", false, false)]
+    [InlineData("RP039-Inserted-Paras-at-End", false, false)]
+    [InlineData("RP040-Deleted-Paras-at-End", false, false)]
+    [InlineData("RP041-Cell-With-Empty-Paras-at-End", false, false)]
+    [InlineData("RP042-Deleted-Para-Mark-at-End", false, false)]
+    [InlineData("RP043-MERGEFORMAT-Field-Code", false, false)]
+    [InlineData("RP044-MERGEFORMAT-Field-Code", false, false)]
+    [InlineData("RP045-One-and-Half-Deleted-Lines-at-End", false, false)]
+    [InlineData("RP046-Consecutive-Deleted-Ranges", false, false)]
+    [InlineData("RP048-Deleted-Inserted-Para-Mark", false, false)]
+    [InlineData("RP049-Deleted-Para-Before-Table", false, false)]
+    [InlineData("RP050-Deleted-Footnote", false, false)]
+    [InlineData("RP051-Arabic", false, false)]
+    [InlineData("RP052-Deleted-Para-Mark", false, false)]
+    public void RRS001_WordAuthoredRedline_AcceptAndRejectRecoverTheOracleDocuments(
+        string stem,
+        bool acceptEquivalent,
+        bool rejectEquivalent)
+    {
+        var (redline, acceptedOracle, rejectedOracle) = RpTriple(stem);
+
+        var run = RedlineReversibilityVerifier.Prove(rejectedOracle, acceptedOracle, redline);
+        var proof = run.Proof;
+
+        Assert.NotNull(proof.AcceptToFinal);
+        Assert.NotNull(proof.RejectToBaseline);
+        Assert.True(proof.AcceptToFinal!.Completed, proof.ToJson());
+        Assert.True(proof.RejectToBaseline!.Completed, proof.ToJson());
+
+        // A Word-authored redline over its fully-rejected baseline owns every revision.
+        Assert.NotEmpty(proof.RevisionClassifications);
+        Assert.All(proof.RevisionClassifications, classification =>
+            Assert.Equal(RedlineRevisionDisposition.Generated, classification.Disposition));
+        AssertResolutionClosure(proof.AcceptToFinal);
+        AssertResolutionClosure(proof.RejectToBaseline);
+
+        // The reversibility contract a reader actually cares about: the accepted output
+        // reads as Word's accepted oracle, the rejected output as Word's rejected oracle.
+        Assert.Equal(StoryTexts(acceptedOracle), StoryTexts(run.AcceptedPackageBytes!));
+        Assert.Equal(StoryTexts(rejectedOracle), StoryTexts(run.RejectedPackageBytes!));
+
+        // The stronger pinned claim, per direction.
+        Assert.True(proof.AcceptToFinal.Equivalent == acceptEquivalent, proof.ToJson());
+        Assert.True(proof.RejectToBaseline.Equivalent == rejectEquivalent, proof.ToJson());
+        Assert.True(proof.Success == (acceptEquivalent && rejectEquivalent), proof.ToJson());
+
+        // A non-equivalent path must say so with an error finding, never silently.
+        AssertNonEquivalenceIsEvidenced(proof.AcceptToFinal);
+        AssertNonEquivalenceIsEvidenced(proof.RejectToBaseline);
+    }
+
+    // Word-authored triples whose revision families the resolver does not support: the
+    // proof must refuse to run either path rather than guess, and must name the reason.
+    [Theory]
+    [InlineData("RP018-MoveFrom-MoveTo-CC", "unsupported_custom_xml_move_range")]
+    [InlineData("RP047-Inserted-and-Deleted-Paragraph-Mark", "unsupported_revision_family")]
+    public void RRS002_WordAuthoredRedline_UnsupportedFamilyFailsClosedWithDiagnostic(
+        string stem,
+        string expectedDiagnosticCode)
+    {
+        var (redline, acceptedOracle, rejectedOracle) = RpTriple(stem);
+
+        var run = RedlineReversibilityVerifier.Prove(rejectedOracle, acceptedOracle, redline);
+
+        Assert.False(run.Proof.Success);
+        Assert.Null(run.Proof.AcceptToFinal);
+        Assert.Null(run.Proof.RejectToBaseline);
+        Assert.Null(run.AcceptedPackageBytes);
+        Assert.Null(run.RejectedPackageBytes);
+        Assert.Contains(run.Proof.Findings, finding =>
+            finding.Code == "generated_revision_not_resolvable");
+        Assert.Contains(run.Proof.RevisionClassifications, classification =>
+            classification.Redline?.Diagnostic?.Code == expectedDiagnosticCode);
+    }
+
+    // Keeps RRS001 + RRS002 honest: every complete triple in TestFiles/RP must be pinned in
+    // exactly one of them, so adding a fixture without sweeping it fails here.
+    [Fact]
+    public void RRS003_EveryCompleteFixtureTripleIsPinned()
+    {
+        var rpDir = Path.Combine(TestFilesDir, "RP");
+        var files = new HashSet<string>(
+            Directory.GetFiles(rpDir, "*.docx").Select(Path.GetFileName)!,
+            StringComparer.Ordinal);
+        var completeTriples = files
+            .Where(name => !name.EndsWith("-Accepted.docx", StringComparison.Ordinal)
+                && !name.EndsWith("-Rejected.docx", StringComparison.Ordinal))
+            .Select(name => name[..^".docx".Length])
+            .Where(stem => files.Contains(stem + "-Accepted.docx")
+                && files.Contains(stem + "-Rejected.docx"))
+            .OrderBy(stem => stem, StringComparer.Ordinal)
+            .ToArray();
+
+        var pinned = PinnedStems(nameof(RRS001_WordAuthoredRedline_AcceptAndRejectRecoverTheOracleDocuments))
+            .Concat(PinnedStems(nameof(RRS002_WordAuthoredRedline_UnsupportedFamilyFailsClosedWithDiagnostic)))
+            .OrderBy(stem => stem, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(completeTriples, pinned);
+    }
+
+    // ------------------------------------------------------------------
+    // 2. Engine-generated redlines: the WCB comparison corpus.
+    // ------------------------------------------------------------------
+
+    // Every before/after pair from the WCB corpus except the known gaps pinned in
+    // RRS005-RRS007 below. DocxDiff regenerates the package, so normalized whole-package
+    // equivalence never holds here (asserted); the reversibility claim proven per pair is
+    // content-level: accept recovers right's stories, reject recovers left's.
+    [Theory]
+    [InlineData("CA/CA001-Plain.docx", "CA/CA001-Plain-Mod.docx")]
+    [InlineData("WC/WC001-Digits.docx", "WC/WC001-Digits-Mod.docx")]
+    [InlineData("WC/WC001-Digits.docx", "WC/WC001-Digits-Deleted-Paragraph.docx")]
+    [InlineData("WC/WC001-Digits-Deleted-Paragraph.docx", "WC/WC001-Digits.docx")]
+    [InlineData("WC/WC002-Unmodified.docx", "WC/WC002-DiffInMiddle.docx")]
+    [InlineData("WC/WC002-Unmodified.docx", "WC/WC002-DiffAtBeginning.docx")]
+    [InlineData("WC/WC002-Unmodified.docx", "WC/WC002-DeleteAtBeginning.docx")]
+    [InlineData("WC/WC002-Unmodified.docx", "WC/WC002-InsertAtBeginning.docx")]
+    [InlineData("WC/WC002-Unmodified.docx", "WC/WC002-InsertAtEnd.docx")]
+    [InlineData("WC/WC002-Unmodified.docx", "WC/WC002-DeleteAtEnd.docx")]
+    [InlineData("WC/WC002-Unmodified.docx", "WC/WC002-DeleteInMiddle.docx")]
+    [InlineData("WC/WC002-Unmodified.docx", "WC/WC002-InsertInMiddle.docx")]
+    [InlineData("WC/WC002-DeleteInMiddle.docx", "WC/WC002-Unmodified.docx")]
+    [InlineData("WC/WC006-Table.docx", "WC/WC006-Table-Delete-Row.docx")]
+    [InlineData("WC/WC006-Table-Delete-Row.docx", "WC/WC006-Table.docx")]
+    [InlineData("WC/WC006-Table.docx", "WC/WC006-Table-Delete-Contests-of-Row.docx")]
+    [InlineData("WC/WC007-Unmodified.docx", "WC/WC007-Longest-At-End.docx")]
+    [InlineData("WC/WC007-Unmodified.docx", "WC/WC007-Deleted-at-Beginning-of-Para.docx")]
+    [InlineData("WC/WC007-Unmodified.docx", "WC/WC007-Moved-into-Table.docx")]
+    [InlineData("WC/WC009-Table-Unmodified.docx", "WC/WC009-Table-Cell-1-1-Mod.docx")]
+    [InlineData("WC/WC010-Para-Before-Table-Unmodified.docx", "WC/WC010-Para-Before-Table-Mod.docx")]
+    [InlineData("WC/WC011-Before.docx", "WC/WC011-After.docx")]
+    [InlineData("WC/WC013-Image-Before.docx", "WC/WC013-Image-After.docx")]
+    [InlineData("WC/WC013-Image-Before.docx", "WC/WC013-Image-After2.docx")]
+    [InlineData("WC/WC013-Image-Before2.docx", "WC/WC013-Image-After2.docx")]
+    [InlineData("WC/WC014-SmartArt-Before.docx", "WC/WC014-SmartArt-After.docx")]
+    [InlineData("WC/WC014-SmartArt-With-Image-Before.docx", "WC/WC014-SmartArt-With-Image-After.docx")]
+    [InlineData("WC/WC014-SmartArt-With-Image-Before.docx", "WC/WC014-SmartArt-With-Image-Deleted-After.docx")]
+    [InlineData("WC/WC014-SmartArt-With-Image-Before.docx", "WC/WC014-SmartArt-With-Image-Deleted-After2.docx")]
+    [InlineData("WC/WC015-Three-Paragraphs.docx", "WC/WC015-Three-Paragraphs-After.docx")]
+    [InlineData("WC/WC016-Para-Image-Para.docx", "WC/WC016-Para-Image-Para-w-Deleted-Image.docx")]
+    [InlineData("WC/WC017-Image.docx", "WC/WC017-Image-After.docx")]
+    [InlineData("WC/WC018-Field-Simple-Before.docx", "WC/WC018-Field-Simple-After-1.docx")]
+    [InlineData("WC/WC018-Field-Simple-Before.docx", "WC/WC018-Field-Simple-After-2.docx")]
+    [InlineData("WC/WC019-Hyperlink-Before.docx", "WC/WC019-Hyperlink-After-1.docx")]
+    [InlineData("WC/WC019-Hyperlink-Before.docx", "WC/WC019-Hyperlink-After-2.docx")]
+    [InlineData("WC/WC020-FootNote-Before.docx", "WC/WC020-FootNote-After-1.docx")]
+    [InlineData("WC/WC020-FootNote-Before.docx", "WC/WC020-FootNote-After-2.docx")]
+    [InlineData("WC/WC021-Math-Before-1.docx", "WC/WC021-Math-After-1.docx")]
+    [InlineData("WC/WC021-Math-Before-2.docx", "WC/WC021-Math-After-2.docx")]
+    [InlineData("WC/WC022-Image-Math-Para-Before.docx", "WC/WC022-Image-Math-Para-After.docx")]
+    [InlineData("WC/WC023-Table-4-Row-Image-Before.docx", "WC/WC023-Table-4-Row-Image-After-Delete-1-Row.docx")]
+    [InlineData("WC/WC024-Table-Before.docx", "WC/WC024-Table-After.docx")]
+    [InlineData("WC/WC024-Table-Before.docx", "WC/WC024-Table-After2.docx")]
+    [InlineData("WC/WC025-Simple-Table-Before.docx", "WC/WC025-Simple-Table-After.docx")]
+    [InlineData("WC/WC026-Long-Table-Before.docx", "WC/WC026-Long-Table-After-1.docx")]
+    [InlineData("WC/WC027-Twenty-Paras-Before.docx", "WC/WC027-Twenty-Paras-After-1.docx")]
+    [InlineData("WC/WC027-Twenty-Paras-After-1.docx", "WC/WC027-Twenty-Paras-Before.docx")]
+    [InlineData("WC/WC027-Twenty-Paras-Before.docx", "WC/WC027-Twenty-Paras-After-2.docx")]
+    [InlineData("WC/WC030-Image-Math-Before.docx", "WC/WC030-Image-Math-After.docx")]
+    [InlineData("WC/WC031-Two-Maths-Before.docx", "WC/WC031-Two-Maths-After.docx")]
+    [InlineData("WC/WC032-Para-with-Para-Props.docx", "WC/WC032-Para-with-Para-Props-After.docx")]
+    [InlineData("WC/WC033-Merged-Cells-Before.docx", "WC/WC033-Merged-Cells-After1.docx")]
+    [InlineData("WC/WC033-Merged-Cells-Before.docx", "WC/WC033-Merged-Cells-After2.docx")]
+    [InlineData("WC/WC034-Footnotes-Before.docx", "WC/WC034-Footnotes-After1.docx")]
+    [InlineData("WC/WC034-Footnotes-Before.docx", "WC/WC034-Footnotes-After2.docx")]
+    [InlineData("WC/WC034-Footnotes-Before.docx", "WC/WC034-Footnotes-After3.docx")]
+    [InlineData("WC/WC034-Footnotes-After3.docx", "WC/WC034-Footnotes-Before.docx")]
+    [InlineData("WC/WC036-Footnote-With-Table-Before.docx", "WC/WC036-Footnote-With-Table-After.docx")]
+    [InlineData("WC/WC036-Footnote-With-Table-After.docx", "WC/WC036-Footnote-With-Table-Before.docx")]
+    [InlineData("WC/WC034-Endnotes-Before.docx", "WC/WC034-Endnotes-After1.docx")]
+    [InlineData("WC/WC034-Endnotes-Before.docx", "WC/WC034-Endnotes-After2.docx")]
+    [InlineData("WC/WC034-Endnotes-Before.docx", "WC/WC034-Endnotes-After3.docx")]
+    [InlineData("WC/WC034-Endnotes-After3.docx", "WC/WC034-Endnotes-Before.docx")]
+    [InlineData("WC/WC036-Endnote-With-Table-Before.docx", "WC/WC036-Endnote-With-Table-After.docx")]
+    [InlineData("WC/WC036-Endnote-With-Table-After.docx", "WC/WC036-Endnote-With-Table-Before.docx")]
+    [InlineData("WC/WC038-Document-With-BR-Before.docx", "WC/WC038-Document-With-BR-After.docx")]
+    [InlineData("RC/RC001-Before.docx", "RC/RC001-After1.docx")]
+    [InlineData("RC/RC002-Image.docx", "RC/RC002-Image-After1.docx")]
+    public void RRS004_EngineGeneratedRedline_RoundTripsContentAcrossComparisonCorpus(
+        string leftName,
+        string rightName)
+    {
+        var left = Fixture(leftName);
+        var right = Fixture(rightName);
+        var redline = EngineRedline(left, right);
+
+        var run = RedlineReversibilityVerifier.Prove(left, right, redline);
+        var proof = run.Proof;
+
+        Assert.NotNull(proof.AcceptToFinal);
+        Assert.NotNull(proof.RejectToBaseline);
+        Assert.True(proof.AcceptToFinal!.Completed, proof.ToJson());
+        Assert.True(proof.RejectToBaseline!.Completed, proof.ToJson());
+        Assert.NotEmpty(proof.RevisionClassifications);
+        Assert.All(proof.RevisionClassifications, classification =>
+            Assert.Equal(RedlineRevisionDisposition.Generated, classification.Disposition));
+        AssertResolutionClosure(proof.AcceptToFinal);
+        AssertResolutionClosure(proof.RejectToBaseline);
+
+        // The content-level reversibility contract.
+        Assert.Equal(StoryTexts(right), StoryTexts(run.AcceptedPackageBytes!));
+        Assert.Equal(StoryTexts(left), StoryTexts(run.RejectedPackageBytes!));
+
+        // DocxDiff rebuilds the output package, so the strict whole-package proof does not
+        // hold for engine output today — and the proof must say so rather than succeed.
+        Assert.False(proof.Success, proof.ToJson());
+        AssertNonEquivalenceIsEvidenced(proof.AcceptToFinal);
+        AssertNonEquivalenceIsEvidenced(proof.RejectToBaseline);
+    }
+
+    // ------------------------------------------------------------------
+    // Known gaps in the engine corpus, pinned by exact failure signature. Each of these is
+    // excluded from RRS004; when the underlying defect is fixed the pin fails and both the
+    // pin and the RRS004 exclusion must be updated.
+    // ------------------------------------------------------------------
+
+    // WC004-Large: rejecting the engine redline through the proof's *selective* resolver
+    // strips every w:del wrapper but leaves the deleted content behind as orphaned
+    // w:delText nodes, so ~1.3k characters of restored text are lost from the rejected
+    // body. RevisionProcessor's reject-all on the very same redline restores the text (see
+    // DocxDiffOpsRoundTripTests), so the loss is specific to selective resolution. The
+    // accept direction is content-faithful.
+    [Fact]
+    public void RRS005_KnownGap_LargeDocumentSelectiveRejectStrandsDeletedText()
+    {
+        var left = Fixture("WC/WC004-Large.docx");
+        var right = Fixture("WC/WC004-Large-Mod.docx");
+        var redline = EngineRedline(left, right);
+
+        var run = RedlineReversibilityVerifier.Prove(left, right, redline);
+
+        Assert.True(run.Proof.AcceptToFinal?.Completed, run.Proof.ToJson());
+        Assert.True(run.Proof.RejectToBaseline?.Completed, run.Proof.ToJson());
+        Assert.Equal(StoryTexts(right), StoryTexts(run.AcceptedPackageBytes!));
+
+        using var stream = new MemoryStream(run.RejectedPackageBytes!, writable: false);
+        using var rejected = WordprocessingDocument.Open(stream, false);
+        var body = rejected.MainDocumentPart!.Document.Body!;
+        Assert.Empty(body.Descendants<DeletedRun>());
+        Assert.Empty(body.Descendants<InsertedRun>());
+        var strandedDeletedText = string.Concat(
+            body.Descendants<DeletedText>().Select(text => text.Text));
+        Assert.NotEmpty(strandedDeletedText); // the bug: content survives only as w:delText
+        Assert.NotEqual(StoryTexts(left), StoryTexts(run.RejectedPackageBytes!));
+
+        // The proof itself must expose the loss rather than certify the round-trip.
+        Assert.False(run.Proof.Success);
+        Assert.Contains(run.Proof.RejectToBaseline!.Findings, finding =>
+            finding.Code == "modeled_semantic_mismatch"
+            && finding.Severity == VerificationFindingSeverity.Error);
+    }
+
+    // WC035: when a comparison adds the document's first footnote/endnote, the redline
+    // package gains a notes part. Resolving toward the endpoint that has no notes leaves
+    // that (now content-empty) part behind instead of removing it, so the output package
+    // has a story the expected document never had. Body and note text themselves
+    // round-trip; only the empty-part residue diverges.
+    [Theory]
+    [InlineData("WC/WC035-Footnote-Before.docx", "WC/WC035-Footnote-After.docx", "footnotes")]
+    [InlineData("WC/WC035-Footnote-After.docx", "WC/WC035-Footnote-Before.docx", "footnotes")]
+    [InlineData("WC/WC035-Endnote-Before.docx", "WC/WC035-Endnote-After.docx", "endnotes")]
+    [InlineData("WC/WC035-Endnote-After.docx", "WC/WC035-Endnote-Before.docx", "endnotes")]
+    public void RRS006_KnownGap_ResolvingAwayTheOnlyNoteLeavesAnEmptyNotesPart(
+        string leftName,
+        string rightName,
+        string storyKind)
+    {
+        var left = Fixture(leftName);
+        var right = Fixture(rightName);
+        var redline = EngineRedline(left, right);
+
+        var run = RedlineReversibilityVerifier.Prove(left, right, redline);
+
+        Assert.True(run.Proof.AcceptToFinal?.Completed, run.Proof.ToJson());
+        Assert.True(run.Proof.RejectToBaseline?.Completed, run.Proof.ToJson());
+
+        // One endpoint has the note, the other has no notes part at all.
+        var (noteless, noteBearing, notelessOutput, noteBearingOutput) =
+            NotesText(left, storyKind) is null
+                ? (left, right, run.RejectedPackageBytes!, run.AcceptedPackageBytes!)
+                : (right, left, run.AcceptedPackageBytes!, run.RejectedPackageBytes!);
+        Assert.Null(NotesText(noteless, storyKind));
+        Assert.False(string.IsNullOrEmpty(NotesText(noteBearing, storyKind)));
+
+        // Toward the note-bearing endpoint the round-trip is faithful.
+        Assert.Equal(StoryTexts(noteBearing), StoryTexts(noteBearingOutput));
+
+        // Toward the noteless endpoint the body text round-trips but an empty notes part
+        // is left behind — the residue this pin exists for.
+        Assert.Equal(BodyText(noteless), BodyText(notelessOutput));
+        Assert.Equal(string.Empty, NotesText(notelessOutput, storyKind));
+        Assert.False(run.Proof.Success);
+    }
+
+    // WC012-Math: the After document carries its own tracked insertions, and
+    // DocxDiff.Compare does not reproduce that pre-existing review state in the redline.
+    // Accepting such a redline can never recover the After document exactly, and the proof
+    // must refuse to certify rather than resolve around the loss.
+    [Fact]
+    public void RRS007_KnownGap_RedlineMissingIntendedFinalReviewStateFailsClosed()
+    {
+        var left = Fixture("WC/WC012-Math-Before.docx");
+        var right = Fixture("WC/WC012-Math-After.docx");
+        Assert.True(ContainsNativeRevisions(right)); // the After doc's own review state
+        var redline = EngineRedline(left, right);
+
+        var run = RedlineReversibilityVerifier.Prove(left, right, redline);
+
+        Assert.False(run.Proof.Success);
+        Assert.Null(run.Proof.AcceptToFinal);
+        Assert.Null(run.Proof.RejectToBaseline);
+        Assert.Contains(run.Proof.Findings, finding =>
+            finding.Code == "intended_final_revision_missing_from_redline");
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers.
+    // ------------------------------------------------------------------
+
+    private static byte[] Fixture(string relativeName) =>
+        File.ReadAllBytes(Path.Combine(TestFilesDir, relativeName));
+
+    private static (byte[] Redline, byte[] AcceptedOracle, byte[] RejectedOracle) RpTriple(
+        string stem)
+    {
+        var rpDir = Path.Combine(TestFilesDir, "RP");
+        return (
+            File.ReadAllBytes(Path.Combine(rpDir, stem + ".docx")),
+            File.ReadAllBytes(Path.Combine(rpDir, stem + "-Accepted.docx")),
+            File.ReadAllBytes(Path.Combine(rpDir, stem + "-Rejected.docx")));
+    }
+
+    private static byte[] EngineRedline(byte[] left, byte[] right) => DocxDiff.Compare(
+        new WmlDocument("left.docx", left),
+        new WmlDocument("right.docx", right),
+        new DocxDiffSettings { AuthorForRevisions = "Docxodus Engine" }).DocumentByteArray;
+
+    private static IEnumerable<string> PinnedStems(string theoryMethodName) =>
+        typeof(RedlineReversibilityFixtureSweepTests)
+            .GetMethod(theoryMethodName)!
+            .GetCustomAttributes(typeof(InlineDataAttribute), inherit: false)
+            .Cast<InlineDataAttribute>()
+            .SelectMany(attribute => attribute.GetData(null!))
+            .Select(row => (string)row[0]!);
+
+    private static void AssertResolutionClosure(RedlineProofPathResult path)
+    {
+        var accountedFor = path.ResolvedRevisionIds
+            .Concat(path.ImplicitlyResolvedRevisionIds)
+            .OrderBy(id => id, StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(
+            path.RequestedRevisionIds.OrderBy(id => id, StringComparer.Ordinal),
+            accountedFor);
+        Assert.Equal(accountedFor.Length, accountedFor.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    private static void AssertNonEquivalenceIsEvidenced(RedlineProofPathResult path)
+    {
+        if (path.Equivalent)
+            return;
+        Assert.Contains(path.Findings, finding =>
+            finding.Severity == VerificationFindingSeverity.Error);
+        if (!path.NormalizedWholePackageEquivalent)
+            Assert.NotNull(path.FirstDivergence);
+    }
+
+    /// <summary>
+    /// Canonical story-text projection of a package: the concatenated <c>w:t</c> text of the
+    /// body and of every header, footer, footnotes and endnotes part, keyed by story kind.
+    /// Part presence counts — an empty part produces an empty entry, absence produces none —
+    /// so growing or losing a story cannot pass unnoticed.
+    /// </summary>
+    private static string StoryTexts(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes, writable: false);
+        using var document = WordprocessingDocument.Open(stream, false);
+        var main = document.MainDocumentPart!;
+        var builder = new StringBuilder();
+        builder.Append("body: ").Append(TextOf(main.Document)).Append('\n');
+        AppendStory(builder, "headers", main.HeaderParts.Select(part => TextOf(part.Header)));
+        AppendStory(builder, "footers", main.FooterParts.Select(part => TextOf(part.Footer)));
+        AppendStory(builder, "footnotes", main.FootnotesPart is { } footnotes
+            ? new[] { TextOf(footnotes.Footnotes) }
+            : Array.Empty<string>());
+        AppendStory(builder, "endnotes", main.EndnotesPart is { } endnotes
+            ? new[] { TextOf(endnotes.Endnotes) }
+            : Array.Empty<string>());
+        return builder.ToString();
+    }
+
+    private static void AppendStory(
+        StringBuilder builder, string kind, IEnumerable<string> texts)
+    {
+        foreach (var text in texts.OrderBy(text => text, StringComparer.Ordinal))
+            builder.Append(kind).Append(": ").Append(text).Append('\n');
+    }
+
+    private static string TextOf(DocumentFormat.OpenXml.OpenXmlElement? root) =>
+        root is null ? "" : string.Concat(root.Descendants<Text>().Select(text => text.Text));
+
+    private static string BodyText(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes, writable: false);
+        using var document = WordprocessingDocument.Open(stream, false);
+        return TextOf(document.MainDocumentPart!.Document.Body);
+    }
+
+    private static string? NotesText(byte[] bytes, string storyKind)
+    {
+        using var stream = new MemoryStream(bytes, writable: false);
+        using var document = WordprocessingDocument.Open(stream, false);
+        var main = document.MainDocumentPart!;
+        return storyKind == "footnotes"
+            ? main.FootnotesPart is { } footnotes ? TextOf(footnotes.Footnotes) : null
+            : main.EndnotesPart is { } endnotes ? TextOf(endnotes.Endnotes) : null;
+    }
+
+    private static bool ContainsNativeRevisions(byte[] bytes)
+    {
+        const string w = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+        using var stream = new MemoryStream(bytes, writable: false);
+        using var document = WordprocessingDocument.Open(stream, false);
+        return document.MainDocumentPart!.Document
+            .Descendants()
+            .Any(element => element.NamespaceUri == w
+                && element.LocalName is "ins" or "del");
+    }
+}


### PR DESCRIPTION
## Summary

PR #495 claims accept/reject reversibility but its suite exercises only 6 of the 51 Word-authored fixture triples already sitting in `TestFiles/RP`, and never runs an engine-generated redline over a real document pair to a content-level oracle. This stacked PR adds `RedlineReversibilityFixtureSweepTests` (127 test cases, ~31s) so the claim is proven — or its limits pinned — against the full real-fixture corpus:

- **RRS001** — all 49 resolvable Word-authored triples: the selective resolver must accept to the `-Accepted` oracle and reject to the `-Rejected` oracle at story-text level (body + headers + footers + footnotes + endnotes, part presence counts), with per-direction normalized whole-package equivalence pinned per fixture. 10 triples are package-perfect both ways; every one is content-perfect both ways.
- **RRS002** — the two fail-closed triples (`RP018` custom-XML move range, `RP047` insert+delete paragraph mark) pinned with their exact diagnostics.
- **RRS003** — a completeness guard: the pinned list must equal the set of complete triples on disk, so a new fixture cannot land unswept.
- **RRS004** — 69 real before/after pairs from the WCB comparison corpus: `DocxDiff.Compare` → `Prove` must complete both paths, classify everything as generated, and round-trip content exactly (accept ≡ right, reject ≡ left).
- **RRS005–RRS007** — three genuine gaps the sweep found, pinned by exact failure signature so they are visible and fail loudly when fixed:
  - **WC004-Large**: selective reject strips every `w:del` wrapper but strands ~1,300 characters as orphaned `w:delText` — real content loss; `RevisionProcessor` reject-all on the same redline restores the text, so the defect is in the selective resolution path.
  - **WC035 footnote/endnote**: resolving toward the endpoint with no notes leaves a content-empty notes part behind.
  - **WC012-Math**: `DocxDiff.Compare` drops the After document's own tracked insertion, so the proof correctly fails closed with `intended_final_revision_missing_from_redline`.

## Verification

- 127 passed / 0 failed in the new sweep (~31s)
- 234 passed / 0 failed across `RedlineReversibility*`, `DocxDiffOpsRoundTrip*`, `DeliverableVerifier*` on this head
- `git diff --check` clean; no fixture files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7qpcN9euy1W7tmxWoCTNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7qpcN9euy1W7tmxWoCTNR)_