### PR TITLE
Give a format-only nested-table change its typed semantic records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -738,6 +738,15 @@ All notable changes to this project will be documented in this file.
   version bump at release time.
 
 ### Fixed
+- **Semantic diff: a nested table's format-only change now gets typed records (#511).** When a
+  table nested inside a cell changed only its formatting — `w:tblPr`, `w:tblGrid`, or a nested
+  paragraph's `w:pPr` — and no content hash moved, `SemanticDiff` descended into the cell only on
+  a `ContentHash` difference, so the nested table produced no `table.style`/`table.width`/
+  `table.properties` record at all; the change was visible only as the outer table's moved
+  `formatDigest`. `IrCell` now retains a `FormatFingerprint` (the ordered fold of its blocks'
+  format fingerprints, which the reader already computed for the enclosing table) and the cell
+  recursion gate consults it alongside `ContentHash`, so format-only nested changes report fully
+  on the nested table's own anchor. Unchanged documents still compare with zero extra recursion.
 - **`@docxodus/export` docs asserted the font runtime was still unimplemented (#442).** The
   README's "Runtime boundaries" section claimed `--font-directory` fails with
   `unsupported_runtime`, the `original` review profile is fail-closed, and the generated-PDF

--- a/Docxodus.Tests/Verification/SemanticDiffProjectionRegressionTests.cs
+++ b/Docxodus.Tests/Verification/SemanticDiffProjectionRegressionTests.cs
@@ -216,6 +216,68 @@ public class SemanticDiffProjectionRegressionTests
         AssertModifyValuesDiffer(result);
     }
 
+    [Fact]
+    public void Nested_table_format_only_change_reports_typed_records_on_the_nested_anchor()
+    {
+        // Issue #511: identical documents apart from the NESTED table's w:tblStyle and
+        // w:tblW — no content moves, no cell w:tcPr changes. The nested table used to get
+        // no typed record at all (its format edit was visible only as the OUTER table's
+        // moved formatDigest), because the cell recursion gate consulted ContentHash alone.
+        var left = IrTestDocuments.FromBodyXml(
+            FormatOnlyNestedTableXml(nestedStyle: "NestedA", nestedWidth: 800));
+        var right = IrTestDocuments.FromBodyXml(
+            FormatOnlyNestedTableXml(nestedStyle: "NestedB", nestedWidth: 900));
+
+        var result = SemanticDiff.Compare(left, right,
+            new SemanticDiffOptions { IncludePackageChanges = false });
+
+        // The nested table reports its own typed records against its own anchor.
+        var nestedStyle = Assert.Single(result.Changes, change => change.Path == "table.style");
+        Assert.Equal("NestedA", nestedStyle.Before.StringValue);
+        Assert.Equal("NestedB", nestedStyle.After.StringValue);
+        var nestedWidth = Assert.Single(result.Changes, change => change.Path == "table.width");
+        Assert.Equal("800", StringProperty(nestedWidth.Before, "w"));
+        Assert.Equal("900", StringProperty(nestedWidth.After, "w"));
+        var nestedProperties = Assert.Single(result.Changes, change => change.Path == "table.properties");
+        Assert.Equal(nestedStyle.LeftAnchor, nestedProperties.LeftAnchor);
+
+        // Two "table" envelope records: the outer table (its format fingerprint folds the
+        // nested one) and the nested table itself, on distinct anchors.
+        var tableEnvelopes = result.Changes.Where(change => change.Path == "table").ToArray();
+        Assert.Equal(2, tableEnvelopes.Length);
+        Assert.NotEqual(tableEnvelopes[0].LeftAnchor, tableEnvelopes[1].LeftAnchor);
+        Assert.Contains(tableEnvelopes, change => change.LeftAnchor == nestedStyle.LeftAnchor);
+
+        // Format-only: nothing reports as content, cell, or row change.
+        Assert.DoesNotContain(result.Changes, change =>
+            change.Path is "table.cell" or "table.cell.properties" or "table.row.properties" or "block");
+        AssertModifyValuesDiffer(result);
+    }
+
+    /// <summary>Like <see cref="NestedTableXml"/>, but the nested width parameter reaches ONLY the
+    /// nested table's <c>w:tblW</c> — every <c>w:tcPr</c> stays constant, so the change is purely
+    /// table-shell formatting and no content hash moves anywhere.</summary>
+    private static string FormatOnlyNestedTableXml(string nestedStyle, int nestedWidth) =>
+        "<w:tbl>" +
+        "<w:tblPr><w:tblBorders><w:top w:val=\"single\" w:sz=\"4\"/></w:tblBorders></w:tblPr>" +
+        "<w:tblGrid>" +
+        string.Concat(Enumerable.Repeat("<w:gridCol w:w=\"1000\"/>", 3)) +
+        "</w:tblGrid>" +
+        "<w:tr><w:tc><w:tcPr/>" +
+        "<w:tbl>" +
+        $"<w:tblPr><w:tblStyle w:val=\"{nestedStyle}\"/>" +
+        $"<w:tblW w:w=\"{nestedWidth}\" w:type=\"dxa\"/></w:tblPr>" +
+        "<w:tblGrid><w:gridCol w:w=\"500\"/><w:gridCol w:w=\"500\"/></w:tblGrid>" +
+        "<w:tr><w:tc><w:tcPr><w:tcW w:w=\"500\" w:type=\"dxa\"/></w:tcPr>" +
+        "<w:p><w:r><w:t>Nested</w:t></w:r></w:p></w:tc>" +
+        "<w:tc><w:tcPr><w:tcW w:w=\"500\" w:type=\"dxa\"/></w:tcPr>" +
+        "<w:p><w:r><w:t>Cell</w:t></w:r></w:p></w:tc></w:tr>" +
+        "</w:tbl>" +
+        "<w:p><w:r><w:t>Outer</w:t></w:r></w:p></w:tc>" +
+        "<w:tc><w:tcPr/><w:p><w:r><w:t>B</w:t></w:r></w:p></w:tc>" +
+        "<w:tc><w:tcPr/><w:p><w:r><w:t>C</w:t></w:r></w:p></w:tc></w:tr>" +
+        "</w:tbl>";
+
     private static string InlineImageXml(string relId, long widthEmu) =>
         "<w:p><w:r><w:drawing>" +
         "<wp:inline xmlns:wp=\"http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing\" " +

