### PR TITLE
Surface the cause of a failed Chromium launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -519,6 +519,22 @@ All notable changes to this project will be documented in this file.
   version bump at release time.
 
 ### Fixed
+- **Chromium launch failures say why, and an unavailable sandbox is named as a host policy**
+  (issue #525). The Node export runtime already attached the real reason a launch failed to
+  `DocxodusExportError.cause`, but the CLI rendered only code, phase, message, remediation, and
+  detail, so the diagnostic was discarded at the one surface an operator reads. On any host that
+  restricts unprivileged user namespaces — Ubuntu 23.10 and later do by default — every export
+  failed with "Chromium could not be launched" plus a remediation pointing at the executable and
+  its shared libraries, which is exactly where the problem is not. `docxodus convert` now prints
+  the whole cause chain to stderr beneath the remediation, unwrapping `AggregateError` so a wrapped
+  cleanup failure is visible too, cycle-safe, depth-bounded, and holding its own character budget so
+  a long detail cannot crowd it out. The rendering strips every escape sequence and control code
+  point except newline, which Chromium's multi-line launch log needs. Causes still reach stderr
+  only: they never enter `detail`, `toJSON()`, or the render report. A launch that fails because the
+  host denies Chromium's process sandbox is additionally recognized as its own condition and
+  remediated as the host policy it is — the runtime never answers it by dropping `chromiumSandbox`,
+  so the operator is told which knob is actually theirs. Every surface that reports a remediation,
+  the framed host included, carries the corrected wording.
 - **Worker resource-limit failures are classified by code, not message text** (issue #523).
   The standalone export matched worker error message wording to decide whether a failure was
   a resource limit, so rewording a message would silently downgrade the typed `resource_limit`

--- a/docs/architecture/standalone_paginated_export.md
+++ b/docs/architecture/standalone_paginated_export.md
@@ -411,9 +411,14 @@ unattested system font lowers the environment result to `browserObserved` and fa
 `browser` and `browserExecutablePath` are mutually exclusive. An explicit executable is snapshotted
 as a stable, bounded, ordinary executable file and hashed before launch; symlinks, devices,
 identity changes, relative executable paths, and security-weakening launch configurations fail.
-The owned supported runtime does not opt out of Chromium's process sandbox. An injected browser is
-caller-trusted and receives a fresh context, but it remains outside the process-sandbox and
-background-network guarantee because those launch facts are not observable.
+The owned supported runtime does not opt out of Chromium's process sandbox. A host that denies that
+sandbox — the AppArmor restriction on unprivileged user namespaces that Ubuntu 23.10 and later apply
+by default, most commonly — is therefore a launch failure the runtime cannot resolve on the
+operator's behalf, and `browser_launch_failure` names it as one: the message and remediation say the
+host policy has to change rather than sending the operator to inspect the executable and its shared
+libraries. An injected browser is caller-trusted and receives a fresh context, but it remains
+outside the process-sandbox and background-network guarantee because those launch facts are not
+observable.
 
 Schema-v1 fidelity support is maintained on the pinned Linux x64 release image, matching the
 existing visual ratchet environment. Windows x64, Linux arm64, and macOS x64/arm64 may use an explicit or injected
@@ -698,7 +703,17 @@ version failures retain their distinct codes across the host. Each error include
 `error`, failed phase, message, remediation, and optional bounded safe detail, pending resources,
 part URI, anchor, and resource. Causes/stacks may be retained on the local Node object but are never
 serialized automatically. Cleanup failure does not replace a primary failure; it is attached as a
-bounded secondary diagnostic. The public limit shape is:
+bounded secondary diagnostic.
+
+Retaining a cause is worth nothing if no surface reads it. The CLI therefore renders the whole
+chain — `cause` links and `AggregateError` members alike, so the wrapped cleanup failure is visible
+too — to stderr beneath the remediation, cycle-safe, depth-bounded, and given its own character
+budget so a long `detail` cannot crowd it out. Writing a cause to an operator's terminal is not
+serializing it: the chain never enters `detail`, `toJSON()`, or the render report, and the rendering
+is stripped of every escape sequence and control code point except the newlines the diagnostic
+itself needs.
+
+The public limit shape is:
 
 ```ts
 interface ExportResourceLimits {

--- a/npm-export/README.md
+++ b/npm-export/README.md
@@ -88,9 +88,15 @@ input aliases, and duplicate destinations are rejected; the CLI never overwrites
   fonts remain reported honestly; `strictFonts` therefore fails closed.
 - The `original` review profile remains fail-closed until issue #444 completes its projection.
 - Mixed-section and broader fidelity ratchets are extended by issues #440 and #443.
+- Chromium keeps its process sandbox, so the render host has to permit unprivileged user
+  namespaces. Ubuntu 23.10 and later restrict them through AppArmor by default; check with
+  `unshare --user --map-root-user true` and permit them with
+  `sysctl -w kernel.apparmor_restrict_unprivileged_userns=0`. A launch that fails this way is
+  reported as its own condition rather than as a suspect executable.
 
 Failures are `DocxodusExportError` objects with stable code, phase, remediation, safe detail, and a
-structured failed report when materialization had begun.
+structured failed report when materialization had begun. The CLI additionally writes the underlying
+cause chain to stderr, which is where a Chromium launch diagnostic becomes readable.
 
 ## Framed host
 

--- a/npm-export/src/browser-session.ts
+++ b/npm-export/src/browser-session.ts
@@ -21,6 +21,7 @@ import {
   exportError,
   fromBrowserFailure,
 } from "./contracts.js";
+import { errorMessages } from "./diagnostics.js";
 
 const PLAYWRIGHT_VERSION = "1.57.0";
 const EXECUTABLE_BYTES_MAX = 1024 * 1024 * 1024;
@@ -90,6 +91,32 @@ interface HostOwnedBrowserIdentity {
 }
 
 const HOST_OWNED_BROWSERS = new WeakMap<Browser, HostOwnedBrowserIdentity>();
+
+/**
+ * Playwright's substituted banner plus the three markers it keys that substitution on, so the
+ * condition is still recognized when Chromium's own log reaches us unrewritten.
+ */
+const SANDBOX_UNAVAILABLE_MARKERS = Object.freeze([
+  "Chromium sandboxing failed",
+  "No usable sandbox!",
+  "crbug.com/357670",
+  "crbug.com/638180",
+]);
+
+/**
+ * A host that denies Chromium its process sandbox — Ubuntu 23.10 and later restrict unprivileged
+ * user namespaces through AppArmor by default — is a distinct and common launch failure, and one
+ * this runtime deliberately cannot resolve for the operator, since it never drops `chromiumSandbox`.
+ * Recognizing it is what lets the failure name the knob that is actually theirs.
+ *
+ * Exported so the predicate can be tested on a host where the condition cannot be created — CI
+ * permits the namespaces this detects the absence of.
+ */
+export function chromiumSandboxUnavailable(cause: unknown): boolean {
+  return errorMessages(cause).some(
+    (text) => SANDBOX_UNAVAILABLE_MARKERS.some((marker) => text.includes(marker)),
+  );
+}
 
 function timeoutError(phase: "browser_launch" | "wasm_initialization" | "pdf_print", pending: string) {
   return new DocxodusExportError(
@@ -372,13 +399,20 @@ async function launchBrowser(
         report: cause.report,
       });
     }
+    const sandboxUnavailable = chromiumSandboxUnavailable(cause);
     exportError(
       "browser_launch_failure",
       "browser_launch",
-      "Chromium could not be launched for export.",
-      explicit
-        ? "Verify browserExecutablePath and its shared-library dependencies."
-        : "Install @playwright/browser-chromium during deployment or provide browserExecutablePath.",
+      sandboxUnavailable
+        ? "Chromium could not be launched because this host denies its process sandbox."
+        : "Chromium could not be launched for export.",
+      sandboxUnavailable
+        ? "Permit unprivileged user namespaces on the render host, for example "
+          + "kernel.apparmor_restrict_unprivileged_userns=0 on Ubuntu 23.10 and later; "
+          + "the export runtime never launches Chromium without its process sandbox."
+        : explicit
+          ? "Verify browserExecutablePath and its shared-library dependencies."
+          : "Install @playwright/browser-chromium during deployment or provide browserExecutablePath.",
       { cause: cleanupFailure === undefined ? cause : new AggregateError([cause, cleanupFailure]) },
     );
   }

--- a/npm-export/src/cli.ts
+++ b/npm-export/src/cli.ts
@@ -15,11 +15,11 @@ import {
   type ReviewProfile,
 } from "./index.js";
 import { canonicalJsonBytes } from "./canonical.js";
+import { humanDiagnostic } from "./diagnostics.js";
 import { writeDiagnosticNoReplace } from "./files.js";
 import { decodeStrictUtf8, strictJsonParse } from "./strict-json.js";
 
 const MAX_CONFIGURATION_BYTES = 1_048_576;
-const MAX_HUMAN_DIAGNOSTIC_CHARACTERS = 16_384;
 
 const HELP = `Usage:
   docxodus convert <input.docx> --to <html|pdf> --output <path>
@@ -120,22 +120,6 @@ async function readJson<T>(path: string | undefined, label: string): Promise<T |
   } finally {
     await handle?.close().catch(() => undefined);
   }
-}
-
-function humanError(error: unknown): string {
-  let message: string;
-  if (error instanceof DocxodusExportError) {
-    message = `${error.code} (${error.phase}): ${error.message}\nRemediation: ${error.remediation}`
-      + (error.detail ? `\nDetail: ${error.detail}` : "")
-      + (error.committedDestinations.length
-        ? `\nAlready committed: ${error.committedDestinations.join(", ")}`
-        : "");
-  } else {
-    message = error instanceof Error ? error.message : String(error);
-  }
-  return message.length <= MAX_HUMAN_DIAGNOSTIC_CHARACTERS
-    ? message
-    : `${message.slice(0, MAX_HUMAN_DIAGNOSTIC_CHARACTERS - 3)}...`;
 }
 
 export async function runCli(argv: readonly string[]): Promise<number> {
@@ -259,10 +243,10 @@ export async function runCli(argv: readonly string[]): Promise<number> {
       try {
         await writeDiagnosticNoReplace(reportPath, canonicalJsonBytes(error.report));
       } catch (reportError) {
-        process.stderr.write(`Failed to preserve render report: ${humanError(reportError)}\n`);
+        process.stderr.write(`Failed to preserve render report: ${humanDiagnostic(reportError)}\n`);
       }
     }
-    process.stderr.write(`${humanError(error)}\n`);
+    process.stderr.write(`${humanDiagnostic(error)}\n`);
     return signalExitCode ?? (error instanceof DocxodusExportError ? 1 : 2);
   }
 }

