### PR TITLE
Delete a note orphaned by revision resolution; compare Word's two no-notes spellings as one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -747,6 +747,20 @@ All notable changes to this project will be documented in this file.
   version bump at release time.
 
 ### Fixed
+- **Resolving away a document's only footnote/endnote no longer leaves a reference-less
+  husk, and the reversibility proof accepts Word's two "no notes" spellings (#516, #552).**
+  When revision resolution removed a note's last reference — rejecting the insertion that
+  carried it, or accepting its deletion — the note survived in its part as an empty husk.
+  `AcceptRevision`/`RejectRevision`/`AcceptAllRevisions`/`RejectAllRevisions` now delete a
+  note whose last reference that resolution itself removed (a note that was already
+  dangling beforehand is untouched, and the notes part itself always stays — Word never
+  prunes one, per the WC/RP oracle corpus). Separately, `RedlineReversibilityVerifier`
+  treats an absent notes part and Word's eagerly-created separator-only part as the same
+  statement: when strict normalized identity fails, both sides are re-compared with
+  separator-only notes parts elided (disclosed via the new
+  `separator_only_notes_part_normalized` info finding), while the raw/OPC digests and
+  reported package identities stay strict. The WC035 note-appearance pairs now run the
+  full RRS004 reversibility corpus contract in all four directions.
 - **Semantic diff: a nested table's format-only change now gets typed records (#511).** When a
   table nested inside a cell changed only its formatting — `w:tblPr`, `w:tblGrid`, or a nested
   paragraph's `w:pPr` — and no content hash moved, `SemanticDiff` descended into the cell only on

--- a/Docxodus.Tests/DocxSessionRevisionTests.cs
+++ b/Docxodus.Tests/DocxSessionRevisionTests.cs
@@ -1204,4 +1204,129 @@ public class DocxSessionRevisionTests
             Assert.True(XNode.DeepEquals(before, MainDocumentRoot(s.Save())));
         }
     }
