### PR TITLE
Prove multi-author consolidated redlines and pin the proof to its published schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ All notable changes to this project will be documented in this file.
   fingerprint, fingerprints from before this change do not compare equal to ones after it.
 
 ### Added
+- **Multi-author Consolidate coverage and schema conformance for the reversibility proof (#464).**
+  The proof suite now exercises `DocxDiff.Consolidate` output: a redline carrying two distinct
+  reviewer authors — disjoint edits and a policy-resolved merge conflict — proves reject ≡ shared
+  base and accept ≡ policy-resolved composite at the story-text and modeled-semantic levels, with
+  every revision classified as generated for its own reviewer (multi-author attribution is not an
+  ownership conflict). A new contract test validates the emitted canonical proof JSON — from the
+  verifier and from the shared `VerificationOps` facade, in both completed and fail-closed shapes —
+  against the checked-in `redline-reversibility-proof-v1` schema, with negative controls proving
+  the validation rejects each constraint kind the schema relies on.
+
 - **Workflow evaluation scaffold (#466).** Added `eval/`, a corpus of deterministic
   document-workflow scenarios, and `Docxodus.Tests/Eval/`, the scripted caller that runs them.
   A scenario declares a fixture, the tool calls that perform the task, and the invariants that

--- a/Docxodus.Tests/RedlineReversibilityFixtureSweepTests.cs
+++ b/Docxodus.Tests/RedlineReversibilityFixtureSweepTests.cs
@@ -15,7 +15,7 @@ namespace Docxodus.Tests;
 /// Fixture-scale evidence for the redline reversibility proof (#464), complementing the
 /// scenario-focused cases in <see cref="RedlineReversibilityProofTests"/>.
 ///
-/// Two corpora, two claims:
+/// Three redline sources, three claims:
 ///
 /// 1. Word-authored redlines — every complete triple in <c>TestFiles/RP</c>
 ///    (<c>{stem}.docx</c> + <c>{stem}-Accepted.docx</c> + <c>{stem}-Rejected.docx</c>, the
@@ -33,6 +33,12 @@ namespace Docxodus.Tests;
 ///    reject at the story-text level. Pairs where that does not currently hold are pinned as
 ///    explicit known gaps with their exact failure signature, so the gap is visible here and
 ///    this file must be updated when it is fixed.
+///
+/// 3. Consolidated multi-author redlines — <c>DocxDiff.Consolidate</c> over two reviewers with
+///    DISTINCT author names (RRS008/RRS009). Ownership classification compares revision
+///    authors, so a redline carrying two reviewer identities exercises a path the
+///    single-author corpora above never reach. The proven contract is Consolidate's own:
+///    reject recovers the shared base, accept recovers the policy-resolved composite.
 ///
 /// "Story text" means the concatenated <c>w:t</c> runs of the body plus every header,
 /// footer, footnotes and endnotes part — presence of a story part counts, so an output that
@@ -393,6 +399,116 @@ public class RedlineReversibilityFixtureSweepTests
     }
 
     // ------------------------------------------------------------------
+    // 3. Consolidated multi-author redlines: DocxDiff.Consolidate.
+    // ------------------------------------------------------------------
+
+    // Two reviewers with disjoint edits of the same base, each stamped with a distinct
+    // author name. The proof classifies every revision from BOTH reviewers as generated —
+    // multi-author attribution must never read as conflicted ownership — and both paths
+    // complete: accept recovers the composite (the accept-all of the consolidated redline,
+    // Consolidate's own round-trip contract) and reject recovers the shared base, at the
+    // story-text level AND at the modeled-semantic level. As with every engine-generated
+    // redline (RRS004), Consolidate rebuilds the output package, so the strict
+    // whole-package proof does not hold today and the proof must say so with evidence.
+    [Fact]
+    public void RRS008_ConsolidatedTwoReviewerRedline_RoundTripsWithPerAuthorClassification()
+    {
+        var baseBytes = Fixture("WC/WC002-Unmodified.docx");
+        var consolidated = ConsolidatedRedline(
+            baseBytes,
+            Fixture("WC/WC002-DiffInMiddle.docx"),
+            Fixture("WC/WC002-InsertAtEnd.docx"));
+        var intendedComposite = RevisionProcessor.AcceptRevisions(consolidated).DocumentByteArray;
+
+        var run = RedlineReversibilityVerifier.Prove(
+            baseBytes, intendedComposite, consolidated.DocumentByteArray);
+        var proof = run.Proof;
+
+        // Both reviewer identities are present, and every revision classifies as generated.
+        Assert.NotEmpty(proof.RevisionClassifications);
+        Assert.All(proof.RevisionClassifications, classification =>
+            Assert.Equal(RedlineRevisionDisposition.Generated, classification.Disposition));
+        Assert.Contains(proof.RevisionClassifications, classification =>
+            classification.Redline?.Author == "Reviewer A");
+        Assert.Contains(proof.RevisionClassifications, classification =>
+            classification.Redline?.Author == "Reviewer B");
+
+        Assert.NotNull(proof.AcceptToFinal);
+        Assert.NotNull(proof.RejectToBaseline);
+        Assert.True(proof.AcceptToFinal!.Completed, proof.ToJson());
+        Assert.True(proof.RejectToBaseline!.Completed, proof.ToJson());
+        AssertResolutionClosure(proof.AcceptToFinal);
+        AssertResolutionClosure(proof.RejectToBaseline);
+
+        // Accept recovers the composite, reject recovers the shared base.
+        Assert.Equal(StoryTexts(intendedComposite), StoryTexts(run.AcceptedPackageBytes!));
+        Assert.Equal(StoryTexts(baseBytes), StoryTexts(run.RejectedPackageBytes!));
+        Assert.True(proof.AcceptToFinal.ModeledSemantic.Equivalent, proof.ToJson());
+        Assert.True(proof.RejectToBaseline.ModeledSemantic.Equivalent, proof.ToJson());
+
+        // The rebuilt package prevents the strict whole-package claim — evidenced, never silent.
+        Assert.False(proof.Success, proof.ToJson());
+        AssertNonEquivalenceIsEvidenced(proof.AcceptToFinal);
+        AssertNonEquivalenceIsEvidenced(proof.RejectToBaseline);
+    }
+
+    // Two reviewers editing the SAME span differently — a genuine merge conflict, resolved
+    // by the default BaseWins policy. The policy decides what markup survives into the
+    // consolidated document (observed: the conflicted span resolves to base, so a
+    // reviewer's competing edit may not appear at all); whatever survives must still
+    // classify as generated for its own reviewer — a policy-resolved merge conflict is not
+    // an ownership conflict — and the proof round-trips against the policy-resolved
+    // composite exactly as in RRS008.
+    [Fact]
+    public void RRS009_ConsolidatedConflictingReviewers_ProveAgainstThePolicyResolvedComposite()
+    {
+        var baseBytes = Fixture("WC/WC002-Unmodified.docx");
+        var reviewerA = Fixture("WC/WC002-DiffInMiddle.docx");
+        var reviewerB = Fixture("WC/WC002-DeleteInMiddle.docx");
+
+        // The pair genuinely conflicts: both reviewers appear as competitors on a base span.
+        var conflicts = DocxDiff.GetConflicts(
+            new WmlDocument("base.docx", baseBytes),
+            Reviewers(reviewerA, reviewerB));
+        Assert.NotEmpty(conflicts);
+        Assert.Contains(conflicts.SelectMany(conflict => conflict.Competitors),
+            competitor => competitor.Author == "Reviewer A");
+        Assert.Contains(conflicts.SelectMany(conflict => conflict.Competitors),
+            competitor => competitor.Author == "Reviewer B");
+
+        var consolidated = ConsolidatedRedline(baseBytes, reviewerA, reviewerB);
+        var intendedComposite = RevisionProcessor.AcceptRevisions(consolidated).DocumentByteArray;
+
+        var run = RedlineReversibilityVerifier.Prove(
+            baseBytes, intendedComposite, consolidated.DocumentByteArray);
+        var proof = run.Proof;
+
+        Assert.NotEmpty(proof.RevisionClassifications);
+        Assert.All(proof.RevisionClassifications, classification =>
+        {
+            Assert.Equal(RedlineRevisionDisposition.Generated, classification.Disposition);
+            Assert.Contains(classification.Redline?.Author,
+                new[] { "Reviewer A", "Reviewer B" });
+        });
+
+        Assert.NotNull(proof.AcceptToFinal);
+        Assert.NotNull(proof.RejectToBaseline);
+        Assert.True(proof.AcceptToFinal!.Completed, proof.ToJson());
+        Assert.True(proof.RejectToBaseline!.Completed, proof.ToJson());
+        AssertResolutionClosure(proof.AcceptToFinal);
+        AssertResolutionClosure(proof.RejectToBaseline);
+
+        Assert.Equal(StoryTexts(intendedComposite), StoryTexts(run.AcceptedPackageBytes!));
+        Assert.Equal(StoryTexts(baseBytes), StoryTexts(run.RejectedPackageBytes!));
+        Assert.True(proof.AcceptToFinal.ModeledSemantic.Equivalent, proof.ToJson());
+        Assert.True(proof.RejectToBaseline.ModeledSemantic.Equivalent, proof.ToJson());
+
+        Assert.False(proof.Success, proof.ToJson());
+        AssertNonEquivalenceIsEvidenced(proof.AcceptToFinal);
+        AssertNonEquivalenceIsEvidenced(proof.RejectToBaseline);
+    }
+
+    // ------------------------------------------------------------------
     // Helpers.
     // ------------------------------------------------------------------
 
@@ -413,6 +529,25 @@ public class RedlineReversibilityFixtureSweepTests
         new WmlDocument("left.docx", left),
         new WmlDocument("right.docx", right),
         new DocxDiffSettings { AuthorForRevisions = "Docxodus Engine" }).DocumentByteArray;