--- a/npm-export/src/diagnostics.ts
+++ b/npm-export/src/diagnostics.ts
@@ -1,0 +1,106 @@
+import { DocxodusExportError } from "./contracts.js";
+
+/**
+ * Operator diagnostics for stderr.
+ *
+ * Writing a cause to a terminal is not serializing it: nothing here reaches `detail`, `toJSON()`,
+ * or the render report, which stay free of the cause and stack material a Node error may carry.
+ */
+
+const MAX_HUMAN_DIAGNOSTIC_CHARACTERS = 16_384;
+const MAX_HUMAN_CAUSE_CHARACTERS = 8_192;
+const MAX_CAUSE_DEPTH = 8;
+
+/** Escapes are matched whole, so no bracket or parameter residue survives the strip. */
+const ANSI_OPERATING_SYSTEM_COMMAND = /\u001b\][\s\S]*?(?:\u0007|\u001b\\)/g;
+const ANSI_CONTROL_SEQUENCE = /\u001b\[[\u0020-\u003f]*[\u0040-\u007e]/g;
+/** Every C0/C1 code point and DEL except the newline this rendering uses as its separator. */
+const FORBIDDEN_CONTROL = /[\u0000-\u0009\u000b-\u001f\u007f-\u009f]/g;
+
+/**
+ * Renders text a terminal can print. Newline survives deliberately: the diagnostics this exists to
+ * surface — Chromium's launch log above all — are multi-line, and flattening them would restore
+ * exactly the unreadability being fixed.
+ */
+function terminalSafeText(text: string): string {
+  return text
+    .replace(ANSI_OPERATING_SYSTEM_COMMAND, "")
+    .replace(ANSI_CONTROL_SEQUENCE, "")
+    .replace(/\r\n?/g, "\n")
+    .replace(/\t/g, " ")
+    .replace(FORBIDDEN_CONTROL, "");
+}
+
+function boundedText(text: string, maximum: number): string {
+  if (maximum <= 0) return "";
+  if (text.length <= maximum) return text;
+  return maximum <= 3 ? text.slice(0, maximum) : `${text.slice(0, maximum - 3)}...`;
+}
+
+function errorText(value: unknown): string {
+  try {
+    return value instanceof Error ? value.message : String(value);
+  } catch {
+    return "an unrenderable diagnostic value";
+  }
+}
+
+function walk(root: unknown, includeRoot: boolean, maxDepth: number): string[] {
+  const seen = new Set<unknown>();
+  const messages: string[] = [];
+  const visit = (value: unknown, depth: number): void => {
+    if (value === undefined || value === null || depth > maxDepth) return;
+    if (typeof value === "object" || typeof value === "function") {
+      if (seen.has(value)) return;
+      seen.add(value);
+    }
+    if (depth > 0 || includeRoot) {
+      const text = errorText(value);
+      // `new AggregateError([...])` carries no message of its own; only its members say anything.
+      if (text.length > 0) messages.push(text);
+    }
+    if (value instanceof AggregateError && Array.isArray(value.errors)) {
+      for (const entry of value.errors) visit(entry, depth + 1);
+    }
+    if (value instanceof Error && value.cause !== undefined) visit(value.cause, depth + 1);
+  };
+  visit(root, 0);
+  return messages;
+}
+
+/** Every message in the chain, the root's own included. */
+export function errorMessages(value: unknown, maxDepth: number = MAX_CAUSE_DEPTH): string[] {
+  return walk(value, true, maxDepth);
+}
+
+/**
+ * Everything beneath `error`: `cause` chains and `AggregateError` members alike, because the browser
+ * launch path wraps a primary failure together with a cleanup failure. The root's own message is
+ * omitted, since callers render it themselves.
+ */
+function causeMessages(error: unknown, maxDepth: number = MAX_CAUSE_DEPTH): string[] {
+  return walk(error, false, maxDepth);
+}
+
+export function humanDiagnostic(error: unknown): string {
+  let message: string;
+  if (error instanceof DocxodusExportError) {
+    message = `${error.code} (${error.phase}): ${error.message}\nRemediation: ${error.remediation}`
+      + (error.detail ? `\nDetail: ${error.detail}` : "")
+      + (error.committedDestinations.length
+        ? `\nAlready committed: ${error.committedDestinations.join(", ")}`
+        : "");
+  } else {
+    message = errorText(error);
+  }
+  const causes = causeMessages(error).map((text) => `Cause: ${terminalSafeText(text)}`);
+  // The cause gets its own budget before the rest is bounded, so a long detail cannot truncate away
+  // the one line that explains the failure.
+  const causeBlock = causes.length === 0
+    ? ""
+    : `\n${boundedText(causes.join("\n"), MAX_HUMAN_CAUSE_CHARACTERS)}`;
+  return boundedText(
+    terminalSafeText(message),
+    MAX_HUMAN_DIAGNOSTIC_CHARACTERS - causeBlock.length,
+  ) + causeBlock;
+}

--- a/npm-export/tests/hardening.test.mjs
+++ b/npm-export/tests/hardening.test.mjs
@@ -19,6 +19,8 @@ import {
   convertDocxToPdf,
   DocxodusExportError,
 } from "../dist/index.js";
+import { chromiumSandboxUnavailable } from "../dist/browser-session.js";
+import { humanDiagnostic } from "../dist/diagnostics.js";
 import {
   prepareDestinations,
   publishNoReplace,
@@ -304,5 +306,98 @@ describe("hardening boundaries", { concurrency: false }, () => {
     });
     assert.equal(conflicting.status, 2);
     assert.match(conflicting.stderr.toString(), /conflicts/i);
+  });
+
+  test("human diagnostics render the cause chain, terminal-safe and newline-preserving", () => {
+    const launchLog = [
+      "browserType.launch: Target page, context or browser has been closed",
+      "Browser logs:",
+      "Chromium sandboxing failed!",
+      "================================",
+      "  - (preferred): Configure your environment to support sandboxing",
+      "================================",
+    ].join("\n");
+    const decorated = `\u001b[2m${launchLog}\u001b[22m\r\nCall\tlog:\u0000`;
+    const rendered = humanDiagnostic(new DocxodusExportError(
+      "browser_launch_failure",
+      "browser_launch",
+      "Chromium could not be launched because this host denies its process sandbox.",
+      "Permit unprivileged user namespaces on the render host.",
+      {
+        cause: new AggregateError([
+          new Error(decorated),
+          new Error("the private temporary directory could not be removed"),
+        ]),
+      },
+    ));
+    assert.match(rendered, /^browser_launch_failure \(browser_launch\): /);
+    assert.match(rendered, /^Cause: browserType\.launch: /m);
+    assert.ok(rendered.includes("Chromium sandboxing failed!"));
+    assert.match(rendered, /^Cause: the private temporary directory could not be removed$/m);
+    assert.match(rendered, /^Call log:$/m);
+    assert.equal(/[\u0000-\u0009\u000b-\u001f\u007f-\u009f]/.test(rendered), false);
+  });
+
+  test("cause rendering is bounded and terminates on cyclic chains", () => {
+    const inner = new Error("inner");
+    const outer = new Error("outer", { cause: inner });
+    inner.cause = outer;
+    const cyclic = humanDiagnostic(outer);
+    assert.equal(cyclic.match(/^Cause: /gm).length, 1);
+    assert.match(cyclic, /^Cause: inner$/m);
+
+    const bounded = humanDiagnostic(new Error("top", {
+      cause: new Error("x".repeat(64 * 1024)),
+    }));
+    assert.ok(bounded.length <= 16_384, `rendered ${bounded.length} characters`);
+    assert.ok(bounded.endsWith("..."));
+
+    const starved = humanDiagnostic(new DocxodusExportError(
+      "conversion_failure",
+      "conversion",
+      "m",
+      "r",
+      { detail: "d".repeat(64 * 1024), cause: new Error("the reason this failed") },
+    ));
+    assert.match(starved, /^Cause: the reason this failed$/m);
+  });
+
+  test("an unavailable Chromium process sandbox is recognized behind its cause chain", () => {
+    assert.equal(chromiumSandboxUnavailable(new Error("Chromium sandboxing failed!\nlogs")), true);
+    assert.equal(
+      chromiumSandboxUnavailable(new Error(
+        "[err] No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro",
+      )),
+      true,
+    );
+    assert.equal(
+      chromiumSandboxUnavailable(new AggregateError([
+        new Error("[err] see https://crbug.com/638180 for more information"),
+        new Error("cleanup failed"),
+      ])),
+      true,
+    );
+    assert.equal(chromiumSandboxUnavailable(new Error("ENOENT: no such file or directory")), false);
+    assert.equal(chromiumSandboxUnavailable(undefined), false);
+  });
+
+  test("CLI stderr carries the reason a Chromium launch failed", async () => {
+    const output = join(scratch, "launch-cause-must-not-exist.pdf");
+    const missing = join(scratch, "chromium-that-does-not-exist");
+    const failed = spawnSync(process.execPath, [
+      cliEntry,
+      "convert",
+      fixture,
+      "--to", "pdf",
+      "--output", output,
+      "--review-profile", "final",
+      "--comments", "hidden",
+      "--browser-executable", missing,
+    ], { cwd: packageRoot });
+    const stderr = failed.stderr.toString();
+    assert.equal(failed.status, 1, stderr);
+    assert.match(stderr, /^browser_launch_failure \(browser_launch\): /m);
+    assert.match(stderr, /^Cause: [\s\S]*ENOENT/m);
+    await assert.rejects(stat(output), { code: "ENOENT" });
   });
 });


