### PR TITLE
Ask for human-readable PR descriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,11 @@ duplicated description is one that will go stale.
 
 - **Never credit yourself in commits.** Do not add "Generated with Claude Code" or
   "Co-Authored-By: Claude" to commit messages.
+- **Write PR descriptions for a human reviewer, not for the next agent.** Explain, in plain
+  language, why the change exists, how it works at a mechanism level, and how it was
+  validated. Don't invent terminology, lean on internal issue-number shorthand, or use
+  jargon a reader outside the change wouldn't recognize — a reviewer who hasn't read the
+  code should be able to follow the description on its own.
 
 ## Coding Standards
 


### PR DESCRIPTION
## What this does and why

While reviewing PR #529, its description turned out to be hard to follow unless you already had the code open — it leaned on internal shorthand (test-criterion numbers, phase names, issue-number references) instead of just explaining, in plain terms, why the change existed and how it worked. I rewrote that description in plain language and, since this is a recurring pattern for changes generated with Claude Code in this repo, added a short instruction to CLAUDE.md so future PRs default to being readable by someone who hasn't read the diff yet.

## What changed

One new bullet under "Important Instructions" in CLAUDE.md, next to the existing commit-message guidance: PR descriptions should explain why a change exists, how it works, and how it was validated, in plain language, without inventing terminology or leaning on internal jargon.

## How it was validated

Documentation-only change; no code or tests affected.