+
+    private static WmlDocument ConsolidatedRedline(
+        byte[] baseBytes, byte[] reviewerA, byte[] reviewerB) => DocxDiff.Consolidate(
+        new WmlDocument("base.docx", baseBytes),
+        Reviewers(reviewerA, reviewerB));
+
+    private static DocxDiffReviewer[] Reviewers(byte[] reviewerA, byte[] reviewerB) => new[]
+    {
+        new DocxDiffReviewer
+        {
+            Document = new WmlDocument("reviewer-a.docx", reviewerA),
+            Author = "Reviewer A",
+        },
+        new DocxDiffReviewer
+        {
+            Document = new WmlDocument("reviewer-b.docx", reviewerB),
+            Author = "Reviewer B",
+        },
+    };
 
     private static IEnumerable<string> PinnedStems(string theoryMethodName) =>
         typeof(RedlineReversibilityFixtureSweepTests)

--- a/Docxodus.Tests/Verification/RedlineReversibilityContractTests.cs
+++ b/Docxodus.Tests/Verification/RedlineReversibilityContractTests.cs
@@ -1,0 +1,270 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Docxodus.Internal;
+using Docxodus.Verification;
+using Xunit;
+
+namespace Docxodus.Tests.Verification;
+
+/// <summary>
+/// Pins the emitted redline-reversibility proof JSON to the published v1 schema
+/// (<c>docs/schemas/redline-reversibility-proof-v1.schema.json</c>), the way
+/// <see cref="SemanticChangeSetContractTests"/> pins the semantic-changes wire shape. The
+/// validator below implements exactly the draft 2020-12 subset the checked-in schema uses and
+/// fails closed on any keyword it does not know, so evolving the schema past that subset breaks
+/// this test loudly instead of silently validating nothing.
+/// </summary>
+public class RedlineReversibilityContractTests
+{
+    private static readonly string SchemaPath = Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory,
+        "../../../../docs/schemas/redline-reversibility-proof-v1.schema.json"));
+
+    [Fact]
+    public void Emitted_proof_json_conforms_to_the_published_v1_schema()
+    {
+        using var schema = JsonDocument.Parse(File.ReadAllBytes(SchemaPath));
+        Assert.Equal(RedlineReversibilityProof.SchemaId,
+            schema.RootElement.GetProperty("$id").GetString());
+        Assert.Equal(RedlineReversibilityProof.SchemaId,
+            schema.RootElement.GetProperty("properties")
+                .GetProperty("schema").GetProperty("const").GetString());
+
+        // A completed two-path proof: classifications, both paths, divergences and findings
+        // are all populated, so every referenced $defs shape is exercised.
+        var baseline = Document("The original clause.");
+        var intendedFinal = Document("The revised clause.");
+        var redline = EngineRedline(baseline, intendedFinal);
+        var completed = RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline).Proof;
+        Assert.NotEmpty(completed.RevisionClassifications);
+        Assert.NotNull(completed.AcceptToFinal);
+        using (var instance = JsonDocument.Parse(completed.ToCanonicalUtf8Bytes()))
+            Assert.Empty(ValidationErrors(schema.RootElement, instance.RootElement));
+
+        // A fail-closed proof (malformed redline package): both paths are null, exercising
+        // the schema's nullablePath branches.
+        var failed = RedlineReversibilityVerifier.Prove(
+            baseline, baseline, new byte[] { 1, 2, 3 }).Proof;
+        Assert.Null(failed.AcceptToFinal);
+        using (var instance = JsonDocument.Parse(failed.ToCanonicalUtf8Bytes()))
+            Assert.Empty(ValidationErrors(schema.RootElement, instance.RootElement));
+
+        // The shared facade every transport routes through emits the same conformant shape.
+        var wireJson = VerificationOps.ProveRedlineReversibility(baseline, intendedFinal, redline);
+        using (var instance = JsonDocument.Parse(wireJson))
+            Assert.Empty(ValidationErrors(schema.RootElement, instance.RootElement));
+    }
+
+    // Negative control: the validator must actually reject nonconforming documents, or the
+    // conformance assertion above proves nothing. One mutation per constraint kind the
+    // schema relies on.
+    [Fact]
+    public void Schema_validation_rejects_each_constraint_violation_kind()
+    {
+        using var schema = JsonDocument.Parse(File.ReadAllBytes(SchemaPath));
+        var baseline = Document("The original clause.");
+        var intendedFinal = Document("The revised clause.");
+        var redline = EngineRedline(baseline, intendedFinal);
+        var canonicalJson = RedlineReversibilityVerifier
+            .Prove(baseline, intendedFinal, redline).Proof.ToCanonicalJson();
+
+        // The unmutated document validates; every mutation below must not.
+        using (var wellFormed = JsonDocument.Parse(canonicalJson))
+            Assert.Empty(ValidationErrors(schema.RootElement, wellFormed.RootElement));
+
+        AssertRejected(schema, canonicalJson, // required
+            node => node.AsObject().Remove("success"));
+        AssertRejected(schema, canonicalJson, // additionalProperties: false
+            node => node.AsObject()["unexpected"] = true);
+        AssertRejected(schema, canonicalJson, // const
+            node => node.AsObject()["schemaVersion"] = 2);
+        AssertRejected(schema, canonicalJson, // type
+            node => node.AsObject()["success"] = "yes");
+        AssertRejected(schema, canonicalJson, // pattern
+            node => node["baselinePackage"]!["rawPackageBytesDigest"]!["value"] = "not-a-digest");
+        AssertRejected(schema, canonicalJson, // enum
+            node => node["revisionClassifications"]![0]!["disposition"] = "bogus");
+        AssertRejected(schema, canonicalJson, // oneOf (neither object-shaped nor null)
+            node => node.AsObject()["acceptToFinal"] = 42);
+    }
+
+    private static void AssertRejected(
+        JsonDocument schema, string canonicalJson, Action<JsonNode> mutate)
+    {
+        var node = JsonNode.Parse(canonicalJson)!;
+        mutate(node);
+        using var mutated = JsonDocument.Parse(node.ToJsonString());
+        Assert.NotEmpty(ValidationErrors(schema.RootElement, mutated.RootElement));
+    }
+
+    // ------------------------------------------------------------------
+    // Minimal JSON-schema validator: exactly the draft 2020-12 subset the checked-in proof
+    // schema uses, failing closed on anything else.
+    // ------------------------------------------------------------------
+
+    private static readonly string[] KnownKeywords =
+    {
+        "$schema", "$id", "title", "description", "$defs",
+        "type", "required", "properties", "additionalProperties",
+        "enum", "const", "oneOf", "items", "$ref", "pattern", "minLength", "minimum",
+    };
+
+    private static IReadOnlyList<string> ValidationErrors(
+        JsonElement schemaRoot, JsonElement instance)
+    {
+        var errors = new List<string>();
+        Validate(schemaRoot, instance, schemaRoot, "$", errors);
+        return errors;
+    }
+
+    private static void Validate(
+        JsonElement schema, JsonElement instance, JsonElement root, string path,
+        List<string> errors)
+    {
+        foreach (var keyword in schema.EnumerateObject())
+            Assert.Contains(keyword.Name, KnownKeywords);
+
+        if (schema.TryGetProperty("$ref", out var reference))
+        {
+            Validate(ResolveRef(root, reference.GetString()!), instance, root, path, errors);
+            return;
+        }
+
+        if (schema.TryGetProperty("oneOf", out var oneOf))
+        {
+            var matches = oneOf.EnumerateArray().Count(branch =>
+            {
+                var branchErrors = new List<string>();
+                Validate(branch, instance, root, path, branchErrors);
+                return branchErrors.Count == 0;
+            });
+            if (matches != 1)
+                errors.Add($"{path}: matched {matches} oneOf branches, expected exactly 1");
+            return; // The schema never combines oneOf with sibling constraints.
+        }
+
+        if (schema.TryGetProperty("const", out var constant)
+            && !JsonElement.DeepEquals(constant, instance))
+            errors.Add($"{path}: does not equal const {constant.GetRawText()}");
+
+        if (schema.TryGetProperty("enum", out var enumeration)
+            && !enumeration.EnumerateArray().Any(option => JsonElement.DeepEquals(option, instance)))
+            errors.Add($"{path}: {instance.GetRawText()} is not in the enum");
+
+        if (schema.TryGetProperty("type", out var type) && !TypeMatches(type, instance))
+            errors.Add($"{path}: {instance.ValueKind} does not satisfy type {type.GetRawText()}");
+
+        if (instance.ValueKind == JsonValueKind.String)
+        {
+            var value = instance.GetString()!;
+            if (schema.TryGetProperty("pattern", out var pattern)
+                && !Regex.IsMatch(value, pattern.GetString()!))
+                errors.Add($"{path}: '{value}' does not match pattern {pattern.GetString()}");
+            if (schema.TryGetProperty("minLength", out var minLength)
+                && value.Length < minLength.GetInt32())
+                errors.Add($"{path}: shorter than minLength {minLength.GetInt32()}");
+        }
+
+        if (instance.ValueKind == JsonValueKind.Number
+            && schema.TryGetProperty("minimum", out var minimum)
+            && instance.GetDouble() < minimum.GetDouble())
+            errors.Add($"{path}: below minimum {minimum.GetRawText()}");
+
+        if (instance.ValueKind == JsonValueKind.Object)
+        {
+            var hasProperties = schema.TryGetProperty("properties", out var properties);
+            if (schema.TryGetProperty("required", out var required))
+            {
+                foreach (var name in required.EnumerateArray())
+                {
+                    if (!instance.TryGetProperty(name.GetString()!, out _))
+                        errors.Add($"{path}: missing required property '{name.GetString()}'");
+                }
+            }
+
+            foreach (var property in instance.EnumerateObject())
+            {
+                if (hasProperties
+                    && properties.TryGetProperty(property.Name, out var propertySchema))
+                {
+                    Validate(propertySchema, property.Value, root,
+                        $"{path}.{property.Name}", errors);
+                }
+                else if (schema.TryGetProperty("additionalProperties", out var additional)
+                    && additional.ValueKind == JsonValueKind.False)
+                {
+                    errors.Add($"{path}: unexpected property '{property.Name}'");
+                }
+            }
+        }
+
+        if (instance.ValueKind == JsonValueKind.Array
+            && schema.TryGetProperty("items", out var items))
+        {
+            var index = 0;
+            foreach (var element in instance.EnumerateArray())
+                Validate(items, element, root, $"{path}[{index++}]", errors);
+        }
+    }
+
+    private static JsonElement ResolveRef(JsonElement root, string reference)
+    {
+        Assert.StartsWith("#/$defs/", reference);
+        return root.GetProperty("$defs").GetProperty(reference["#/$defs/".Length..]);
+    }
+
+    private static bool TypeMatches(JsonElement type, JsonElement instance) =>
+        type.ValueKind == JsonValueKind.Array
+            ? type.EnumerateArray().Any(entry => TypeNameMatches(entry.GetString()!, instance))
+            : TypeNameMatches(type.GetString()!, instance);
+
+    private static bool TypeNameMatches(string name, JsonElement instance) => name switch
+    {
+        "object" => instance.ValueKind == JsonValueKind.Object,
+        "array" => instance.ValueKind == JsonValueKind.Array,
+        "string" => instance.ValueKind == JsonValueKind.String,
+        "boolean" => instance.ValueKind is JsonValueKind.True or JsonValueKind.False,
+        "null" => instance.ValueKind == JsonValueKind.Null,
+        "integer" => instance.ValueKind == JsonValueKind.Number && instance.TryGetInt64(out _),
+        "number" => instance.ValueKind == JsonValueKind.Number,
+        _ => throw new InvalidOperationException($"Unsupported schema type '{name}'."),
+    };
+
+    // ------------------------------------------------------------------
+    // Fixtures.
+    // ------------------------------------------------------------------
+
+    private static byte[] EngineRedline(byte[] baseline, byte[] intendedFinal) =>
+        DocxDiff.Compare(
+            new WmlDocument("baseline.docx", baseline),
+            new WmlDocument("final.docx", intendedFinal),
+            new DocxDiffSettings { AuthorForRevisions = "Comparison Engine" }).DocumentByteArray;
+
+    private static byte[] Document(string text)
+    {
+        using var stream = new MemoryStream();
+        using (var document = WordprocessingDocument.Create(
+                   stream, WordprocessingDocumentType.Document))
+        {
+            var main = document.AddMainDocumentPart();
+            main.Document = new Document(new Body(new Paragraph(new Run(new Text(text)))));
+            main.AddNewPart<DocumentSettingsPart>().Settings = new Settings();
+            document.Save();
+        }
+
+        return stream.ToArray();
+    }
+}