+
+    // ─── Note cleanup on resolution (issue #516) ─────────────────────────
+
+    /// <summary>
+    /// Issue #516: resolving away a document's first-and-only footnote/endnote must delete
+    /// the note itself, not leave it as an empty reference-less husk in the notes part.
+    /// Word removes a note when the resolution that carries its reference away lands. The
+    /// PART deliberately stays — Word never prunes a notes part (the RP050 oracle keeps its
+    /// separator-only footnotes.xml after accepting the only note's deletion) — so the
+    /// resolved part must hold nothing but separator definitions.
+    /// </summary>
+    [Theory]
+    [InlineData("WC035-Footnote-Before.docx", "WC035-Footnote-After.docx", "footnote")]
+    [InlineData("WC035-Footnote-After.docx", "WC035-Footnote-Before.docx", "footnote")]
+    [InlineData("WC035-Endnote-Before.docx", "WC035-Endnote-After.docx", "endnote")]
+    [InlineData("WC035-Endnote-After.docx", "WC035-Endnote-Before.docx", "endnote")]
+    public void DS418_ResolvingAwayTheOnlyNote_DeletesTheNoteNotJustItsContent(
+        string leftName, string rightName, string kind)
+    {
+        var left = File.ReadAllBytes(Path.Combine("../../../../TestFiles/WC", leftName));
+        var right = File.ReadAllBytes(Path.Combine("../../../../TestFiles/WC", rightName));
+        var redline = DocxDiff.Compare(
+            new WmlDocument(leftName, left), new WmlDocument(rightName, right)).DocumentByteArray;
+
+        // Resolve toward the endpoint WITHOUT the note: reject lands on left, accept on right.
+        bool accept = HasNotesPart(left, kind);
+
+        using var session = new DocxSession(redline);
+        for (var revisions = session.ListRevisions(); revisions.Count > 0; revisions = session.ListRevisions())
+        {
+            var edit = accept
+                ? session.AcceptRevision(revisions[0].Id)
+                : session.RejectRevision(revisions[0].Id);
+            Assert.True(edit.Success, edit.Error?.Message);
+        }
+
+        var resolved = session.Save();
+        using var stream = new MemoryStream(resolved, writable: false);
+        using var document = WordprocessingDocument.Open(stream, false);
+        var main = document.MainDocumentPart!;
+        Assert.Empty(main.Document.Descendants<FootnoteReference>());
+        Assert.Empty(main.Document.Descendants<EndnoteReference>());
+        if (kind == "footnote")
+        {
+            var husks = main.FootnotesPart!.Footnotes!.Elements<Footnote>()
+                .Where(note => note.Type is null
+                    || note.Type == FootnoteEndnoteValues.Normal).ToArray();
+            Assert.Empty(husks);
+        }
+        else
+        {
+            var husks = main.EndnotesPart!.Endnotes!.Elements<Endnote>()
+                .Where(note => note.Type is null
+                    || note.Type == FootnoteEndnoteValues.Normal).ToArray();
+            Assert.Empty(husks);
+        }
+    }
+
+    /// <summary>
+    /// The cleanup in DS418 is scoped to notes whose reference the resolution itself removed:
+    /// a note that was ALREADY dangling before any resolution (its id referenced nowhere) is
+    /// pre-existing document state, and resolving an unrelated revision must not garbage-collect
+    /// it — that would be silent content loss.
+    /// </summary>
+    [Fact]
+    public void DS419_ResolvingUnrelatedRevision_LeavesPreExistingDanglingNoteAlone()
+    {
+        var bytes = BuildWithBody(
+            new XElement(W.p,
+                new XElement(W.r, new XElement(W.t, "Kept. ")),
+                new XElement(W.ins,
+                    new XAttribute(W.id, "101"),
+                    new XAttribute(W.author, "Alice"),
+                    new XAttribute(W.date, "2026-01-01T00:00:00Z"),
+                    new XElement(W.r, new XElement(W.t, "Inserted.")))));
+        bytes = AddDanglingFootnote(bytes, noteId: 7, text: "Orphan note body.");
+
+        using var session = new DocxSession(bytes);
+        var revision = Assert.Single(session.ListRevisions());
+        Assert.True(session.RejectRevision(revision.Id).Success);
+
+        var resolved = session.Save();
+        Assert.True(HasNotesPart(resolved, "footnote"), "pre-existing notes part was deleted");
+        using var stream = new MemoryStream(resolved, writable: false);
+        using var document = WordprocessingDocument.Open(stream, false);
+        var texts = document.MainDocumentPart!.FootnotesPart!.Footnotes!
+            .Elements<Footnote>().Select(note => note.InnerText).ToArray();
+        Assert.Contains("Orphan note body.", string.Concat(texts));
+    }
+
+    private static bool HasNotesPart(byte[] bytes, string kind)
+    {
+        using var stream = new MemoryStream(bytes, writable: false);
+        using var document = WordprocessingDocument.Open(stream, false);
+        return kind == "footnote"
+            ? document.MainDocumentPart!.FootnotesPart is not null
+            : document.MainDocumentPart!.EndnotesPart is not null;
+    }
+
+    /// <summary>Add a footnotes part holding separator stubs plus one real note that nothing
+    /// in the body references — the pre-existing dangling-note shape DS419 protects.</summary>
+    private static byte[] AddDanglingFootnote(byte[] source, int noteId, string text)
+    {
+        using var ms = new MemoryStream();
+        ms.Write(source);
+        ms.Position = 0;
+        using (var wDoc = WordprocessingDocument.Open(ms, true))
+        {
+            var part = wDoc.MainDocumentPart!.AddNewPart<FootnotesPart>();
+            part.Footnotes = new Footnotes(
+                new Footnote(new Paragraph(new Run(new SeparatorMark())))
+                {
+                    Type = FootnoteEndnoteValues.Separator,
+                    Id = -1,
+                },
+                new Footnote(new Paragraph(new Run(new SeparatorMark())))
+                {
+                    Type = FootnoteEndnoteValues.ContinuationSeparator,
+                    Id = 0,
+                },
+                new Footnote(new Paragraph(new Run(new Text(text)))) { Id = noteId });
+            part.Footnotes.Save();
+        }
+        return ms.ToArray();
+    }
 }

--- a/Docxodus.Tests/RedlineReversibilityFixtureSweepTests.cs
+++ b/Docxodus.Tests/RedlineReversibilityFixtureSweepTests.cs
@@ -270,6 +270,10 @@ public class RedlineReversibilityFixtureSweepTests
     [InlineData("WC/WC034-Endnotes-After3.docx", "WC/WC034-Endnotes-Before.docx")]
     [InlineData("WC/WC036-Endnote-With-Table-Before.docx", "WC/WC036-Endnote-With-Table-After.docx")]
     [InlineData("WC/WC036-Endnote-With-Table-After.docx", "WC/WC036-Endnote-With-Table-Before.docx")]
