### PR TITLE
Recover the stranded review-profile disclosure work and prove the profile contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- **Revision and comment export profiles report what they cannot draw (#444).** Under `markup`,
+  a custom XML revision range now raises `revision_family_not_rendered` and a block-level property
+  revision — paragraph, table, section or numbering — raises
+  `revision_property_change_not_rendered`. Under any visible comment profile, comment threading
+  raises `comment_thread_flattened` and resolved state raises
+  `comment_resolved_state_not_rendered`, because the topology in `commentsExtended` is not read: a
+  reply is drawn as an independent comment and a resolved comment is indistinguishable from an open
+  one. `final` and `original` need none of the revision warnings — they apply the projection and
+  then assert no revision survived it, so an unrenderable family fails the projection instead of
+  passing through unseen. All four route through the `unsupportedContent` policy, so **an existing
+  caller passing `unsupportedContent: "strict"` now gets a closed `resource_policy_failure` where
+  such a document previously exported**; pass `"warn"` to keep the old outcome. Warnings count only
+  what is actually missing: `rPrChange` and tracked cell insert/delete/merge are drawn, so neither
+  is reported, and the package manifest gains `revisions.runPropertyChanges` so the property count
+  can be split without a second inventory pass.
+
 - **Render report schema v1 → v2 (#442).** `fonts[]` entries were a closed five-field record
   with a `browser | embedded | configured` source; they now carry the full resolver-backed
   resolution shape, `status` gains `load_failed`, and `source` becomes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,14 @@ All notable changes to this project will be documented in this file.
   such a document previously exported**; pass `"warn"` to keep the old outcome. Warnings count only
   what is actually missing: `rPrChange` and tracked cell insert/delete/merge are drawn, so neither
   is reported, and the package manifest gains `revisions.runPropertyChanges` so the property count
-  can be split without a second inventory pass.
+  can be split without a second inventory pass. The profile contract is now also pinned where it
+  was previously asserted without evidence: PDF text extraction per profile (deleted content
+  extracts in document order under `markup` and never under `final`; inserted content never under
+  `original`), revision rendering inside headers, footers, footnotes and endnotes, a comment range
+  overlapping an insertion and a deletion, and per-profile comment-body rendering (`endnotes`
+  lists every referenced body; `inline` drops a range-less reply body — the flattening the warning
+  discloses; `hidden` renders none). The design doc no longer promises a threaded reply tree or
+  resolved-state rendering the converter does not perform.
 
 - **Render report schema v1 → v2 (#442).** `fonts[]` entries were a closed five-field record
   with a `browser | embedded | configured` source; they now carry the full resolver-backed

--- a/Docxodus.Tests/HtmlConverterTests.cs
+++ b/Docxodus.Tests/HtmlConverterTests.cs
@@ -4500,6 +4500,271 @@ namespace OxPt
         }
 
         #endregion
+
+        #region Running Story Revision and Comment Overlap Tests
+
+        private static readonly XNamespace XhtmlNs = "http://www.w3.org/1999/xhtml";
+
+        /// <summary>A story paragraph carrying one native insertion and one native deletion.</summary>
+        private static Paragraph RevisedStoryParagraph(string baseText, string insText, string delText, int revisionIdSeed)
+        {
+            return new Paragraph(
+                new Run(new Text(baseText)),
+                new InsertedRun(new Run(new Text(insText)))
+                {
+                    Author = "Reviewer",
+                    Date = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                    Id = revisionIdSeed.ToString(),
+                },
+                new DeletedRun(new Run(new DeletedText(delText)))
+                {
+                    Author = "Reviewer",
+                    Date = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                    Id = (revisionIdSeed + 1).ToString(),
+                });
+        }
+
+        /// <summary>
+        /// A document with native tracked changes (w:ins and w:del) in four running stories:
+        /// the default header, the default footer, a footnote body, and an endnote body.
+        /// The body cites both notes so the note stories are reachable from the main part.
+        /// </summary>
+        private static byte[] BuildDocWithRevisionsInRunningStories()
+        {
+            using (MemoryStream ms = new MemoryStream())
+            {
+                using (WordprocessingDocument wDoc = WordprocessingDocument.Create(
+                    ms, DocumentFormat.OpenXml.WordprocessingDocumentType.Document))
+                {
+                    var main = wDoc.AddMainDocumentPart();
+                    main.Document = new Document();
+                    var body = new Body();
+                    main.Document.Body = body;
+
+                    body.Append(new Paragraph(
+                        new Run(new Text("Body text citing the notes.")),
+                        new Run(new FootnoteReference() { Id = 1 }),
+                        new Run(new EndnoteReference() { Id = 1 })));
+
+                    var headerPart = main.AddNewPart<HeaderPart>();
+                    headerPart.Header = new Header(
+                        RevisedStoryParagraph("Header base", "HEADER-INS", "HEADER-DEL", 101));
+
+                    var footerPart = main.AddNewPart<FooterPart>();
+                    footerPart.Footer = new Footer(
+                        RevisedStoryParagraph("Footer base", "FOOTER-INS", "FOOTER-DEL", 103));
+
+                    var footnotesPart = main.AddNewPart<FootnotesPart>();
+                    footnotesPart.Footnotes = new Footnotes(
+                        new Footnote(new Paragraph(new Run(new SeparatorMark())))
+                        { Type = FootnoteEndnoteValues.Separator, Id = -1 },
+                        new Footnote(new Paragraph(new Run(new ContinuationSeparatorMark())))
+                        { Type = FootnoteEndnoteValues.ContinuationSeparator, Id = 0 },
+                        new Footnote(
+                            RevisedStoryParagraph("Footnote base", "FOOTNOTE-INS", "FOOTNOTE-DEL", 105))
+                        { Id = 1 });
+
+                    var endnotesPart = main.AddNewPart<EndnotesPart>();
+                    endnotesPart.Endnotes = new Endnotes(
+                        new Endnote(new Paragraph(new Run(new SeparatorMark())))
+                        { Type = FootnoteEndnoteValues.Separator, Id = -1 },
+                        new Endnote(new Paragraph(new Run(new ContinuationSeparatorMark())))
+                        { Type = FootnoteEndnoteValues.ContinuationSeparator, Id = 0 },
+                        new Endnote(
+                            RevisedStoryParagraph("Endnote base", "ENDNOTE-INS", "ENDNOTE-DEL", 107))
+                        { Id = 1 });
+
+                    body.Append(new SectionProperties(
+                        new HeaderReference() { Type = HeaderFooterValues.Default, Id = main.GetIdOfPart(headerPart) },
+                        new FooterReference() { Type = HeaderFooterValues.Default, Id = main.GetIdOfPart(footerPart) },
+                        new PageSize() { Width = 12240u, Height = 15840u },
+                        new PageMargin()
+                        {
+                            Top = 1440, Bottom = 1440, Left = 1440, Right = 1440,
+                            Header = 720, Footer = 720, Gutter = 0,
+                        }));
+
+                    main.Document.Save();
+                }
+                return ms.ToArray();
+            }
+        }
+
+        /// <summary>Asserts one story's HTML contains its insertion inside a rev-ins &lt;ins&gt;
+        /// and its deletion inside a rev-del &lt;del&gt;.</summary>
+        private static void AssertStoryRendersRevisionMarkup(XElement story, string insText, string delText)
+        {
+            // The revision class leads the attribute; a fabricated style class may follow it.
+            var ins = story.Descendants(XhtmlNs + "ins")
+                .Single(e => (((string)e.Attribute("class")) ?? "").StartsWith("rev-ins"));
+            Assert.Contains(insText, ins.Value);
+
+            var del = story.Descendants(XhtmlNs + "del")
+                .Single(e => (((string)e.Attribute("class")) ?? "").StartsWith("rev-del"));
+            Assert.Contains(delText, del.Value);
+        }
+
+        [Fact]
+        public void HC063_TrackedChanges_RenderInRunningStories()
+        {
+            // Issue #444: revisions in running stories (header, footer, footnote, endnote)
+            // must render under <ins>/<del> markup, not just body revisions.
+            byte[] docBytes = BuildDocWithRevisionsInRunningStories();
+            using (MemoryStream ms = new MemoryStream())
+            {
+                ms.Write(docBytes, 0, docBytes.Length);
+                using (WordprocessingDocument wDoc = WordprocessingDocument.Open(ms, true))
+                {
+                    WmlToHtmlConverterSettings settings = new WmlToHtmlConverterSettings()
+                    {
+                        PageTitle = "Running Story Revisions Test",
+                        FabricateCssClasses = true,
+                        CssClassPrefix = "pt-",
+                        RenderTrackedChanges = true,
+                        IncludeRevisionMetadata = true,
+                        ShowDeletedContent = true,
+                        // Non-paginated mode renders all four stories: the default header and
+                        // footer as <header>/<footer> wrappers, the notes as <section> lists.
+                        RenderHeadersAndFooters = true,
+                        RenderFootnotesAndEndnotes = true,
+                    };
+
+                    XElement html = WmlToHtmlConverter.ConvertToHtml(wDoc, settings);
+                    string htmlString = html.ToString();
+
+                    var header = html.Descendants(XhtmlNs + "header")
+                        .Single(e => (((string)e.Attribute("class")) ?? "").Contains("document-header"));
+                    AssertStoryRendersRevisionMarkup(header, "HEADER-INS", "HEADER-DEL");
+
+                    var footer = html.Descendants(XhtmlNs + "footer")
+                        .Single(e => (((string)e.Attribute("class")) ?? "").Contains("document-footer"));
+                    AssertStoryRendersRevisionMarkup(footer, "FOOTER-INS", "FOOTER-DEL");
+
+                    var footnotes = html.Descendants(XhtmlNs + "section")
+                        .Single(e => (((string)e.Attribute("class")) ?? "").Contains("footnotes"));
+                    AssertStoryRendersRevisionMarkup(footnotes, "FOOTNOTE-INS", "FOOTNOTE-DEL");
+
+                    var endnotes = html.Descendants(XhtmlNs + "section")
+                        .Single(e => (((string)e.Attribute("class")) ?? "").Contains("endnotes"));
+                    AssertStoryRendersRevisionMarkup(endnotes, "ENDNOTE-INS", "ENDNOTE-DEL");
+
+                    // Revision metadata reaches stories rendered from other parts.
+                    Assert.Contains("data-author=\"Reviewer\"", htmlString);
+
+                    // Save for debugging
+                    var destFileName = new FileInfo(Path.Combine(TestUtil.TempDir.FullName, "TrackedChanges-RunningStories.html"));
+                    File.WriteAllText(destFileName.FullName, htmlString, Encoding.UTF8);
+                }
+            }
+        }
+
+        /// <summary>A document where one comment range spans both a w:ins run and a w:del run.</summary>
+        private static byte[] BuildDocWithCommentSpanningRevisions()
+        {
+            using (MemoryStream ms = new MemoryStream())
+            {
+                using (WordprocessingDocument wDoc = WordprocessingDocument.Create(
+                    ms, DocumentFormat.OpenXml.WordprocessingDocumentType.Document))
+                {
+                    var main = wDoc.AddMainDocumentPart();
+                    main.Document = new Document();
+                    var body = new Body();
+                    main.Document.Body = body;
+
+                    body.Append(new Paragraph(
+                        new Run(new Text("Before the overlap.")),
+                        new CommentRangeStart() { Id = "1" },
+                        new InsertedRun(new Run(new Text("OVERLAP-INS")))
+                        {
+                            Author = "Reviewer",
+                            Date = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                            Id = "201",
+                        },
+                        new DeletedRun(new Run(new DeletedText("OVERLAP-DEL")))
+                        {
+                            Author = "Reviewer",
+                            Date = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                            Id = "202",
+                        },
+                        new CommentRangeEnd() { Id = "1" },
+                        new Run(new CommentReference() { Id = "1" }),
+                        new Run(new Text("After the overlap."))));
+
+                    var commentsPart = main.AddNewPart<WordprocessingCommentsPart>();
+                    commentsPart.Comments = new Comments(
+                        new Comment(
+                            new Paragraph(new Run(new Text("Comment spanning revised text."))))
+                        { Id = "1", Author = "Commenter" });
+
+                    main.Document.Save();
+                }
+                return ms.ToArray();
+            }
+        }
+
+        [Fact]
+        public void HC064_Comments_OverlappingTrackedChanges()
+        {
+            // Issue #444: a comment range overlapping insertions and deletions must render
+            // BOTH the revision markup and the comment markup — neither suppresses the other.
+            byte[] docBytes = BuildDocWithCommentSpanningRevisions();
+            using (MemoryStream ms = new MemoryStream())
+            {
+                ms.Write(docBytes, 0, docBytes.Length);
+                using (WordprocessingDocument wDoc = WordprocessingDocument.Open(ms, true))
+                {
+                    WmlToHtmlConverterSettings settings = new WmlToHtmlConverterSettings()
+                    {
+                        PageTitle = "Overlapping Comment and Revision Test",
+                        FabricateCssClasses = true,
+                        CssClassPrefix = "pt-",
+                        RenderTrackedChanges = true,
+                        IncludeRevisionMetadata = true,
+                        ShowDeletedContent = true,
+                        RenderComments = true,
+                        // EndnoteStyle renders the comments section in non-paginated mode.
+                        CommentRenderMode = CommentRenderMode.EndnoteStyle,
+                        IncludeCommentMetadata = true,
+                    };
+
+                    XElement html = WmlToHtmlConverter.ConvertToHtml(wDoc, settings);
+                    string htmlString = html.ToString();
+
+                    // (a) Both revisions render with their revision classes and content.
+                    var ins = html.Descendants(XhtmlNs + "ins")
+                        .Single(e => (((string)e.Attribute("class")) ?? "").StartsWith("rev-ins"));
+                    Assert.Contains("OVERLAP-INS", ins.Value);
+
+                    var del = html.Descendants(XhtmlNs + "del")
+                        .Single(e => (((string)e.Attribute("class")) ?? "").StartsWith("rev-del"));
+                    Assert.Contains("OVERLAP-DEL", del.Value);
+
+                    // (b) The comment highlight spans BOTH revisions: each revision element
+                    // carries a highlight span wired to the comment id.
+                    Assert.Contains(ins.Descendants(XhtmlNs + "span"), s =>
+                        (((string)s.Attribute("class")) ?? "").Contains("comment-highlight")
+                        && (string)s.Attribute("data-comment-id") == "1");
+                    Assert.Contains(del.Descendants(XhtmlNs + "span"), s =>
+                        (((string)s.Attribute("class")) ?? "").Contains("comment-highlight")
+                        && (string)s.Attribute("data-comment-id") == "1");
+
+                    // The comment reference marker is present.
+                    Assert.Contains("comment-marker", htmlString);
+                    Assert.Contains("href=\"#comment-1\"", htmlString);
+
+                    // (c) The comment body renders in the comments section.
+                    Assert.Contains("comments-section", htmlString);
+                    Assert.Contains("id=\"comment-1\"", htmlString);
+                    Assert.Contains("Comment spanning revised text.", htmlString);
+
+                    // Save for debugging
+                    var destFileName = new FileInfo(Path.Combine(TestUtil.TempDir.FullName, "Comments-OverlappingRevisions.html"));
+                    File.WriteAllText(destFileName.FullName, htmlString, Encoding.UTF8);
+                }
+            }
+        }
+
+        #endregion
     }
 }
 