--- a/docs/architecture/redline_reversibility_proof.md
+++ b/docs/architecture/redline_reversibility_proof.md
@@ -131,8 +131,10 @@ The canonical JSON schema is
 `https://docxodus.dev/schemas/verification/redline-reversibility-proof/v1`.
 Serialization is deterministic. It includes algorithm-labelled input/output digests,
 revision classifications, both path results, part divergences, and findings. The
-delivery receipt embeds this object as a value and includes its canonical JSON digest;
-it does not reinterpret or flatten proof fields.
+delivery receipt hash-addresses this object rather than embedding it as a value: a
+`DeliveryEvidenceReference` carries the proof's schema identifier and canonical JSON
+digest, with the exact canonical bytes stored as a receipt artifact; the receipt does
+not reinterpret or flatten proof fields.
 
 The checked-in schema is
 [`docs/schemas/redline-reversibility-proof-v1.schema.json`](../schemas/redline-reversibility-proof-v1.schema.json).


### PR DESCRIPTION
Closes #464.

## Why

An acceptance audit of #464 against `main` found the proof engine complete and its criteria met — classification of generated vs. pre-existing revisions, both round-trip comparisons, the four independent equivalence layers, first-divergence evidence, and receipt embeddability are all implemented and tested — with exactly three residuals. This PR closes them.