### PR DESCRIPTION
Closes #525.

The Node export runtime captured the real reason a Chromium launch failed and then discarded it at
the only human-facing surface. `launchBrowser` attaches the cause to `DocxodusExportError.cause`,
but `humanError` in `cli.ts` rendered only code, phase, message, remediation, detail, and committed
destinations — so on any host that restricts unprivileged user namespaces (Ubuntu 23.10 and later
by default, and the GitHub Actions runners) every export reported this, and only this:

```
browser_launch_failure (browser_launch): Chromium could not be launched for export.
Remediation: Verify browserExecutablePath and its shared-library dependencies.
```

The executable and its shared libraries were fine. The remediation actively pointed away from the
problem, which is a host policy setting.

## What changed

**The cause chain reaches stderr.** A new `npm-export/src/diagnostics.ts` owns operator-facing
rendering; the CLI calls `humanDiagnostic`. The walk follows `cause` links *and*
`AggregateError.errors`, because the launch path wraps a primary failure together with a cleanup
failure; it is cycle-safe through a seen-set and depth-bounded. The cause is given its own 8 KB
budget carved out **before** the existing 16 KB whole-message bound, so a long `detail` cannot
truncate away the one line that explains the failure.

Newline is the single control character the rendering keeps. Chromium's launch log is intrinsically
multi-line, and flattening it would restore exactly the unreadability this fixes; escape sequences
(the real Playwright message carries ANSI dim codes) and every other control code point are
stripped. Causes still reach stderr only — never `detail`, `toJSON()`, or the render report, which
the architecture record keeps free of unserialized cause material.