--- a/Docxodus.Tests/PackageManifestTests.cs
+++ b/Docxodus.Tests/PackageManifestTests.cs
@@ -443,6 +443,33 @@ public class PackageManifestTests
     }
 
     [Fact]
+    public void PM019a_RunPropertyChanges_CountTheRenderableSubsetOfPropertyChanges()
+    {
+        var package = BuildRichPackage(documentText: """
+            <w:rPrChange/><w:rPrChange/>
+            <w:pPrChange/><w:sectPrChange/><w:numberingChange/>
+            <w:tblGridChange/><w:tblPrChange/><w:tblPrExChange/>
+            <w:tcPrChange/><w:trPrChange/>
+            """);
+
+        var manifest = PackageManifestGenerator.Generate(package);
+        var revisions = manifest.Facts.Revisions;
+
+        // rPrChange is the one property revision a renderer can draw inline, so it is counted
+        // apart from the rest; the subset never leaves the parent bucket or enters the total.
+        // The rich package contributes one pPrChange of its own, hence eleven.
+        Assert.Equal(11, revisions.PropertyChanges);
+        Assert.Equal(2, revisions.RunPropertyChanges);
+        Assert.Equal(revisions.Insertions + revisions.Deletions + revisions.MoveFrom
+            + revisions.MoveTo + revisions.PropertyChanges + revisions.StructuralChanges
+            + revisions.OtherChanges, revisions.Total);
+        using var json = JsonDocument.Parse(manifest.ToJson());
+        var revisionJson = json.RootElement.GetProperty("facts").GetProperty("revisions");
+        Assert.Equal(11, revisionJson.GetProperty("propertyChanges").GetInt32());
+        Assert.Equal(2, revisionJson.GetProperty("runPropertyChanges").GetInt32());
+    }
+
+    [Fact]
     public void PM020_DanglingReferencesAndFacts_RequireExactNamespacesAndPartTypes()
     {
         var baseline = PackageManifestGenerator.Generate(BuildRichPackage());

--- a/Docxodus/Verification/PackageManifest.cs
+++ b/Docxodus/Verification/PackageManifest.cs
@@ -204,7 +204,19 @@ public sealed record PackageRevisionCounts
     public int Deletions { get; init; }
     public int MoveFrom { get; init; }
     public int MoveTo { get; init; }
+    /// <summary>
+    /// Every property revision: <c>numberingChange</c>, <c>pPrChange</c>, <c>rPrChange</c>,
+    /// <c>sectPrChange</c>, <c>tblGridChange</c>, <c>tblPrChange</c>, <c>tblPrExChange</c>,
+    /// <c>tcPrChange</c> and <c>trPrChange</c>.
+    /// </summary>
     public int PropertyChanges { get; init; }
+
+    /// <summary>
+    /// The <c>rPrChange</c> subset of <see cref="PropertyChanges"/>, counted separately because
+    /// run-level format changes are the only property revision a renderer can draw inline.
+    /// Never exceeds <see cref="PropertyChanges"/> and is not added into <see cref="Total"/>.
+    /// </summary>
+    public int RunPropertyChanges { get; init; }
 
     /// <summary>Cell insert/delete/merge revision markers.</summary>
     public int StructuralChanges { get; init; }
@@ -457,6 +469,7 @@ public sealed record PackageManifest
         writer.WriteNumber("moveFrom", facts.Revisions.MoveFrom);
         writer.WriteNumber("moveTo", facts.Revisions.MoveTo);
         writer.WriteNumber("propertyChanges", facts.Revisions.PropertyChanges);
+        writer.WriteNumber("runPropertyChanges", facts.Revisions.RunPropertyChanges);
         writer.WriteNumber("structuralChanges", facts.Revisions.StructuralChanges);
         writer.WriteNumber("otherChanges", facts.Revisions.OtherChanges);
         writer.WriteNumber("total", facts.Revisions.Total);

--- a/Docxodus/Verification/PackageManifestGenerator.cs
+++ b/Docxodus/Verification/PackageManifestGenerator.cs
@@ -902,6 +902,7 @@ public static class PackageManifestGenerator
         var moveFrom = 0;
         var moveTo = 0;
         var propertyChanges = 0;
+        var runPropertyChanges = 0;
         var structuralChanges = 0;
         var otherChanges = 0;
         var comments = 0;
@@ -950,6 +951,8 @@ public static class PackageManifestGenerator
             moveTo += storyElements.Count(element => element.Name.LocalName == "moveTo");
             propertyChanges += storyElements.Count(element =>
                 IsPropertyRevisionName(element.Name.LocalName));
+            runPropertyChanges += storyElements.Count(element =>
+                element.Name.LocalName == "rPrChange");
             structuralChanges += storyElements.Count(element =>
                 element.Name.LocalName is "cellIns" or "cellDel" or "cellMerge");
             otherChanges += storyElements.Count(element =>
@@ -995,6 +998,7 @@ public static class PackageManifestGenerator
             MoveFrom = moveFrom,
             MoveTo = moveTo,
             PropertyChanges = propertyChanges,
+            RunPropertyChanges = runPropertyChanges,
             StructuralChanges = structuralChanges,
             OtherChanges = otherChanges,
             Total = insertions + deletions + moveFrom + moveTo + propertyChanges

--- a/docs/architecture/standalone_paginated_export.md
+++ b/docs/architecture/standalone_paginated_export.md
@@ -576,11 +576,12 @@ source. When #465 supplies an already policy-derived exact profile source, the r
 bytes directly and never applies the policy a second time.
 
 Comments are orthogonal: `hidden`, `inline`, `endnotes`, or `margin`. A visible profile retains
-range, body, the ordered reply tree, author, date, and resolved state in body, headers, footers,
-footnotes, and endnotes. Missing extended-comment metadata is represented as unknown rather than
-invented. An unsupported story or revision/comment family produces a structured warning naming the
-family and owning part; strict unsupported-content policy fails. HTML, PDF, CLI, and #465 use these
-exact strings.
+range, body, author, and date in body, headers, footers, footnotes, and endnotes. Comment topology
+is not drawn: a reply renders as an independent comment and resolved state is not represented,
+disclosed as `comment_thread_flattened` and `comment_resolved_state_not_rendered` (see "Revision
+and comment families that are not drawn" below). An unsupported story or revision/comment family
+produces a structured warning naming the family; strict unsupported-content policy fails. HTML,
+PDF, CLI, and #465 use these exact strings.
 
 ## Readiness and diagnostics
 

--- a/docs/architecture/standalone_paginated_export.md
+++ b/docs/architecture/standalone_paginated_export.md
@@ -722,6 +722,42 @@ for a family it has never heard of. `strictFonts` rejects any outcome that is no
 digest-identified, license-evidenced face with complete glyph coverage, which is why a
 browser-observed environment can never satisfy it.
 
+### Revision and comment families that are not drawn
+
+`markup` draws insertions, deletions, moves, run-level format changes, and tracked cell
+insert/delete/merge — the last as tinted, struck-through or dashed cells. Two families it does not
+draw travel through the projection untouched and leave no mark a reader can see, so each is
+reported rather than approximated: a custom XML revision range raises
+`revision_family_not_rendered`, and the block-level property revisions — paragraph, table, section
+and numbering — raise `revision_property_change_not_rendered`.
+
+That second warning counts only what is missing. `rPrChange` is a property revision the converter
+does draw, so the manifest counts it separately as `runPropertyChanges` and the warning reports
+`propertyChanges - runPropertyChanges`. Splitting the count in the inventory rather than
+approximating it in the export is what keeps `unsupportedContent: "strict"` honest: a document
+whose only property revisions are run-level format changes is drawn in full and must not fail
+closed. The split costs no extra work — it is one more counter in the pass the manifest already
+makes, not a second inventory pass over the package.
+
+`final` and `original` need no such warnings. They apply the projection and then assert the derived
+package retains no revisions at all, so a family that cannot be applied fails the projection instead
+of passing through unseen. This is also what keeps the source package intact: the projection derives
+a new package and the original bytes are never accepted, rejected, or rewritten in place.
+
+Any visible comment profile renders comment bodies, ranges and authors, but not the topology
+recorded in `commentsExtended`: a reply is drawn as an independent comment
+(`comment_thread_flattened`) and a resolved comment is drawn identically to an open one
+(`comment_resolved_state_not_rendered`). Both silently change what a review PDF means, which is why
+they are reported instead of approximated. Comments survive the `final`/`original` projection
+unchanged, so these two are raised against the source package only; the derived preflight would
+otherwise report each of them twice.
+
+All four warnings route through the `unsupportedContent` policy, so `strict` turns the first one
+raised into a closed `resource_policy_failure` in `package_preflight` rather than a warning a
+caller has to notice. As everywhere else in preflight, a strict export reports the first policy
+breach and stops; `warn` is what enumerates every one of them in a single pass.
+
+
 ## Error taxonomy and limits
 
 Public failures are `DocxodusExportError` values with one of these codes:

--- a/npm-export/package-lock.json
+++ b/npm-export/package-lock.json
@@ -46,6 +46,8 @@
         "@types/node": "^20.10.0",
         "@types/react": "^19.2.7",
         "esbuild": "^0.28.1",
+        "pdf-lib": "1.17.1",
+        "pdfjs-dist": "6.2.108",
         "typescript": "^5.3.0"
       },
       "peerDependencies": {

--- a/npm-export/tests/export.test.mjs
+++ b/npm-export/tests/export.test.mjs
@@ -26,6 +26,7 @@ import { canonicalJson } from "../dist/canonical.js";
 import {
   generateLongFootnoteDocx,
   generateMixedSectionDocx,
+  generateTrackedRevisionDocx,
 } from "./mixed-section-fixture.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -728,6 +729,39 @@ describe("@docxodus/export", { concurrency: false }, () => {
     await writeFile(join(successArtifacts, "long-footnote.html"), result.html);
     await writeJson(join(successArtifacts, "long-footnote-page-map.json"), result.pageMap);
     await writeJson(join(successArtifacts, "long-footnote-pdf-inspection.json"), inspection);
+  });
+
+  test("PDF text extraction is predictable for each review profile", { timeout: 180_000 }, async () => {
+    // The markup profile is the only one that draws inserted and deleted content
+    // side by side, so extraction order is part of its contract: tokens come out
+    // in document order, deleted content included. The derived profiles must
+    // instead prove the losing side of each revision never reaches the PDF text.
+    const source = generateTrackedRevisionDocx();
+    const expectations = [
+      { reviewProfile: "markup", present: ["Before", "removed", "added", "after."], absent: [] },
+      { reviewProfile: "final", present: ["Before", "added", "after."], absent: ["removed"] },
+      { reviewProfile: "original", present: ["Before", "removed", "after."], absent: ["added"] },
+    ];
+    for (const { reviewProfile, present, absent } of expectations) {
+      const result = await convertDocxToPdf(source, {
+        reviewProfile,
+        commentProfile: "hidden",
+        timeoutMs: 120_000,
+        browser,
+      });
+      const text = (await inspectPdf(result.pdf)).searchableText;
+      let priorOffset = -1;
+      for (const token of present) {
+        const pattern = new RegExp(`\\b${token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`, "g");
+        const matches = [...text.matchAll(pattern)];
+        assert.equal(matches.length, 1, `${token} must appear exactly once under ${reviewProfile}`);
+        assert.ok(matches[0].index > priorOffset, `${token} out of order under ${reviewProfile}`);
+        priorOffset = matches[0].index;
+      }
+      for (const token of absent) {
+        assert.doesNotMatch(text, new RegExp(`\\b${token}\\b`), `${token} must not extract under ${reviewProfile}`);
+      }
+    }
   });
 
   test("retains a structured report when post-layout PDF verification fails", { timeout: 180_000 }, async () => {

--- a/npm-export/tests/mixed-section-fixture.mjs
+++ b/npm-export/tests/mixed-section-fixture.mjs
@@ -282,3 +282,55 @@ export function generateLongFootnoteDocx(wordCount = 600) {
     },
   ]);
 }
