### PR TITLE
Document the shipped font runtime instead of promising it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -646,6 +646,16 @@ All notable changes to this project will be documented in this file.
   version bump at release time.
 
 ### Fixed
+- **`@docxodus/export` docs asserted the font runtime was still unimplemented (#442).** The
+  README's "Runtime boundaries" section claimed `--font-directory` fails with
+  `unsupported_runtime`, the `original` review profile is fail-closed, and the generated-PDF
+  fidelity ratchet is future work — all three shipped. The stale claims are replaced with the
+  delivered contracts, a "Reproducible font configuration" section documents the license-safe
+  metric-substitute set (Carlito / Caladea / Liberation) with packages and directories for a
+  reproducible CLI render, the CLI help no longer marks `--font-directory` as pending, the
+  export design doc names the shipped `font_unavailable` warning code instead of
+  `font_family_unavailable`, and the `docxodus` README's export-browser section no longer
+  claims `original` and `strictFonts` are pending or that the render report is schema v1.
 - **Empty paragraphs lost their line box in paginated export (#443).** A paragraph Word serialized
   as an explicit run holding an empty `w:t` — how it commonly writes a blank line, including
   signature-table spacer rows — counted as having content, so it received no placeholder run and

--- a/docs/architecture/standalone_paginated_export.md
+++ b/docs/architecture/standalone_paginated_export.md
@@ -659,7 +659,7 @@ Font readiness proves availability, not identity. `FontFaceSet.check()` reports 
 downloads have settled rather than whether a family exists — Chromium answers true for a family it
 has never heard of — so each requested family's first entry is measured through advance widths
 against every generic fallback. A family that matches all of them is being silently substituted for
-and is recorded `missing` with an aggregate `font_family_unavailable` warning; one that resolves
+and is recorded `missing` with an aggregate `font_unavailable` warning; one that resolves
 stays `unverified`, since rendering it proves neither which file supplied it nor its version.
 Because an unresolvable family is a font-policy matter governed by `strictFonts` rather than
 unsupported content, it always warns and never fails the render on its own. Image and inline-SVG

--- a/npm-export/README.md
+++ b/npm-export/README.md
@@ -86,11 +86,16 @@ input aliases, and duplicate destinations are rejected; the CLI never overwrites
 
 ## Runtime boundaries
 
-- Explicit font-directory loading is accepted by the public contract but fails with
-  `unsupported_runtime` until issue #442 supplies the verified pre-layout font hook. Browser-observed
-  fonts remain reported honestly; `strictFonts` therefore fails closed.
-- The `original` review profile remains fail-closed until issue #444 completes its projection.
-- The broader generated-PDF fidelity ratchet is extended by issue #443.
+- Repeatable `--font-directory` (API: `fontDirectories`) supplies verified fonts: each file is
+  discovered, licence-checked, hashed, and matched inside the sandboxed page through a resolver
+  binding — font bytes cross the boundary, filesystem paths never do. The render report records
+  every requested family's resolution (`resolved`, `substituted`, `missing`, `load_failed`) with
+  file digests, and `strictFonts` turns unresolved or unverified families into failures. Without
+  font directories the render falls back to browser-observed fonts, reported honestly as
+  unverified. See "Reproducible font configuration" below.
+- All three review profiles (`final`, `original`, `markup`) are supported; `final` and `original`
+  derive their projection out-of-place and never mutate the source bytes.
+- Generated PDFs are covered by the same visual-fidelity ratchet as the HTML renderer.
 - Chromium keeps its process sandbox, so the render host has to permit unprivileged user
   namespaces. Ubuntu 23.10 and later restrict them through AppArmor by default; check with
   `unshare --user --map-root-user true` and permit them with
@@ -100,6 +105,37 @@ input aliases, and duplicate destinations are rejected; the CLI never overwrites
 Failures are `DocxodusExportError` objects with stable code, phase, remediation, safe detail, and a
 structured failed report when materialization had begun. The CLI additionally writes the underlying
 cause chain to stderr, which is where a Chromium launch diagnostic becomes readable.
+
+## Reproducible font configuration
+
+Layout depends on fonts, so a reproducible render pins them. The supported configuration is the
+license-safe metric-substitute set the visual-parity gates run under (the shared contract in
+`docxodus`'s `font-contract` module; rationale in `npm/tests/visual-parity/README.md`):
+
+| Declared family | Substitute | Debian package | Metric-compatible |
+|---|---|---|---|
+| Calibri | Carlito | fonts-crosextra-carlito | yes |
+| Calibri Light | Carlito | fonts-crosextra-carlito | no — documented approximation |
+| Cambria | Caladea | fonts-crosextra-caladea | yes |
+| Times New Roman | Liberation Serif | fonts-liberation2 | yes |
+| Arial | Liberation Sans | fonts-liberation2 | yes |
+| Courier New | Liberation Mono | fonts-liberation2 | yes |
+
+Install the packages and hand the exporter their directories:
+
+```console
+apt-get install fonts-crosextra-carlito fonts-crosextra-caladea fonts-liberation2
+docxodus convert contract.docx --to pdf --output contract.pdf \
+  --font-directory /usr/share/fonts/truetype/crosextra \
+  --font-directory /usr/share/fonts/truetype/liberation
+```
+
+The render report then records each family's resolution with the exact file SHA-256, and the
+renderer fingerprint binds the Chromium identity to the font-resolution digest, so two hosts
+running this configuration produce comparable fingerprints. TTF and OTF files are admitted on
+their embedded licensing flags alone; WOFF and WOFF2 files additionally require an explicit
+embedding attestation (`--font-license-attestations`). A font whose embedded license forbids
+embedding is never used — the export fails rather than silently substituting.
 
 ## Framed host
 

--- a/npm-export/src/cli.ts
+++ b/npm-export/src/cli.ts
@@ -32,7 +32,7 @@ Options:
   --strict-fonts
   --timeout <milliseconds>
   --browser-executable <path>        Or DOCXODUS_CHROMIUM_PATH
-  --font-directory <path>            Repeatable; implemented by issue #442
+  --font-directory <path>            Repeatable; verified font sources
   --font-license-attestations <path>
   --environment-attestation <path>
   --limit <name=integer>              Repeatable; values may only lower defaults

--- a/npm/README.md
+++ b/npm/README.md
@@ -642,7 +642,7 @@ first `<bundle dir>/wasm/`, then `<bundle dir>/` as a fallback. On a CDN that re
 
 `docxodus/export-browser` turns a DOCX into a complete offline HTML document whose body contains
 the finalized fixed page boxes—not the hidden measurement tree. It returns the HTML together with
-the exact PageMap, renderer fingerprint, warnings, and a schema-v1 render report from that same
+the exact PageMap, renderer fingerprint, warnings, and a schema-v2 render report from that same
 sanitized tree.
 
 ```ts
@@ -667,10 +667,12 @@ External HTTPS/mail/tel links remain user-activated links and are inventoried in
 exporter never follows them. `unsupportedContent: 'strict'` rejects visible placeholders or omitted
 resources instead of returning a nominally complete artifact.
 
-The browser surface currently supports `final` and `markup` revision profiles. `original` fails
-explicitly until the shared revision projection in issue #444 lands. Likewise, `strictFonts: true`
-fails until issue #442 supplies attestable font resolution. The normal browser result is labelled
-`browserObserved`; it is not presented as a verified host-font environment.
+All three revision profiles (`final`, `original`, `markup`) are supported; `final` and `original`
+derive their projection out-of-place and never mutate the caller's bytes. `strictFonts: true`
+turns unresolved or unverified font families into failures; supplying a `fontResolver` (in Node,
+`fontDirectories` on `@docxodus/export`) is what makes families verifiable. A font the browser
+supplied on its own is labelled `browserObserved`; it is not presented as a verified host-font
+environment.
 
 By default the worker loads from `dist/wasm/` beside the package entry point. A deployment that
 hosts those files elsewhere may pass `wasmBasePath`. `docxodus/export-assets.json` is the closed,


### PR DESCRIPTION
Closes #442.

## Why

Every acceptance criterion of #442 except one is already implemented and tested on `main` (landed with the verified font runtime PR #529 and its predecessors): repeatable CLI `--font-directory`, full resolution records (`resolved` / `substituted` / `missing` / `load_failed`) with file digests in the schema-v2 render report, `strictFonts` strictness, the two-layer renderer fingerprint binding Chromium identity to the font-resolution digest, browser-injection without bundling a browser into the browser package, all five required test cases, and reuse of the visual-parity font contract as the single source of truth.

The one unmet criterion was documentation — and the docs didn't merely omit the runtime, they asserted the opposite of what shipped:

- `npm-export/README.md` claimed `--font-directory` "fails with `unsupported_runtime` until issue #442" — false; a reader would never try the flag.
- The same block claimed the `original` review profile is fail-closed until #444 and the PDF fidelity ratchet is future #443 work — both shipped.
- `npm/README.md` claimed `strictFonts: true` "fails until issue #442", `original` "fails explicitly until #444 lands", and called the render report "schema-v1" after the v2 migration.
- `npm-export/src/cli.ts` help text marked `--font-directory` as "implemented by issue #442".
- `docs/architecture/standalone_paginated_export.md` named a warning code (`font_family_unavailable`) that does not exist; the shipped code is `font_unavailable`.

## What changed

- Replaced the stale "Runtime boundaries" bullets in `npm-export/README.md` with the delivered contracts, and added a **Reproducible font configuration** section: the license-safe metric-substitute table (Carlito / Caladea / Liberation) with Debian packages and install directories, wired to `--font-directory`, plus the WOFF/WOFF2 attestation and fail-closed licensing rules. This satisfies the "documented reproducible font configuration for the supported CLI distribution" criterion by naming the same set the visual-parity gates run under.
- Corrected the `docxodus` README's export-browser section (profiles, `strictFonts`, schema v2).
- Fixed the CLI help line and the design doc's warning-code name.

Docs and one help-string only — no behavior change. Note the profile-support wording states only what is on `main` today; the disclosure-warnings work from #444 is being recovered separately (its PR #531 merged into an already-merged stacked base and never reached `main`).

## Validation

The only code change is a help-text string literal with no test assertions on it. Install paths in the new section were verified against the actual Debian packages (`dpkg -L`).