+    [InlineData("WC/WC035-Footnote-Before.docx", "WC/WC035-Footnote-After.docx")]
+    [InlineData("WC/WC035-Footnote-After.docx", "WC/WC035-Footnote-Before.docx")]
+    [InlineData("WC/WC035-Endnote-Before.docx", "WC/WC035-Endnote-After.docx")]
+    [InlineData("WC/WC035-Endnote-After.docx", "WC/WC035-Endnote-Before.docx")]
     [InlineData("WC/WC038-Document-With-BR-Before.docx", "WC/WC038-Document-With-BR-After.docx")]
     [InlineData("RC/RC001-Before.docx", "RC/RC001-After1.docx")]
     [InlineData("RC/RC002-Image.docx", "RC/RC002-Image-After1.docx")]
@@ -335,17 +339,24 @@ public class RedlineReversibilityFixtureSweepTests
         Assert.Empty(body.Descendants<InsertedRun>());
     }
 
-    // WC035: when a comparison adds the document's first footnote/endnote, the redline
-    // package gains a notes part. Resolving toward the endpoint that has no notes leaves
-    // that (now content-empty) part behind instead of removing it, so the output package
-    // has a story the expected document never had. Body and note text themselves
-    // round-trip; only the empty-part residue diverges.
+    // WC035 regression pin for the resolve-time note cleanup (issues #516/#552): when a
+    // comparison adds the document's first footnote/endnote, the redline package gains a
+    // notes part. Resolving toward the endpoint that has no notes used to leave the note
+    // itself behind as an empty reference-less husk, and the proof's normalized layer
+    // refused the direction over pure no-notes spelling: Word writes "no notes" either as
+    // an absent part or as an eagerly-created separator-only part (a footnote document
+    // even ships a separator-only endnotes.xml), and the two spellings hashed apart.
+    // The session's selective resolver now deletes a note whose last reference the
+    // resolution carried away (the part stays — Word never prunes one; see the RP050
+    // oracle), and the proof compares the two no-notes spellings as equivalent, saying so
+    // with a separator_only_notes_part_normalized finding. These pairs also run through
+    // RRS004's corpus contract; this pin adds the #516-specific assertions on top.
     [Theory]
     [InlineData("WC/WC035-Footnote-Before.docx", "WC/WC035-Footnote-After.docx", "footnotes")]
     [InlineData("WC/WC035-Footnote-After.docx", "WC/WC035-Footnote-Before.docx", "footnotes")]
     [InlineData("WC/WC035-Endnote-Before.docx", "WC/WC035-Endnote-After.docx", "endnotes")]
     [InlineData("WC/WC035-Endnote-After.docx", "WC/WC035-Endnote-Before.docx", "endnotes")]
-    public void RRS006_KnownGap_ResolvingAwayTheOnlyNoteLeavesAnEmptyNotesPart(
+    public void RRS006_ResolvingAwayTheOnlyNoteRemovesTheNotesPart(
         string leftName,
         string rightName,
         string storyKind)
@@ -367,14 +378,25 @@ public class RedlineReversibilityFixtureSweepTests
         Assert.Null(NotesText(noteless, storyKind));
         Assert.False(string.IsNullOrEmpty(NotesText(noteBearing, storyKind)));
 
-        // Toward the note-bearing endpoint the round-trip is faithful.
+        // Both directions are faithful at story level (empty note stories compare as
+        // absent — see StoryTexts). The noteless direction's part holds nothing but
+        // separator definitions: the reference-less husk is gone.
         Assert.Equal(StoryTexts(noteBearing), StoryTexts(noteBearingOutput));
-
-        // Toward the noteless endpoint the body text round-trips but an empty notes part
-        // is left behind — the residue this pin exists for.
+        Assert.Equal(StoryTexts(noteless), StoryTexts(notelessOutput));
         Assert.Equal(BodyText(noteless), BodyText(notelessOutput));
         Assert.Equal(string.Empty, NotesText(notelessOutput, storyKind));
-        Assert.False(run.Proof.Success);
+
+        // The proof disclosed the no-notes spelling normalization, and after it neither
+        // notes part appears in the divergence view — the #516 residue is gone; what
+        // remains diverging is the generic rebuilt-package delta RRS004 pins.
+        var notelessPath = NotesText(left, storyKind) is null
+            ? run.Proof.RejectToBaseline
+            : run.Proof.AcceptToFinal;
+        Assert.Contains(notelessPath!.Findings, finding =>
+            finding.Code == "separator_only_notes_part_normalized");
+        Assert.DoesNotContain(notelessPath.Divergences, divergence =>
+            divergence.PartUri.Contains("footnotes", StringComparison.Ordinal)
+            || divergence.PartUri.Contains("endnotes", StringComparison.Ordinal));
     }
 
     // WC012-Math: the After document carries its own tracked insertions, and
