### PR TITLE
Fail a zero-match ReplaceTextRange as text_not_found on every path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- **`ReplaceTextRange` with a needle that matches nothing now fails with the new
+  `TextNotFound` error code (#490)** — `text_not_found` on the wire — carrying the anchor id
+  and the needle, instead of returning an empty list a caller could not distinguish from a
+  successful replacement. The same structured failure surfaces identically when the op runs
+  as a mutation batch step: the step fails (rolling back an atomic batch) with
+  `text_not_found` rather than the former `internal_error` or, post-#497, a silent no-op.
+  **A caller that relied on the empty-list no-op** should pass `ExpectedMatchCount = 0`
+  (`expectedMatchCount` on the wire) to assert absence as a successful no-op;
+  `MaxReplacements = 0` likewise remains a successful found-but-unconsumed no-op.
 - **Revision and comment export profiles report what they cannot draw (#444).** Under `markup`,
   a custom XML revision range now raises `revision_family_not_rendered` and a block-level property
   revision — paragraph, table, section or numbering — raises

--- a/Docxodus.Tests/DocxSessionAtomicBatchTests.cs
+++ b/Docxodus.Tests/DocxSessionAtomicBatchTests.cs
@@ -620,6 +620,33 @@ public class DocxSessionAtomicBatchTests
     }
 
     [Fact]
+    public void DS479_AtomicBatch_NoMatchReplaceFailsAsTextNotFound()
+    {
+        // Issue #490: this used to surface as internal_error ("batch mutation returned
+        // no valid edit results") and, after #497, as a silent successful no-op. A
+        // zero-match replace is an ordinary, actionable targeting failure: the step
+        // fails with TextNotFound and an atomic batch rolls back around it.
+        using var session = Open();
+        var anchor = BodyParagraphs(session)[0];
+        var before = session.Save(persistAnchorIds: false);
+
+        var result = session.ExecuteBatch(new[]
+        {
+            new MutationBatchStep("docxodus_edit", "replace_text_range",
+                s => s.ReplaceTextRange(anchor, "ZZZ-not-present-ZZZ", "x")),
+        });
+
+        Assert.False(result.Success);
+        Assert.True(result.RolledBack);
+        Assert.NotNull(result.Failure);
+        Assert.Equal(EditErrorCode.TextNotFound, result.Failure!.Error.Code);
+        Assert.Equal("replace_text_range", result.Failure.Action);
+        Assert.Equal(0, session.Version);
+        Assert.Equal(0, session.UndoCount);
+        AssertSamePackage(before, session.Save(persistAnchorIds: false));
+    }
+
+    [Fact]
     public void DS462_EditResultWireShape_RoundTripsTheTableAnchorMapping()
     {
         // Batch adapters re-serialize every step through Serialize(EditResult) and read it back

--- a/Docxodus.Tests/DocxSessionTests.cs
+++ b/Docxodus.Tests/DocxSessionTests.cs
@@ -2704,13 +2704,60 @@ public class DocxSessionTests
     }
 
     [Fact]
-    public void DS113_ReplaceTextRange_FindNotFound_ReturnsEmpty()
+    public void DS113_ReplaceTextRange_FindNotFound_FailsWithTextNotFound()
     {
+        // Issue #490: a needle that matches nothing used to return an empty list — a
+        // silent no-op indistinguishable from success. It must fail with a dedicated
+        // code carrying the anchor and the needle, so both the direct call and a batch
+        // step report the condition identically.
+        using var s = new DocxSession(BuildDS100_GrepFixture());
+        var anchor = s.Project().AnchorIndex.Values.First(t => t.Anchor.Kind == "p").Anchor.Id;
+        var before = FlatBodyText(s);
+        var versionBefore = s.Version;
+
+        var results = s.ReplaceTextRange(anchor, "nope-this-is-not-in-the-doc", "irrelevant");
+
+        var result = Assert.Single(results);
+        Assert.False(result.Success);
+        Assert.Equal(EditErrorCode.TextNotFound, result.Error!.Code);
+        Assert.Equal(anchor, result.Error.AnchorId);
+        Assert.Contains("nope-this-is-not-in-the-doc", result.Error.Message);
+        Assert.Equal(before, FlatBodyText(s));
+        Assert.Equal(versionBefore, s.Version);
+        Assert.Equal(0, s.UndoCount);
+    }
+
+    [Fact]
+    public void DS113B_ReplaceTextRange_ExpectedMatchCountZero_AssertsAbsenceAsSuccess()
+    {
+        // ExpectedMatchCount = 0 is the explicit assert-absence spelling: the caller's
+        // model of the document already includes the needle being gone, so zero matches
+        // is the asserted outcome, not a targeting failure.
         using var s = new DocxSession(BuildDS100_GrepFixture());
         var anchor = s.Project().AnchorIndex.Values.First(t => t.Anchor.Kind == "p").Anchor.Id;
         var before = FlatBodyText(s);
 
-        var results = s.ReplaceTextRange(anchor, "nope-this-is-not-in-the-doc", "irrelevant");
+        var viaOptions = s.ReplaceTextRange(anchor, "nope-this-is-not-in-the-doc", "x",
+            new ReplaceOptions { ExpectedMatchCount = 0 });
+        var viaGuards = s.ReplaceTextRange(anchor, "nope-this-is-not-in-the-doc", "x",
+            new ReplaceOptions { Preconditions = new MutationPreconditions { ExpectedMatchCount = 0 } });
+
+        Assert.Empty(viaOptions);
+        Assert.Empty(viaGuards);
+        Assert.Equal(before, FlatBodyText(s));
+    }
+
+    [Fact]
+    public void DS113C_ReplaceTextRange_MaxReplacementsZero_IsCappedNotNotFound()
+    {
+        // A present needle capped to zero replacements is a deliberate no-op, not a
+        // TextNotFound: the needle WAS found; the caller chose not to consume it.
+        using var s = new DocxSession(BuildDS100_GrepFixture());
+        var anchor = s.Project().AnchorIndex.Values.First(t => t.Anchor.Kind == "p").Anchor.Id;
+        var before = FlatBodyText(s);
+
+        var results = s.ReplaceTextRange(anchor, "faraway", "distant",
+            new ReplaceOptions { MaxReplacements = 0 });
 
         Assert.Empty(results);
         Assert.Equal(before, FlatBodyText(s));

--- a/Docxodus.Tests/McpServerDispatcherTests.cs
+++ b/Docxodus.Tests/McpServerDispatcherTests.cs
@@ -2758,4 +2758,42 @@ public class McpServerDispatcherTests : IDisposable
 
         Assert.Contains("CaptureInitialProjection", ex.Message, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void MCP153_ReplaceTextRange_NoMatch_ReportsTextNotFoundOnBothPaths()
+    {
+        // Issue #490: the direct call used to answer a zero-match replace with a bare [],
+        // and the same op inside a batch used to fail as internal_error. Both paths must
+        // report the same structured text_not_found, naming the anchor and the needle.
+        var sessionId = OpenSession();
+        var sessionArg = JsonSerializer.Serialize(sessionId);
+        var anchor = FirstBodyAnchorId(sessionId, _store);
+
+        var direct = Parse(Dispatcher.Call(_store, "docxodus_edit", J(
+            $$"""{"sessionId":{{sessionArg}},"action":"replace_text_range","anchorId":"{{anchor}}","find":"ZZZ-not-present-ZZZ","replace":"x"}""")));
+        Assert.Equal(JsonValueKind.Array, direct.ValueKind);
+        Assert.Equal(1, direct.GetArrayLength());
+        var directResult = direct[0];
+        Assert.False(directResult.GetProperty("success").GetBoolean());
+        var directError = directResult.GetProperty("error");
+        Assert.Equal("text_not_found", directError.GetProperty("code").GetString());
+        Assert.Equal(anchor, directError.GetProperty("anchorId").GetString());
+        Assert.Contains("ZZZ-not-present-ZZZ", directError.GetProperty("message").GetString());
+
+        var batch = Parse(Dispatcher.Call(_store, "docxodus_mutations", J(
+            $$"""
+            {
+              "sessionId": {{sessionArg}},
+              "mode": "atomic",
+              "steps": [
+                { "tool": "docxodus_edit", "args": { "action": "replace_text_range", "anchorId": "{{anchor}}", "find": "ZZZ-not-present-ZZZ", "replace": "x" } }
+              ]
+            }
+            """)));
+        Assert.Equal("failed", batch.GetProperty("status").GetString());
+        Assert.True(batch.GetProperty("rolledBack").GetBoolean());
+        var failure = batch.GetProperty("failure");
+        Assert.Equal("replace_text_range", failure.GetProperty("action").GetString());
+        Assert.Equal("text_not_found", failure.GetProperty("error").GetProperty("code").GetString());
+    }
 }

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -1613,6 +1613,13 @@ public enum EditErrorCode
     OffsetOutOfRange,
     InvalidPosition,
 
+    /// <summary>A text needle that matches nothing in the target anchor's visible text.
+    /// <see cref="DocxSession.ReplaceTextRange"/> reports it instead of a silent
+    /// zero-replacement so a caller can distinguish "replaced nothing" from "replaced
+    /// something" — re-inspect the anchor and retarget. Pass
+    /// <see cref="ReplaceOptions.ExpectedMatchCount"/> = 0 to assert absence instead.</summary>
+    TextNotFound,
+
     UnknownStyle,
     InvalidListLevel,
 
@@ -4874,6 +4881,14 @@ public sealed partial class DocxSession : IDisposable
     /// </summary>
     /// <remarks>
     /// <para>
+    /// A <paramref name="find"/> that matches nothing fails with a single
+    /// <see cref="EditErrorCode.TextNotFound"/> result naming the anchor and the needle —
+    /// never an empty list a caller could mistake for success. The exceptions are the two
+    /// explicit no-op spellings: <see cref="ReplaceOptions.ExpectedMatchCount"/> = 0
+    /// (assert absence) and <see cref="ReplaceOptions.MaxReplacements"/> = 0 (found but
+    /// deliberately unconsumed), which return an empty list.
+    /// </para>
+    /// <para>
     /// The replacement text is plain-text and inherits the formatting of the FIRST run the
     /// match spanned — middle/trailing runs keep their <c>w:rPr</c> but lose the slice of
     /// text the match consumed (so a bold run that contributed three chars to the match now
@@ -4942,6 +4957,16 @@ public sealed partial class DocxSession : IDisposable
             .ToList();
         if (EvaluatePreconditions(guards, matches.Count) is { } countPreconditionError)
             return new[] { new EditResult { Success = false, Error = countPreconditionError } };
+        if (matches.Count == 0)
+        {
+            // ExpectedMatchCount = 0 already asserted absence above, so an empty result is
+            // the caller's asserted outcome; any other zero-match call is a targeting
+            // failure the caller must be able to distinguish from success (issue #490).
+            if (guards?.ExpectedMatchCount == 0) return Array.Empty<EditResult>();
+            return new[] { EditResult.Fail(EditErrorCode.TextNotFound,
+                $"text not found in anchor's visible text: \"{find}\"", anchorId) };
+        }
+
         if (opts.MaxReplacements is int cap) matches = matches.Take(cap).ToList();
         if (matches.Count == 0) return Array.Empty<EditResult>();
 

--- a/docs/architecture/docx_mutation_api.md
+++ b/docs/architecture/docx_mutation_api.md
@@ -1575,6 +1575,18 @@ session.ReplaceTextAtSpan(anchor, spanStart, spanLength, repl) // exact-span var
 how many to apply), `ExpectedMatchCount` (require the exact live count before the
 cap), and `Preconditions` (the common optimistic guard object).
 
+### No-match contract
+
+A `find` that matches nothing in the anchor's visible text fails with a single
+`TextNotFound` (`text_not_found` on the wire) result carrying the anchor id and the
+needle — never an empty list, which a caller could not distinguish from a successful
+replacement. The same failure surfaces identically when the op runs as a mutation
+batch step, where it fails the step (and rolls back an atomic batch) instead of the
+pre-#490 `internal_error`. Two explicit spellings remain successful empty-list
+no-ops: `ExpectedMatchCount = 0` (the caller asserts absence — zero matches is the
+asserted outcome) and `MaxReplacements = 0` (the needle was found but deliberately
+left unconsumed).
+
 ### Formatting-preservation contract
 
 The replacement text inherits the formatting of the FIRST run the match spanned. Middle and trailing runs keep their `w:rPr` but lose the slice of text the match consumed — so a bold phrase that got partially overwritten still has bold formatting for any surviving text. This is the practical sweet spot: it solves the template-fill case where you want `[___]` → `Bluth Co.` to take on the surrounding text's formatting, and it's predictable for cross-formatting matches.

--- a/npm/src/session.ts
+++ b/npm/src/session.ts
@@ -1321,6 +1321,10 @@ export class DocxSession {
    * replaces it with `replace`, preserving the surrounding run formatting that
    * the match didn't touch. Returns one `EditResult` per attempted match.
    *
+   * A `find` that matches nothing fails with a single `text_not_found` result
+   * naming the anchor and the needle — never an empty array. Pass
+   * `expectedMatchCount: 0` to assert absence as a successful no-op instead.
+   *
    * Run-formatting contract: the replacement text inherits the formatting of
    * the FIRST run the match spanned. Middle/trailing runs keep their `w:rPr`
    * but lose the slice of text the match consumed.

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -1910,6 +1910,7 @@ export type EditErrorCode =
   | "anchor_token_in_payload"
   | "offset_out_of_range"
   | "invalid_position"
+  | "text_not_found"
   | "unknown_style"
   | "invalid_list_level"
   | "invalid_list_start_value"

--- a/python/src/docx_scalpel/enums.py
+++ b/python/src/docx_scalpel/enums.py
@@ -338,6 +338,7 @@ class EditErrorCode(str, Enum):
     ANCHOR_TOKEN_IN_PAYLOAD = "anchor_token_in_payload"
     OFFSET_OUT_OF_RANGE = "offset_out_of_range"
     INVALID_POSITION = "invalid_position"
+    TEXT_NOT_FOUND = "text_not_found"
     UNKNOWN_STYLE = "unknown_style"
     INVALID_LIST_LEVEL = "invalid_list_level"
     INVALID_LIST_START_VALUE = "invalid_list_start_value"

--- a/tools/mcp-server/ToolCatalog.cs
+++ b/tools/mcp-server/ToolCatalog.cs
@@ -220,7 +220,7 @@ internal static class ToolCatalog
                 "anchorId": { "type": "string", "description": "Target block. Required for every action except delete_range, delete_section, undo, redo." },
                 "position": { "type": "string", "enum": ["before", "after"], "description": "insert_paragraph/move_block only." },
                 "markdown": { "type": "string", "description": "insert_paragraph/replace_text payload, in the supported markdown subset (headings, bullet/ordered lists, bold/italic/code/strike, links, hard breaks)." },
-                "find": { "type": "string", "description": "replace_text_range: literal text to find within the block." },
+                "find": { "type": "string", "description": "replace_text_range: literal text to find within the block. A find that matches nothing fails with text_not_found (both directly and as a batch step); pass preconditions.expectedMatchCount 0 to assert absence as a successful no-op instead." },
                 "replace": { "type": "string", "description": "replace_text_range: replacement text." },
                 "caseSensitive": { "type": "boolean", "description": "replace_text_range only. Default false." },
                 "toAnchorIdExclusive": { "type": "string", "description": "delete_range: end boundary, exclusive." },


### PR DESCRIPTION
Closes #490.

## The problem

`replace_text_range` with a `find` string that is genuinely absent from the target anchor behaved two different — and both unhelpful — ways depending on the surface. Called directly, it returned `[]`: no error, no count, no signal, and since the success shape for one replacement is a one-element array, an agent could not distinguish "replaced nothing" from "replaced something". Inside a mutation batch it originally failed as `internal_error` ("batch mutation returned no valid edit results") — the one code a caller cannot act on. After #497 reclassified an empty step result as a successful no-op, the batch path stopped erroring and instead silently pretended the edit happened, same as the direct call.

## The fix

`DocxSession.ReplaceTextRange` now reports a needle that matches nothing as a single failed `EditResult` with the new `EditErrorCode.TextNotFound` (`text_not_found` on the wire), carrying the anchor id and the needle in the message. This matches the issue's suggested resolution and the codebase's existing precedent: the sibling substring-addressed op (`ApplyFormatToSubstring`) already fails on a missing substring rather than silently succeeding.

Because every transport funnels through this one core method and error codes serialize by enum name, the same structured failure now surfaces identically everywhere with no per-surface logic: the direct MCP call returns `[{"success":false,"error":{"code":"text_not_found",…}}]`, a batch step fails with that code (rolling back an atomic batch) instead of `internal_error` or silence, and the stdio host, WASM bridge, npm and Python clients pass it through unchanged.

Two spellings deliberately keep the successful empty-list no-op:

- `ExpectedMatchCount = 0` — the caller explicitly asserts the needle is absent, so zero matches is the asserted outcome. This is also the migration path for any caller that relied on the old empty return.
- `MaxReplacements = 0` — the needle *was* found; the caller chose to consume none of it. Found-but-capped is not "not found".

## Validation

Test-first: all three behavioral tests were run and failed against the pre-change behavior before the implementation landed.

- `DS113` (rewritten): direct call fails with `TextNotFound`, names the anchor and needle, leaves bytes/version/undo history untouched.
- `DS113B` / `DS113C`: pin the two deliberate no-op spellings — the naive implementation breaks both.
- `DS479`: core atomic batch fails with `TextNotFound`, rolls back, and restores the package byte-for-byte.
- `MCP153`: the issue's exact reproducer at the MCP dispatcher — both the direct wire shape and the batch failure envelope.

Full .NET suite: 4383 passed / 0 failed / 3 skipped (the standing fixture-regeneration skips). `npm run typecheck` clean (both src and tests configs).

## Ripple

New enum member only — the serializer converts enum names to wire strings generically, so no serializer changes: npm `EditErrorCode` union + `replaceTextRange` JSDoc, Python `enums.py` constant (the decoded `code` field is a plain string, so older clients keep working), MCP tool-catalog `find` description, a "No-match contract" section in `docs/architecture/docx_mutation_api.md`, and a CHANGELOG entry under Unreleased that states what changes for existing callers and how to keep the old behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)