## 1. The multi-author gap (the real one)

Every generated redline in the reversibility suite was single-author `DocxDiff.Compare` output, while the repo ships a first-class multi-author surface — `DocxDiff.Consolidate` — whose contract (reject ≡ base, accept ≡ policy-resolved composite) is precisely what this proof exists to verify. Ownership matching compares authors, so a generated set carrying two distinct reviewer names is a distinct classification path that had never run.

Two sweep tests now pin the observed behavior (observed first, asserted second — nothing here was written before running it):

- **RRS008** — two reviewers with disjoint edits, consolidated: every revision classifies `Generated` (multi-author attribution does not trip the `Conflicted` disposition), both reviewer names appear in the classifications, accept recovers the composite and reject recovers the shared base with `ModeledSemantic.Equivalent` true in both directions. The rebuilt package prevents the strict whole-package claim, exactly as with two-way engine output — pinned as evidenced non-equivalence, never silence.
- **RRS009** — two reviewers editing the *same* span, resolved by the default BaseWins policy: `GetConflicts` proves the pair genuinely conflicts, and the proof round-trips against the policy-resolved composite. The policy-mechanics detail of *which* markup survives is documented in a comment but deliberately not hard-pinned.

## 2. Schema conformance

`docs/schemas/redline-reversibility-proof-v1.schema.json` was checked in with no test validating emitted proof JSON against it. `RedlineReversibilityContractTests` now validates both a completed two-path proof and a fail-closed proof (null paths) against the schema, plus seven negative controls (required, additionalProperties, const, type, pattern, enum, oneOf) proving the validator actually rejects violations.

A judgment call worth review: the repo has no JSON-schema library, and the existing contract-test pattern is structural `JsonDocument` checks. Rather than adding a NuGet dependency, the test carries a small validator implementing exactly the draft 2020-12 subset the schema uses — and it **fails closed**: any schema keyword or type outside the known set fails the test, so evolving the schema past the subset breaks loudly instead of silently validating nothing.

## 3. One false doc sentence

`redline_reversibility_proof.md` claimed the delivery receipt embeds the proof "as a value." It does not — the receipt hash-addresses the canonical proof bytes as an artifact plus a `DeliveryEvidenceReference`, which `delivery_change_receipt.md` states correctly. The sentence now matches the code.

## Validation

`dotnet test --filter "FullyQualifiedName~RedlineReversibility"`: **193/193 passed** (includes the 4 new tests).