### PR TITLE
Pin the no-edit round-trip stability of a comment-ranged revision paragraph

### DIFF
--- a/Docxodus.Tests/Verification/SemanticDiffNoiseTests.cs
+++ b/Docxodus.Tests/Verification/SemanticDiffNoiseTests.cs
@@ -170,4 +170,64 @@ public class SemanticDiffNoiseTests
         }
         return new WmlDocument(source.FileName, stream.ToArray());
     }
+
+    [Fact]
+    public void Comment_ranged_paragraph_with_revision_markup_round_trips_without_noise()
+    {
+        // Issue #546 observed a comment-ranged paragraph carrying live tracked-change markup
+        // shifting its content-derived anchor id on every no-edit open → save cycle, which made
+        // the semantic surface report a phantom comment modification. The shape is authored the
+        // way the eval corpus authored it — a sub-span comment added first, then a tracked
+        // replacement threading through the commented paragraph — and must round-trip silent.
+        byte[] authored;
+        using (var author = new Docxodus.DocxSession(
+            Docxodus.DocxSession.CreateBlankDocxBytes()))
+        {
+            var seed = author.Project().AnchorIndex.Values
+                .First(target => target.Anchor.Kind == "p" && target.Anchor.Scope == "body")
+                .Anchor.Id;
+            var inserted = author.InsertParagraph(
+                seed, Docxodus.Position.After,
+                "The Client shall pay the **annual fees** set out below, invoiced quarterly in advance.");
+            Assert.True(inserted.Success, inserted.Error?.Message);
+            var anchor = inserted.Created.Single().Id;
+
+            var visible = "The Client shall pay the annual fees set out below, invoiced quarterly in advance.";
+            var start = visible.IndexOf("invoiced", StringComparison.Ordinal);
+            var comment = author.AddComment(
+                anchor,
+                new Docxodus.CharSpan(start, "invoiced quarterly in advance.".Length),
+                "Prior Reviewer",
+                "Confirm before circulation.");
+            Assert.True(comment.Success, comment.Error?.Message);
+
+            author.SetTrackedChanges(Docxodus.TrackedChangeMode.RenderInline);
+            author.SetRevisionAuthor("Prior Reviewer");
+            var edits = author.ReplaceTextRange(
+                anchor, "in advance.", "in advance, net forty-five (45) days.");
+            Assert.True(edits.All(result => result.Success),
+                edits.FirstOrDefault(result => !result.Success)?.Error?.Message);
+            author.SetTrackedChanges(Docxodus.TrackedChangeMode.Accept);
+            authored = author.Save();
+        }
+
+        byte[] resaved;
+        string[] anchorsBefore;
+        using (var session = new Docxodus.DocxSession(authored))
+        {
+            anchorsBefore = session.Project().AnchorIndex.Keys
+                .OrderBy(id => id, StringComparer.Ordinal).ToArray();
+            resaved = session.Save();
+        }
+
+        var diff = SemanticDiff.Compare(
+            new WmlDocument("before.docx", authored),
+            new WmlDocument("after.docx", resaved));
+        Assert.Empty(diff.Changes);
+
+        using var reopened = new Docxodus.DocxSession(resaved);
+        var anchorsAfter = reopened.Project().AnchorIndex.Keys
+            .OrderBy(id => id, StringComparer.Ordinal).ToArray();
+        Assert.Equal(anchorsBefore, anchorsAfter);
+    }
 }


### PR DESCRIPTION
Closes #546.

## What the issue reported

While building the #466 eval corpus, a paragraph carrying both a comment range and live tracked-change markup shifted its content-derived anchor id (`p:body:7b09e69…` → `p:body:b9aacb01…`) on every no-edit open → save round trip, making the semantic change surface report a phantom `comment` modification. The corpus worked around it by anchoring the fixture's pre-existing comment on a revision-free paragraph.

## What re-verification found

The defect **no longer reproduces on current `main`**. Five authoring shapes were tried, escalating to a full MCP-dispatcher replay of the master-services-agreement fixture's own recipe with the comment restored to its pre-workaround target — sub-span comment added first via the comment tool, tracked replacement threading through the commented paragraph under `render_inline`, headers and footers present. Every shape round-trips with byte-identical `document.xml`, identical anchor sets across sessions, and an empty semantic change set. Whatever save-normalization instability the corpus work hit in that code's earlier state has been resolved by intervening changes.

## What this PR adds

A regression pin in the semantic-noise suite (`Comment_ranged_paragraph_with_revision_markup_round_trips_without_noise`): the eval corpus's own authoring shape must keep producing an empty change set and an unchanged anchor index across a no-edit cycle. If the instability ever returns, this fails with the phantom-change signature rather than being rediscovered in a corpus build.

The eval fixture's workaround (comment on a revision-free paragraph) is left as-is — it is a valid fixture either way, and its README note now describes a historical observation guarded by this test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)