### PR TITLE
Pin the bounded change budget to published findings

### DIFF
--- a/Docxodus.Tests/Verification/SemanticDiffAnchorConsistencyTests.cs
+++ b/Docxodus.Tests/Verification/SemanticDiffAnchorConsistencyTests.cs
@@ -56,14 +56,7 @@ public class SemanticDiffAnchorConsistencyTests
     [Fact]
     public void Editing_text_around_a_bookmark_is_not_a_bookmark_move()
     {
-        var left = IrTestDocuments.FromBodyXml(
-            "<w:p><w:r><w:t xml:space=\"preserve\">hello </w:t></w:r>" +
-            "<w:bookmarkStart w:id=\"1\" w:name=\"bm1\"/><w:bookmarkEnd w:id=\"1\"/>" +
-            "<w:r><w:t>world</w:t></w:r></w:p>");
-        var right = IrTestDocuments.FromBodyXml(
-            "<w:p><w:r><w:t xml:space=\"preserve\">hello brave </w:t></w:r>" +
-            "<w:bookmarkStart w:id=\"1\" w:name=\"bm1\"/><w:bookmarkEnd w:id=\"1\"/>" +
-            "<w:r><w:t>world</w:t></w:r></w:p>");
+        var (left, right) = TextEditedAroundABookmark();
 
         var result = SemanticDiff.Compare(left, right);
 
@@ -113,6 +106,90 @@ public class SemanticDiffAnchorConsistencyTests
         Assert.Equal(SemanticChangeOperation.Move, move.Operation);
         Assert.False(string.IsNullOrEmpty(move.MoveId));
     }
+
+    /// <summary>
+    /// The bounded evidence budget governs findings the caller is actually handed, so a package
+    /// draft dropped as an aligned relocation must not consume it. The two facts meet on one
+    /// statement in SemanticDiffEngine: the alignment filter has to run BEFORE the budget check.
+    /// Reversing them makes the cap fire on evidence that is never published — a caller whose
+    /// document merely had text edited around a bookmark would get a limit failure instead of a
+    /// report.
+    ///
+    /// Calibration note: the assertion has teeth only while this fixture still produces an
+    /// aligned relocation for the filter to drop. Its sibling
+    /// <see cref="Editing_text_around_a_bookmark_is_not_a_bookmark_move"/> pins that the draft is
+    /// suppressed, and <see cref="A_bookmark_relocated_to_another_paragraph_is_still_a_move"/>
+    /// pins that the detector does emit Move drafts for this construct.
+    /// </summary>
+    [Fact]
+    public void An_aligned_relocation_does_not_consume_the_bounded_change_budget()
+    {
+        var (left, right) = TextEditedAroundABookmark();
+        var options = new SemanticDiffOptions();
+
+        // The exact number of findings the caller is handed — every one of them published.
+        var published = SemanticDiff.Compare(left, right, options).Changes.Count;
+        Assert.True(published > 0, "the fixture must produce findings for the budget to bound");
+
+        // A budget of exactly that many is sufficient: nothing published is dropped, and the
+        // filtered aligned relocation is not evidence anyone has to retain. Counting the
+        // unfiltered draft here would overshoot the budget by one and throw.
+        var bounded = SemanticDiff.CompareBounded(left, right, options, published);
+
+        Assert.Equal(published, bounded.Changes.Count);
+    }
+
+    /// <summary>
+    /// The companion to <see cref="An_aligned_relocation_does_not_consume_the_bounded_change_budget"/>:
+    /// the budget is still live at the boundary. Without this, that test would also pass against a
+    /// cap that never fires at all.
+    /// </summary>
+    [Fact]
+    public void The_bounded_change_budget_still_fails_closed_one_finding_short()
+    {
+        var (left, right) = TextEditedAroundTwoBookmarks();
+        var options = new SemanticDiffOptions();
+
+        var published = SemanticDiff.Compare(left, right, options).Changes.Count;
+        Assert.True(published > 1, "a budget one short of the published count must be reachable");
+
+        Assert.Throws<SemanticChangeLimitExceededException>(() =>
+            SemanticDiff.CompareBounded(left, right, options, published - 1));
+    }
+
+    /// <summary>
+    /// Text edited on both sides of an untouched bookmark: the IR aligns the containing paragraph
+    /// in place, so the package detector's relocation draft describes a block that did not move.
+    /// </summary>
+    /// <summary>
+    /// The same construct in two paragraphs, so the published finding count is high enough for a
+    /// budget one short of it to be a legal (positive) budget.
+    /// </summary>
+    private static (WmlDocument Left, WmlDocument Right) TextEditedAroundTwoBookmarks() => (
+        IrTestDocuments.FromBodyXml(
+            "<w:p><w:r><w:t xml:space=\"preserve\">hello </w:t></w:r>" +
+            "<w:bookmarkStart w:id=\"1\" w:name=\"bm1\"/><w:bookmarkEnd w:id=\"1\"/>" +
+            "<w:r><w:t>world</w:t></w:r></w:p>" +
+            "<w:p><w:r><w:t xml:space=\"preserve\">second </w:t></w:r>" +
+            "<w:bookmarkStart w:id=\"2\" w:name=\"bm2\"/><w:bookmarkEnd w:id=\"2\"/>" +
+            "<w:r><w:t>line</w:t></w:r></w:p>"),
+        IrTestDocuments.FromBodyXml(
+            "<w:p><w:r><w:t xml:space=\"preserve\">hello brave </w:t></w:r>" +
+            "<w:bookmarkStart w:id=\"1\" w:name=\"bm1\"/><w:bookmarkEnd w:id=\"1\"/>" +
+            "<w:r><w:t>world</w:t></w:r></w:p>" +
+            "<w:p><w:r><w:t xml:space=\"preserve\">second edited </w:t></w:r>" +
+            "<w:bookmarkStart w:id=\"2\" w:name=\"bm2\"/><w:bookmarkEnd w:id=\"2\"/>" +
+            "<w:r><w:t>line</w:t></w:r></w:p>"));
+
+    private static (WmlDocument Left, WmlDocument Right) TextEditedAroundABookmark() => (
+        IrTestDocuments.FromBodyXml(
+            "<w:p><w:r><w:t xml:space=\"preserve\">hello </w:t></w:r>" +
+            "<w:bookmarkStart w:id=\"1\" w:name=\"bm1\"/><w:bookmarkEnd w:id=\"1\"/>" +
+            "<w:r><w:t>world</w:t></w:r></w:p>"),
+        IrTestDocuments.FromBodyXml(
+            "<w:p><w:r><w:t xml:space=\"preserve\">hello brave </w:t></w:r>" +
+            "<w:bookmarkStart w:id=\"1\" w:name=\"bm1\"/><w:bookmarkEnd w:id=\"1\"/>" +
+            "<w:r><w:t>world</w:t></w:r></w:p>"));
 
     /// <summary>
     /// Two headers whose main-part relationship order is REVERSED relative to their part-name


