### PR TITLE
Restore delText when selectively rejecting a move (#515)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -456,6 +456,20 @@ All notable changes to this project will be documented in this file.
   version bump at release time.
 
 ### Fixed
+- **Selectively rejecting a move no longer strands the moved text as orphaned
+  `w:delText` (#515).** The comparison engine serializes move-source runs as `w:delText`
+  inside `w:moveFrom` (delete-grade, unlike Word's own `w:t` serialization), but
+  `AcceptRevision`/`RejectRevision`'s resolver only performed the `delText → t` restore
+  when unwrapping a surviving `w:del`. Rejecting an engine-generated move therefore
+  removed the `w:moveFrom` wrapper and left its payload behind as schema-orphaned
+  `w:delText` — on `WC004-Large` ~1.3k characters of restored text were missing from the
+  rejected body, and the stranded nodes then surfaced as phantom unresolvable "delete"
+  revisions in the live registry. A surviving `w:moveFrom` now restores its payload
+  exactly like a surviving `w:del`, matching `RevisionProcessor.RejectRevisions`'s
+  unconditional `delText → t` transform; Word-authored moves (already `w:t`) are
+  unaffected. Covered by the WC004-Large rows of
+  `RedlineReversibilityFixtureSweepTests` (RRS004 content round-trip + RRS005 regression
+  pin on the corruption shape).
 - **npm — a Web Worker call no longer detaches the caller's `Uint8Array`.** Every
   `createWorkerDocxodus` entry point that takes document bytes (`convertDocxToHtml`,
   `compareDocuments`, the session opens, and the new `generatePackageManifest`) put the

--- a/Docxodus.Tests/RedlineReversibilityFixtureSweepTests.cs
+++ b/Docxodus.Tests/RedlineReversibilityFixtureSweepTests.cs
@@ -199,6 +199,7 @@ public class RedlineReversibilityFixtureSweepTests
     [Theory]
     [InlineData("CA/CA001-Plain.docx", "CA/CA001-Plain-Mod.docx")]
     [InlineData("WC/WC001-Digits.docx", "WC/WC001-Digits-Mod.docx")]
+    [InlineData("WC/WC004-Large.docx", "WC/WC004-Large-Mod.docx")]
     [InlineData("WC/WC001-Digits.docx", "WC/WC001-Digits-Deleted-Paragraph.docx")]
     [InlineData("WC/WC001-Digits-Deleted-Paragraph.docx", "WC/WC001-Digits.docx")]
     [InlineData("WC/WC002-Unmodified.docx", "WC/WC002-DiffInMiddle.docx")]
@@ -304,14 +305,14 @@ public class RedlineReversibilityFixtureSweepTests
     // pin and the RRS004 exclusion must be updated.
     // ------------------------------------------------------------------
 
-    // WC004-Large: rejecting the engine redline through the proof's *selective* resolver
-    // strips every w:del wrapper but leaves the deleted content behind as orphaned
-    // w:delText nodes, so ~1.3k characters of restored text are lost from the rejected
-    // body. RevisionProcessor's reject-all on the very same redline restores the text (see
-    // DocxDiffOpsRoundTripTests), so the loss is specific to selective resolution. The
-    // accept direction is content-faithful.
+    // WC004-Large regression pin for the selective-reject moveFrom fix: the comparison
+    // engine serializes move-source text as w:delText inside w:moveFrom, and rejecting
+    // those moves used to strand ~1.3k characters as orphaned w:delText once the wrapper
+    // was unwrapped without the delText → t restore. Beyond RRS004's story-text oracle
+    // (which WC004 now passes), assert the specific corruption shape can never return:
+    // the rejected package contains no w:delText outside a delete-grade wrapper.
     [Fact]
-    public void RRS005_KnownGap_LargeDocumentSelectiveRejectStrandsDeletedText()
+    public void RRS005_RejectedMoveRestoresDeletedTextInsteadOfStrandingIt()
     {
         var left = Fixture("WC/WC004-Large.docx");
         var right = Fixture("WC/WC004-Large-Mod.docx");
@@ -319,25 +320,13 @@ public class RedlineReversibilityFixtureSweepTests
 
         var run = RedlineReversibilityVerifier.Prove(left, right, redline);
 
-        Assert.True(run.Proof.AcceptToFinal?.Completed, run.Proof.ToJson());
         Assert.True(run.Proof.RejectToBaseline?.Completed, run.Proof.ToJson());
-        Assert.Equal(StoryTexts(right), StoryTexts(run.AcceptedPackageBytes!));
-
         using var stream = new MemoryStream(run.RejectedPackageBytes!, writable: false);
         using var rejected = WordprocessingDocument.Open(stream, false);
         var body = rejected.MainDocumentPart!.Document.Body!;
+        Assert.Empty(body.Descendants<DeletedText>());
         Assert.Empty(body.Descendants<DeletedRun>());
         Assert.Empty(body.Descendants<InsertedRun>());
-        var strandedDeletedText = string.Concat(
-            body.Descendants<DeletedText>().Select(text => text.Text));
-        Assert.NotEmpty(strandedDeletedText); // the bug: content survives only as w:delText
-        Assert.NotEqual(StoryTexts(left), StoryTexts(run.RejectedPackageBytes!));
-
-        // The proof itself must expose the loss rather than certify the round-trip.
-        Assert.False(run.Proof.Success);
-        Assert.Contains(run.Proof.RejectToBaseline!.Findings, finding =>
-            finding.Code == "modeled_semantic_mismatch"
-            && finding.Severity == VerificationFindingSeverity.Error);
     }
 
     // WC035: when a comparison adds the document's first footnote/endnote, the redline

--- a/Docxodus/Internal/RevisionOps.cs
+++ b/Docxodus/Internal/RevisionOps.cs
@@ -1866,7 +1866,13 @@ internal static class RevisionOps
             if (Detached(u.Element)) continue;
             if (u.Paragraph is not null) touchedParagraphs.Add(u.Paragraph);
             if (ContentSurvives(u.Element.Name, accept))
-                UnwrapWrapper(u.Element, restoreDeleted: u.Element.Name == W.del);
+                // A surviving w:del OR w:moveFrom un-deletes its payload: the comparison
+                // engine serializes move-source text as w:delText (delete-grade), so a
+                // rejected move must restore it exactly like a rejected deletion — the
+                // reject-all transform converts every delText unconditionally, and leaving
+                // it strands the text as orphaned w:delText once the wrapper is gone.
+                UnwrapWrapper(u.Element, restoreDeleted:
+                    u.Element.Name == W.del || u.Element.Name == W.moveFrom);
             else
                 RemoveContentWrapper(u.Element);
         }


### PR DESCRIPTION
## Summary

Fixes the content-loss bug the #514 fixture sweep exposed (issue #515), stacked on `agent/issue-464-redline-proof` so #495 no longer ships a selective resolver that loses text on real documents.

**Root cause.** `DocxDiff` serializes move-source runs as `w:delText` inside `w:moveFrom` (delete-grade — unlike Word's own serialization, which keeps `w:t` there; see `RP015-MoveFrom-MoveTo.docx` and `docs/architecture/native_move_markup.md`). The selective resolver's `Apply` only performed the `delText → t` restore when unwrapping a surviving `w:del`. Rejecting an engine-generated move therefore unwrapped the `w:moveFrom` and stranded its payload as schema-orphaned `w:delText`: on `WC004-Large` ~1,300 characters were missing from the rejected body text, and the stranded nodes then re-entered the live registry as phantom unresolvable "delete" revisions (`delText is recognized tracked-change markup but cannot be selectively resolved`).

**Fix.** One resolver branch in `RevisionOps.Apply`: a surviving `w:moveFrom` now restores its payload exactly like a surviving `w:del`. This matches `RevisionProcessor.RejectRevisions`' unconditional `delText → t` transform (which is why reject-all always round-tripped this same redline), and is a no-op for Word-authored moves that already carry `w:t`.

**Test pins updated** (`RedlineReversibilityFixtureSweepTests`):
- `WC004-Large` joins the RRS004 engine corpus — full story-text round-trip proven in both directions.
- RRS005 flips from known-gap pin to regression pin: the rejected package must contain no `w:delText` (or any revision wrapper) at all.

Not addressed here, by design: #516 (empty notes-part residue) needs baseline knowledge the session resolver doesn't have — scoping rationale is on the issue; it stays pinned in RRS006. #517 (engine drops the right side's own tracked changes) is an emitter design question; the proof correctly fails closed, pinned in RRS007.

## Verification

- Diagnosis reproduced with a step-by-step probe: three move rejects strand 399 → 847 → 1,299 chars before the fix; zero after, and the four phantom unresolvable revisions disappear.
- Full .NET suite on this head: **4,167 passed / 0 failed / 3 skipped** (~6 min) — no other fixture pins moved.
- `git diff --check` clean; CHANGELOG entry added under `[Unreleased] → Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7qpcN9euy1W7tmxWoCTNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7qpcN9euy1W7tmxWoCTNR)_