@@ -594,11 +616,16 @@ public class RedlineReversibilityFixtureSweepTests
         builder.Append("body: ").Append(TextOf(main.Document)).Append('\n');
         AppendStory(builder, "headers", main.HeaderParts.Select(part => TextOf(part.Header)));
         AppendStory(builder, "footers", main.FooterParts.Select(part => TextOf(part.Footer)));
+        // An absent notes part and Word's eagerly-created separator-only part are the same
+        // "no notes" statement (issues #516/#552): a text-empty notes story appends no line,
+        // so the two spellings compare equal here exactly as in the proof's normalized layer.
         AppendStory(builder, "footnotes", main.FootnotesPart is { } footnotes
-            ? new[] { TextOf(footnotes.Footnotes) }
+            && TextOf(footnotes.Footnotes) is { Length: > 0 } footnoteText
+            ? new[] { footnoteText }
             : Array.Empty<string>());
         AppendStory(builder, "endnotes", main.EndnotesPart is { } endnotes
-            ? new[] { TextOf(endnotes.Endnotes) }
+            && TextOf(endnotes.Endnotes) is { Length: > 0 } endnoteText
+            ? new[] { endnoteText }
             : Array.Empty<string>());
         return builder.ToString();
     }

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -2761,6 +2761,7 @@ public sealed partial class DocxSession : IDisposable
         // Capture the block anchors the resolution touches BEFORE applying — elements
         // detach during Apply and can no longer be resolved to a part afterwards.
         var modified = RevisionGroupAnchors(group, partUri);
+        var referencedNotesBefore = ReferencedNoteIds();
 
         _history.RecordPreOp(TakeSnapshot());
         try
@@ -2784,6 +2785,7 @@ public sealed partial class DocxSession : IDisposable
             }
             if (!accept && rejectedNumberingIds.Length > 0)
                 PruneUnreferencedDocxodusNumbering(rejectedNumberingIds);
+            var prunedNotes = PruneNotesOrphanedByResolution(referencedNotesBefore);
 
             var removed = new List<Anchor>();
             var seenRemoved = new HashSet<string>(StringComparer.Ordinal);
@@ -2794,6 +2796,17 @@ public sealed partial class DocxSession : IDisposable
                     var unid = (string?)d.Attribute(PtOpenXml.Unid);
                     if (unid is null) continue;
                     if (AnchorForUnid(unid, partUri) is { } anch && seenRemoved.Add(anch.Id))
+                        removed.Add(anch);
+                }
+            }
+
+            foreach (var (note, notePartUri) in prunedNotes)
+            {
+                foreach (var d in note.DescendantsAndSelf())
+                {
+                    var unid = (string?)d.Attribute(PtOpenXml.Unid);
+                    if (unid is null) continue;
+                    if (AnchorForUnid(unid, notePartUri) is { } anch && seenRemoved.Add(anch.Id))
                         removed.Add(anch);
                 }
             }
@@ -2851,6 +2864,7 @@ public sealed partial class DocxSession : IDisposable
             ? Array.Empty<int>()
             : registry.Entries.SelectMany(NumberingIdsIntroducedBy)
                 .Except(_settings.ProtectedRevisionNumberingIds).Distinct().ToArray();
+        var referencedNotesBefore = ReferencedNoteIds();
 
         _history.RecordPreOp(TakeSnapshot());
         try
@@ -2876,6 +2890,7 @@ public sealed partial class DocxSession : IDisposable
             }
             if (!accept && rejectedNumberingIds.Length > 0)
                 PruneUnreferencedDocxodusNumbering(rejectedNumberingIds);