+
+/** One paragraph carrying a native deletion and insertion, for review-profile assertions. */
+export function generateTrackedRevisionDocx() {
+  return storedZip([
+    {
+      name: "[Content_Types].xml",
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
+</Types>`),
+    },
+    {
+      name: "_rels/.rels",
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${R_NS}/officeDocument" Target="word/document.xml"/>
+</Relationships>`),
+    },
+    {
+      name: "word/_rels/document.xml.rels",
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${R_NS}/styles" Target="styles.xml"/>
+</Relationships>`),
+    },
+    {
+      name: "word/styles.xml",
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles xmlns:w="${W_NS}">
+  <w:docDefaults><w:rPrDefault><w:rPr>
+    <w:rFonts w:ascii="Liberation Serif" w:hAnsi="Liberation Serif"/>
+    <w:sz w:val="24"/><w:szCs w:val="24"/>
+  </w:rPr></w:rPrDefault></w:docDefaults>
+  <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+</w:styles>`),
+    },
+    {
+      name: "word/document.xml",
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="${W_NS}"><w:body>
+  <w:p><w:r><w:t xml:space="preserve">Before </w:t></w:r>
+    <w:del w:id="1" w:author="Reviewer" w:date="2026-08-16T00:00:00Z"><w:r><w:delText>removed</w:delText></w:r></w:del>
+    <w:ins w:id="2" w:author="Reviewer" w:date="2026-08-16T00:00:00Z"><w:r><w:t>added</w:t></w:r></w:ins>
+    <w:r><w:t xml:space="preserve"> after.</w:t></w:r></w:p>
+  <w:sectPr><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr>
+</w:body></w:document>`),
+    },
+  ]);
+}

--- a/npm/src/export-browser.ts
+++ b/npm/src/export-browser.ts
@@ -1407,8 +1407,8 @@ function validatePackageManifestJson(source: string): PackageManifest {
     "mediaPartCount", "customXmlPartCount", "drawingCount", "altChunkCount", "fieldCount",
   ]) integerAt(facts[name], `$.facts.${name}`);
   const revisions = recordAt(facts.revisions, "$.facts.revisions", [
-    "insertions", "deletions", "moveFrom", "moveTo", "propertyChanges", "structuralChanges",
-    "otherChanges", "total",
+    "insertions", "deletions", "moveFrom", "moveTo", "propertyChanges", "runPropertyChanges",
+    "structuralChanges", "otherChanges", "total",
   ]);
   for (const name of Object.keys(revisions)) integerAt(revisions[name], `$.facts.revisions.${name}`);
   const annotations = recordAt(facts.annotations, "$.facts.annotations", [
@@ -1482,7 +1482,7 @@ async function preflightManifest(
   bytes: Uint8Array,
   options: NormalizedOptions,
   state: ExecutionState,
-  compareExpectedDigest: boolean,
+  isSourcePackage: boolean,
 ): Promise<void> {
   const sourceDigest = manifest.rawPackageBytesDigest.value;
   const recomputedDigest = await sha256(bytes);
@@ -1493,7 +1493,7 @@ async function preflightManifest(
         detail: `manifest=${sourceDigest}; recomputed=${recomputedDigest}`,
       });
   }
-  if (compareExpectedDigest && options.expectedSourceDigest
+  if (isSourcePackage && options.expectedSourceDigest
     && !constantTimeDigestEqual(options.expectedSourceDigest, sourceDigest)) {
     fail("source_digest_mismatch", "package_preflight", "The source digest does not match expectedSourceDigest.",
       "Render the exact verified source bytes or update the expected digest.", {
@@ -1623,6 +1623,102 @@ async function preflightManifest(
     if (options.unsupportedContent === "strict") {
       fail("resource_policy_failure", "package_preflight", warning.message, warning.remediation);
     }
+  }
+  if (isSourcePackage) {
+    warnUnrenderedRevisionFamilies(manifest, state, options);
+    warnUnrenderedCommentTopology(manifest, state, options);
+  }
+}
+
+/**
+ * Warns for tracked-revision families the markup profile cannot draw.
+ *
+ * The converter draws insertions, deletions, moves, run-level format changes, and tracked cell
+ * insert/delete/merge (as tinted, struck-through or dashed cells). What it never draws is a custom
+ * XML revision range, and the block-level property revisions — paragraph, table, section and
+ * numbering — which travel through the projection untouched but leave no mark a reader can see.
+ *
+ * Only `markup` needs these. `final` and `original` apply the projection and then assert the
+ * derived package has no revisions left at all, so an unrenderable family cannot survive them
+ * silently — it fails the projection instead.
+ */
+function warnUnrenderedRevisionFamilies(
+  manifest: PackageManifest,
+  state: ExecutionState,
+  options: NormalizedOptions,
+): void {
+  if (options.reviewProfile !== "markup") return;
+  const revisions = manifest.facts.revisions;
+  const customXmlRanges = revisions.otherChanges;
+  if (customXmlRanges > 0) {
+    policyWarning(state, options, {
+      code: "revision_family_not_rendered",
+      phase: "package_preflight",
+      message: customXmlRanges === 1
+        ? "1 custom XML revision range is present but is not drawn as markup."
+        : `${customXmlRanges} custom XML revision ranges are present but are not drawn as markup.`,
+      remediation: "Use the final or original profile, or resolve the custom XML revisions before export.",
+      detail: "customXmlInsRangeStart, customXmlDelRangeStart, customXmlMoveFromRangeStart, customXmlMoveToRangeStart",
+    });
+  }
+  // rPrChange is the one property revision the converter draws (as a marked format change), so
+  // only the remainder is unrepresented. The manifest counts that subset for exactly this reason;
+  // reporting the combined figure would fail a strict export whose content is fully drawn.
+  const blockPropertyChanges = revisions.propertyChanges - revisions.runPropertyChanges;
+  if (blockPropertyChanges > 0) {
+    policyWarning(state, options, {
+      code: "revision_property_change_not_rendered",
+      phase: "package_preflight",
+      message: blockPropertyChanges === 1
+        ? "1 paragraph, table, section, or numbering property revision is present but is not drawn as markup."
+        : `${blockPropertyChanges} paragraph, table, section, and numbering property revisions are `
+          + "present but are not drawn as markup.",
+      remediation: "Use the final or original profile when block-level property revisions must be reflected in the output.",
+      detail: "numberingChange, pPrChange, sectPrChange, tblGridChange, tblPrChange, "
+        + "tblPrExChange, tcPrChange, trPrChange",
+    });
+  }
+}
+
+/**
+ * Warns when a visible comment profile cannot represent the source's comment topology.
+ *
+ * Comment bodies, ranges and authors render, but the threading recorded in commentsExtended does
+ * not: a reply is drawn as an independent comment, and a resolved comment is indistinguishable
+ * from an open one. That silently changes what a review PDF means, so it is reported rather than
+ * approximated.
+ *
+ * Comments survive the `final`/`original` projection unchanged, so this must run against the
+ * source package only — the derived preflight would otherwise report every one of them twice.
+ */
+function warnUnrenderedCommentTopology(
+  manifest: PackageManifest,
+  state: ExecutionState,
+  options: NormalizedOptions,
+): void {
+  if (options.commentProfile === "hidden") return;
+  const annotations = manifest.facts.annotations;
+  if (annotations.commentReplies > 0) {
+    policyWarning(state, options, {
+      code: "comment_thread_flattened",
+      phase: "package_preflight",
+      message: annotations.commentReplies === 1
+        ? "1 comment reply is drawn as an independent comment rather than as a threaded reply."
+        : `${annotations.commentReplies} comment replies are drawn as independent comments rather `
+          + "than as threaded replies.",
+      remediation: "Read the exported comments in document order, which preserves reply sequence, "
+        + "or flatten the threads in Word before export.",
+    });
+  }
+  if (annotations.resolvedComments > 0) {
+    policyWarning(state, options, {
+      code: "comment_resolved_state_not_rendered",
+      phase: "package_preflight",
+      message: annotations.resolvedComments === 1
+        ? "1 resolved comment is drawn identically to an open comment."
+        : `${annotations.resolvedComments} resolved comments are drawn identically to open comments.`,
+      remediation: "Delete the resolved comments before export so the output carries only open ones.",
+    });
   }
 }
 

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -932,6 +932,8 @@ export interface PackageRevisionCounts {
   moveFrom: number;
   moveTo: number;
   propertyChanges: number;
+  /** The `rPrChange` subset of `propertyChanges`; not added into `total`. */
+  runPropertyChanges: number;
   structuralChanges: number;
   otherChanges: number;
   total: number;

--- a/npm/tests/docx-review-topology-fixture.ts
+++ b/npm/tests/docx-review-topology-fixture.ts
@@ -1,0 +1,230 @@
+import { R_NS, storedZip, W_NS, xml } from './docx-zip.js';
+
+/**
+ * Fixtures for the revision and comment families the export profiles cannot draw.
+ *
+ * These are built from readable XML rather than committed binaries because the whole point of
+ * each is one specific element the manifest counts — a `w:pPrChange` against a `w:rPrChange`, a
+ * `w:customXmlInsRangeStart`, a `w15:commentEx` with a `paraIdParent` — and a binary fixture
+ * would hide exactly that.
+ */
+
+const W15_NS = 'http://schemas.microsoft.com/office/word/2012/wordml';
+const W14_NS = 'http://schemas.microsoft.com/office/word/2010/wordml';
+const CT_NS = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const PKG_REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const AUTHORED = 'w:author="Reviewer" w:date="2026-08-16T00:00:00Z"';
+
+const STYLES_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles xmlns:w="${W_NS}">
+  <w:docDefaults><w:rPrDefault><w:rPr>
+    <w:rFonts w:ascii="Liberation Serif" w:hAnsi="Liberation Serif"/>
+    <w:sz w:val="24"/><w:szCs w:val="24"/>
+  </w:rPr></w:rPrDefault></w:docDefaults>
+  <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style>
+</w:styles>`;
+
+const SECT_PR = '<w:sectPr><w:pgSz w:w="12240" w:h="15840"/>'
+  + '<w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr>';
+
+interface PackageParts {
+  /** Body markup, excluding the trailing `w:sectPr`. */
+  body: string;
+  /** Root element attributes for `w:document` beyond the `w` namespace. */
+  documentAttributes?: string;
+  /** Extra `[Content_Types].xml` overrides. */
+  overrides?: string;
+  /** Extra `word/_rels/document.xml.rels` relationships. */
+  relationships?: string;
+  /** Extra parts keyed by ZIP entry name. */
+  parts?: Record<string, string>;
+}
+
+/** The smallest package the export accepts, so each fixture contributes only its own subject. */
+function minimalPackage({
+  body,
+  documentAttributes = '',
+  overrides = '',
+  relationships = '',
+  parts = {},
+}: PackageParts): Uint8Array {
+  return storedZip([
+    {
+      name: '[Content_Types].xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="${CT_NS}">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
+  ${overrides}
+</Types>`),
+    },
+    {
+      name: '_rels/.rels',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="${PKG_REL_NS}">
+  <Relationship Id="rId1" Type="${R_NS}/officeDocument" Target="word/document.xml"/>
+</Relationships>`),
+    },
+    {
+      name: 'word/_rels/document.xml.rels',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="${PKG_REL_NS}">
+  <Relationship Id="rId1" Type="${R_NS}/styles" Target="styles.xml"/>
+  ${relationships}
+</Relationships>`),
+    },
+    { name: 'word/styles.xml', data: xml(STYLES_XML) },
+    {
+      name: 'word/document.xml',
+      data: xml(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="${W_NS}"${documentAttributes}><w:body>
+  ${body}
+  ${SECT_PR}
+</w:body></w:document>`),
+    },
+    ...Object.entries(parts).map(([name, data]) => ({ name, data: xml(data) })),
+  ]);
+}
+
+/**
+ * A document carrying both sides of the property-revision split plus the one family that is
+ * genuinely never drawn.
+ *
+ * Two `w:pPrChange` and one `w:customXmlInsRangeStart` are unrepresentable; the `w:rPrChange`
+ * and the `w:ins` beside them are drawn, and exist so the warnings can be shown to count only
+ * what is actually missing. Manifest counts: `propertyChanges` 3, `runPropertyChanges` 1,
+ * `otherChanges` 1, `insertions` 1.
+ */
+export function generateUnrenderableRevisionDocx(): Uint8Array {
+  return minimalPackage({
+    body: `<w:p>
+    <w:pPr>
+      <w:jc w:val="center"/>
+      <!-- Word records the previous paragraph properties; markup cannot draw this. -->
+      <w:pPrChange w:id="10" ${AUTHORED}>
+        <w:pPr><w:jc w:val="left"/></w:pPr>
+      </w:pPrChange>
+    </w:pPr>
+    <w:r>
+      <w:rPr>
+        <w:b/>
+        <!-- A run-level format change; markup DOES draw this one. -->
+        <w:rPrChange w:id="11" ${AUTHORED}><w:rPr/></w:rPrChange>
+      </w:rPr>
+      <w:t xml:space="preserve">Bolded by a reviewer. </w:t>
+    </w:r>
+    <w:ins w:id="12" ${AUTHORED}>
+      <w:r><w:t>This insertion is drawn.</w:t></w:r>
+    </w:ins>
+  </w:p>
+  <w:p>
+    <w:pPr>
+      <w:ind w:left="720"/>
+      <w:pPrChange w:id="13" ${AUTHORED}><w:pPr/></w:pPrChange>
+    </w:pPr>
+    <!-- A custom XML revision range; the converter has no handling for these at all. -->
+    <w:customXmlInsRangeStart w:id="14" ${AUTHORED}/>
+    <w:r><w:t>Indented, and wrapped in custom XML by a reviewer.</w:t></w:r>
+    <w:customXmlInsRangeEnd w:id="14"/>
+  </w:p>`,
+  });
+}
+
+/**
+ * A document whose every revision is one the markup profile draws: a run-level format change and
+ * an insertion. Nothing about it is unrepresentable, so it must raise no revision warning and
+ * must survive `unsupportedContent: "strict"`.
+ */
+export function generateRenderedRevisionOnlyDocx(): Uint8Array {
+  return minimalPackage({
+    body: `<w:p>
+    <w:r>
+      <w:rPr>
+        <w:i/>
+        <w:rPrChange w:id="20" ${AUTHORED}><w:rPr/></w:rPrChange>
+      </w:rPr>
+      <w:t xml:space="preserve">Italicised by a reviewer. </w:t>
+    </w:r>
+    <w:ins w:id="21" ${AUTHORED}>
+      <w:r><w:t>And an insertion beside it.</w:t></w:r>
+    </w:ins>
+  </w:p>`,
+  });
+}
+
+/**
+ * A table whose second cell is a tracked insertion and whose third is a tracked deletion.
+ *
+ * These are drawn — the converter stamps `rev-cell-ins`/`rev-cell-del` on the cell and emits CSS
+ * that tints and strikes it — so they must raise no warning. The fixture exists to hold that line:
+ * reporting them would fail a strict export whose content is fully visible.
+ */
+export function generateCellRevisionDocx(): Uint8Array {
+  return minimalPackage({
+    body: `<w:tbl>
+    <w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>
+    <w:tblGrid><w:gridCol w:w="3120"/><w:gridCol w:w="3120"/><w:gridCol w:w="3120"/></w:tblGrid>
+    <w:tr>
+      <w:tc>
+        <w:tcPr><w:tcW w:w="3120" w:type="dxa"/></w:tcPr>
+        <w:p><w:r><w:t>Existing cell</w:t></w:r></w:p>
+      </w:tc>
+      <w:tc>
+        <w:tcPr>
+          <w:tcW w:w="3120" w:type="dxa"/>
+          <w:cellIns w:id="30" ${AUTHORED}/>
+        </w:tcPr>
+        <w:p><w:r><w:t>Inserted cell</w:t></w:r></w:p>
+      </w:tc>
+      <w:tc>
+        <w:tcPr>
+          <w:tcW w:w="3120" w:type="dxa"/>
+          <w:cellDel w:id="31" ${AUTHORED}/>
+        </w:tcPr>
+        <w:p><w:r><w:t>Deleted cell</w:t></w:r></w:p>
+      </w:tc>
+    </w:tr>
+  </w:tbl>
+  <w:p/>`,
+  });
+}
+
+/**
+ * A document with two comments where the second is a reply to the first, and the first is
+ * marked resolved. The threading and resolved state live only in commentsExtended, which the
+ * converter does not read.
+ */
+export function generateCommentTopologyDocx(): Uint8Array {
+  return minimalPackage({
+    documentAttributes: ` xmlns:r="${R_NS}"`,
+    overrides: '<Override PartName="/word/comments.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.comments+xml"/>\n'
+      + '  <Override PartName="/word/commentsExtended.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.commentsExtended+xml"/>',
+    relationships: `<Relationship Id="rId2" Type="${R_NS}/comments" Target="comments.xml"/>\n`
+      + '  <Relationship Id="rId3" Type="http://schemas.microsoft.com/office/2011/relationships/commentsExtended" Target="commentsExtended.xml"/>',
+    body: `<w:p>
+    <w:commentRangeStart w:id="1"/>
+    <w:r><w:t>The clause under review.</w:t></w:r>
+    <w:commentRangeEnd w:id="1"/>
+    <w:r><w:commentReference w:id="1"/></w:r>
+    <w:r><w:commentReference w:id="2"/></w:r>
+  </w:p>`,
+    parts: {
+      'word/comments.xml': `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:comments xmlns:w="${W_NS}" xmlns:w14="${W14_NS}">
+  <w:comment w:id="1" w:author="First Reviewer" w:initials="FR" w:date="2026-08-16T00:00:00Z">
+    <w:p w14:paraId="11111111"><w:r><w:t>Is this clause still needed?</w:t></w:r></w:p>
+  </w:comment>
+  <w:comment w:id="2" w:author="Second Reviewer" w:initials="SR" w:date="2026-08-16T01:00:00Z">
+    <w:p w14:paraId="22222222"><w:r><w:t>No, it was superseded.</w:t></w:r></w:p>
+  </w:comment>
+</w:comments>`,
+      'word/commentsExtended.xml': `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w15:commentsEx xmlns:w15="${W15_NS}">
+  <w15:commentEx w15:paraId="11111111" w15:done="1"/>
+  <w15:commentEx w15:paraId="22222222" w15:paraIdParent="11111111" w15:done="0"/>
+</w15:commentsEx>`,
+    },
+  });
+}