--- a/Docxodus/Ir/IrBlocks.cs
+++ b/Docxodus/Ir/IrBlocks.cs
@@ -266,6 +266,17 @@ internal sealed record IrCell(IrAnchor Anchor, IrNodeList<IrBlock> Blocks,
     public IrHash TcPrShellDigest { get; init; }
 
     /// <summary>
+    /// Ordered fold of the cell's blocks' <see cref="IrBlock.FormatFingerprint"/>s — the format-side
+    /// counterpart of <see cref="ContentHash"/>. A nested table's <c>w:tblPr</c>/<c>w:tblGrid</c> (or a
+    /// paragraph's <c>w:pPr</c>) edit moves no content hash, so <see cref="ContentHash"/> alone cannot
+    /// tell the semantic projector that this cell's blocks need descending; gating recursion on this
+    /// fingerprint too is what gives a format-only nested-table change its typed records (issue #511).
+    /// The cell's own <see cref="ShellDigest"/> is deliberately NOT folded in — it is already compared
+    /// (and reported) at the cell level.
+    /// </summary>
+    public IrHash FormatFingerprint { get; init; }
+
+    /// <summary>
     /// True when this cell was delivered by a row-level <c>w:sdt</c> wrapping a <c>w:tc</c>
     /// (the SDT-unwrap discipline in <c>IrReader.BuildRow</c>), rather than being a direct
     /// <c>w:tc</c> child of the <c>w:tr</c>. It is EQUALITY-PARTICIPATING (a positional structural

--- a/Docxodus/Ir/IrReader.cs
+++ b/Docxodus/Ir/IrReader.cs
@@ -2779,6 +2779,10 @@ internal static class IrReader
             }
         }
 
