### PR TITLE
Complete the workflow evaluation suite: enforced contracts, six new scenario families, and an agent-surface compare tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
           dotnet build tools/docx2oc/docx2oc.csproj -c Release --no-restore
 
       - name: Run tests
+        env:
+          DOCXODUS_EVAL_ARTIFACTS: ${{ github.workspace }}/eval-artifacts
         run: dotnet test Docxodus.Tests/Docxodus.Tests.csproj -c Release --verbosity normal --logger "trx;LogFileName=test-results.trx"
 
       - name: Upload test results
@@ -48,6 +50,16 @@ jobs:
         with:
           name: test-results
           path: Docxodus.Tests/TestResults/*.trx
+
+      # A failed eval scenario is diagnosed from its preserved artifacts (both DOCX packages,
+      # rendered HTML, semantic diff, verification report, reversibility proof), not by re-running.
+      - name: Upload eval artifacts
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: eval-artifacts
+          path: eval-artifacts/
+          if-no-files-found: ignore
 
   build-npm:
     runs-on: ubuntu-latest

--- a/.github/workflows/eval-corpus.yml
+++ b/.github/workflows/eval-corpus.yml
@@ -1,0 +1,41 @@
+name: Eval corpus
+
+# The full workflow-evaluation corpus (issue #466): the fast deterministic subset runs
+# unfiltered in ci.yml on every push; this gate additionally executes every scenario under
+# eval/scenarios/corpus/ and always uploads the per-scenario scorecards, which are the engine
+# baseline agent-scored runs are compared against.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '41 7 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  corpus:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Run evaluation suite with the corpus tier
+        env:
+          DOCXODUS_RUN_EVAL_CORPUS: '1'
+          DOCXODUS_EVAL_ARTIFACTS: ${{ github.workspace }}/eval-artifacts
+        run: dotnet test Docxodus.Tests/Docxodus.Tests.csproj -c Release --filter "FullyQualifiedName~Docxodus.Tests.Eval" --verbosity normal
+
+      - name: Upload scorecards and failure artifacts
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: eval-corpus-artifacts
+          path: eval-artifacts/
+          if-no-files-found: ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ All notable changes to this project will be documented in this file.
   fingerprint, fingerprints from before this change do not compare equal to ones after it.
 
 ### Added
+- **`docxodus_compare` MCP tool (#466).** A sessionless agent-server tool that turns stored
+  document versions into one native tracked-changes redline: `baselinePath` plus `revisedPath`
+  (two-way `DocxDiff` compare) or `revisedPaths` with per-reviewer `authors` (N-way
+  consolidate), written to `outputPath`. Every path resolves through the document store's
+  containment check like `docxodus_open`'s, the response summarizes generated revisions by
+  author, and the tool is refused as a `docxodus_mutations` step — it mutates no session.
+  Backed entirely by the existing `DocxDiffOps` facade; no new engine surface.
+
+- **All nine #466 scenario families ship in the eval corpus.** Clause insertion into a real
+  auto-numbered list (renumbering proven through rendered labels), comment + threaded reply +
+  footnote + bookmark-anchored internal link (a field-based `REF` cross-reference is not yet
+  authorable — #545 tracks the op), body edit under part-identity protection of the signature
+  block, header, and page-number-field footer, content-control template fill (via the corpus's
+  first programmatic fixture builder, since the tool surface fills but cannot create controls),
+  two-reviewer compare-and-consolidate through `docxodus_compare` with a `redline` invariant
+  group asserting the written redline's attributed revisions through a fresh session, and an
+  edit over pre-existing revisions and comments that must both survive. The
+  master-services-agreement fixture now carries a footer page-number field and a pre-existing
+  comment; every scenario runs in the fast deterministic tier.
+
 - **Workflow evaluation runner completed (#466).** The eval runner now supports multi-anchor
   steps (`targets` maps an argument name to a content-resolved target, unlocking range formats,
   moves, and bookmark spans), a `changedPartsMustBeWithin` part-URI allowlist that turns "how

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ All notable changes to this project will be documented in this file.
   fingerprint, fingerprints from before this change do not compare equal to ones after it.
 
 ### Added
+- **Workflow evaluation runner completed (#466).** The eval runner now supports multi-anchor
+  steps (`targets` maps an argument name to a content-resolved target, unlocking range formats,
+  moves, and bookmark spans), a `changedPartsMustBeWithin` part-URI allowlist that turns "how
+  many parts changed" into "the right parts changed", and `trackedRevisions`/`comments`
+  invariant groups read through the same MCP dispatcher the steps drive — so a scenario can
+  assert a pre-existing reviewer's markup is still live outside the reversibility path. The
+  scenario schema is now enforced rather than decorative: every scenario file is validated
+  against it, its invariant vocabulary is pinned to the checkers' vocabulary in both
+  directions, and each new checker ships a negative control proving it fails when violated.
+  Every run writes a per-scenario `scorecard.json` — the machine-readable engine baseline
+  later agent-scored runs are compared against — CI uploads eval artifacts on failure, and a
+  weekly `eval-corpus` workflow executes the opt-in tier under `eval/scenarios/corpus/`
+  (`DOCXODUS_RUN_EVAL_CORPUS=1`). Fixtures declare their own `expectedContent` anchor, so the
+  corpus is no longer limited to a single fixture. Delivery change receipts stay deliberately
+  out of the eval artifacts: their lineage must come from mutation evidence captured at
+  execution time, which belongs to the #465 delivery operation.
 - **Workflow evaluation scaffold (#466).** Added `eval/`, a corpus of deterministic
   document-workflow scenarios, and `Docxodus.Tests/Eval/`, the scripted caller that runs them.
   A scenario declares a fixture, the tool calls that perform the task, and the invariants that

--- a/Docxodus.Tests/Eval/EvalFixtureBuilders.cs
+++ b/Docxodus.Tests/Eval/EvalFixtureBuilders.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using Docxodus;
+using Docxodus.Internal;
+
+namespace Docxodus.Tests.Eval;
+
+/// <summary>
+/// Programmatic fixture builders, for the one corpus need the step format cannot express: the
+/// tool surface fills content controls but has no action that creates one, so a template
+/// fixture is authored here instead of as a step script. Builders must be deterministic —
+/// EV003 builds every fixture twice and requires the same document — and, like the step
+/// scripts, they keep committed document bytes out of the corpus.
+/// </summary>
+internal static class EvalFixtureBuilders
+{
+    private static readonly XNamespace W =
+        "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+
+    private static readonly XNamespace W14 = "http://schemas.microsoft.com/office/word/2010/wordml";
+
+    public static byte[] Build(string builder) => builder switch
+    {
+        "content-control-template" => ContentControlTemplate(),
+        _ => throw new InvalidOperationException($"unknown fixture builder '{builder}'"),
+    };
+
+    /// <summary>
+    /// An engagement-letter template: prose around a plain-text control (tag
+    /// <c>client-name</c>), a drop-down (tag <c>governing-law</c>), and a checkbox (tag
+    /// <c>include-arbitration</c>), each carrying visible placeholder content a fill must
+    /// replace.
+    /// </summary>
+    private static byte[] ContentControlTemplate()
+    {
+        using var stream = new MemoryStream();
+        stream.Write(DocxSessionOps.CreateBlankDocx());
+        stream.Position = 0;
+        using (var document = WordprocessingDocument.Open(stream, true))
+        {
+            var main = document.MainDocumentPart!;
+            var body = main.GetXDocument().Root!.Element(W + "body")!;
+            body.Elements().Where(element => element.Name != W + "sectPr").Remove();
+            body.AddFirst(
+                Paragraph("ENGAGEMENT LETTER TEMPLATE"),
+                Paragraph("This engagement letter is entered into by the client named below."),
+                BlockSdt("201", "client-name", "Client name",
+                    new XElement(W + "text"), "[CLIENT NAME]"),
+                BlockSdt("202", "governing-law", "Governing law",
+                    new XElement(
+                        W + "dropDownList",
+                        Item("New York"),
+                        Item("Delaware")),
+                    "[GOVERNING LAW]"),
+                BlockSdt("203", "include-arbitration", "Include arbitration",
+                    new XElement(
+                        W14 + "checkbox",
+                        new XElement(W14 + "checked", new XAttribute(W14 + "val", "0")),
+                        new XElement(W14 + "checkedState", new XAttribute(W14 + "val", "2612")),
+                        new XElement(W14 + "uncheckedState", new XAttribute(W14 + "val", "2610"))),
+                    "☐"),
+                Paragraph("Signature follows on the final page."));
+            main.PutXDocument();
+        }
+
+        // One session round-trip puts the hand-authored XML into saved-normal form. Without it,
+        // the scenario's own save would renormalize every paragraph and the change set would
+        // report the whole template as modified by a three-control fill.
+        using var session = new DocxSession(stream.ToArray());
+        return session.Save();
+    }
+
+    private static XElement Paragraph(string text) =>
+        new(W + "p", new XElement(W + "r", new XElement(W + "t", text)));
+
+    private static XElement BlockSdt(
+        string id, string tag, string alias, XElement type, string placeholder) =>
+        new(W + "sdt",
+            new XElement(W + "sdtPr",
+                new XElement(W + "id", new XAttribute(W + "val", id)),
+                new XElement(W + "tag", new XAttribute(W + "val", tag)),
+                new XElement(W + "alias", new XAttribute(W + "val", alias)),
+                type),
+            new XElement(W + "sdtContent", Paragraph(placeholder)));
+
+    private static XElement Item(string display) =>
+        new(W + "listItem",
+            new XAttribute(W + "displayText", display),
+            new XAttribute(W + "value", display));
+}

--- a/Docxodus.Tests/Eval/EvalHarness.cs
+++ b/Docxodus.Tests/Eval/EvalHarness.cs
@@ -36,6 +36,10 @@ internal sealed record EvalOutcome
     required public string Text { get; init; }
     required public string Html { get; init; }
     required public string SemanticChangesJson { get; init; }
+    /// <summary>docxodus_track_changes list on the delivered session — live markup, agent-surface view.</summary>
+    required public string RevisionsJson { get; init; }
+    /// <summary>docxodus_comment list on the delivered session.</summary>
+    required public string CommentsJson { get; init; }
     public RedlineReversibilityProof? Reversibility { get; init; }
     public int GeneratedRevisionCount { get; init; }
 }
@@ -56,9 +60,26 @@ internal static class EvalHarness
     /// <summary>The <c>eval/</c> corpus directory, located by walking up from the test binary.</summary>
     public static string CorpusRoot { get; } = LocateCorpusRoot();
 
+    /// <summary>The fast deterministic subset: runs unfiltered on every push.</summary>
     public static IEnumerable<string> ScenarioFiles() =>
         Directory.EnumerateFiles(Path.Combine(CorpusRoot, "scenarios"), "*.json")
             .OrderBy(path => path, StringComparer.Ordinal);
+
+    /// <summary>
+    /// The opt-in corpus tier under <c>scenarios/corpus/</c>. Executed only when
+    /// <c>DOCXODUS_RUN_EVAL_CORPUS=1</c> (the scheduled eval-corpus workflow sets it);
+    /// its scenarios' declarations are validated on every push regardless.
+    /// </summary>
+    public static IEnumerable<string> CorpusScenarioFiles()
+    {
+        var directory = Path.Combine(CorpusRoot, "scenarios", "corpus");
+        return Directory.Exists(directory)
+            ? Directory.EnumerateFiles(directory, "*.json").OrderBy(path => path, StringComparer.Ordinal)
+            : Enumerable.Empty<string>();
+    }
+
+    public static bool RunCorpusTier { get; } = string.Equals(
+        Environment.GetEnvironmentVariable("DOCXODUS_RUN_EVAL_CORPUS"), "1", StringComparison.Ordinal);
 
     public static JsonElement LoadJson(string path)
     {
@@ -66,8 +87,13 @@ internal static class EvalHarness
         return document.RootElement.Clone();
     }
 
-    public static JsonElement LoadScenario(string id) =>
-        LoadJson(Path.Combine(CorpusRoot, "scenarios", $"{id}.json"));
+    public static JsonElement LoadScenario(string id)
+    {
+        var fast = Path.Combine(CorpusRoot, "scenarios", $"{id}.json");
+        return LoadJson(File.Exists(fast)
+            ? fast
+            : Path.Combine(CorpusRoot, "scenarios", "corpus", $"{id}.json"));
+    }
 
     /// <summary>Build a fixture's bytes by running its step script over a blank document.</summary>
     public static byte[] BuildFixture(string name)
@@ -123,6 +149,16 @@ internal static class EvalHarness
             Text = ReadStringProperty(workspace.Content(sessionId, "text"), "text"),
             Html = ReadStringProperty(workspace.Content(sessionId, "html"), "html"),
             SemanticChangesJson = semanticChangesJson,
+            RevisionsJson = workspace.Call("docxodus_track_changes", new JsonObject
+            {
+                ["sessionId"] = sessionId,
+                ["action"] = "list",
+            }),
+            CommentsJson = workspace.Call("docxodus_comment", new JsonObject
+            {
+                ["sessionId"] = sessionId,
+                ["action"] = "list",
+            }),
         };
 
         if (ReversibilityMode(scenario) != "acceptAll")
@@ -206,6 +242,20 @@ internal static class EvalHarness
             args["sessionId"] = sessionId;
             if (step.TryGetProperty("target", out var target))
                 args[TargetArgumentName(target)] = ResolveAnchor(workspace, sessionId, target);
+            if (step.TryGetProperty("targets", out var targets))
+            {
+                // The key names the argument, so a target that also says `as` is contradictory
+                // and must fail the scenario rather than silently prefer one of the two names.
+                foreach (var entry in targets.EnumerateObject())
+                {
+                    if (entry.Value.TryGetProperty("as", out _))
+                        throw new InvalidOperationException(
+                            $"step '{tool}': targets['{entry.Name}'] must not declare 'as' — "
+                            + "the key already names the argument.");
+                    args[entry.Name] = ResolveAnchor(workspace, sessionId, entry.Value);
+                }
+            }
+
             ThrowOnFailedStep(tool, workspace.Call(tool, args));
         }
     }

--- a/Docxodus.Tests/Eval/EvalHarness.cs
+++ b/Docxodus.Tests/Eval/EvalHarness.cs
@@ -40,6 +40,12 @@ internal sealed record EvalOutcome
     required public string RevisionsJson { get; init; }
     /// <summary>docxodus_comment list on the delivered session.</summary>
     required public string CommentsJson { get; init; }
+    /// <summary>
+    /// docxodus_track_changes list over the document a compare step wrote (the scenario's
+    /// <c>redline.fromPath</c>), read through a fresh session — the harness's own view of the
+    /// produced redline, independent of whatever the compare tool's response claimed.
+    /// </summary>
+    public string? RedlineRevisionsJson { get; init; }
     public RedlineReversibilityProof? Reversibility { get; init; }
     public int GeneratedRevisionCount { get; init; }
 }
@@ -95,10 +101,19 @@ internal static class EvalHarness
             : Path.Combine(CorpusRoot, "scenarios", "corpus", $"{id}.json"));
     }
 
-    /// <summary>Build a fixture's bytes by running its step script over a blank document.</summary>
+    /// <summary>
+    /// Build a fixture's bytes: replay its step script over a blank document, or — when the
+    /// fixture declares <c>builder</c> instead of steps — call the named programmatic builder.
+    /// Builders exist for the one thing the step format cannot author (the tool surface fills
+    /// content controls but cannot create them); they are C# in this assembly, so the corpus
+    /// still carries no committed document bytes.
+    /// </summary>
     public static byte[] BuildFixture(string name)
     {
         var script = LoadJson(Path.Combine(CorpusRoot, "fixtures", $"{name}.json"));
+        if (script.TryGetProperty("builder", out var builder))
+            return EvalFixtureBuilders.Build(builder.GetString()!);
+
         using var workspace = new EvalWorkspace();
         var sessionId = workspace.Open(DocxSessionOps.CreateBlankDocx(), trackedChanges: "accept");
         RunSteps(workspace, sessionId, script.GetProperty("steps"));
@@ -159,6 +174,8 @@ internal static class EvalHarness
                 ["sessionId"] = sessionId,
                 ["action"] = "list",
             }),
+            RedlineRevisionsJson = ReadRedlineRevisions(
+                workspace, scenario.GetProperty("invariants")),
         };
 
         if (ReversibilityMode(scenario) != "acceptAll")
@@ -180,6 +197,28 @@ internal static class EvalHarness
             GeneratedRevisionCount = proof.RevisionClassifications
                 .Count(item => item.Disposition == RedlineRevisionDisposition.Generated),
         };
+    }
+
+    /// <summary>
+    /// When the scenario declares <c>redline</c> invariants, open the document a compare step
+    /// wrote (named by <c>fromPath</c>, resolved inside the workspace like every step path) in a
+    /// fresh session and read its live markup through docxodus_track_changes — the same
+    /// agent-surface view <c>trackedRevisions</c> uses for the delivered session, and
+    /// independent of the compare tool's own response.
+    /// </summary>
+    private static string? ReadRedlineRevisions(EvalWorkspace workspace, JsonElement invariants)
+    {
+        if (!invariants.TryGetProperty("redline", out var redline))
+            return null;
+        if (!redline.TryGetProperty("fromPath", out var fromPath))
+            throw new InvalidOperationException("redline invariants require fromPath");
+
+        var sessionId = workspace.OpenPath(fromPath.GetString()!);
+        return workspace.Call("docxodus_track_changes", new JsonObject
+        {
+            ["sessionId"] = sessionId,
+            ["action"] = "list",
+        });
     }
 
     public static string ReversibilityMode(JsonElement scenario) =>
@@ -408,6 +447,17 @@ internal sealed class EvalWorkspace : IDisposable
         using var opened = JsonDocument.Parse(Call("docxodus_open", new JsonObject
         {
             ["path"] = path,
+            ["trackedChanges"] = trackedChanges,
+        }));
+        return opened.RootElement.GetProperty("sessionId").GetString()!;
+    }
+
+    /// <summary>Open a document a step wrote into the workspace, by its step-visible path.</summary>
+    public string OpenPath(string relativePath, string trackedChanges = "accept")
+    {
+        using var opened = JsonDocument.Parse(Call("docxodus_open", new JsonObject
+        {
+            ["path"] = relativePath,
             ["trackedChanges"] = trackedChanges,
         }));
         return opened.RootElement.GetProperty("sessionId").GetString()!;

--- a/Docxodus.Tests/Eval/EvalSchemaValidator.cs
+++ b/Docxodus.Tests/Eval/EvalSchemaValidator.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Docxodus.Tests.Eval;
+
+/// <summary>
+/// A deliberately small JSON-Schema interpreter covering exactly the constructs
+/// <c>eval/scenario.schema.json</c> uses: <c>$ref</c> into <c>$defs</c>, <c>type</c>,
+/// <c>enum</c>, <c>required</c>, <c>properties</c>, <c>additionalProperties</c> (false or a
+/// schema), <c>items</c>, <c>minItems</c>, <c>minLength</c>, <c>minProperties</c>,
+/// <c>minimum</c>, and <c>pattern</c>. The suite has no JSON-Schema package dependency, and a
+/// generic validator is not the point — the point is that a scenario the schema rejects must
+/// also be rejected where the tests run, so the two contracts cannot drift silently.
+/// </summary>
+internal static class EvalSchemaValidator
+{
+    /// <summary>Validate one instance against the schema, returning human-readable errors.</summary>
+    public static IReadOnlyList<string> Validate(JsonElement instance, JsonElement schema)
+    {
+        var errors = new List<string>();
+        Check(instance, schema, schema, "$", errors);
+        return errors;
+    }
+
+    private static void Check(
+        JsonElement instance, JsonElement schema, JsonElement root, string path, List<string> errors)
+    {
+        if (schema.TryGetProperty("$ref", out var reference))
+        {
+            Check(instance, ResolveRef(root, reference.GetString()!), root, path, errors);
+            return;
+        }
+
+        if (schema.TryGetProperty("type", out var type)
+            && !TypeMatches(instance, type.GetString()!))
+        {
+            errors.Add($"{path}: expected {type.GetString()}, found {instance.ValueKind}");
+            return;
+        }
+
+        if (schema.TryGetProperty("enum", out var allowed)
+            && !allowed.EnumerateArray().Any(candidate => JsonEquals(candidate, instance)))
+            errors.Add($"{path}: value {instance.GetRawText()} is not one of {allowed.GetRawText()}");
+
+        if (instance.ValueKind == JsonValueKind.String)
+        {
+            var value = instance.GetString()!;
+            if (schema.TryGetProperty("minLength", out var minLength)
+                && value.Length < minLength.GetInt32())
+                errors.Add($"{path}: string shorter than minLength {minLength.GetInt32()}");
+            if (schema.TryGetProperty("pattern", out var pattern)
+                && !Regex.IsMatch(value, pattern.GetString()!))
+                errors.Add($"{path}: \"{value}\" does not match pattern {pattern.GetString()}");
+        }
+
+        if (instance.ValueKind == JsonValueKind.Number
+            && schema.TryGetProperty("minimum", out var minimum)
+            && instance.GetDouble() < minimum.GetDouble())
+            errors.Add($"{path}: {instance.GetRawText()} is below minimum {minimum.GetRawText()}");
+
+        if (instance.ValueKind == JsonValueKind.Array)
+        {
+            var count = instance.GetArrayLength();
+            if (schema.TryGetProperty("minItems", out var minItems)
+                && count < minItems.GetInt32())
+                errors.Add($"{path}: {count} item(s), minItems is {minItems.GetInt32()}");
+            if (schema.TryGetProperty("items", out var items))
+            {
+                var index = 0;
+                foreach (var item in instance.EnumerateArray())
+                    Check(item, items, root, $"{path}[{index++}]", errors);
+            }
+        }
+
+        if (instance.ValueKind == JsonValueKind.Object)
+            CheckObject(instance, schema, root, path, errors);
+    }
+
+    private static void CheckObject(
+        JsonElement instance, JsonElement schema, JsonElement root, string path, List<string> errors)
+    {
+        if (schema.TryGetProperty("minProperties", out var minProperties)
+            && instance.EnumerateObject().Count() < minProperties.GetInt32())
+            errors.Add($"{path}: fewer than minProperties {minProperties.GetInt32()} member(s)");
+
+        if (schema.TryGetProperty("required", out var required))
+        {
+            foreach (var name in required.EnumerateArray())
+            {
+                if (!instance.TryGetProperty(name.GetString()!, out _))
+                    errors.Add($"{path}: missing required property '{name.GetString()}'");
+            }
+        }
+
+        var hasProperties = schema.TryGetProperty("properties", out var properties);
+        var hasAdditional = schema.TryGetProperty("additionalProperties", out var additional);
+        foreach (var member in instance.EnumerateObject())
+        {
+            if (hasProperties && properties.TryGetProperty(member.Name, out var memberSchema))
+            {
+                Check(member.Value, memberSchema, root, $"{path}.{member.Name}", errors);
+            }
+            else if (hasAdditional)
+            {
+                if (additional.ValueKind == JsonValueKind.False)
+                    errors.Add($"{path}: property '{member.Name}' is not allowed");
+                else
+                    Check(member.Value, additional, root, $"{path}.{member.Name}", errors);
+            }
+        }
+    }
+
+    private static JsonElement ResolveRef(JsonElement root, string reference)
+    {
+        if (!reference.StartsWith("#/", StringComparison.Ordinal))
+            throw new InvalidOperationException($"unsupported $ref '{reference}'");
+        var current = root;
+        foreach (var segment in reference[2..].Split('/'))
+            current = current.GetProperty(segment);
+        return current;
+    }
+
+    private static bool TypeMatches(JsonElement instance, string type) => type switch
+    {
+        "object" => instance.ValueKind == JsonValueKind.Object,
+        "array" => instance.ValueKind == JsonValueKind.Array,
+        "string" => instance.ValueKind == JsonValueKind.String,
+        "integer" => instance.ValueKind == JsonValueKind.Number
+            && instance.TryGetInt64(out _),
+        "number" => instance.ValueKind == JsonValueKind.Number,
+        "boolean" => instance.ValueKind is JsonValueKind.True or JsonValueKind.False,
+        _ => throw new InvalidOperationException($"unsupported schema type '{type}'"),
+    };
+
+    private static bool JsonEquals(JsonElement left, JsonElement right) =>
+        left.ValueKind == right.ValueKind && left.GetRawText() == right.GetRawText();
+}

--- a/Docxodus.Tests/Eval/WorkflowEvalTests.cs
+++ b/Docxodus.Tests/Eval/WorkflowEvalTests.cs
@@ -20,13 +20,35 @@ namespace Docxodus.Tests.Eval;
 /// </summary>
 public sealed class WorkflowEvalTests
 {
+    /// <summary>
+    /// Scenarios the current run executes: the fast subset always, plus the corpus tier when
+    /// <c>DOCXODUS_RUN_EVAL_CORPUS=1</c>.
+    /// </summary>
     public static TheoryData<string> Scenarios()
     {
         var data = new TheoryData<string>();
-        foreach (var file in EvalHarness.ScenarioFiles())
+        foreach (var file in ExecutableScenarioFiles())
             data.Add(Path.GetFileNameWithoutExtension(file));
         return data;
     }
+
+    /// <summary>
+    /// Every scenario in the repository, both tiers. Declaration checks (vacuity, schema
+    /// conformance) are cheap, so a corpus scenario cannot sit malformed until the weekly run.
+    /// </summary>
+    public static TheoryData<string> DeclaredScenarios()
+    {
+        var data = new TheoryData<string>();
+        foreach (var file in AllScenarioFiles())
+            data.Add(Path.GetFileNameWithoutExtension(file));
+        return data;
+    }
+
+    private static IEnumerable<string> ExecutableScenarioFiles() =>
+        EvalHarness.RunCorpusTier ? AllScenarioFiles() : EvalHarness.ScenarioFiles();
+
+    private static IEnumerable<string> AllScenarioFiles() =>
+        EvalHarness.ScenarioFiles().Concat(EvalHarness.CorpusScenarioFiles());
 
     [Theory]
     [MemberData(nameof(Scenarios))]
@@ -41,9 +63,14 @@ public sealed class WorkflowEvalTests
         CheckTargetPrecision(invariants, outcome, failures);
         CheckCollateral(invariants, outcome, failures);
         CheckValidity(invariants, outcome, failures);
+        CheckTrackedRevisions(invariants, outcome, failures);
+        CheckComments(invariants, outcome, failures);
         CheckReversibility(invariants, outcome, failures);
         CheckRendering(invariants, outcome, failures);
 
+        // The scorecard is written on success too: it is the machine-readable engine baseline a
+        // later agent-scored run of the same scenario is compared against.
+        WriteScorecard(outcome, failures);
         if (failures.Count == 0)
             return;
 
@@ -65,8 +92,12 @@ public sealed class WorkflowEvalTests
             ["taskCompletion"] = ["textPresent", "textAbsent"],
             ["targetPrecision"] =
                 ["changedAnchorsAtLeast", "changedAnchorsAtMost", "changedPartsAtMost"],
-            ["collateral"] = ["partsAdded", "partsRemoved", "textPreserved"],
+            ["collateral"] =
+                ["partsAdded", "partsRemoved", "textPreserved", "changedPartsMustBeWithin"],
             ["validity"] = ["decisionIn"],
+            ["trackedRevisions"] = ["countAtLeast", "countAtMost", "authorsMustInclude"],
+            ["comments"] =
+                ["countAtLeast", "countAtMost", "authorsMustInclude", "repliesAtLeast", "resolvedAtLeast"],
             ["reversibility"] =
             [
                 "mode", "mustSucceed", "generatedRevisionsAtLeast", "pathsMustComplete",
@@ -80,7 +111,7 @@ public sealed class WorkflowEvalTests
     /// mean writing down what "done" and "only that" look like, not eyeballing the output.
     /// </summary>
     [Theory]
-    [MemberData(nameof(Scenarios))]
+    [MemberData(nameof(DeclaredScenarios))]
     public void EV002_ScenarioDeclaresScoreableExpectations(string id)
     {
         var scenario = EvalHarness.LoadScenario(id);
@@ -112,6 +143,9 @@ public sealed class WorkflowEvalTests
             Assert.True(
                 InvariantVocabulary.TryGetValue(group.Name, out var known),
                 $"scenario '{id}' declares unknown invariant group '{group.Name}'.");
+            Assert.True(
+                group.Value.EnumerateObject().Any(),
+                $"scenario '{id}' declares an empty '{group.Name}': it asserts nothing.");
             foreach (var property in group.Value.EnumerateObject())
                 Assert.True(
                     known!.Contains(property.Name, StringComparer.Ordinal),
@@ -133,7 +167,7 @@ public sealed class WorkflowEvalTests
     [Fact]
     public void EV003_FixturesAreDeterministicAndComplete()
     {
-        var names = EvalHarness.ScenarioFiles()
+        var names = AllScenarioFiles()
             .Select(file => EvalHarness.LoadJson(file).GetProperty("fixture").GetString()!)
             .Distinct(StringComparer.Ordinal)
             .ToList();
@@ -141,16 +175,185 @@ public sealed class WorkflowEvalTests
 
         foreach (var name in names)
         {
+            var script = EvalHarness.LoadJson(
+                Path.Combine(EvalHarness.CorpusRoot, "fixtures", $"{name}.json"));
+            // Each fixture declares its own content anchor: identical-but-empty projections must
+            // not count as reproducible, and a hardcoded anchor here would block a second fixture.
+            var expected = script.GetProperty("expectedContent").EnumerateArray()
+                .Select(value => value.GetString()!)
+                .ToList();
+            Assert.NotEmpty(expected);
+
             var first = EvalHarness.BuildFixture(name);
             var second = EvalHarness.BuildFixture(name);
             Assert.True(first.Length > 1_000, $"fixture '{name}' did not build a real package");
             Assert.Equal(EvalHarness.PartUris(first), EvalHarness.PartUris(second));
             var projection = EvalHarness.TextProjection(first);
-            // A non-empty anchor: identical-but-empty projections must not count as reproducible.
-            Assert.Contains("MASTER SERVICES AGREEMENT", projection, StringComparison.Ordinal);
+            foreach (var needle in expected)
+                Assert.Contains(needle, projection, StringComparison.Ordinal);
             Assert.Equal(projection, EvalHarness.TextProjection(second));
         }
     }
+
+    /// <summary>
+    /// Every scenario file, both tiers, must satisfy the published schema. Until now the schema
+    /// was only the corpus-root marker: its enums, patterns, and closed objects were prose. A
+    /// negative control proves the validator can actually reject (an unknown invariant group and
+    /// a bad target mode), so a regression that turns it into a yes-machine fails here.
+    /// </summary>
+    [Fact]
+    public void EV004_ScenariosConformToTheirSchema()
+    {
+        var schema = EvalHarness.LoadJson(
+            Path.Combine(EvalHarness.CorpusRoot, "scenario.schema.json"));
+
+        foreach (var file in AllScenarioFiles())
+        {
+            var errors = EvalSchemaValidator.Validate(EvalHarness.LoadJson(file), schema);
+            Assert.True(
+                errors.Count == 0,
+                $"{Path.GetFileName(file)} violates scenario.schema.json:{Environment.NewLine}"
+                + string.Join(Environment.NewLine, errors.Select(error => "  - " + error)));
+        }
+
+        using var invalid = JsonDocument.Parse("""
+            {
+              "id": "Bad Id With Spaces",
+              "title": "x",
+              "fixture": "master-services-agreement",
+              "steps": [{ "tool": "docxodus_edit", "target": { "mode": "nonsense", "query": "q" }, "args": {} }],
+              "invariants": { "notAGroup": { "x": 1 } }
+            }
+            """);
+        var rejected = EvalSchemaValidator.Validate(invalid.RootElement, schema);
+        Assert.Contains(rejected, error => error.Contains("pattern", StringComparison.Ordinal));
+        Assert.Contains(rejected, error => error.Contains("mode", StringComparison.Ordinal));
+        Assert.Contains(rejected, error => error.Contains("notAGroup", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The schema's invariant vocabulary and the checkers' vocabulary are two views of one
+    /// contract. The C# side stays authoritative for "what a checker actually reads"; this pins
+    /// the schema to it in both directions, so neither can grow a key the other ignores.
+    /// </summary>
+    [Fact]
+    public void EV005_SchemaAndCheckerInvariantVocabulariesAgree()
+    {
+        var schema = EvalHarness.LoadJson(
+            Path.Combine(EvalHarness.CorpusRoot, "scenario.schema.json"));
+        var groups = schema.GetProperty("$defs").GetProperty("invariants").GetProperty("properties");
+
+        var schemaGroups = groups.EnumerateObject().Select(group => group.Name)
+            .OrderBy(name => name, StringComparer.Ordinal).ToList();
+        Assert.Equal(
+            InvariantVocabulary.Keys.OrderBy(name => name, StringComparer.Ordinal).ToList(),
+            schemaGroups);
+
+        foreach (var group in groups.EnumerateObject())
+        {
+            var schemaKeys = group.Value.GetProperty("properties").EnumerateObject()
+                .Select(property => property.Name)
+                .OrderBy(name => name, StringComparer.Ordinal).ToList();
+            Assert.Equal(
+                InvariantVocabulary[group.Name].OrderBy(name => name, StringComparer.Ordinal).ToList(),
+                schemaKeys);
+        }
+    }
+
+    /// <summary>
+    /// Negative controls for the invariant checkers added for the #466 close-out: each one must
+    /// record a failure when its expectation is violated and stay silent when it is met. A
+    /// checker that cannot fail is decoration, not an invariant.
+    /// </summary>
+    [Fact]
+    public void EV006_NewInvariantChecksFailWhenViolated()
+    {
+        var outcome = SyntheticOutcome();
+
+        AssertCheck(
+            outcome,
+            """{ "collateral": { "changedPartsMustBeWithin": ["/word/document.xml"] } }""",
+            CheckCollateral,
+            expectFailure: true,
+            "the change set touched /word/header1.xml");
+        AssertCheck(
+            outcome,
+            """{ "collateral": { "changedPartsMustBeWithin": ["/word/document.xml", "/word/header1.xml"] } }""",
+            CheckCollateral,
+            expectFailure: false,
+            "both changed parts are allowlisted");
+
+        AssertCheck(
+            outcome,
+            """{ "trackedRevisions": { "countAtLeast": 2, "authorsMustInclude": ["Prior Reviewer", "Absent Author"] } }""",
+            CheckTrackedRevisions,
+            expectFailure: true,
+            "only one revision, and Absent Author has none");
+        AssertCheck(
+            outcome,
+            """{ "trackedRevisions": { "countAtLeast": 1, "countAtMost": 1, "authorsMustInclude": ["Prior Reviewer"] } }""",
+            CheckTrackedRevisions,
+            expectFailure: false,
+            "the live revision matches every bound");
+
+        AssertCheck(
+            outcome,
+            """{ "comments": { "repliesAtLeast": 2, "resolvedAtLeast": 2 } }""",
+            CheckComments,
+            expectFailure: true,
+            "one reply and one resolved comment fall short of two");
+        AssertCheck(
+            outcome,
+            """{ "comments": { "countAtLeast": 2, "authorsMustInclude": ["First Reviewer"], "repliesAtLeast": 1, "resolvedAtLeast": 1 } }""",
+            CheckComments,
+            expectFailure: false,
+            "the comment thread matches every bound");
+    }
+
+    private static void AssertCheck(
+        EvalOutcome outcome,
+        string invariantsJson,
+        Action<JsonElement, EvalOutcome, List<string>> checker,
+        bool expectFailure,
+        string because)
+    {
+        using var document = JsonDocument.Parse(invariantsJson);
+        var failures = new List<string>();
+        checker(document.RootElement, outcome, failures);
+        if (expectFailure)
+            Assert.True(failures.Count > 0, $"expected a failure ({because}), got none");
+        else
+            Assert.True(
+                failures.Count == 0,
+                $"expected no failure ({because}), got: {string.Join("; ", failures)}");
+    }
+
+    private static EvalOutcome SyntheticOutcome() => new()
+    {
+        Id = "synthetic-negative-control",
+        OpeningBytes = [],
+        DeliverableBytes = [],
+        ChangedAnchors = ["p:body:00000001"],
+        ChangedParts = ["/word/document.xml", "/word/header1.xml"],
+        PartsAdded = 0,
+        PartsRemoved = 0,
+        ValidityDecision = "passed",
+        VerificationJson = "{}",
+        TextMatchCounts = new Dictionary<string, int>(StringComparer.Ordinal),
+        Text = string.Empty,
+        Html = string.Empty,
+        SemanticChangesJson = "{}",
+        RevisionsJson = """
+            {"revisions":[{"id":"r1","type":"insert","family":"run","constituentIds":[],
+            "constituentKeys":[],"author":"Prior Reviewer","text":"x","partUri":"word/document.xml",
+            "scope":"body","affectedAnchors":[],"resolutionStatus":"open"}]}
+            """,
+        CommentsJson = """
+            {"comments":[
+            {"anchorId":"cmt:cmt:1","author":"First Reviewer","text":"Q?","resolved":true},
+            {"anchorId":"cmt:cmt:2","author":"Second Reviewer","text":"A.","parentAnchorId":"cmt:cmt:1"}]}
+            """,
+    };
 
     private static void CheckTaskCompletion(
         JsonElement invariants, EvalOutcome outcome, List<string> failures)
@@ -219,6 +422,101 @@ public sealed class WorkflowEvalTests
         {
             if (Matches(outcome, needle) == 0)
                 failures.Add($"collateral: unrelated content was damaged, lost: \"{needle}\"");
+        }
+
+        // Identity, not cardinality: an edit that stayed within its part budget but landed in
+        // the wrong part (a header instead of the body) fails here.
+        if (collateral.TryGetProperty("changedPartsMustBeWithin", out var allowlist))
+        {
+            var allowed = allowlist.EnumerateArray()
+                .Select(value => value.GetString() ?? string.Empty)
+                .ToHashSet(StringComparer.Ordinal);
+            var outside = outcome.ChangedParts
+                .Where(part => !allowed.Contains(part))
+                .ToList();
+            if (outside.Count > 0)
+                failures.Add(
+                    "collateral: change set touched part(s) outside the allowlist "
+                    + $"[{string.Join(", ", outside)}], allowed [{string.Join(", ", allowed)}]");
+        }
+    }
+
+    /// <summary>
+    /// Both of the next two groups are agent-surface facts: they parse the same
+    /// docxodus_track_changes/docxodus_comment list responses an agent would read, captured from
+    /// the delivered session, not the typed .NET view.
+    /// </summary>
+    private static void CheckTrackedRevisions(
+        JsonElement invariants, EvalOutcome outcome, List<string> failures)
+    {
+        if (!invariants.TryGetProperty("trackedRevisions", out var expected))
+            return;
+
+        using var document = JsonDocument.Parse(outcome.RevisionsJson);
+        var revisions = document.RootElement.GetProperty("revisions").EnumerateArray().ToList();
+        CheckCountBounds(expected, revisions.Count, "trackedRevisions", "revision", failures);
+        CheckAuthors(
+            expected,
+            revisions.Select(item => item.GetProperty("author").GetString() ?? string.Empty),
+            "trackedRevisions",
+            failures);
+    }
+
+    private static void CheckComments(
+        JsonElement invariants, EvalOutcome outcome, List<string> failures)
+    {
+        if (!invariants.TryGetProperty("comments", out var expected))
+            return;
+
+        using var document = JsonDocument.Parse(outcome.CommentsJson);
+        var comments = document.RootElement.GetProperty("comments").EnumerateArray().ToList();
+        CheckCountBounds(expected, comments.Count, "comments", "comment", failures);
+        CheckAuthors(
+            expected,
+            comments.Select(item => item.GetProperty("author").GetString() ?? string.Empty),
+            "comments",
+            failures);
+
+        var replies = comments.Count(item => item.TryGetProperty("parentAnchorId", out _));
+        if (expected.TryGetProperty("repliesAtLeast", out var repliesAtLeast)
+            && replies < repliesAtLeast.GetInt32())
+            failures.Add(
+                $"comments: {replies} repl(ies) present, expected at least {repliesAtLeast.GetInt32()}");
+
+        var resolved = comments.Count(item =>
+            item.TryGetProperty("resolved", out var flag) && flag.ValueKind == JsonValueKind.True);
+        if (expected.TryGetProperty("resolvedAtLeast", out var resolvedAtLeast)
+            && resolved < resolvedAtLeast.GetInt32())
+            failures.Add(
+                $"comments: {resolved} resolved comment(s), expected at least "
+                + $"{resolvedAtLeast.GetInt32()}");
+    }
+
+    private static void CheckCountBounds(
+        JsonElement expected, int count, string group, string noun, List<string> failures)
+    {
+        if (expected.TryGetProperty("countAtLeast", out var atLeast)
+            && count < atLeast.GetInt32())
+            failures.Add($"{group}: {count} {noun}(s) present, expected at least {atLeast.GetInt32()}");
+        if (expected.TryGetProperty("countAtMost", out var atMost)
+            && count > atMost.GetInt32())
+            failures.Add($"{group}: {count} {noun}(s) present, expected at most {atMost.GetInt32()}");
+    }
+
+    private static void CheckAuthors(
+        JsonElement expected, IEnumerable<string> actual, string group, List<string> failures)
+    {
+        if (!expected.TryGetProperty("authorsMustInclude", out var required))
+            return;
+
+        var present = actual.ToHashSet(StringComparer.Ordinal);
+        foreach (var author in required.EnumerateArray())
+        {
+            var name = author.GetString() ?? string.Empty;
+            if (!present.Contains(name))
+                failures.Add(
+                    $"{group}: no entry by author \"{name}\" "
+                    + $"[present: {string.Join(", ", present.OrderBy(a => a, StringComparer.Ordinal))}]");
         }
     }
 
@@ -339,12 +637,7 @@ public sealed class WorkflowEvalTests
     /// </summary>
     private static string WriteArtifacts(EvalOutcome outcome)
     {
-        var directory = Path.Combine(
-            Environment.GetEnvironmentVariable("DOCXODUS_EVAL_ARTIFACTS")
-                ?? Path.Combine(Path.GetTempPath(), "docxodus-eval-artifacts"),
-            outcome.Id);
-        Directory.CreateDirectory(directory);
-
+        var directory = ArtifactDirectory(outcome.Id);
         File.WriteAllBytes(Path.Combine(directory, "opening.docx"), outcome.OpeningBytes);
         File.WriteAllBytes(Path.Combine(directory, "delivered.docx"), outcome.DeliverableBytes);
         File.WriteAllText(Path.Combine(directory, "delivered.html"), outcome.Html, Encoding.UTF8);
@@ -357,6 +650,10 @@ public sealed class WorkflowEvalTests
             Path.Combine(directory, "verification.json"),
             outcome.VerificationJson,
             Encoding.UTF8);
+        File.WriteAllText(
+            Path.Combine(directory, "revisions.json"), outcome.RevisionsJson, Encoding.UTF8);
+        File.WriteAllText(
+            Path.Combine(directory, "comments.json"), outcome.CommentsJson, Encoding.UTF8);
         if (outcome.Reversibility is { } proof)
         {
             File.WriteAllText(
@@ -366,5 +663,58 @@ public sealed class WorkflowEvalTests
         }
 
         return directory;
+    }
+
+    private static string ArtifactDirectory(string id)
+    {
+        var directory = Path.Combine(
+            Environment.GetEnvironmentVariable("DOCXODUS_EVAL_ARTIFACTS")
+                ?? Path.Combine(Path.GetTempPath(), "docxodus-eval-artifacts"),
+            id);
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    /// <summary>
+    /// The per-scenario engine baseline, written pass or fail: every metric the run measured,
+    /// in one machine-readable file. An agent-scored run of the same scenario is compared
+    /// against this — same fixture, same invariants, measured by the same scripted caller.
+    /// </summary>
+    private static void WriteScorecard(EvalOutcome outcome, IReadOnlyList<string> failures)
+    {
+        var scorecard = new
+        {
+            scenario = outcome.Id,
+            passed = failures.Count == 0,
+            invariantFailures = failures,
+            metrics = new
+            {
+                changedAnchors = outcome.ChangedAnchors,
+                changedParts = outcome.ChangedParts,
+                partsAdded = outcome.PartsAdded,
+                partsRemoved = outcome.PartsRemoved,
+                validityDecision = outcome.ValidityDecision,
+                textMatchCounts = outcome.TextMatchCounts,
+                generatedRevisionCount = outcome.GeneratedRevisionCount,
+                reversibility = outcome.Reversibility is { } proof
+                    ? new
+                    {
+                        acceptCompleted = proof.AcceptToFinal?.Completed,
+                        rejectCompleted = proof.RejectToBaseline?.Completed,
+                        rejectSemanticallyRestoresBaseline =
+                            proof.RejectToBaseline?.ModeledSemantic.Equivalent,
+                        preExistingPreserved =
+                            proof.AcceptToFinal?.PreExistingRevisionsPreserved == true
+                            && proof.RejectToBaseline?.PreExistingRevisionsPreserved == true,
+                        fullPackageSuccess = proof.Success,
+                    }
+                    : null,
+            },
+        };
+        File.WriteAllText(
+            Path.Combine(ArtifactDirectory(outcome.Id), "scorecard.json"),
+            JsonSerializer.Serialize(
+                scorecard, new JsonSerializerOptions { WriteIndented = true }),
+            Encoding.UTF8);
     }
 }

--- a/Docxodus.Tests/Eval/WorkflowEvalTests.cs
+++ b/Docxodus.Tests/Eval/WorkflowEvalTests.cs
@@ -65,6 +65,7 @@ public sealed class WorkflowEvalTests
         CheckValidity(invariants, outcome, failures);
         CheckTrackedRevisions(invariants, outcome, failures);
         CheckComments(invariants, outcome, failures);
+        CheckRedline(invariants, outcome, failures);
         CheckReversibility(invariants, outcome, failures);
         CheckRendering(invariants, outcome, failures);
 
@@ -98,6 +99,7 @@ public sealed class WorkflowEvalTests
             ["trackedRevisions"] = ["countAtLeast", "countAtMost", "authorsMustInclude"],
             ["comments"] =
                 ["countAtLeast", "countAtMost", "authorsMustInclude", "repliesAtLeast", "resolvedAtLeast"],
+            ["redline"] = ["fromPath", "countAtLeast", "countAtMost", "authorsMustInclude"],
             ["reversibility"] =
             [
                 "mode", "mustSucceed", "generatedRevisionsAtLeast", "pathsMustComplete",
@@ -308,6 +310,25 @@ public sealed class WorkflowEvalTests
             CheckComments,
             expectFailure: false,
             "the comment thread matches every bound");
+
+        AssertCheck(
+            outcome,
+            """{ "redline": { "fromPath": "out.docx", "countAtLeast": 3, "authorsMustInclude": ["Reviewer B"] } }""",
+            CheckRedline,
+            expectFailure: true,
+            "the captured redline has two revisions and no Reviewer B");
+        AssertCheck(
+            outcome,
+            """{ "redline": { "fromPath": "out.docx", "countAtLeast": 2, "countAtMost": 2, "authorsMustInclude": ["Reviewer A"] } }""",
+            CheckRedline,
+            expectFailure: false,
+            "the captured redline matches every bound");
+        AssertCheck(
+            outcome with { RedlineRevisionsJson = null },
+            """{ "redline": { "fromPath": "out.docx", "countAtLeast": 1 } }""",
+            CheckRedline,
+            expectFailure: true,
+            "declared redline invariants with no captured redline must fail, not skip");
     }
 
     private static void AssertCheck(
@@ -352,6 +373,11 @@ public sealed class WorkflowEvalTests
             {"comments":[
             {"anchorId":"cmt:cmt:1","author":"First Reviewer","text":"Q?","resolved":true},
             {"anchorId":"cmt:cmt:2","author":"Second Reviewer","text":"A.","parentAnchorId":"cmt:cmt:1"}]}
+            """,
+        RedlineRevisionsJson = """
+            {"revisions":[
+            {"id":"r1","type":"insert","author":"Reviewer A","text":"x"},
+            {"id":"r2","type":"delete","author":"Reviewer A","text":"y"}]}
             """,
     };
 
@@ -490,6 +516,33 @@ public sealed class WorkflowEvalTests
             failures.Add(
                 $"comments: {resolved} resolved comment(s), expected at least "
                 + $"{resolvedAtLeast.GetInt32()}");
+    }
+
+    /// <summary>
+    /// Assertions over the document a compare step wrote (<c>redline.fromPath</c>): the harness
+    /// opened it in a fresh session and read docxodus_track_changes list, so these bounds
+    /// describe the produced file itself, independent of the compare tool's own response.
+    /// </summary>
+    private static void CheckRedline(
+        JsonElement invariants, EvalOutcome outcome, List<string> failures)
+    {
+        if (!invariants.TryGetProperty("redline", out var expected))
+            return;
+
+        if (outcome.RedlineRevisionsJson is not { } revisionsJson)
+        {
+            failures.Add("redline: invariants declared but no redline document was captured");
+            return;
+        }
+
+        using var document = JsonDocument.Parse(revisionsJson);
+        var revisions = document.RootElement.GetProperty("revisions").EnumerateArray().ToList();
+        CheckCountBounds(expected, revisions.Count, "redline", "revision", failures);
+        CheckAuthors(
+            expected,
+            revisions.Select(item => item.GetProperty("author").GetString() ?? string.Empty),
+            "redline",
+            failures);
     }
 
     private static void CheckCountBounds(
@@ -654,6 +707,12 @@ public sealed class WorkflowEvalTests
             Path.Combine(directory, "revisions.json"), outcome.RevisionsJson, Encoding.UTF8);
         File.WriteAllText(
             Path.Combine(directory, "comments.json"), outcome.CommentsJson, Encoding.UTF8);
+        if (outcome.RedlineRevisionsJson is { } redlineRevisions)
+        {
+            File.WriteAllText(
+                Path.Combine(directory, "redline-revisions.json"), redlineRevisions, Encoding.UTF8);
+        }
+
         if (outcome.Reversibility is { } proof)
         {
             File.WriteAllText(
@@ -682,6 +741,13 @@ public sealed class WorkflowEvalTests
     /// </summary>
     private static void WriteScorecard(EvalOutcome outcome, IReadOnlyList<string> failures)
     {
+        int? redlineRevisionCount = null;
+        if (outcome.RedlineRevisionsJson is { } redlineJson)
+        {
+            using var redline = JsonDocument.Parse(redlineJson);
+            redlineRevisionCount = redline.RootElement.GetProperty("revisions").GetArrayLength();
+        }
+
         var scorecard = new
         {
             scenario = outcome.Id,
@@ -696,6 +762,7 @@ public sealed class WorkflowEvalTests
                 validityDecision = outcome.ValidityDecision,
                 textMatchCounts = outcome.TextMatchCounts,
                 generatedRevisionCount = outcome.GeneratedRevisionCount,
+                redlineRevisionCount,
                 reversibility = outcome.Reversibility is { } proof
                     ? new
                     {

--- a/Docxodus.Tests/McpCompareTransportTests.cs
+++ b/Docxodus.Tests/McpCompareTransportTests.cs
@@ -1,0 +1,220 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Text.Json;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Docxodus.McpServer;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+/// <summary>
+/// Transport-seam coverage for the sessionless <c>docxodus_compare</c> tool. The comparison
+/// engines are covered by their own suites; these tests assert only the seam: store-scoped path
+/// resolution on every input and the output, honest revision attribution in the summary and the
+/// written redline, the two-form contract, and that the tool cannot be smuggled into a mutation
+/// batch.
+/// </summary>
+public sealed class McpCompareTransportTests
+{
+    [Fact]
+    public void CT001_TwoWayCompareWritesAnAttributedRedlineAndSummarizesIt()
+    {
+        using var workspace = new StoreWorkspace();
+        workspace.Write("baseline.docx", Document("The original clause."));
+        workspace.Write("revised.docx", Document("The revised clause."));
+
+        var response = workspace.Call("docxodus_compare", $$"""
+            {"baselinePath":"baseline.docx","revisedPath":"revised.docx",
+             "author":"Reviewer A","outputPath":"redline.docx"}
+            """);
+
+        using var summary = JsonDocument.Parse(response);
+        var total = summary.RootElement.GetProperty("revisions").GetProperty("total").GetInt32();
+        Assert.True(total > 0, response);
+        Assert.Equal(
+            total,
+            summary.RootElement.GetProperty("revisions").GetProperty("byAuthor")
+                .GetProperty("Reviewer A").GetInt32());
+
+        // The written file, opened like any other document, carries the same live markup the
+        // summary claimed — the summary cannot drift from the artifact.
+        var sessionId = workspace.OpenSession("redline.docx");
+        using var listed = JsonDocument.Parse(workspace.Call("docxodus_track_changes", $$"""
+            {"sessionId":{{JsonSerializer.Serialize(sessionId)}},"action":"list"}
+            """));
+        var revisions = listed.RootElement.GetProperty("revisions").EnumerateArray().ToList();
+        Assert.Equal(total, revisions.Count);
+        Assert.All(revisions, revision =>
+            Assert.Equal("Reviewer A", revision.GetProperty("author").GetString()));
+    }
+
+    [Fact]
+    public void CT002_ConsolidateAttributesEachReviewersChangesToTheirAuthor()
+    {
+        using var workspace = new StoreWorkspace();
+        workspace.Write("base.docx", Document("Alpha stays. Beta stays."));
+        workspace.Write("a.docx", Document("Alpha revised. Beta stays."));
+        workspace.Write("b.docx", Document("Alpha stays. Beta revised."));
+
+        var response = workspace.Call("docxodus_compare", """
+            {"baselinePath":"base.docx","revisedPaths":["a.docx","b.docx"],
+             "authors":["Reviewer A","Reviewer B"],"outputPath":"consolidated.docx"}
+            """);
+
+        using var summary = JsonDocument.Parse(response);
+        var byAuthor = summary.RootElement.GetProperty("revisions").GetProperty("byAuthor");
+        Assert.True(byAuthor.GetProperty("Reviewer A").GetInt32() > 0, response);
+        Assert.True(byAuthor.GetProperty("Reviewer B").GetInt32() > 0, response);
+
+        var sessionId = workspace.OpenSession("consolidated.docx");
+        using var listed = JsonDocument.Parse(workspace.Call("docxodus_track_changes", $$"""
+            {"sessionId":{{JsonSerializer.Serialize(sessionId)}},"action":"list"}
+            """));
+        var authors = listed.RootElement.GetProperty("revisions").EnumerateArray()
+            .Select(revision => revision.GetProperty("author").GetString())
+            .ToHashSet();
+        Assert.Contains("Reviewer A", authors);
+        Assert.Contains("Reviewer B", authors);
+    }
+
+    [Fact]
+    public void CT003_EveryPathIsResolvedInsideTheDocumentScope()
+    {
+        using var workspace = new StoreWorkspace();
+        workspace.Write("baseline.docx", Document("Text."));
+        workspace.Write("revised.docx", Document("Changed text."));
+        var outside = Path.Combine(
+            Path.GetTempPath(), $"compare-outside-{Guid.NewGuid():N}.docx");
+        File.WriteAllBytes(outside, Document("Text."));
+        try
+        {
+            foreach (var request in new[]
+                     {
+                         $$"""
+                           {"baselinePath":{{JsonSerializer.Serialize(outside)}},
+                            "revisedPath":"revised.docx","outputPath":"out.docx"}
+                           """,
+                         $$"""
+                           {"baselinePath":"baseline.docx",
+                            "revisedPath":{{JsonSerializer.Serialize(outside)}},"outputPath":"out.docx"}
+                           """,
+                         $$"""
+                           {"baselinePath":"baseline.docx","revisedPath":"revised.docx",
+                            "outputPath":{{JsonSerializer.Serialize(outside)}}}
+                           """,
+                     })
+            {
+                var escape = Assert.Throws<McpToolException>(
+                    () => workspace.Call("docxodus_compare", request));
+                Assert.Contains("outside this server's document scope", escape.Message);
+            }
+        }
+        finally
+        {
+            File.Delete(outside);
+        }
+    }
+
+    [Fact]
+    public void CT004_TheTwoFormsAreExclusiveAndAuthorsMustMatch()
+    {
+        using var workspace = new StoreWorkspace();
+        workspace.Write("baseline.docx", Document("Text."));
+        workspace.Write("revised.docx", Document("Changed text."));
+
+        var both = Assert.Throws<McpToolException>(() => workspace.Call("docxodus_compare", """
+            {"baselinePath":"baseline.docx","revisedPath":"revised.docx",
+             "revisedPaths":["revised.docx","revised.docx"],"outputPath":"out.docx"}
+            """));
+        Assert.Contains("exactly one of", both.Message);
+
+        var neither = Assert.Throws<McpToolException>(() => workspace.Call("docxodus_compare", """
+            {"baselinePath":"baseline.docx","outputPath":"out.docx"}
+            """));
+        Assert.Contains("exactly one of", neither.Message);
+
+        var mismatched = Assert.Throws<McpToolException>(() => workspace.Call("docxodus_compare", """
+            {"baselinePath":"baseline.docx","revisedPaths":["revised.docx","revised.docx"],
+             "authors":["Only One"],"outputPath":"out.docx"}
+            """));
+        Assert.Contains("authors must match revisedPaths", mismatched.Message);
+    }
+
+    [Fact]
+    public void CT005_CompareIsNotAcceptedAsAMutationBatchStep()
+    {
+        using var workspace = new StoreWorkspace();
+        workspace.Write("document.docx", Document("Text."));
+        var sessionId = workspace.OpenSession("document.docx");
+
+        // Behavioral, not schema text: the batch validator's own allowlist must refuse the tool —
+        // nothing executed, the batch reports the step as invalid.
+        var response = workspace.Call("docxodus_mutations", $$$"""
+            {"sessionId":{{{JsonSerializer.Serialize(sessionId)}}},"steps":[
+                {"tool":"docxodus_compare","args":{"action":"compare",
+                 "baselinePath":"document.docx","revisedPath":"document.docx",
+                 "outputPath":"out.docx"}}]}
+            """);
+        using var batch = JsonDocument.Parse(response);
+        Assert.False(batch.RootElement.GetProperty("success").GetBoolean());
+        Assert.Contains("unsupported or read-only batch action: docxodus_compare", response);
+    }
+
+    /// <summary>A disposable store rooted in a private directory, mirroring the MCP server.</summary>
+    private sealed class StoreWorkspace : IDisposable
+    {
+        private readonly string _root =
+            Path.Combine(Path.GetTempPath(), $"docxodus-compare-{Guid.NewGuid():N}");
+
+        private readonly SessionStore _store;
+
+        public StoreWorkspace()
+        {
+            Directory.CreateDirectory(_root);
+            _store = new SessionStore(new LocalFileDocumentStore(_root));
+        }
+
+        public void Write(string name, byte[] bytes) =>
+            File.WriteAllBytes(Path.Combine(_root, name), bytes);
+
+        public string Call(string tool, string argsJson)
+        {
+            using var document = JsonDocument.Parse(argsJson);
+            return Dispatcher.Call(_store, tool, document.RootElement.Clone());
+        }
+
+        public string OpenSession(string name)
+        {
+            using var opened = JsonDocument.Parse(Call(
+                "docxodus_open",
+                $$"""{"path":{{JsonSerializer.Serialize(name)}}}"""));
+            return opened.RootElement.GetProperty("sessionId").GetString()!;
+        }
+
+        public void Dispose()
+        {
+            _store.CloseAll();
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    private static byte[] Document(string text)
+    {
+        using var stream = new MemoryStream();
+        using (var document = WordprocessingDocument.Create(
+                   stream, WordprocessingDocumentType.Document))
+        {
+            var main = document.AddMainDocumentPart();
+            main.Document = new Document(new Body(new Paragraph(new Run(new Text(text)))));
+            main.AddNewPart<DocumentSettingsPart>().Settings = new Settings();
+            document.Save();
+        }
+
+        return stream.ToArray();
+    }
+}

--- a/Docxodus.Tests/McpServerDispatcherTests.cs
+++ b/Docxodus.Tests/McpServerDispatcherTests.cs
@@ -1591,6 +1591,7 @@ public class McpServerDispatcherTests : IDisposable
             "docxodus_annotate",
             "docxodus_close",
             "docxodus_comment",
+            "docxodus_compare",
             "docxodus_content_controls",
             "docxodus_create",
             "docxodus_edit",

--- a/docs/architecture/docx_agent_server.md
+++ b/docs/architecture/docx_agent_server.md
@@ -81,7 +81,7 @@ session registry assumes single-threaded access.
   — the requested `protocolVersion` is echoed when present (every implemented method is
   shape-stable across published revisions; the UI extension negotiates via `capabilities.extensions`)
 - `notifications/initialized` → no response (notification)
-- `tools/list` → `{ tools: [ { name, description, inputSchema, _meta? }, ... ] }` — the 19 tools below
+- `tools/list` → `{ tools: [ { name, description, inputSchema, _meta? }, ... ] }` — the 20 tools below
 - `tools/call` params `{ name, arguments }` → `{ content: [ { type: "text", text: <JSON string> } ], isError }`
   (plus `structuredContent`/`_meta` on the two preview-related tools — see "Inline preview" below)
 - `resources/list` / `resources/read` / `resources/templates/list` — serve the `ui://` viewer
@@ -517,6 +517,20 @@ is deliberately **not** a `docxodus_mutations` step, because a batch is a sequen
 Malformed, encrypted, and safety-limited inputs come back as typed proof findings rather than
 errors, and fail closed: when a package cannot be admitted, neither path is attempted at all, so
 a partial result can never be misread as evidence.
+
+### `docxodus_compare` — versions into one attributed redline (issue #466)
+
+Sessionless: `baselinePath` plus either `revisedPath` (two-way `DocxDiff` compare) or
+`revisedPaths` (N-way consolidate, each reviewer's changes attributed to the matching `authors`
+entry) produce a native tracked-changes redline written to `outputPath`. Every path — inputs and
+output — resolves through the document store's containment check exactly like `docxodus_open`'s,
+so the tool can neither read nor write outside the server's scope. The response summarizes the
+generated revisions by author; the written file is a plain DOCX an agent then opens with
+`docxodus_open` to inspect, comment on, resolve, or prove with `prove_reversibility`.
+
+It is sessionless because it operates on stored documents, not the open session's state, and it
+is not a `docxodus_mutations` step for the same reason a proof is not: a batch is a sequence of
+session mutations, and this mutates no session.
 
 ### `docxodus_mutations` — atomic batches, explicit partial apply, or isolated preview
 

--- a/eval/PROVENANCE.md
+++ b/eval/PROVENANCE.md
@@ -12,6 +12,14 @@ nothing in this corpus originates outside the repository.
 | Fixture | Origin | Rights |
 |---------|--------|--------|
 | `master-services-agreement` | Written for this repository | Same MIT license as the rest of the repository |
+| `clause-library` | Written for this repository | Same MIT license as the rest of the repository |
+| `content-control-template` | Written for this repository (programmatic builder) | Same MIT license as the rest of the repository |
+
+One fixture kind exists beyond step scripts: `content-control-template` declares a named
+programmatic **builder** (`Docxodus.Tests/Eval/EvalFixtureBuilders.cs`) instead of steps, because
+the tool surface can fill content controls but has no action that creates one. The builder is C#
+in this repository, deterministic under the same EV003 gate, and commits no document bytes — the
+no-third-party-content property is unchanged.
 
 ## The content is fictional
 

--- a/eval/README.md
+++ b/eval/README.md
@@ -48,7 +48,10 @@ contradictory.
 ## Fixtures
 
 Fixtures under `fixtures/` are **build scripts in the same step format**, not `.docx` files.
-`EvalHarness.BuildFixture` replays one over a blank document. Two consequences:
+`EvalHarness.BuildFixture` replays one over a blank document. A fixture may instead declare a
+named programmatic `builder` (C# in `Docxodus.Tests/Eval/EvalFixtureBuilders.cs`) for the one
+thing the step format cannot express — the tool surface fills content controls but cannot create
+one — under the same determinism gate and still without committing bytes. Two consequences:
 
 - The corpus carries no third-party document bytes, so there is no redistribution question to
   answer. See [PROVENANCE.md](PROVENANCE.md).
@@ -71,6 +74,7 @@ contract rather than a bespoke comparison:
 | `validity` | Is the deliverable structurally sound? | #463 deliverable gate |
 | `trackedRevisions` | Is the expected live markup present — including another reviewer's? | `docxodus_track_changes list` on the delivered session |
 | `comments` | Are the expected comments, replies, and resolved flags present? | `docxodus_comment list` on the delivered session |
+| `redline` | Does the redline a `docxodus_compare` step wrote carry the expected attributed revisions? | `docxodus_track_changes list` over a fresh session opened on `fromPath` |
 | `reversibility` | Does the redline accept and reject cleanly? | #464 proof |
 | `rendering` | Does it still render? | HTML projection |
 
@@ -166,7 +170,19 @@ Deliberately **not** here, and tracked separately:
 - Delivery change receipts, which belong to the #465 delivery operation (see "Scorecards and
   failure artifacts").
 
-The remaining #466 scenario families — clause insertion with numbering, comment/footnote/
-cross-reference authoring, content-control templates, N-way consolidation, and documents
-carrying pre-existing revisions — are corpus work in progress; the runner capabilities they
-need (multi-anchor targets, part allowlists, markup and comment invariants) are in place.
+All nine #466 scenario families now run in the fast tier (the whole suite executes in seconds,
+so nothing yet warrants the corpus tier, which stands ready for heavier fixtures). Two
+deliberate descopes are recorded where they bind:
+
+- `review-annotations` covers comment, threaded reply, footnote, bookmark, and a
+  bookmark-anchored internal hyperlink. A field-based `REF` cross-reference is not authorable on
+  the tool surface — issue #545 tracks the op; the scenario notes the substitution.
+- `layout-preservation` is single-section: no section-break authoring op exists on the tool
+  surface, so a multi-section fixture cannot be built through steps. Part identity does the
+  layout work — any touch of a header or footer part fails `changedPartsMustBeWithin`.
+
+One engine observation from building the corpus, worth knowing when authoring fixtures: a
+comment whose range covers a paragraph carrying live tracked-change markup reports a spurious
+`comment` modification in the #457 change set on every open→save cycle (the target paragraph's
+content-derived anchor id is not stable across the save normalization). The fixture therefore
+anchors its pre-existing comment on a revision-free paragraph.

--- a/eval/README.md
+++ b/eval/README.md
@@ -10,9 +10,11 @@ This directory is the **corpus and the contract**. The runner lives in
 ## What a scenario is
 
 A scenario is one JSON file under `scenarios/`. [`scenario.schema.json`](scenario.schema.json)
-documents the contract; the suite's `EV002` test enforces its substance directly — a non-empty
-completion and preservation list, at least one precision bound, and no invariant key outside the
-vocabulary the checkers actually read, so a typo cannot silently switch a check off:
+is the contract, and it is enforced, not decorative: `EV004` validates every scenario file
+against it, `EV005` pins its invariant vocabulary to the checkers' vocabulary in both
+directions, and `EV002` enforces its substance directly — a non-empty completion and
+preservation list, at least one precision bound, no empty invariant group, and no invariant key
+outside the vocabulary the checkers actually read, so a typo cannot silently switch a check off:
 
 | Part | Answers |
 |------|---------|
@@ -38,6 +40,11 @@ response. A step is therefore independent of the shape of what came before, and 
 drifts fails loudly: if a target matches fewer blocks than the requested `index`, the run errors
 out instead of quietly editing a different block and then reporting good precision.
 
+A tool that takes several anchors — a range format, a move, a bookmark span — declares `targets`
+instead: a map whose keys name the arguments and whose values are resolved exactly like `target`.
+The key names the argument, so a `targets` entry that also declares `as` fails the scenario as
+contradictory.
+
 ## Fixtures
 
 Fixtures under `fixtures/` are **build scripts in the same step format**, not `.docx` files.
@@ -60,10 +67,18 @@ contract rather than a bespoke comparison:
 |-----------|----------|--------|
 | `taskCompletion` | Did the intended change land? | `docxodus_search` over every story |
 | `targetPrecision` | Did it change *only* that? | distinct anchors in the #457 semantic change set |
-| `collateral` | Was unrelated package state preserved? | #456 package manifests, before and after |
+| `collateral` | Was unrelated package state preserved? | #456 package manifests, before and after; `changedPartsMustBeWithin` additionally pins *which* parts the change set may touch |
 | `validity` | Is the deliverable structurally sound? | #463 deliverable gate |
+| `trackedRevisions` | Is the expected live markup present — including another reviewer's? | `docxodus_track_changes list` on the delivered session |
+| `comments` | Are the expected comments, replies, and resolved flags present? | `docxodus_comment list` on the delivered session |
 | `reversibility` | Does the redline accept and reject cleanly? | #464 proof |
 | `rendering` | Does it still render? | HTML projection |
+
+`trackedRevisions` and `comments` are read through the same MCP dispatcher the steps drive, so
+they assert the agent-surface view of the document, and only what those tools actually report —
+replies are entries carrying `parentAnchorId`, resolved state is the tool's own `resolved` flag.
+`changedPartsMustBeWithin` names part URIs exactly as the change set reports them
+(`/word/document.xml`); an entry outside the list fails loudly, so a misspelled URI cannot pass.
 
 ### Text assertions ask the document, not a rendering of it
 
@@ -99,12 +114,30 @@ can be made to land; the interesting question is what else moved. Each scenario'
 `collateral.textPreserved` lists the near-miss content a careless edit would also have caught —
 for `term-replacement`, the two *other* occurrences of the defined term.
 
-## Failure artifacts
+## Scorecards and failure artifacts
 
-A failing scenario writes `opening.docx`, `delivered.docx`, `delivered.html`, `delivered.txt`,
-`semantic-changes.json`, `verification.json`, and `reversibility-proof.json` (when one was
-produced) so a failure is diagnosable without re-running it. Set `DOCXODUS_EVAL_ARTIFACTS` to choose the directory;
-otherwise they land under the system temp directory.
+Every run — pass or fail — writes a per-scenario `scorecard.json`: the metrics that were
+actually measured (changed anchors and parts, part-inventory deltas, validity decision, text
+match counts, reversibility outcomes). The scorecard is the machine-readable **engine
+baseline**: a later agent-scored run of the same scenario — same fixture, same invariants,
+planned by a model instead of scripted — is compared against it. Scripted first, agent second,
+in that order, is what criterion-level "separate engine correctness from planning quality"
+means operationally.
+
+A failing scenario additionally writes `opening.docx`, `delivered.docx`, `delivered.html`,
+`delivered.txt`, `semantic-changes.json`, `verification.json`, `revisions.json`,
+`comments.json`, and `reversibility-proof.json` (when one was produced) so a failure is
+diagnosable without re-running it. Set `DOCXODUS_EVAL_ARTIFACTS` to choose the directory;
+otherwise they land under the system temp directory. CI sets it and uploads the directory as a
+build artifact when the suite fails; the weekly corpus workflow uploads it always, scorecards
+included.
+
+A delivery change receipt is deliberately **not** among the artifacts. A receipt's transaction
+lineage must come from authoritative mutation evidence captured at execution time
+(`DeliveryTransactionContribution.FromMutationBatchResult` over a recorded batch); the harness
+executes steps as independent tool calls and holds only before/after snapshots, and the receipt
+contract explicitly forbids reconstructing history from a before/after comparison. Receipt
+production belongs to the #465 delivery operation, which owns that evidence.
 
 ## Adding a scenario
 
@@ -114,14 +147,26 @@ otherwise they land under the system temp directory.
    "it looked right" is not an acceptance criterion.
 3. Run `dotnet test --filter "FullyQualifiedName~WorkflowEvalTests"`.
 
+## The two tiers
+
+Scenarios directly under `scenarios/` are the **fast deterministic subset**: no PDF, no browser,
+no network, executed unfiltered on every push. Scenarios under `scenarios/corpus/` are the
+**opt-in corpus tier**: executed only when `DOCXODUS_RUN_EVAL_CORPUS=1`, which the weekly
+`eval-corpus` workflow (also runnable on demand via `workflow_dispatch`) sets. Declaration
+checks — vacuity, schema conformance — run for both tiers on every push, so a corpus scenario
+cannot sit malformed until Monday.
+
 ## Scope
 
-This is the deterministic fast subset: no PDF, no browser, no network, so it runs on every push.
 Deliberately **not** here, and tracked separately:
 
 - Generated-PDF and visual-regression scoring — that is #443's ratchet, and depending on it before
   it exists would bake unstable numbers into this suite's baselines.
-- Agent-scored runs and model planning quality, which need this scripted baseline to exist first.
-- The larger opt-in corpus, and the remaining #466 scenarios: clause insertion with numbering,
-  comment/footnote/cross-reference authoring, content-control templates, N-way consolidation, and
-  documents carrying pre-existing revisions.
+- Agent-scored runs and model planning quality, which consume the scorecard baseline above.
+- Delivery change receipts, which belong to the #465 delivery operation (see "Scorecards and
+  failure artifacts").
+
+The remaining #466 scenario families — clause insertion with numbering, comment/footnote/
+cross-reference authoring, content-control templates, N-way consolidation, and documents
+carrying pre-existing revisions — are corpus work in progress; the runner capabilities they
+need (multi-anchor targets, part allowlists, markup and comment invariants) are in place.

--- a/eval/fixtures/clause-library.json
+++ b/eval/fixtures/clause-library.json
@@ -1,0 +1,102 @@
+{
+  "id": "clause-library",
+  "title": "Clause library",
+  "description": "A heading and four boilerplate clauses joined into one real auto-numbered Word list (a single shared w:num instance, via apply_format_range). The prose deliberately contains no literal digits, so a rendered list label like \"5.\" can only come from live numbering — which is what the clause-insertion scenario asserts renumbers.",
+  "expectedContent": [
+    "CLAUSE LIBRARY",
+    "Assignment requires prior written consent."
+  ],
+  "steps": [
+    {
+      "tool": "docxodus_create",
+      "target": {
+        "mode": "kind",
+        "query": "p",
+        "index": 0
+      },
+      "args": {
+        "action": "insert_heading",
+        "position": "after",
+        "text": "CLAUSE LIBRARY",
+        "level": 1
+      }
+    },
+    {
+      "tool": "docxodus_create",
+      "target": {
+        "mode": "text",
+        "query": "CLAUSE LIBRARY"
+      },
+      "args": {
+        "action": "insert_paragraph",
+        "position": "after",
+        "markdown": "Standard clauses follow."
+      }
+    },
+    {
+      "tool": "docxodus_create",
+      "target": {
+        "mode": "text",
+        "query": "Standard clauses follow."
+      },
+      "args": {
+        "action": "insert_paragraph",
+        "position": "after",
+        "markdown": "Confidentiality obligations survive termination."
+      }
+    },
+    {
+      "tool": "docxodus_create",
+      "target": {
+        "mode": "text",
+        "query": "Confidentiality obligations survive termination."
+      },
+      "args": {
+        "action": "insert_paragraph",
+        "position": "after",
+        "markdown": "Assignment requires prior written consent."
+      }
+    },
+    {
+      "tool": "docxodus_create",
+      "target": {
+        "mode": "text",
+        "query": "Assignment requires prior written consent."
+      },
+      "args": {
+        "action": "insert_paragraph",
+        "position": "after",
+        "markdown": "Notices must be delivered in writing."
+      }
+    },
+    {
+      "tool": "docxodus_create",
+      "target": {
+        "mode": "text",
+        "query": "Notices must be delivered in writing."
+      },
+      "args": {
+        "action": "insert_paragraph",
+        "position": "after",
+        "markdown": "Waiver requires a signed instrument."
+      }
+    },
+    {
+      "tool": "docxodus_list",
+      "targets": {
+        "firstAnchorId": {
+          "mode": "text",
+          "query": "Confidentiality obligations survive termination."
+        },
+        "lastAnchorId": {
+          "mode": "text",
+          "query": "Waiver requires a signed instrument."
+        }
+      },
+      "args": {
+        "action": "apply_format_range",
+        "listFormat": "decimal"
+      }
+    }
+  ]
+}

--- a/eval/fixtures/content-control-template.json
+++ b/eval/fixtures/content-control-template.json
@@ -1,0 +1,10 @@
+{
+  "id": "content-control-template",
+  "title": "Engagement letter template",
+  "description": "An engagement-letter template whose blanks are native content controls: a plain-text client name (tag client-name), a governing-law drop-down (tag governing-law), and an include-arbitration checkbox (tag include-arbitration), each showing placeholder content a fill must replace. The tool surface can fill content controls but cannot create them, so this fixture is authored by the named programmatic builder in Docxodus.Tests/Eval/EvalFixtureBuilders.cs rather than as a step script — still deterministic, still no committed document bytes.",
+  "builder": "content-control-template",
+  "expectedContent": [
+    "ENGAGEMENT LETTER TEMPLATE",
+    "the client named below"
+  ]
+}

--- a/eval/fixtures/master-services-agreement.json
+++ b/eval/fixtures/master-services-agreement.json
@@ -2,6 +2,9 @@
   "id": "master-services-agreement",
   "title": "Master Services Agreement",
   "description": "A short commercial agreement shaped around the things the scenarios must not damage: a defined term used three times, a notice period written in words-and-digits, a fee table, a signature block, a running header and footer, and one pre-existing tracked change by another reviewer that every later operation must leave live. Built programmatically so the corpus carries no third-party bytes.",
+  "expectedContent": [
+    "MASTER SERVICES AGREEMENT"
+  ],
   "steps": [
     {
       "tool": "docxodus_create",

--- a/eval/fixtures/master-services-agreement.json
+++ b/eval/fixtures/master-services-agreement.json
@@ -1,7 +1,7 @@
 {
   "id": "master-services-agreement",
   "title": "Master Services Agreement",
-  "description": "A short commercial agreement shaped around the things the scenarios must not damage: a defined term used three times, a notice period written in words-and-digits, a fee table, a signature block, a running header and footer, and one pre-existing tracked change by another reviewer that every later operation must leave live. Built programmatically so the corpus carries no third-party bytes.",
+  "description": "A short commercial agreement shaped around the things the scenarios must not damage: a defined term used three times, a notice period written in words-and-digits, a fee table, a signature block, a running header, a footer carrying a page-number field, one pre-existing comment, and one pre-existing tracked change by another reviewer that every later operation must leave live. Built programmatically so the corpus carries no third-party bytes.",
   "expectedContent": [
     "MASTER SERVICES AGREEMENT"
   ],
@@ -191,6 +191,30 @@
         "action": "set_footer_text",
         "markdown": "Confidential",
         "kind": "default"
+      }
+    },
+    {
+      "tool": "docxodus_create",
+      "target": {
+        "mode": "text",
+        "query": "Confidential",
+        "scope": "footers"
+      },
+      "args": {
+        "action": "insert_page_number_field"
+      }
+    },
+    {
+      "tool": "docxodus_comment",
+      "target": {
+        "mode": "text",
+        "query": "Name: Dana Reyes"
+      },
+      "args": {
+        "action": "add",
+        "author": "Prior Reviewer",
+        "initials": "PR",
+        "markdown": "Confirm signatory authority before circulation."
       }
     },
     {

--- a/eval/scenario.schema.json
+++ b/eval/scenario.schema.json
@@ -69,9 +69,17 @@
           "$ref": "#/$defs/target",
           "description": "Resolved to an anchor id by docxodus_search before the call, then injected into args. Targeting by content rather than by a chained response keeps a step independent of the previous step's result shape."
         },
+        "targets": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "$ref": "#/$defs/target"
+          },
+          "description": "For tools taking several anchors (ranges, moves, bookmarks): each key names the argument that receives its resolved anchor id, each value is a target resolved exactly like `target`. The key already names the argument, so `as` is rejected inside these targets. May be combined with `target` when the argument names do not collide."
+        },
         "args": {
           "type": "object",
-          "description": "The tool's own arguments, minus sessionId (supplied by the runner) and minus the argument that `target` fills in."
+          "description": "The tool's own arguments, minus sessionId (supplied by the runner) and minus the argument(s) that `target`/`targets` fill in."
         }
       }
     },
@@ -185,6 +193,68 @@
                 "type": "string"
               },
               "description": "Content that must survive untouched \u2014 the near-miss occurrences a careless edit would also catch."
+            },
+            "changedPartsMustBeWithin": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string"
+              },
+              "description": "Part URIs the #457 change set may touch, exactly as the change set reports them (leading slash: \"/word/document.xml\"). Any changed part outside this allowlist fails the scenario \u2014 the identity assertion that turns 'how many parts changed' into 'the right parts changed'. A misspelled entry fails loudly rather than passing, because the real changed part is then outside the list."
+            }
+          }
+        },
+        "trackedRevisions": {
+          "type": "object",
+          "additionalProperties": false,
+          "minProperties": 1,
+          "description": "Live tracked-change markup in the delivered session, read through docxodus_track_changes list. This is how a scenario asserts a pre-existing reviewer's revision is still live outside the reversibility path.",
+          "properties": {
+            "countAtLeast": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "countAtMost": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "authorsMustInclude": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "comments": {
+          "type": "object",
+          "additionalProperties": false,
+          "minProperties": 1,
+          "description": "Comments in the delivered session, read through docxodus_comment list. Replies are entries carrying parentAnchorId; resolved state is the tool's own resolved flag \u2014 only what the tool reports is assertable.",
+          "properties": {
+            "countAtLeast": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "countAtMost": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "authorsMustInclude": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string"
+              }
+            },
+            "repliesAtLeast": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "resolvedAtLeast": {
+              "type": "integer",
+              "minimum": 0
             }
           }
         },

--- a/eval/scenario.schema.json
+++ b/eval/scenario.schema.json
@@ -258,6 +258,36 @@
             }
           }
         },
+        "redline": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "fromPath"
+          ],
+          "description": "Assertions over a redline document a docxodus_compare step wrote. The runner opens fromPath in a fresh session and reads docxodus_track_changes list — the same agent-surface view trackedRevisions uses for the delivered session — so the bounds describe the produced file itself, not the compare tool's own summary.",
+          "properties": {
+            "fromPath": {
+              "type": "string",
+              "minLength": 1,
+              "description": "The workspace path a step wrote the redline to — the same path vocabulary steps use for docxodus_save and docxodus_compare."
+            },
+            "countAtLeast": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "countAtMost": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "authorsMustInclude": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "validity": {
           "type": "object",
           "additionalProperties": false,

--- a/eval/scenarios/clause-insertion.json
+++ b/eval/scenarios/clause-insertion.json
@@ -1,0 +1,74 @@
+{
+  "id": "clause-insertion",
+  "title": "Insert a clause into an auto-numbered list, preserving styles and numbering",
+  "intent": "Add a severability clause after the assignment clause, keeping it in the numbered clause list so the later clauses renumber.",
+  "fixture": "clause-library",
+  "steps": [
+    {
+      "tool": "docxodus_create",
+      "target": {
+        "mode": "text",
+        "query": "Assignment requires prior written consent."
+      },
+      "args": {
+        "action": "insert_paragraph",
+        "position": "after",
+        "markdown": "Severability preserves the remainder of these clauses."
+      }
+    },
+    {
+      "tool": "docxodus_list",
+      "targets": {
+        "firstAnchorId": {
+          "mode": "text",
+          "query": "Confidentiality obligations survive termination."
+        },
+        "lastAnchorId": {
+          "mode": "text",
+          "query": "Waiver requires a signed instrument."
+        }
+      },
+      "args": {
+        "action": "apply_format_range",
+        "listFormat": "decimal"
+      }
+    }
+  ],
+  "invariants": {
+    "taskCompletion": {
+      "textPresent": [
+        "Severability preserves the remainder of these clauses."
+      ]
+    },
+    "targetPrecision": {
+      "changedAnchorsAtLeast": 1,
+      "changedAnchorsAtMost": 7
+    },
+    "collateral": {
+      "partsAdded": 0,
+      "partsRemoved": 0,
+      "textPreserved": [
+        "Confidentiality obligations survive termination.",
+        "Notices must be delivered in writing.",
+        "Waiver requires a signed instrument."
+      ],
+      "changedPartsMustBeWithin": [
+        "/word/document.xml",
+        "/word/numbering.xml"
+      ]
+    },
+    "validity": {
+      "decisionIn": [
+        "passed",
+        "passedWithPreExistingFindings"
+      ]
+    },
+    "rendering": {
+      "htmlMustContain": [
+        "Severability preserves the remainder of these clauses.",
+        "4.",
+        "5."
+      ]
+    }
+  }
+}

--- a/eval/scenarios/layout-preservation.json
+++ b/eval/scenarios/layout-preservation.json
@@ -1,0 +1,55 @@
+{
+  "id": "layout-preservation",
+  "title": "Edit the body while preserving signature blocks, header, footer field, and section layout",
+  "intent": "Broaden the services clause slightly; the signature block, running header, the footer with its page-number field, and the section layout must come through untouched. (The fixture is single-section: a section-break authoring op does not exist on the tool surface, so part-identity is the layout assertion — any touch of a header or footer part fails the allowlist.)",
+  "fixture": "master-services-agreement",
+  "steps": [
+    {
+      "tool": "docxodus_edit",
+      "target": {
+        "mode": "text",
+        "query": "each Statement of Work"
+      },
+      "args": {
+        "action": "replace_text_range",
+        "find": "executed under this Agreement.",
+        "replace": "executed under this Agreement from time to time.",
+        "caseSensitive": true
+      }
+    }
+  ],
+  "invariants": {
+    "taskCompletion": {
+      "textPresent": [
+        "from time to time"
+      ]
+    },
+    "targetPrecision": {
+      "changedAnchorsAtMost": 1
+    },
+    "collateral": {
+      "partsAdded": 0,
+      "partsRemoved": 0,
+      "textPreserved": [
+        "Acme Holdings LLC — Master Services Agreement",
+        "Confidential",
+        "Name: Dana Reyes Title: General Counsel",
+        "Name: Sam Okafor Title: Managing Partner"
+      ],
+      "changedPartsMustBeWithin": [
+        "/word/document.xml"
+      ]
+    },
+    "validity": {
+      "decisionIn": [
+        "passed",
+        "passedWithPreExistingFindings"
+      ]
+    },
+    "rendering": {
+      "htmlMustContain": [
+        "from time to time"
+      ]
+    }
+  }
+}

--- a/eval/scenarios/preexisting-markup.json
+++ b/eval/scenarios/preexisting-markup.json
@@ -1,0 +1,65 @@
+{
+  "id": "preexisting-markup",
+  "title": "Operate on a document carrying pre-existing revisions and comments",
+  "intent": "Make one unrelated wording change; the prior reviewer's live tracked change and open comment must both survive, unaccepted and unresolved.",
+  "fixture": "master-services-agreement",
+  "steps": [
+    {
+      "tool": "docxodus_edit",
+      "target": {
+        "mode": "text",
+        "query": "is entered into by"
+      },
+      "args": {
+        "action": "replace_text_range",
+        "find": "is entered into by",
+        "replace": "is made and entered into by",
+        "caseSensitive": true
+      }
+    }
+  ],
+  "invariants": {
+    "taskCompletion": {
+      "textPresent": [
+        "is made and entered into by"
+      ]
+    },
+    "targetPrecision": {
+      "changedAnchorsAtMost": 1
+    },
+    "collateral": {
+      "partsAdded": 0,
+      "partsRemoved": 0,
+      "textPreserved": [
+        "net forty-five (45) days",
+        "Confirm signatory authority before circulation."
+      ],
+      "changedPartsMustBeWithin": [
+        "/word/document.xml"
+      ]
+    },
+    "trackedRevisions": {
+      "countAtLeast": 2,
+      "authorsMustInclude": [
+        "Prior Reviewer"
+      ]
+    },
+    "comments": {
+      "countAtLeast": 1,
+      "authorsMustInclude": [
+        "Prior Reviewer"
+      ]
+    },
+    "validity": {
+      "decisionIn": [
+        "passed",
+        "passedWithPreExistingFindings"
+      ]
+    },
+    "rendering": {
+      "htmlMustContain": [
+        "is made and entered into by"
+      ]
+    }
+  }
+}

--- a/eval/scenarios/review-annotations.json
+++ b/eval/scenarios/review-annotations.json
@@ -1,0 +1,132 @@
+{
+  "id": "review-annotations",
+  "title": "Add a comment, a threaded reply, a footnote, and an internal cross-reference",
+  "intent": "Comment on the termination clause and reply to that comment, footnote the fees clause, and link the services mention in the fees clause back to the bookmarked services clause. (A field-based REF cross-reference is not yet authorable on the tool surface — issue #545 tracks it; the internal link is bookmark-anchored w:anchor markup.)",
+  "fixture": "master-services-agreement",
+  "steps": [
+    {
+      "tool": "docxodus_comment",
+      "target": {
+        "mode": "text",
+        "query": "terminate this Agreement for convenience"
+      },
+      "args": {
+        "action": "add",
+        "author": "Associate",
+        "initials": "AS",
+        "markdown": "Please confirm the notice period is market."
+      }
+    },
+    {
+      "tool": "docxodus_comment",
+      "target": {
+        "mode": "kind",
+        "query": "cmt",
+        "index": 1,
+        "as": "commentAnchorId"
+      },
+      "args": {
+        "action": "reply",
+        "author": "Partner",
+        "initials": "PT",
+        "markdown": "Confirmed; sixty days is standard."
+      }
+    },
+    {
+      "tool": "docxodus_create",
+      "target": {
+        "mode": "text",
+        "query": "annual fees set out below"
+      },
+      "args": {
+        "action": "insert_footnote",
+        "characterOffset": 0,
+        "markdown": "Fees are exclusive of taxes."
+      }
+    },
+    {
+      "tool": "docxodus_links",
+      "targets": {
+        "startAnchorId": {
+          "mode": "text",
+          "query": "1. Services"
+        },
+        "endAnchorId": {
+          "mode": "text",
+          "query": "1. Services"
+        }
+      },
+      "args": {
+        "action": "add_bookmark",
+        "name": "clause_services",
+        "startOffset": 0,
+        "endOffset": 11
+      }
+    },
+    {
+      "tool": "docxodus_links",
+      "target": {
+        "mode": "text",
+        "query": "each Statement of Work"
+      },
+      "args": {
+        "action": "add_hyperlink",
+        "kind": "internal",
+        "target": "clause_services",
+        "startOffset": 35,
+        "length": 12
+      }
+    }
+  ],
+  "invariants": {
+    "taskCompletion": {
+      "textPresent": [
+        "Please confirm the notice period is market.",
+        "Confirmed; sixty days is standard.",
+        "Fees are exclusive of taxes."
+      ]
+    },
+    "targetPrecision": {
+      "changedAnchorsAtLeast": 2,
+      "changedAnchorsAtMost": 8
+    },
+    "collateral": {
+      "partsAdded": 3,
+      "partsRemoved": 0,
+      "textPreserved": [
+        "thirty (30) days",
+        "(the \"Service Provider\")",
+        "$132,000"
+      ],
+      "changedPartsMustBeWithin": [
+        "/word/document.xml",
+        "/word/comments.xml",
+        "/word/commentsExtended.xml",
+        "/word/commentsIds.xml",
+        "/word/footnotes.xml",
+        "/word/settings.xml",
+        "/word/styles.xml"
+      ]
+    },
+    "comments": {
+      "countAtLeast": 3,
+      "authorsMustInclude": [
+        "Prior Reviewer",
+        "Associate",
+        "Partner"
+      ],
+      "repliesAtLeast": 1
+    },
+    "validity": {
+      "decisionIn": [
+        "passed",
+        "passedWithPreExistingFindings"
+      ]
+    },
+    "rendering": {
+      "htmlMustContain": [
+        "Fees are exclusive of taxes."
+      ]
+    }
+  }
+}

--- a/eval/scenarios/template-fill.json
+++ b/eval/scenarios/template-fill.json
@@ -1,0 +1,85 @@
+{
+  "id": "template-fill",
+  "title": "Fill content controls in a template",
+  "intent": "Complete the engagement-letter template: client name Acme Holdings LLC, governing law Delaware, arbitration included — leaving the template prose and every control wrapper intact.",
+  "fixture": "content-control-template",
+  "steps": [
+    {
+      "tool": "docxodus_content_controls",
+      "target": {
+        "mode": "kind",
+        "query": "sdt",
+        "index": 0
+      },
+      "args": {
+        "action": "fill_text",
+        "text": "Acme Holdings LLC"
+      }
+    },
+    {
+      "tool": "docxodus_content_controls",
+      "target": {
+        "mode": "kind",
+        "query": "sdt",
+        "index": 1
+      },
+      "args": {
+        "action": "select_item",
+        "value": "Delaware"
+      }
+    },
+    {
+      "tool": "docxodus_content_controls",
+      "target": {
+        "mode": "kind",
+        "query": "sdt",
+        "index": 2
+      },
+      "args": {
+        "action": "set_checked",
+        "checked": true
+      }
+    }
+  ],
+  "invariants": {
+    "taskCompletion": {
+      "textPresent": [
+        "Acme Holdings LLC",
+        "Delaware",
+        "☒"
+      ],
+      "textAbsent": [
+        "CLIENT NAME",
+        "GOVERNING LAW"
+      ]
+    },
+    "targetPrecision": {
+      "changedAnchorsAtLeast": 3,
+      "changedAnchorsAtMost": 9
+    },
+    "collateral": {
+      "partsAdded": 0,
+      "partsRemoved": 0,
+      "textPreserved": [
+        "entered into by the client named below",
+        "Signature follows on the final page."
+      ],
+      "changedPartsMustBeWithin": [
+        "/word/document.xml"
+      ]
+    },
+    "validity": {
+      "decisionIn": [
+        "passed",
+        "passedWithPreExistingFindings"
+      ]
+    },
+    "rendering": {
+      "htmlMustContain": [
+        "Acme Holdings LLC",
+        "Delaware",
+        "☒"
+      ]
+    }
+  }
+}

--- a/eval/scenarios/version-consolidation.json
+++ b/eval/scenarios/version-consolidation.json
@@ -1,0 +1,111 @@
+{
+  "id": "version-consolidation",
+  "title": "Compare and consolidate two reviewer versions into one attributed redline",
+  "intent": "Save the current draft as the base, produce two reviewer variants, undo the working copy back to the base, and consolidate both variants into one redline whose tracked changes are attributed to each reviewer.",
+  "fixture": "master-services-agreement",
+  "steps": [
+    {
+      "tool": "docxodus_save",
+      "args": {
+        "path": "version-base.docx"
+      }
+    },
+    {
+      "tool": "docxodus_edit",
+      "target": {
+        "mode": "text",
+        "query": "terminate this Agreement for convenience"
+      },
+      "args": {
+        "action": "replace_text_range",
+        "find": "thirty (30) days",
+        "replace": "forty-five (45) days",
+        "caseSensitive": true
+      }
+    },
+    {
+      "tool": "docxodus_save",
+      "args": {
+        "path": "version-reviewer-a.docx"
+      }
+    },
+    {
+      "tool": "docxodus_edit",
+      "args": {
+        "action": "undo"
+      }
+    },
+    {
+      "tool": "docxodus_edit",
+      "target": {
+        "mode": "text",
+        "query": "each Statement of Work"
+      },
+      "args": {
+        "action": "replace_text_range",
+        "find": "executed under this Agreement.",
+        "replace": "executed under this Agreement or any amendment.",
+        "caseSensitive": true
+      }
+    },
+    {
+      "tool": "docxodus_save",
+      "args": {
+        "path": "version-reviewer-b.docx"
+      }
+    },
+    {
+      "tool": "docxodus_edit",
+      "args": {
+        "action": "undo"
+      }
+    },
+    {
+      "tool": "docxodus_compare",
+      "args": {
+        "baselinePath": "version-base.docx",
+        "revisedPaths": [
+          "version-reviewer-a.docx",
+          "version-reviewer-b.docx"
+        ],
+        "authors": [
+          "Reviewer A",
+          "Reviewer B"
+        ],
+        "outputPath": "version-consolidated.docx"
+      }
+    }
+  ],
+  "invariants": {
+    "taskCompletion": {
+      "textPresent": [
+        "thirty (30) days"
+      ]
+    },
+    "targetPrecision": {
+      "changedAnchorsAtMost": 0
+    },
+    "collateral": {
+      "partsAdded": 0,
+      "partsRemoved": 0,
+      "textPreserved": [
+        "(the \"Service Provider\")",
+        "$132,000"
+      ]
+    },
+    "redline": {
+      "fromPath": "version-consolidated.docx",
+      "countAtLeast": 2,
+      "authorsMustInclude": [
+        "Reviewer A",
+        "Reviewer B"
+      ]
+    },
+    "validity": {
+      "decisionIn": [
+        "passed",
+        "passedWithPreExistingFindings"
+      ]
+    }
+  }
+}

--- a/tools/mcp-server/Dispatcher.cs
+++ b/tools/mcp-server/Dispatcher.cs
@@ -39,6 +39,9 @@ internal static class Dispatcher
 
         if (tool == "docxodus_open") return Open(store, args);
         if (tool == "docxodus_close") return Close(store, args);
+        // Sessionless: compare reads and writes stored documents only, so it neither needs nor
+        // serializes against an open session — the output is opened like any other file.
+        if (tool == "docxodus_compare") return Compare(store, args);
         // Static capability discovery has no document state to serialize against.
         if (tool == "docxodus_images" && OptStr(args, "action") == "capabilities")
             return Images(store, args);
@@ -812,6 +815,95 @@ internal static class Dispatcher
             store.Documents.Resolve(Str(args, "intendedFinalPath")));
         return VerificationOps.ProveRedlineReversibility(
             baseline, intendedFinal, DocxSessionOps.Save(session.Handle));
+    }
+
+    /// <summary>
+    /// Sessionless comparison: read the named versions through the document store, produce one
+    /// native tracked-changes redline — a two-way diff or an N-way consolidate — write it to
+    /// outputPath, and summarize the generated revisions by author. The summary comes from the
+    /// same engine family that produced the redline (GetRevisionsJson /
+    /// GetConsolidatedRevisionsJson), so its counts describe the produced markup, not a guess.
+    /// </summary>
+    private static string Compare(SessionStore store, JsonElement args)
+    {
+        var baseline = store.Documents.Read(store.Documents.Resolve(Str(args, "baselinePath")));
+        var revisedPath = OptStr(args, "revisedPath");
+        var hasMany = args.TryGetProperty("revisedPaths", out var revisedPaths)
+            && revisedPaths.ValueKind == JsonValueKind.Array;
+        if ((revisedPath is not null) == hasMany)
+            throw new McpToolException(
+                "pass exactly one of revisedPath (two-way compare) or revisedPaths (consolidate)");
+
+        byte[] redline;
+        string revisionsJson;
+        if (revisedPath is not null)
+        {
+            var revised = store.Documents.Read(store.Documents.Resolve(revisedPath));
+            var settingsJson = OptStr(args, "author") is { } author
+                ? JsonSerializer.Serialize(new { authorForRevisions = author })
+                : null;
+            redline = DocxDiffOps.Compare(baseline, revised, settingsJson);
+            revisionsJson = DocxDiffOps.GetRevisionsJson(baseline, revised, settingsJson);
+        }
+        else
+        {
+            var paths = revisedPaths.EnumerateArray()
+                .Select(value => value.GetString())
+                .ToList();
+            if (paths.Count < 2 || paths.Any(string.IsNullOrWhiteSpace))
+                throw new McpToolException(
+                    "revisedPaths needs at least two non-empty entries; "
+                    + "use revisedPath for a two-way compare");
+            string[]? authors = null;
+            if (args.TryGetProperty("authors", out var declared)
+                && declared.ValueKind == JsonValueKind.Array)
+            {
+                authors = declared.EnumerateArray()
+                    .Select(value => value.GetString() ?? string.Empty)
+                    .ToArray();
+                if (authors.Length != paths.Count)
+                    throw new McpToolException("authors must match revisedPaths in length and order");
+            }
+
+            var reviewersJson = JsonSerializer.Serialize(paths.Select((path, index) => new
+            {
+                author = authors is not null
+                    ? authors[index]
+                    : Path.GetFileNameWithoutExtension(path!),
+                docB64 = Convert.ToBase64String(
+                    store.Documents.Read(store.Documents.Resolve(path!))),
+            }));
+            redline = DocxDiffOps.Consolidate(baseline, reviewersJson, null);
+            revisionsJson = DocxDiffOps.GetConsolidatedRevisionsJson(baseline, reviewersJson, null);
+        }
+
+        var destination = store.Documents.Resolve(Str(args, "outputPath"));
+        store.Documents.Write(destination, redline);
+
+        using var revisions = JsonDocument.Parse(revisionsJson);
+        var byAuthor = new SortedDictionary<string, int>(StringComparer.Ordinal);
+        var total = 0;
+        foreach (var revision in revisions.RootElement.GetProperty("revisions").EnumerateArray())
+        {
+            total++;
+            var name = revision.GetProperty("author").GetString() ?? string.Empty;
+            byAuthor[name] = byAuthor.TryGetValue(name, out var count) ? count + 1 : 1;
+        }
+
+        var summary = new StringBuilder(128);
+        summary.Append("{\"path\":").Append(JsonRpcIo.JsonString(destination));
+        summary.Append(",\"bytesWritten\":").Append(redline.Length);
+        summary.Append(",\"revisions\":{\"total\":").Append(total).Append(",\"byAuthor\":{");
+        var first = true;
+        foreach (var (name, count) in byAuthor)
+        {
+            if (!first) summary.Append(',');
+            first = false;
+            summary.Append(JsonRpcIo.JsonString(name)).Append(':').Append(count);
+        }
+
+        summary.Append("}}}");
+        return summary.ToString();
     }
 
     private static string RunTrackChangesAction(DocSession session, string action, JsonElement args)

--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -78,7 +78,7 @@ path stay as they are.
 
 ## Tool surface
 
-Three lifecycle tools plus thirteen grouped-intent tools, each addressed by the anchor ids the
+Three lifecycle tools plus seventeen grouped-intent tools, each addressed by the anchor ids the
 markdown projection and search tools return:
 
 | Tool | Purpose |
@@ -94,6 +94,7 @@ markdown projection and search tools return:
 | `docxodus_comment` | Native Word review comments (real `w:comment` markup): add on an anchor/span or tracked revision id, reply in-thread, resolve/reopen, update, remove, list |
 | `docxodus_annotate` | Anchor-addressed highlight/label annotations (a custom-XML overlay for external tools, distinct from comments) |
 | `docxodus_track_changes` | List tracked changes; accept/reject one by id, or all |
+| `docxodus_compare` | Sessionless: diff or N-way consolidate stored document versions into one author-attributed native redline written back into the document scope |
 | `docxodus_mutations` | Apply or safely preview a batch atomically by default; opt explicitly into best-effort |
 | `docxodus_table` | Create/read tables; resolve canonical cell anchors ↔ grid coordinates; edit rows/columns/cell content/style |
 

--- a/tools/mcp-server/ToolCatalog.cs
+++ b/tools/mcp-server/ToolCatalog.cs
@@ -505,6 +505,23 @@ internal static class ToolCatalog
             }
             """),
         new ToolDefinition(
+            "docxodus_compare",
+            "Compare stored document versions into one native tracked-changes redline, without an open session: two-way (baselinePath vs revisedPath) or N-way consolidate (baselinePath vs revisedPaths, each reviewer's changes attributed to their author). Every path resolves inside the server's document scope exactly like docxodus_open's; the redline is written to outputPath. The result summarizes the generated revisions by author; open the output with docxodus_open to inspect, comment on, or resolve them.",
+            """
+            {
+              "type": "object",
+              "properties": {
+                "baselinePath": { "type": "string", "description": "The earlier version both forms diff against." },
+                "revisedPath": { "type": "string", "description": "Two-way: the later version. Exactly one of revisedPath / revisedPaths." },
+                "revisedPaths": { "type": "array", "items": { "type": "string" }, "minItems": 2, "description": "Consolidate: two or more revised versions merged into one redline over the baseline." },
+                "author": { "type": "string", "description": "Two-way: the author stamped on generated revisions; absent uses the engine default." },
+                "authors": { "type": "array", "items": { "type": "string" }, "description": "Consolidate: reviewer name per revisedPaths entry, same order and length. Absent uses each file's name without extension." },
+                "outputPath": { "type": "string", "description": "Where the redline is written, resolved in the document scope like docxodus_save's path." }
+              },
+              "required": ["baselinePath", "outputPath"]
+            }
+            """),
+        new ToolDefinition(
             "docxodus_mutations",
             "Apply or safely preview a batch of mutating edit/format/create/table/list/comment/link/image/content-control/track-changes actions. Atomic mode commits as one unit. An optional transactionId makes applying retries idempotent within this open session; preview is isolated and cannot carry a transactionId.",
             $$"""


### PR DESCRIPTION
Closes #466.

## What this delivers

PR #534 established the eval suite's skeleton: three scenarios, a scripted caller driving the MCP dispatcher, and invariants scored from the engine's own verification machinery. This PR closes the issue by finishing the runner's contract enforcement and shipping every scenario family the issue names.

## Runner and contract (first commit)

- **Multi-anchor steps.** `targets` maps argument names to content-resolved targets, unlocking every range/two-anchor tool call (bookmarks, range formats, moves) that the singular `target` could not express.
- **Part identity, not part counts.** `collateral.changedPartsMustBeWithin` turns "at most N parts changed" into "only these parts changed" — the assertion the unintended-change criterion actually wants.
- **`trackedRevisions` and `comments` invariant groups**, read through the same MCP dispatcher the steps drive, so a scenario can assert a pre-existing reviewer's markup is still live outside the reversibility path.
- **The schema is enforced, not decorative.** Every scenario file validates against `scenario.schema.json` (EV004); the schema's invariant vocabulary and the checkers' vocabulary are pinned to each other in both directions (EV005); each new checker ships a negative control proving it fails when violated (EV006).
- **Baseline as an artifact.** Every run writes a per-scenario `scorecard.json` — the machine-readable engine baseline that future agent-scored runs are compared against. CI uploads eval artifacts on failure; a weekly `eval-corpus` workflow runs the opt-in tier (`DOCXODUS_RUN_EVAL_CORPUS=1`, `eval/scenarios/corpus/`), whose declarations still validate on every push.
- **Receipts deliberately stay out**, with the rationale recorded in `eval/README.md`: receipt lineage must come from mutation evidence captured at execution time; reconstructing it post-hoc from before/after snapshots is exactly the fabrication the receipt contract forbids. Receipt production belongs to the #465 delivery operation.

## Six new scenario families (second commit)

All nine families from the issue now run in the fast deterministic tier (the whole suite executes in about a second):

| Scenario | What it proves |
|---|---|
| clause-insertion | Inserting a clause mid-list joins the real `w:num` instance and renumbers successors — proven by rendered labels in a fixture whose prose contains no digits |
| review-annotations | Comment + threaded reply + footnote + bookmark-anchored internal link, with the exact collateral parts pinned |
| layout-preservation | A body edit under `changedPartsMustBeWithin: ["/word/document.xml"]` with header, page-number-field footer, and signature block proven untouched |
| template-fill | Content-control fill (text, drop-down, checkbox) via the corpus's first programmatic fixture builder — the tool surface fills but cannot create controls, and the corpus commits no bytes |
| version-consolidation | Two reviewer variants consolidated through the new `docxodus_compare`; a `redline` invariant group reopens the written file in a fresh session and asserts both reviewers' attributed revisions |
| preexisting-markup | An unrelated edit over live pre-existing revisions and comments, both asserted to survive |

Two explicit descopes, each recorded where it bites: a field-based `REF` cross-reference is not authorable on the tool surface (#545), and no section-break authoring op exists, so layout preservation is proven by part identity on a single-section fixture.

## The `docxodus_compare` tool

Scenario 8 requires compare/consolidate to exist where agents actually work. The new tool is sessionless, resolves every path through the document store's containment check, writes the native redline to `outputPath`, and summarizes generated revisions by author. It is pure composition over the existing `DocxDiffOps` facade — zero new engine surface — and is refused as a `docxodus_mutations` step since it mutates no session.

## Found along the way

A comment range covering a revision-bearing paragraph destabilizes that paragraph's content-derived anchor id across save normalization, producing phantom semantic changes on a no-edit round trip — filed as #546 with the workaround noted in `eval/README.md`.

## Validation

- Eval suite: **22/22** ungated and **22/22** with the corpus gate on; post-merge with `main`: eval + MCP + reversibility filters **307/307**.
- `McpCompareTransportTests` 5/5 (two-way, consolidate, path-escape refusal, batch refusal); MCP regression suites 124/124.
- Live negative controls demonstrated for the new checkers (wrong part allowlist, unknown invariant group, wrong redline author — each fails with named actuals).
- `mcpserver` Release build (TreatWarningsAsErrors) clean.