--- a/npm/tests/standalone-export.spec.ts
+++ b/npm/tests/standalone-export.spec.ts
@@ -5,6 +5,12 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { expect, test, type Page, type TestInfo } from '@playwright/test';
 import { generateFootnoteDocx } from './docx-footnote-fixture.js';
 import { generateTableCommentDocx } from './docx-page-map-fixture.js';
+import {
+  generateCellRevisionDocx,
+  generateCommentTopologyDocx,
+  generateRenderedRevisionOnlyDocx,
+  generateUnrenderableRevisionDocx,
+} from './docx-review-topology-fixture.js';
 import { generateUndecodableImageDocx } from './docx-undecodable-image-fixture.js';
 import { R_NS, storedZip, W_NS, xml } from './docx-zip.js';
 
@@ -76,7 +82,10 @@ interface BrowserExportResult {
       substitutionContractDigest: string;
       resolutionDigest: string;
     };
-    warnings: Array<{ code: string; severity: string; phase: string }>;
+    warnings: Array<{
+      code: string; severity: string; phase: string;
+      message: string; remediation: string; detail?: string;
+    }>;
     resources: Array<{ kind: string; status: string; resource?: string }>;
     readiness: Array<{ phase: string; status: string; elapsedMs: number; pending: string[] }>;
   };