**An unavailable process sandbox is its own condition.** `chromiumSandboxUnavailable` recognizes
Playwright's substituted banner plus the three markers it keys that substitution on, verified
against the pinned 1.57.0 tree rather than a newer local copy. Because recognition sits at the
launch site and lands on `message`/`remediation`, every surface that reports a remediation — the
framed host included — carries the corrected wording. The runtime deliberately never answers this
failure by dropping `chromiumSandbox`, so the operator has to be told which knob is actually theirs.

Same command, after:

```
browser_launch_failure (browser_launch): Chromium could not be launched because this host denies its process sandbox.
Remediation: Permit unprivileged user namespaces on the render host, for example
kernel.apparmor_restrict_unprivileged_userns=0 on Ubuntu 23.10 and later; the export runtime
never launches Chromium without its process sandbox.
Cause: browserType.launch: Target page, context or browser has been closed
Browser logs:
Chromium sandboxing failed!
================================
To avoid the sandboxing issue, do either of the following:
  - (preferred): Configure your environment to support sandboxing
  - (alternative): Launch Chromium without sandbox using 'chromiumSandbox: false' option
================================

Call log:
  - <launching> …
```

## Verification

- Reproduced the original bug on a host with `kernel.apparmor_restrict_unprivileged_userns=1`, and
  captured before/after stderr from the same command against the same Chromium build. The two
  blocks above are that capture, not a reconstruction.