+        var fingerprintBuilder = new IrContentHashBuilder();
+        foreach (var fingerprint in fingerprints)
+            fingerprintBuilder.AppendHash(fingerprint);
+
         var cell = new IrCell(
             AnchorFor(IrAnchorKind.Tc, tc, ctx),
             IrNodeList.From(blocks),
@@ -2789,6 +2793,7 @@ internal static class IrReader
             Source = ctx.Provenance(tc),
             ShellDigest = shellDigest,
             TcPrShellDigest = tcPrShellDigest,
+            FormatFingerprint = fingerprintBuilder.Build(),
         };
         return (cell, fingerprints);
     }

--- a/Docxodus/Verification/SemanticDiff.cs
+++ b/Docxodus/Verification/SemanticDiff.cs
@@ -1316,7 +1316,13 @@ internal static class SemanticDiffEngine
                     CompareCellWidth(lc, rc, part);
                 }
                 var blockOps = cellOp.BlockOps;
-                if (blockOps is null && lc.ContentHash != rc.ContentHash)
+                // Descend on a format-only difference too: a nested table's w:tblPr/w:tblGrid
+                // (or a paragraph's w:pPr) edit moves no content hash, and gating on content
+                // alone left such a change with no typed record at all (issue #511). The
+                // aligner classifies equal-content/changed-format blocks FormatOnlyBlock,
+                // which ProjectOps descends into.
+                if (blockOps is null
+                    && (lc.ContentHash != rc.ContentHash || lc.FormatFingerprint != rc.FormatFingerprint))
                 {
                     var alignment = IrBlockAligner.AlignBlocks(lc.Blocks, rc.Blocks, _settings);
                     blockOps = IrNodeList.From(


### PR DESCRIPTION
Closes #511.

## The problem

When a table nested inside a cell changed only its formatting — `w:tblPr`, `w:tblGrid`, or a nested paragraph's `w:pPr` — and nothing moved a content hash, `SemanticDiff` produced no typed record for the nested table at all. The change surfaced only as an opaque `formatDigest` movement on the *outer* table's `table` record: no anchor, no path, no before/after values. An audit consumer reading typed records had to fall back to comparing digests. Documents built on nested layout tables (invoice and form templates) are where this bites.

Adding any content-hash-moving edit alongside (say a nested cell's `w:tcW`) made the same nested table suddenly report in full — which is the tell for where the defect lived.

## Why it happened

The cell loop's recursion gate descended into a cell's blocks only when `IrCell.ContentHash` differed. But a nested table's shell digests never reach any content hash: `IrTable.ContentHash` folds row content hashes, rows fold cell content hashes, and `tblPr`/`tblGrid` are folded only into the *format* fingerprint stream. So a format-only nested edit left every content hash equal, the gate stayed shut, and the nested table was never compared.

## The fix

Two small pieces, no new projection code:

1. **`IrCell` retains a `FormatFingerprint`** — the ordered fold of its blocks' `FormatFingerprint`s. `BuildCell` was already producing exactly this list for the enclosing table's fingerprint and then discarding it; now the cell keeps the fold. The cell's own `ShellDigest` is deliberately not included, because it is already compared (and reported as `table.cell.properties`) at the cell level.
2. **The recursion gate consults it alongside `ContentHash`.** Everything downstream already existed: the block aligner classifies an equal-content/changed-format pair as `FormatOnlyBlock`, and `ProjectOps` descends those into `CompareBlocks` → `CompareTable`, which emits `table`, `table.properties`, `table.style`, and `table.width` on the nested table's own anchor.

Unchanged documents still compare with zero extra recursion — equal fingerprints keep the gate shut — so the issue's concern about the 1,000-paragraph / 200-table performance guards is answered by construction, and those guards pass.

## Validation

- New regression test (`Nested_table_format_only_change_reports_typed_records_on_the_nested_anchor`) reproduces the issue's exact repro — identical documents apart from the nested table's `w:tblStyle`/`w:tblW`, every `w:tcPr` held constant. Run before the fix it fails with precisely the reported signature (a single `table` record on the outer anchor and nothing else); after, the nested table reports its style, width, properties, and envelope on its own anchor, with no spurious content/cell/row records.
- The existing `Nested_table_properties_never_project_onto_the_outer_table` misattribution test (#494) stays green — outer records still describe only the outer table.
- Full .NET suite: 4380 passed / 0 failed / 3 standing skips, including the semantic-diff engine-parity suites and the performance guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)