### PR TITLE
Record the accepted degraded-font-environment caveat as the benchmark's decision

### DIFF
--- a/npm/tests/visual-parity/README.md
+++ b/npm/tests/visual-parity/README.md
@@ -123,6 +123,34 @@ declared contract change — never to silent host-font drift. `environment` disp
 "the two engines lay out the SAME substitute differently" (rasterization, justification, line
 breaking), not "the two engines picked different fonts".
 
+### Standing degraded-environment caveats (issue #537)
+
+Two generated-PDF corpus fixtures request faces the substitution contract cannot fully serve,
+and this is the **accepted, deliberate state** — reported, not gated:
+
+| Case | Request | Degradation |
+|---|---|---|
+| `pdf-final-revisions` | Calibri Light → Carlito | `metricCompatible: false` — no open metric clone of Calibri Light exists (see the table above) |
+| `pdf-endnote-table` | Calibri → Carlito | `glyphCoverage: "partial"` — the document uses a glyph Carlito lacks |
+
+The decision, weighed against the alternatives:
+
+- **Extending the contract** is not possible for Calibri Light (no open metric-compatible face
+  exists to extend it *with*), and patching a single missing glyph with a different face would
+  break the metric story the contract exists to guarantee.
+- **Swapping the fixtures** would trade real Word-authored corpus documents for ones chosen to
+  flatter the font environment — the benchmark would measure less of what users actually send.
+- **Accepting and reporting** keeps the real documents and keeps the caveat visible on every
+  run: `degradedFontEnvironments` in `summary.json` and the `[font environment degraded: …]`
+  note beside the per-case line. Those two cases' raster numbers describe output measured
+  through a font environment that could not satisfy the document; the residual they carry is
+  partly the contract's, not the renderer's — which is exactly why
+  `assertSupportedPdfResult` gates only on the renderer's own guarantees (every face from the
+  configured directories, nothing missing) and *reports* metric compatibility and coverage.
+
+Revisit only if an open metric-compatible Calibri Light appears, or the corpus gains a
+same-category document the contract can fully serve *in addition to* (not instead of) these.
+
 ## Reference-version contract
 
 With fonts pinned, the LibreOffice version was the last uncontracted variable in the comparison


### PR DESCRIPTION
Closes #537.

#537 is a `type:design` decision, not a defect: two generated-PDF corpus fixtures request font faces the substitution contract cannot fully serve — `pdf-final-revisions` asks for Calibri Light (resolved to Carlito, which is metric-compatible with Calibri but not with Calibri Light), and `pdf-endnote-table` uses a glyph Carlito lacks. Since #531 the benchmark *reports* this (`degradedFontEnvironments` in `summary.json`, plus a per-case note) instead of failing on it; the issue asked which of three postures to adopt permanently.

This records the decision as **option 3 — accept both fixtures and treat the existing reporting as the standing caveat** — in the benchmark's font-contract documentation, alongside the reasoning that rules the alternatives out:

- **Option 1 (extend the contract)** is impossible for Calibri Light: the contract's own table already documents that no open metric clone exists, so there is nothing to extend it *with*. Patching the single missing glyph with a different face would break the metric-compatibility story the contract exists to guarantee.
- **Option 2 (swap the fixtures)** would trade real Word-authored corpus documents for ones chosen to flatter the font environment — the benchmark would measure less of what users actually send, and the `revisions` and `endnotes`/`tables` categories would lose their most representative members.
- **Option 3** keeps the documents, keeps the caveat visible on every run, and is consistent with why `assertSupportedPdfResult` gates only on the renderer's own guarantees (every face resolved from the configured directories, nothing missing) while reporting metric compatibility and glyph coverage — failing the unconditional contract on the host font set's limits would name the renderer for something that isn't its fault.

The new README subsection also states the two conditions under which the decision should be revisited: an open metric-compatible Calibri Light appearing, or the corpus gaining a same-category document the contract can fully serve *in addition to* these two.

Documentation-only — no code, corpus, or ratchet change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)