- Full `npm-export` suite: 19 tests, 17 pass. The two failures are exactly the two host-sandbox
  failures documented on #502 — CI sets the sysctl to 0, so they pass on the runner. Their
  assertion output now self-describes the cause. Three unrelated failures from a stale local WASM
  build were cleared by rebuilding rather than explained away.
- Four new tests in `hardening.test.mjs`: cause rendering and sanitization; bounding, cycle
  termination, and the detail-starvation case; the sandbox predicate; and a host-independent CLI
  end-to-end through a nonexistent `--browser-executable`, which produces a cause on any host.
- The sandbox predicate is unit-tested against literal banner text on purpose: CI permits the
  namespaces whose absence it detects, so a committed test cannot depend on the condition existing.
- `tsc --noEmit` clean, `npm run test:package-boundary` clean (47 files).
- Also checked by hand: the `--report` branch writes no report on a launch failure (materialization
  never began) while stderr still carries the cause, and a non-sandbox launch failure keeps its
  original remediation.

## Deliberately not in scope

`host.ts` still builds its fatal envelope from `message` alone. That envelope is *serialized* across
the pipe, so carrying causes there would contradict the architecture record's "causes/stacks may be
retained on the local Node object but are never serialized automatically" — a contract change rather
than a stderr change, and not what #525 asks for.

`chromiumSandboxUnavailable` is exported from `browser-session.ts` solely so the predicate is
testable; the reason is documented at the declaration so it is not read as an accidental widening of
an internal module's surface.

## Docs

CHANGELOG `[Unreleased] → Fixed`; the error-taxonomy and launch-policy sections of
`docs/architecture/standalone_paginated_export.md`; and a runtime-boundary bullet in the
`@docxodus/export` README giving the `unshare` check and the sysctl.
