### PR TITLE
Select even/odd running stories by the page number, not the position in section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -747,6 +747,18 @@ All notable changes to this project will be documented in this file.
   version bump at release time.
 
 ### Fixed
+- **Even/odd running stories follow the page number again (#536).** The paginated renderer's
+  #527 hardening switched even-header/footer selection (and the matching band heights) to the
+  page's one-based position in its section, which flips every story of a section that begins
+  on an even page — `DB001-Sections` lost ink parity with LibreOffice on three of six pages
+  and turned the weekly visual-parity ratchet red on `main`. ECMA-376 §17.10.5 hangs the even
+  story on "even numbered pages": the page NUMBER, which keeps counting across a section
+  boundary unless `w:pgNumType` restarts it — and a restart moves the parity with it, so a
+  section that restarts at 1 on a physically even page shows its odd story, exactly as Word
+  treats a front-matter restart. Selection now keys on the displayed page number (first-page
+  selection under `w:titlePg` is unchanged), and the multi-section parity case measures ink
+  F1 1.0 on all six pages again — the value the ratchet record already pins, so no record
+  refresh is needed.
 - **Resolving away a document's only footnote/endnote no longer leaves a reference-less
   husk, and the reversibility proof accepts Word's two "no notes" spellings (#516, #552).**
   When revision resolution removed a note's last reference — rejecting the insertion that

--- a/npm/src/pagination.ts
+++ b/npm/src/pagination.ts
@@ -715,8 +715,12 @@ export class PaginationEngine {
       this.checkpoint();
       if (page.element.dataset.sectionFiller === "true") continue;
       const pageInSection = parseInt(page.element.dataset.pageInSection || "1", 10);
-      const header = this.selectHeader(page.sectionIndex, pageInSection);
-      const footer = this.selectFooter(page.sectionIndex, pageInSection);
+      const displayedPageNumber = parseInt(
+        page.element.dataset.displayedPageNumber || String(page.pageNumber),
+        10,
+      );
+      const header = this.selectHeader(page.sectionIndex, pageInSection, displayedPageNumber);
+      const footer = this.selectFooter(page.sectionIndex, pageInSection, displayedPageNumber);
       if (header) this.collectExpectedSourceAnchors(header, this.expectedPageMapAnchorIds);
       if (footer) this.collectExpectedSourceAnchors(footer, this.expectedPageMapAnchorIds);
     }
@@ -1595,9 +1599,9 @@ export class PaginationEngine {
    */
   private smallestEffectiveContentHeight(dims: PageDimensions, sectionIndex: number): number {
     return Math.min(
-      this.getPageBands(dims, sectionIndex, 1).bodyHeight,
-      this.getPageBands(dims, sectionIndex, 2).bodyHeight,
-      this.getPageBands(dims, sectionIndex, 3).bodyHeight
+      this.getPageBands(dims, sectionIndex, 1, 1).bodyHeight,
+      this.getPageBands(dims, sectionIndex, 2, 2).bodyHeight,
+      this.getPageBands(dims, sectionIndex, 3, 3).bodyHeight
     );
   }
 
@@ -3038,6 +3042,7 @@ export class PaginationEngine {
   private selectHeader(
     sectionIndex: number,
     pageInSection: number,
+    displayedPageNumber: number,
   ): HTMLElement | undefined {
     const sectionHf = this.hfRegistry.get(sectionIndex);
     if (!sectionHf) return undefined;
@@ -3047,9 +3052,12 @@ export class PaginationEngine {
       return sectionHf.headerFirst;
     }
 
-    // OOXML counts odd/even pages from one inside each section, independently of a PAGE-field
-    // restart or format. The displayed page number is deliberately irrelevant here.
-    if (pageInSection % 2 === 0 && sectionHf.headerEven) {
+    // ECMA-376 §17.10.5 hangs the even story on "even numbered pages": the PAGE NUMBER,
+    // which keeps counting across a section boundary unless w:pgNumType restarts it (and a
+    // restart moves the parity with it). Word and LibreOffice both render DB001-Sections
+    // this way; selecting by position-in-section flips every story of a section that
+    // begins on an even page (issue #536).
+    if (displayedPageNumber % 2 === 0 && sectionHf.headerEven) {
       return sectionHf.headerEven;
     }
 
@@ -3061,6 +3069,7 @@ export class PaginationEngine {
   private selectFooter(
     sectionIndex: number,
     pageInSection: number,
+    displayedPageNumber: number,
   ): HTMLElement | undefined {
     const sectionHf = this.hfRegistry.get(sectionIndex);
     if (!sectionHf) return undefined;
@@ -3070,7 +3079,7 @@ export class PaginationEngine {
       return sectionHf.footerFirst;
     }
 
-    if (pageInSection % 2 === 0 && sectionHf.footerEven) {
+    if (displayedPageNumber % 2 === 0 && sectionHf.footerEven) {
       return sectionHf.footerEven;
     }
 
@@ -3092,6 +3101,7 @@ export class PaginationEngine {
     dims: PageDimensions,
     sectionIndex: number,
     pageInSection: number,
+    displayedPageNumber: number,
   ): PageBands {
     const sectionHf = this.hfRegistry.get(sectionIndex);
     return resolvePageBands(
@@ -3100,13 +3110,15 @@ export class PaginationEngine {
         sectionHf?.headerFirstHeight,
         sectionHf?.headerEvenHeight,
         sectionHf?.headerDefaultHeight,
-        pageInSection
+        pageInSection,
+        displayedPageNumber
       ),
       this.selectStoryHeight(
         sectionHf?.footerFirstHeight,
         sectionHf?.footerEvenHeight,
         sectionHf?.footerDefaultHeight,
-        pageInSection
+        pageInSection,
+        displayedPageNumber
       )
     );
   }
@@ -3120,9 +3132,10 @@ export class PaginationEngine {
     even: number | undefined,
     fallback: number | undefined,
     pageInSection: number,
+    displayedPageNumber: number,
   ): number {
     if (pageInSection === 1 && first != null) return first;
-    if (pageInSection % 2 === 0 && even != null) return even;
+    if (displayedPageNumber % 2 === 0 && even != null) return even;
     return fallback ?? 0;
   }
 
@@ -3214,7 +3227,7 @@ export class PaginationEngine {
 
     // Get effective content height for first page (accounts for header/footer sizes)
     let { bodyHeight: effectiveContentHeight } = this.getPageBands(
-      dimensionsFor(), pageSectionIndex, pageInSection()
+      dimensionsFor(), pageSectionIndex, pageInSection(), displayedPageNumber()
     );
     let remainingHeight = effectiveContentHeight;
 
@@ -3252,6 +3265,7 @@ export class PaginationEngine {
         dimensionsFor(owner),
         owner,
         pageInSection(owner),
+        displayedPageNumber(owner),
       );
       effectiveContentHeight = bands.bodyHeight;
       remainingHeight = effectiveContentHeight;
@@ -3275,6 +3289,7 @@ export class PaginationEngine {
         ownedDimensions,
         pageSectionIndex,
         pageInSection(),
+        displayedPageNumber(),
       );
       const partition = this.splitContinuationForPage(
         currentContinuation!,
@@ -3320,6 +3335,7 @@ export class PaginationEngine {
         ownedDimensions,
         pageSectionIndex,
         ownedPageInSection,
+        ownedDisplayedPageNumber,
       );
       const maxFootnoteHeight = pageBands.bodyHeight * MAX_FOOTNOTE_AREA_RATIO;
       // `prepareCurrentContinuation` has already packed the exact head for this
@@ -3425,6 +3441,7 @@ export class PaginationEngine {
         dimensionsFor(),
         pageSectionIndex,
         pageInSection(),
+        displayedPageNumber(),
       );
       effectiveContentHeight = newBands.bodyHeight;
       remainingHeight = effectiveContentHeight;
@@ -3491,6 +3508,7 @@ export class PaginationEngine {
           ownerDimensions,
           pageSectionIndex,
           pageInSection(),
+          displayedPageNumber(),
         );
         const ownerMaxFootnoteArea = ownerBands.bodyHeight * MAX_FOOTNOTE_AREA_RATIO;
         if (currentFootnoteHeight > ownerMaxFootnoteArea) {
@@ -3534,6 +3552,7 @@ export class PaginationEngine {
         blockDimensions,
         block.sectionIndex,
         nextBlockPageInSection,
+        displayedPageNumber(block.sectionIndex, nextBlockPageInSection, pageNumber + 1),
       ).bodyHeight;
 
       // Handle explicit page breaks
@@ -3597,6 +3616,11 @@ export class PaginationEngine {
               dimensionsFor(block.sectionIndex),
               block.sectionIndex,
               pageInSection(block.sectionIndex, pageNumber + 1),
+              displayedPageNumber(
+                block.sectionIndex,
+                pageInSection(block.sectionIndex, pageNumber + 1),
+                pageNumber + 1,
+              ),
             );
             const freshChainBodyHeight = this.measureKeepWithNextChainBodyHeight(
               keepChain,
@@ -4198,12 +4222,12 @@ export class PaginationEngine {
     pageBox.dataset.pageInSection = String(pageInSection);
 
     // Where the three bands sit on this page (no re-measurement needed)
-    const bands = this.getPageBands(dims, sectionIndex, pageInSection);
+    const bands = this.getPageBands(dims, sectionIndex, pageInSection, displayedPageNumber);
 
     // Add header if available for this section/page
     const headerSource = isSectionFiller
       ? undefined
-      : this.selectHeader(sectionIndex, pageInSection);
+      : this.selectHeader(sectionIndex, pageInSection, displayedPageNumber);
 
     if (headerSource) {
       const headerDiv = this.document.createElement("div");
@@ -4294,7 +4318,7 @@ export class PaginationEngine {
     // Add footer if available for this section/page
     const footerSource = isSectionFiller
       ? undefined
-      : this.selectFooter(sectionIndex, pageInSection);
+      : this.selectFooter(sectionIndex, pageInSection, displayedPageNumber);
     if (footerSource) {
       const footerDiv = this.document.createElement("div");
       footerDiv.className = `${this.cssPrefix}footer`;

--- a/npm/tests/page-numbering.spec.ts
+++ b/npm/tests/page-numbering.spec.ts
@@ -373,7 +373,7 @@ test.describe('Paginated preview substitutes real page numbers', () => {
     );
   });
 
-  test('PAGE fields continue logically while odd/even stories use section-relative parity', async ({
+  test('PAGE fields continue logically while odd/even stories follow the displayed number', async ({
     page,
   }) => {
     await page.setContent(`
@@ -424,11 +424,13 @@ test.describe('Paginated preview substitutes real page numbers', () => {
     });
 
     expect(result).toEqual([
-      // OOXML counts odd/even stories from page one in each section, regardless of w:start.
-      { physical: 1, section: 0, displayed: 10, footer: 'S0 odd 10' },
-      { physical: 2, section: 0, displayed: 11, footer: 'S0 even 11' },
-      // Section 1 omits w:start, so PAGE continues to 12 while its first page is still odd.
-      { physical: 3, section: 1, displayed: 12, footer: 'S1 odd 12' },
+      // ECMA-376 §17.10.5 hangs the even story on "even numbered pages" — the displayed
+      // number, restart-aware, exactly the number the PAGE field prints (issue #536). A
+      // start of 10 therefore begins the section on its EVEN story.
+      { physical: 1, section: 0, displayed: 10, footer: 'S0 even 10' },
+      { physical: 2, section: 0, displayed: 11, footer: 'S0 odd 11' },
+      // Section 1 omits w:start, so PAGE continues to 12 — an even page, even story.
+      { physical: 3, section: 1, displayed: 12, footer: 'S1 even 12' },
     ]);
   });
 });

--- a/npm/tests/pagination-continuous-section.spec.ts
+++ b/npm/tests/pagination-continuous-section.spec.ts
@@ -319,10 +319,12 @@ test.describe('Continuous section breaks', () => {
       .toEqual(ownedBySecondSection.map((_, index) => index + 1));
     expect(ownedBySecondSection.map((index) => result.displayedPageNumbers[index]))
       .toEqual(ownedBySecondSection.map((_, index) => index + 10));
+    // Even/odd stories alternate with the DISPLAYED number (10, 11, 12, …), not the
+    // one-based position in section — see the issue #536 parity tests below.
     expect(ownedBySecondSection.map((index) => result.headers[index]))
       .toEqual(ownedBySecondSection.map((_, index) =>
         index === 0 ? 'section-one-first'
-          : (index + 1) % 2 === 0 ? 'section-one-even' : 'section-one-default'));
+          : (index + 10) % 2 === 0 ? 'section-one-even' : 'section-one-default'));
     expect(result.content.flat()).toEqual(['before 1', 'after continuation']);
     const renderedWords = result.footnotes.join(' ');
     for (const word of words.split(' ')) {
@@ -453,6 +455,64 @@ test.describe('Continuous section breaks', () => {
     expect(result.sectionFillers).toEqual([false, false, true, false]);
     expect(result.sectionIndices).toEqual([0, 0, 0, 1]);
     expect(result.pagesInSection).toEqual([1, 2, 3, 1]);
+  });
+
+  test('even/odd stories follow the page number, not the position in section', async ({
+    page,
+  }) => {
+    // Issue #536: ECMA-376 §17.10.5 hangs the even story on "even numbered pages" — the
+    // page NUMBER, which keeps counting across a section boundary unless w:pgNumType
+    // restarts it. Word and LibreOffice both render DB001-Sections this way; selecting by
+    // position-in-section flips every story in a section that begins on an even page.
+    await page.setContent(staging(`
+      <div id="pagination-hf-registry">
+        <div data-section="0" data-hf-type="header-default"><p>s0 odd</p></div>
+        <div data-section="1" data-hf-type="header-default"><p>s1 odd</p></div>
+        <div data-section="1" data-hf-type="header-even"><p>s1 even</p></div>
+      </div>
+      <div data-section-index="0" ${PAGE_GEOMETRY}>
+        <p style="height: 20pt">alpha</p>
+      </div>
+      <div data-section-index="1" ${PAGE_GEOMETRY}>
+        <p style="height: 60pt">beta</p>
+        <p style="height: 60pt">gamma</p>
+        <p style="height: 60pt">delta</p>
+      </div>`));
+
+    const result = await paginate(page);
+
+    // Section 1 begins on global page 2: its stories alternate with the DOCUMENT page
+    // number (even, odd, even), not with its own one-based position (which would give
+    // the exact opposite sequence).
+    expect(result.sectionIndices).toEqual([0, 1, 1, 1]);
+    expect(result.pagesInSection).toEqual([1, 1, 2, 3]);
+    expect(result.displayedPageNumbers).toEqual([1, 2, 3, 4]);
+    expect(result.headers).toEqual(['s0 odd', 's1 even', 's1 odd', 's1 even']);
+  });
+
+  test('a numbering restart moves story parity with the displayed number', async ({
+    page,
+  }) => {
+    // The page that RESTARTS at 1 displays an odd number, so it takes the odd story even
+    // though its physical ordinal is even — exactly how Word treats a front-matter restart.
+    await page.setContent(staging(`
+      <div id="pagination-hf-registry">
+        <div data-section="0" data-hf-type="header-default"><p>s0 odd</p></div>
+        <div data-section="1" data-hf-type="header-default"><p>s1 odd</p></div>
+        <div data-section="1" data-hf-type="header-even"><p>s1 even</p></div>
+      </div>
+      <div data-section-index="0" ${PAGE_GEOMETRY}>
+        <p style="height: 20pt">alpha</p>
+      </div>
+      <div data-section-index="1" data-page-num-start="1" ${PAGE_GEOMETRY}>
+        <p style="height: 60pt">beta</p>
+        <p style="height: 60pt">gamma</p>
+      </div>`));
+
+    const result = await paginate(page);
+
+    expect(result.displayedPageNumbers).toEqual([1, 1, 2]);
+    expect(result.headers).toEqual(['s0 odd', 's1 odd', 's1 even']);
   });
 
   test('checks the physical-page limit before allocating an over-limit page', async ({ page }) => {


### PR DESCRIPTION
Closes #536.

## What was red and why

The weekly `LibreOffice visual parity` ratchet fails on `main`: `DB001-Sections.docx` lost ink parity on three of its six pages, worst ink F1 falling from the recorded `1.0` to `0.95237` in both the browser-page and generated-PDF pipelines. Reproduced locally to the digit — `0.95237` on page 5 — under a different Poppler than CI, so the number is renderer ink, not environment.

The page-5 overlay makes the defect legible: the page is nearly blank except its header and footer, and Docxodus draws **"sec 1 even"** where LibreOffice draws **"sec 1 odd"**. This is a running-story *selection* disagreement, not a font one.

## The bisect (the issue's suspects are exonerated)

The issue pointed at the #528/#529 font-runtime work as "most likely, not bisected". Bisecting the actual capture: swapping only `npm/src/pagination.ts` back to the recorded commit restores all six pages to 1.0 with everything else at HEAD, and walking that file's history lands on **#527** ("Validate and harden mixed-section page geometry"), whose parent measures clean. #527 switched even-header/footer selection — and the matching band-height selection — from the document page number to the page's one-based position in its section, on the in-code theory that "OOXML counts odd/even pages from one inside each section, independently of a PAGE-field restart or format."

## Why that theory is wrong

ECMA-376 §17.10.5 hangs the even story on *"even numbered pages"* — the page **number**, which keeps counting across a section boundary unless `w:pgNumType` restarts it. `DB001-Sections` has no restarts and `w:evenAndOddHeaders` on, and LibreOffice alternates its stories with the document number: a section beginning on an even page starts with the even story. Position-in-section flips every story of such a section — exactly the measured signature (pages 4–6 belong to a section starting mid-parity). And when numbering *does* restart, the parity moves with the displayed number — a restart to 1 on a physically even page shows the odd story, which is how Word treats a front-matter restart.

## The fix

`selectHeader`/`selectFooter`/`selectStoryHeight` key even-story selection on the page's **displayed page number**, threaded from the same restart-aware computation the PAGE-field substitution already uses. First-page selection under `w:titlePg` (the part of #527's cleanup that was right) is unchanged, as is the odd/even-section-break filler logic.

Two new pagination specs pin the law precisely where the candidate rules disagree:

- a section starting on an even document page must alternate `even, odd, even` with the document number — position-in-section would produce the exact opposite;
- a section that restarts numbering at 1 on an even physical page must show the odd story — global-physical parity would produce the opposite.

Both were run red against the pre-fix bundle. One existing expectation (a footnote-continuation test that encoded position parity under a `start=10` restart) is corrected to displayed parity.

## Validation

- Multi-section parity case: ink F1 **1.0 on all six pages** — the exact value `ratchet.json` records, so no record refresh is needed and the weekly ratchet goes green without banking anything.
- Full 21-case browser parity corpus run locally: every other case unchanged (including `running-content` at its documented reference-deviation value to the digit).
- All 82 pagination/header-footer Playwright specs green; `tsc` clean.
- The generated-PDF pipeline consumes the same pagination bundle (its runner fails fast if the asset is missing), so the same fix flows there; it cannot be exercised on this host — Chromium's sandbox is denied without the userns sysctl CI sets — and the scheduled run is its confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)