+            var prunedNotes = PruneNotesOrphanedByResolution(referencedNotesBefore);
             var removed = new List<Anchor>();
             var seenRemoved = new HashSet<string>(StringComparer.Ordinal);
             foreach (var element in removedElements)
@@ -2890,6 +2905,17 @@ public sealed partial class DocxSession : IDisposable
                     var unid = (string?)descendant.Attribute(PtOpenXml.Unid);
                     if (unid is null) continue;
                     if (AnchorForUnid(unid, partUri) is { } anchor && seenRemoved.Add(anchor.Id))
+                        removed.Add(anchor);
+                }
+            }
+
+            foreach (var (note, notePartUri) in prunedNotes)
+            {
+                foreach (var descendant in note.DescendantsAndSelf())
+                {
+                    var unid = (string?)descendant.Attribute(PtOpenXml.Unid);
+                    if (unid is null) continue;
+                    if (AnchorForUnid(unid, notePartUri) is { } anchor && seenRemoved.Add(anchor.Id))
                         removed.Add(anchor);
                 }
             }
@@ -2990,6 +3016,75 @@ public sealed partial class DocxSession : IDisposable
         if (!root.Elements().Any()) main.DeletePart(part);
         else part.PutXDocument();
     }
+
+    /// <summary>Footnote/endnote ids currently referenced from the main document story —
+    /// the only story OOXML lets a note reference live in.</summary>
+    private (HashSet<int> Footnotes, HashSet<int> Endnotes) ReferencedNoteIds()
+    {
+        var footnotes = new HashSet<int>();
+        var endnotes = new HashSet<int>();
+        var root = _doc?.MainDocumentPart?.GetXDocument().Root;
+        if (root is null) return (footnotes, endnotes);
+        foreach (var reference in root.Descendants(W.footnoteReference))
+            if (int.TryParse((string?)reference.Attribute(W.id), out var id)) footnotes.Add(id);
+        foreach (var reference in root.Descendants(W.endnoteReference))
+            if (int.TryParse((string?)reference.Attribute(W.id), out var id)) endnotes.Add(id);
+        return (footnotes, endnotes);
+    }
+
+    /// <summary>
+    /// Word-faithful note cleanup after revision resolution (issue #516). A note whose LAST
+    /// reference was removed by the resolution is deleted from its part — Word removes the
+    /// note when the rejected insertion (or accepted deletion) carries its reference away,
+    /// and without this the note survived as an empty reference-less husk. The PART itself
+    /// always stays: Word never prunes a notes part (the RP050-Deleted-Footnote oracle
+    /// keeps its separator-only footnotes.xml after accepting the only note's deletion),
+    /// and a separator-only part is exactly what Word ships in every fresh document.
+    /// Scoped strictly to ids referenced before and unreferenced after THIS resolution:
+    /// a note that was already dangling is pre-existing document state and stays untouched.
+    /// </summary>
+    /// <returns>The removed note elements with their part uri, for removed-anchor reporting.</returns>
+    private List<(XElement Note, string PartUri)> PruneNotesOrphanedByResolution(
+        (HashSet<int> Footnotes, HashSet<int> Endnotes) before)
+    {
+        var removed = new List<(XElement, string)>();
+        var main = _doc?.MainDocumentPart;
+        if (main is null) return removed;
+        var after = ReferencedNoteIds();
+        PruneNoteStory(main.FootnotesPart, W.footnote, before.Footnotes, after.Footnotes, removed);
+        PruneNoteStory(main.EndnotesPart, W.endnote, before.Endnotes, after.Endnotes, removed);
+        return removed;
+    }
+
+    private static void PruneNoteStory(
+        OpenXmlPart? part,
+        XName noteName,
+        HashSet<int> referencedBefore,
+        HashSet<int> referencedAfter,
+        List<(XElement, string)> removed)
+    {
+        var root = part?.GetXDocument().Root;
+        if (part is null || root is null) return;
+        var orphaned = referencedBefore.Except(referencedAfter).ToHashSet();
+        if (orphaned.Count == 0) return;
+
+        var partUri = part.Uri.ToString();
+        bool changed = false;
+        foreach (var note in root.Elements(noteName).ToList())
+        {
+            if (!int.TryParse((string?)note.Attribute(W.id), out var id)
+                || !orphaned.Contains(id) || IsSeparatorNote(note))
+                continue;
+            note.Remove();
+            removed.Add((note, partUri));
+            changed = true;
+        }
+
+        if (changed) part.PutXDocument();
+    }
+
+    private static bool IsSeparatorNote(XElement note) =>
+        (string?)note.Attribute(W.type) is "separator" or "continuationSeparator";
 
     internal IReadOnlyList<int> DefinedNumberingIds()
     {

--- a/Docxodus/Verification/RedlineReversibilityVerifier.cs
+++ b/Docxodus/Verification/RedlineReversibilityVerifier.cs
@@ -652,9 +652,47 @@ public static class RedlineReversibilityVerifier
         bool rawEquivalent = DigestEquals(
             expectedManifest.RawPackageBytesDigest,
             actualManifest.RawPackageBytesDigest);
+
+        // A footnotes/endnotes part holding nothing but separator definitions is Word's own
+        // spelling of "this document has no notes": Word ships one in every fresh document
+        // and never deletes it, and a comparison redline inherits whichever spelling its
+        // note-bearing side used (issues #516/#552). When strict normalized identity fails,
+        // re-compare with that spelling difference removed from BOTH sides — the raw and
+        // OPC digests above stay strict, and the reported package identities keep the real
+        // manifests. The normalization is disclosed as a finding whenever it changes the
+        // verdict or the divergence view.
+        var comparisonExpected = expectedManifest;
+        var comparisonActual = actualManifest;
+        if (!normalizedEquivalent)
+        {
+            var expectedComparable = WithoutSeparatorOnlyNotesParts(
+                expectedBytes, out bool expectedStripped);
+            var actualComparable = WithoutSeparatorOnlyNotesParts(
+                outputBytes, out bool actualStripped);
+            if (expectedStripped || actualStripped)
+            {
+                comparisonExpected = PackageManifestGenerator.Generate(
+                    expectedComparable, options.PackageManifestOptions);
+                comparisonActual = PackageManifestGenerator.Generate(
+                    actualComparable, options.PackageManifestOptions);
+                normalizedEquivalent = DigestEquals(
+                    comparisonExpected.NormalizedSemanticDigest,
+                    comparisonActual.NormalizedSemanticDigest);
+                findingBudget.Add(findings, Finding(
+                    "separator_only_notes_part_normalized",
+                    VerificationFindingSeverity.Info,
+                    $"The {DirectionName(direction)} comparison treats a separator-only "
+                        + "footnotes/endnotes part as equivalent to an absent one.",
+                    revisionIds: Array.Empty<string>(),
+                    remediation: "No action is required; the parts differ only in Word's "
+                        + "no-notes spelling.",
+                    direction: direction));
+            }
+        }
+
         var divergenceEvaluation = CompareEntries(
-            expectedManifest,
-            actualManifest,
+            comparisonExpected,
+            comparisonActual,
             generated,
             semantic.ModeledChanges,
             options.MaxPackageChanges);
@@ -1550,6 +1588,59 @@ public static class RedlineReversibilityVerifier
 
     private static bool DigestEquals(VerificationDigest? left, VerificationDigest? right) =>
         DeliveryReceiptValidation.DigestEquals(left, right);
+
+    /// <summary>
+    /// Return <paramref name="package"/> with any footnotes/endnotes part that holds ONLY
+    /// separator-kind definitions (no real note, not even an empty one) deleted, so the
+    /// two Word spellings of "no notes" — an absent part and Word's eagerly-created
+    /// separator-only part — compare as equivalent. <paramref name="stripped"/> reports
+    /// whether anything was removed; when nothing was, the original array is returned.
+    /// A package the SDK cannot open comes back unchanged — the strict digests already
+    /// carry its comparison.
+    /// </summary>
+    private static byte[] WithoutSeparatorOnlyNotesParts(byte[] package, out bool stripped)
+    {
+        stripped = false;
+        try
+        {
+            using var stream = new MemoryStream();
+            stream.Write(package, 0, package.Length);
+            stream.Position = 0;
+            using (var document =
+                DocumentFormat.OpenXml.Packaging.WordprocessingDocument.Open(stream, true))
+            {
+                var main = document.MainDocumentPart;
+                if (main is null) return package;
+                if (IsSeparatorOnlyNotesPart(main.FootnotesPart, W.footnote))
+                {
+                    main.DeletePart(main.FootnotesPart!);
+                    stripped = true;
+                }
+                if (IsSeparatorOnlyNotesPart(main.EndnotesPart, W.endnote))
+                {
+                    main.DeletePart(main.EndnotesPart!);
+                    stripped = true;
+                }
+            }
+            return stripped ? stream.ToArray() : package;
+        }
+        catch (Exception)
+        {
+            stripped = false;
+            return package;
+        }
+    }
+
+    private static bool IsSeparatorOnlyNotesPart(
+        DocumentFormat.OpenXml.Packaging.OpenXmlPart? part,
+        System.Xml.Linq.XName noteName)
+    {
+        var root = part?.GetXDocument().Root;
+        if (root is null) return false;
+        var notes = root.Elements(noteName).ToList();
+        return notes.Count > 0 && notes.All(note =>
+            (string?)note.Attribute(W.type) is "separator" or "continuationSeparator");
+    }
 
     private static DocxSession OpenProofSession(
         byte[] bytes,


### PR DESCRIPTION
Closes #516. Closes #552.

## The two residues

Resolving away a document's first-and-only footnote or endnote — rejecting the insertion that carried it, or accepting its deletion — left the output package different from a document that never had the note, in two separable ways:

1. **A reference-less husk.** The resolution removed the note's *reference* from the body and the tracked content *inside* the note, but the note element itself (`<w:footnote w:id="1">` with one empty paragraph) survived in the part. Word never produces this shape: it deletes a note the moment the edit carrying its reference lands.
2. **A "no notes" spelling mismatch.** Word writes "this document has no notes" two ways: no notes part at all, or an eagerly-created part holding only the separator/continuationSeparator stubs — every fresh Word document ships the latter. A comparison redline inherits whichever spelling its note-bearing input used (a footnote document even carries a separator-only `endnotes.xml`), so the reversibility proof's normalized whole-package layer hashed the resolved output apart from a partless expected endpoint it semantically matched.

## What guided the design

The first draft deleted the whole part when its last real note went — and the Word-oracle corpus immediately falsified it: `RRS001` on `RP050-Deleted-Footnote` shows Word's own accept output *keeps* its separator-only `footnotes.xml`. That evidence split the fix:

- **The session resolver deletes orphaned note bodies, never parts.** Before applying a resolution, `AcceptRevision`/`RejectRevision` (and the resolve-all pair) capture which note ids the main story references; afterwards, any note whose last reference that specific resolution removed is deleted from its part, mirroring the existing scoped cleanups (relationship sweep, numbering prune). A note that was already dangling beforehand is pre-existing document state and is untouched — `DS419` pins that a resolve of an unrelated revision cannot garbage-collect it.
- **The proof compares the two spellings as one statement.** When strict normalized identity fails, `RedlineReversibilityVerifier` re-compares with separator-only notes parts elided from *both* sides, and discloses the step with a new `separator_only_notes_part_normalized` info finding. The raw and OPC digests and the reported package identities stay strict — only the normalized verdict and the divergence view use the elided manifests, so the notes residue no longer buries real divergences.

This is also why #552 closes here: the carried-over separator-only part of the *other* note kind, filed mid-investigation as a part-removal gap, turns out to be Word's own no-notes spelling — the part *should* stay, and the comparison is where the equivalence belonged.

## Validation

Test-first throughout; each new assertion was run red against the prior behavior:

- `DS418` (four WC035 directions): the resolved part holds nothing but separator definitions — the husk is gone — and no note references remain.
- `DS419`: a pre-existing dangling note survives an unrelated resolve untouched.
- `RRS006` (rewritten from the known-gap pin): both directions story-faithful, the noteless direction's part separator-only, the normalization finding present, and neither notes part in the divergence view.
- The four WC035 pairs are promoted into the `RRS004` corpus theory (the issue's closing move), whose story-text oracle now treats a text-empty notes story as absent — symmetrically, matching the proof's normalization.
- `RRS001`/`RP050` (Word oracles) green — the part-retention decision is pinned by ground truth.
- Full .NET suite: 4388 passed / 0 failed / 3 standing skips; the merged tree re-verified after merging main.

No public API shape changes — the new behavior rides existing session ops and the proof's existing finding stream, so no cross-surface ripple beyond CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)