### PR DESCRIPTION
## Summary

Adds a regression pin for a load-bearing statement ordering in
`SemanticDiffEngine.CompareValidated` that landed in #496 and is currently untested.

Two independent facts meet on one statement there:

- package-detector `Move` drafts whose "new location" is the same IR-aligned block are dropped
  rather than published (from #494)
- the bounded evidence budget fails closed when it would be exceeded (from #463)

Their order matters. The alignment filter must run **before** the budget check, so the cap
governs findings the caller is actually handed rather than drafts that are never published.

## Why this needs a test

Nothing pinned the ordering. Reversing the two statements — counting unfiltered drafts against
the budget — leaves the **entire 4,195-test suite green**, while a caller whose document merely
had text edited around a bookmark would receive a limit failure instead of a report.

Verified by mutation: with the statements reversed,
`An_aligned_relocation_does_not_consume_the_bounded_change_budget` fails; restored, it passes.

## What's here

- `An_aligned_relocation_does_not_consume_the_bounded_change_budget` — computes the published
  finding count, then asserts a budget of exactly that many does not throw. Under the reversed
  ordering the filtered draft overshoots by one.
- `The_bounded_change_budget_still_fails_closed_one_finding_short` — the companion, so the first
  test cannot pass against a cap that never fires at all. Uses a two-paragraph fixture because
  the single-paragraph one publishes exactly one finding, and a budget of zero is rejected by
  the API.
- Both share the fixture the existing suppression test uses, which is now extracted to a helper
  so the two cannot drift apart.

Test-only; no production code changes, so no CHANGELOG entry.

## Verification

- full suite: 4,197 passed / 0 failed / 3 pre-existing skips
- mutation check: the pin fails against the reversed ordering and passes against the current one