@@ -803,6 +812,141 @@ test.describe('standalone paginated HTML', () => {
         });
         expect(failure.report.readiness.at(-1).pending.length).toBeGreaterThan(0);
       }
+    });
+
+  test('warns only for the revision families the markup profile cannot draw', async ({ page }) => {
+    const source = generateUnrenderableRevisionDocx();
+    const markup = await convert(page, source, false, { reviewProfile: 'markup' });
+    const warnings = markup.renderReport.warnings;
+
+    // One custom XML range, and two of the three property revisions: the rPrChange beside them
+    // is drawn as a marked format change, so the count must exclude it.
+    expect(warnings).toContainEqual(expect.objectContaining({
+      code: 'revision_family_not_rendered',
+      severity: 'warning',
+      phase: 'package_preflight',
+      message: '1 custom XML revision range is present but is not drawn as markup.',
+      detail: 'customXmlInsRangeStart, customXmlDelRangeStart, customXmlMoveFromRangeStart, '
+        + 'customXmlMoveToRangeStart',
+    }));
+    expect(warnings).toContainEqual(expect.objectContaining({
+      code: 'revision_property_change_not_rendered',
+      severity: 'warning',
+      phase: 'package_preflight',
+      message: '2 paragraph, table, section, and numbering property revisions are present but are '
+        + 'not drawn as markup.',
+    }));
+    // No remediation may point at a profile that shows less than the one being warned about.
+    for (const warning of warnings) expect(warning.remediation).not.toContain('commentProfile: hidden');
+
+    // final applies the projection and then asserts no revision survives it, so no family can
+    // pass through silently and neither warning applies.
+    const final = await convert(page, source, false, { reviewProfile: 'final' });
+    const finalCodes = final.renderReport.warnings.map((warning) => warning.code);
+    expect(finalCodes).not.toContain('revision_family_not_rendered');
+    expect(finalCodes).not.toContain('revision_property_change_not_rendered');
+  });
+
+  test('does not warn for revisions the markup profile does draw', async ({ page }) => {
+    // A run-level format change and an insertion are both drawn, so nothing is unrepresented —
+    // reporting the whole propertyChanges bucket would fail this export closed under strict.
+    const source = generateRenderedRevisionOnlyDocx();
+    const markup = await convert(page, source, false, { reviewProfile: 'markup' });
+    const codes = markup.renderReport.warnings.map((warning) => warning.code);
+    expect(codes).not.toContain('revision_family_not_rendered');
+    expect(codes).not.toContain('revision_property_change_not_rendered');
+
+    const strict = await convert(page, source, false, {
+      reviewProfile: 'markup',
+      unsupportedContent: 'strict',
+    });
+    expect(strict.pageCount).toBeGreaterThan(0);
+  });
+
+  test('draws tracked cell revisions rather than warning about them', async ({ page }) => {
+    // The premise of every warning here is "the converter does not draw this". For cell
+    // insert/delete it does, so this test asserts the drawing and the silence together — the
+    // warning cannot come back without the render evidence going with it.
+    const source = generateCellRevisionDocx();
+    const markup = await convert(page, source, false, { reviewProfile: 'markup' });
+
+    const drawn = await page.evaluate((html: string) => {
+      const parsed = new DOMParser().parseFromString(html, 'text/html');
+      const styles = Array.from(parsed.querySelectorAll('style'), (node) => node.textContent).join('');
+      return {
+        insCells: parsed.querySelectorAll('td.rev-cell-ins').length,
+        delCells: parsed.querySelectorAll('td.rev-cell-del').length,
+        styledIns: styles.includes('td.rev-cell-ins'),
+        styledDel: styles.includes('td.rev-cell-del'),
+      };
+    }, markup.html);
+    expect(drawn).toEqual({ insCells: 1, delCells: 1, styledIns: true, styledDel: true });
+
+    expect(markup.renderReport.warnings.map((warning) => warning.code))
+      .not.toContain('revision_family_not_rendered');
+
+    const strict = await convert(page, source, false, {
+      reviewProfile: 'markup',
+      unsupportedContent: 'strict',
+    });
+    expect(strict.pageCount).toBeGreaterThan(0);
+  });
+
+  test('fails closed under strict for a revision family it cannot draw', async ({ page }) => {
+    const source = generateUnrenderableRevisionDocx();
+    const failure = await page.evaluate(async (bytes) => (window as any).DocxodusStandalone
+      .convertFailure(bytes, {
+        reviewProfile: 'markup',
+        commentProfile: 'hidden',
+        unsupportedContent: 'strict',
+      }), Array.from(source));
+
+    expect(failure.unexpectedSuccess).toBeUndefined();
+    expect(failure.code).toBe('resource_policy_failure');
+    expect(failure.phase).toBe('package_preflight');
+    expect(failure.report.status).toBe('failed');
+  });
+
+  test('warns exactly once that comment threading and resolved state are not drawn',
+    async ({ page }) => {
+      const source = generateCommentTopologyDocx();
+      // The default review profile is final, which preflights the source and the derived package;
+      // comments survive that projection, so a warning per package would report each one twice.
+      const visible = await convert(page, source, false, { commentProfile: 'inline' });
+      const warnings = visible.renderReport.warnings;
+
+      expect(warnings.filter((warning) => warning.code === 'comment_thread_flattened')).toEqual([
+        expect.objectContaining({
+          severity: 'warning',
+          phase: 'package_preflight',
+          message: '1 comment reply is drawn as an independent comment rather than as a threaded reply.',
+        }),
+      ]);
+      expect(warnings.filter(
+        (warning) => warning.code === 'comment_resolved_state_not_rendered',
+      )).toEqual([
+        expect.objectContaining({
+          severity: 'warning',
+          phase: 'package_preflight',
+          message: '1 resolved comment is drawn identically to an open comment.',
+        }),
+      ]);
+
+      // hidden renders no comment bodies at all, so neither limitation applies.
+      const hidden = await convert(page, source, false, { commentProfile: 'hidden' });
+      const hiddenCodes = hidden.renderReport.warnings.map((warning) => warning.code);
+      expect(hiddenCodes).not.toContain('comment_thread_flattened');
+      expect(hiddenCodes).not.toContain('comment_resolved_state_not_rendered');
+
+      const failure = await page.evaluate(async (bytes) => (window as any).DocxodusStandalone
+        .convertFailure(bytes, {
+          reviewProfile: 'final',
+          commentProfile: 'inline',
+          unsupportedContent: 'strict',
+        }), Array.from(source));
+      expect(failure.unexpectedSuccess).toBeUndefined();
+      expect(failure.code).toBe('resource_policy_failure');
+      expect(failure.phase).toBe('package_preflight');
     });
 
   test('fails closed with a report when an indivisible body block would clip', async ({ page }, testInfo) => {

--- a/npm/tests/standalone-export.spec.ts
+++ b/npm/tests/standalone-export.spec.ts
@@ -949,6 +949,28 @@ test.describe('standalone paginated HTML', () => {
       expect(failure.phase).toBe('package_preflight');
     });
 
+  test('renders comment bodies per visible profile and none for hidden', async ({ page }) => {
+    // The warning tests above prove what the profiles cannot represent; this pins what each
+    // does. endnotes lists every referenced comment body. inline attaches a body to its
+    // comment range, so the reply — which has a reference but no range of its own — has no
+    // anchor and its body is dropped: the flattening the comment_thread_flattened warning
+    // discloses (#540 tracks drawing topology). hidden renders no comment content at all.
+    const source = generateCommentTopologyDocx();
+    const endnotes = await convert(page, source, false, { commentProfile: 'endnotes' });
+    expect(endnotes.html).toContain('Is this clause still needed?');
+    expect(endnotes.html).toContain('No, it was superseded.');
+    expect(endnotes.html).toContain('First Reviewer');
+    expect(endnotes.html).toContain('Second Reviewer');
+
+    const inline = await convert(page, source, false, { commentProfile: 'inline' });
+    expect(inline.html).toContain('Is this clause still needed?');
+    expect(inline.html).not.toContain('No, it was superseded.');
+
+    const hidden = await convert(page, source, false, { commentProfile: 'hidden' });
+    expect(hidden.html).not.toContain('Is this clause still needed?');
+    expect(hidden.html).not.toContain('No, it was superseded.');
+  });
+
   test('fails closed with a report when an indivisible body block would clip', async ({ page }, testInfo) => {
     const source = new Uint8Array(readFileSync(join(testFiles, 'HC006-Test-01.docx')));
     const failure = await page.evaluate(async (bytes) => (window as any).DocxodusStandalone.convertFailure(

--- a/python/src/docx_scalpel/types.py
+++ b/python/src/docx_scalpel/types.py
@@ -338,6 +338,7 @@ class PackageRevisionCounts:
     move_from: int = 0
     move_to: int = 0
     property_changes: int = 0
+    run_property_changes: int = 0
     structural_changes: int = 0
     other_changes: int = 0
     total: int = 0
@@ -350,6 +351,7 @@ class PackageRevisionCounts:
             move_from=int(d.get("moveFrom", 0)),
             move_to=int(d.get("moveTo", 0)),
             property_changes=int(d.get("propertyChanges", 0)),
+            run_property_changes=int(d.get("runPropertyChanges", 0)),
             structural_changes=int(d.get("structuralChanges", 0)),
             other_changes=int(d.get("otherChanges", 0)),
             total=int(d.get("total", 0)),


### PR DESCRIPTION
Closes #444.

## The accident this fixes first

PR #531 — "Report the revision and comment families the profiles cannot draw" — was reviewed, approved, and merged on 2026-08-25. **Its content never reached `main`.** It was the top of a four-PR stack, and it merged while its base was still the #443 ratchet branch, which had itself already merged to `main` two days earlier. GitHub landed the squash on that dead branch, nothing ever flowed it forward, and the four warning codes it added exist nowhere on `main` today. (This is also why its `Closes #444` keyword never fired.)

The first commit here is that squash, cherry-picked verbatim onto `main` (it applied cleanly): the `revision_family_not_rendered`, `revision_property_change_not_rendered`, `comment_thread_flattened`, and `comment_resolved_state_not_rendered` warnings, the `revisions.runPropertyChanges` manifest counter that keeps them honest, the review-topology fixtures, and its six tests. Its CHANGELOG entry — including the deliberate `unsupportedContent: "strict"` behavior change — comes with it.

## What the second commit adds

Auditing #444's acceptance criteria against `main` found four criteria that were *true but unproven*, and one documented claim that was false. The second commit pins each:

- **PDF text extraction per profile** (`npm-export/tests/export.test.mjs`): a tracked-revision fixture exported under `markup` extracts deleted and inserted content exactly once each, in document order; `final` never extracts the deleted side; `original` never extracts the inserted side.
- **Revisions in running stories** (`HC063`): native ins/del built into a header, footer, footnote, and endnote all render their revision markup with author metadata under the markup projection. No converter gap was found — the assertion is against real rendered output in all four stories.
- **Overlapping comment and revision** (`HC064`): one comment range spanning an inserted and a deleted run — the comment highlight nests inside both revision elements, the marker and body render, and neither family suppresses the other.
- **Comment bodies per profile** (`npm/tests/standalone-export.spec.ts`): `endnotes` renders every referenced comment body; `inline` attaches bodies to comment ranges, so a range-less reply's body is dropped — precisely the flattening `comment_thread_flattened` discloses (drawing topology is tracked by #540); `hidden` renders none.
- **The false doc claim**: the design doc's profile section promised "the ordered reply tree … and resolved state" render. They do not, and the recovered warnings exist because they do not. The section now states what renders and names the disclosure warnings.

Also syncs `npm-export/package-lock.json` with the linked package's manifest (two pdf devDependencies added by the ratchet work were missing from the lock).

## Validation

- Full `standalone-export.spec.ts` run: **23/23** (includes all six recovered tests and the new profile matrix test).
- New npm-export profile-extraction test: pass (3 profiles through real Chromium + pdf.js).
- `HC063`/`HC064`: pass; neighborhood run of the converter suite (`HcTests.HC0*`): **127/127**.
- Recovered C# manifest changes against current `main`: PackageManifest suite **86/86**.
- `npm run typecheck` green in both packages.

Note for `strict` callers, restated from the recovered CHANGELOG entry: a document containing one of the four disclosed families now fails closed under `unsupportedContent: "strict"` where it previously exported. That is the intended point of strict, and `"warn"` (the default) keeps the old outcome.