### PR TITLE
Pin ZIP entry timestamps to the DOS epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -499,6 +499,15 @@ All notable changes to this project will be documented in this file.
   version bump at release time.
 
 ### Fixed
+- **Live-session package digests are no longer timestamp-dependent** (issue #521).
+  The session's checkpoint clone serialized through `ZipArchive`, which stamps entries
+  with wall-clock time at 2-second DOS granularity, so two `GetPackageManifest()` calls
+  on identical logical content could disagree on `rawPackageBytesDigest` — an
+  intermittent CI flake and a hazard for any workflow comparing raw digests across
+  independent serializations (idempotent-retry and no-op-preview detection included).
+  `ZipPackageOutputNormalizer` now pins every entry timestamp to the ZIP DOS epoch,
+  which is exactly what Word writes; `Save()` output already carried epoch stamps via
+  `System.IO.Packaging`, so saved-package bytes are unchanged.
 - **Package manifests recognize the content-type spellings Word writes, and VML parts
   digest as XML** (issues #512, #513). Five allowlist/counter spellings in the manifest
   generator could never match a real package — glossary

--- a/Docxodus.Tests/PackageCompressionTests.cs
+++ b/Docxodus.Tests/PackageCompressionTests.cs
@@ -49,6 +49,34 @@ public sealed class PackageCompressionTests
     }
 
     [Fact]
+    public void PKG521_AllPackageOutputs_PinZipEntryTimestampsToTheDosEpoch()
+    {
+        var epoch = new DateTime(1980, 1, 1, 0, 0, 0);
+        var input = LoadFixture(RegressionFixture);
+        using var session = new DocxSession(input);
+        var anchor = session.Project().AnchorIndex.Keys
+            .First(id => id.StartsWith("p:body:", StringComparison.Ordinal));
+        Assert.True(session.ReplaceText(anchor, "Deterministic timestamp probe.").Success);
+
+        using var saved = new ZipArchive(
+            new MemoryStream(session.Save()), ZipArchiveMode.Read);
+        Assert.All(saved.Entries, entry => Assert.Equal(epoch, entry.LastWriteTime.DateTime));
+
+        // The #521 flake lived here: the checkpoint clone used to restamp every entry
+        // with wall-clock time at 2-second DOS granularity, so back-to-back manifests of
+        // an untouched session could disagree on the raw package digest.
+        var checkpoint = session.SerializePackageCheckpoint();
+        using var cloned = new ZipArchive(
+            new MemoryStream(checkpoint), ZipArchiveMode.Read);
+        Assert.All(cloned.Entries, entry => Assert.Equal(epoch, entry.LastWriteTime.DateTime));
+        Assert.Equal(checkpoint, session.SerializePackageCheckpoint());
+
+        var first = session.GetPackageManifest();
+        var second = session.GetPackageManifest();
+        Assert.Equal(first.RawPackageBytesDigest.Value, second.RawPackageBytesDigest.Value);
+    }
+
+    [Fact]
     public void PKG332_Normalization_PreservesEveryEntryPayloadAndOpcStructure()
     {
         var input = LoadFixture(RegressionFixture);

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -12469,7 +12469,7 @@ public sealed partial class DocxSession : IDisposable
     /// topology. Every cached XDocument is then overlaid on its clone counterpart so edits that
     /// have not yet reached a part stream are represented in the checkpoint as well.
     /// </summary>
-    private byte[] SerializePackageCheckpoint() => SerializeCheckpointOf(_doc!);
+    internal byte[] SerializePackageCheckpoint() => SerializeCheckpointOf(_doc!);
 
     /// <summary>
     /// The opening package rendered through the same checkpoint pipeline the current side uses,

--- a/Docxodus/ZipPackageOutputNormalizer.cs
+++ b/Docxodus/ZipPackageOutputNormalizer.cs
@@ -32,6 +32,12 @@ internal static class ZipPackageOutputNormalizer
     private const int RegularFilePermissions = 0x1A4 << 16; // -rw-r--r-- (0644)
     private const int DirectoryPermissions = 0x1ED << 16;   // drwxr-xr-x (0755)
 
+    // Word pins every OPC entry to the ZIP DOS epoch. System.IO.Packaging already emits
+    // epoch stamps, but the session's checkpoint clone serializes through ZipArchive,
+    // which stamps wall-clock time at 2-second DOS granularity - making the raw package
+    // digest of identical logical content time-dependent (issue #521).
+    private static readonly DateTimeOffset ZipEpoch = new(1980, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
     /// <summary>
     /// Returns a normalized copy of <paramref name="packageBytes"/>. Invalid/non-ZIP input passes
     /// through unchanged; callers at this boundary ordinarily supply an already-validated OPC
@@ -55,7 +61,7 @@ internal static class ZipPackageOutputNormalizer
                 {
                     var level = GetCompressionLevel(sourceEntry);
                     var targetEntry = target.CreateEntry(sourceEntry.FullName, level);
-                    targetEntry.LastWriteTime = sourceEntry.LastWriteTime;
+                    targetEntry.LastWriteTime = ZipEpoch;
                     targetEntry.Comment = sourceEntry.Comment;
                     targetEntry.ExternalAttributes = NormalizedExternalAttributes(sourceEntry);
 


### PR DESCRIPTION
## Summary

- `SerializePackageCheckpoint()` (the live-session manifest/content-hash path) serializes through `ZipArchive`, which stamps every entry with wall-clock time at 2-second DOS granularity. Two back-to-back `GetPackageManifest()` calls on identical logical content could therefore disagree on `rawPackageBytesDigest` — the intermittent `python-tests` flake seen on #497, and a hazard for any workflow comparing raw digests across independent serializations (the receipt layer's idempotent-retry and no-op-preview detection included).
- `ZipPackageOutputNormalizer` — the declared single owner of output ZIP policy — now pins every entry timestamp to the ZIP DOS epoch (1980-01-01), which is empirically exactly what Word writes for every OPC entry (verified across fixtures).
- **Saved-package bytes are unchanged**: `System.IO.Packaging` already emits epoch stamps on the `Save()` path, so the pin only affects the checkpoint path, whose bytes were nondeterministic to begin with.
- `SerializePackageCheckpoint` is promoted to `internal` so the regression test asserts on checkpoint bytes directly instead of racing a 2-second boundary.

## Verification

- New `PKG521` regression test: watched RED (all 25 checkpoint entries wall-clock-stamped), GREEN after the pin; asserts epoch stamps on both the save and checkpoint paths, byte-identical consecutive checkpoints, and equal back-to-back manifest digests.
- Empirical root-cause probe: two checkpoint serializations 2.5s apart differed **only** in entry timestamps (11:33:42 vs 11:33:44), payloads identical; `Save()` output already all-epoch.
- Full suite: **4,249 passed / 0 failed** / 3 pre-existing skips — zero byte-oracle fallout, consistent with saved bytes being unchanged.

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)