### PR TITLE
Draw block-level property revisions instead of warning about them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,22 +14,17 @@ All notable changes to this project will be documented in this file.
   **A caller that relied on the empty-list no-op** should pass `ExpectedMatchCount = 0`
   (`expectedMatchCount` on the wire) to assert absence as a successful no-op;
   `MaxReplacements = 0` likewise remains a successful found-but-unconsumed no-op.
-- **Revision and comment export profiles report what they cannot draw (#444).** Under `markup`,
-  a block-level property revision — paragraph, table, section or numbering — raises
-  `revision_property_change_not_rendered` (custom XML revision ranges briefly raised
-  `revision_family_not_rendered` in this cycle; #538 below draws them instead, so that
-  warning no longer exists). Under any visible comment profile, comment threading
-  raises `comment_thread_flattened` and resolved state raises
+- **Comment export profiles report what they cannot draw (#444).** Under any visible comment
+  profile, comment threading raises `comment_thread_flattened` and resolved state raises
   `comment_resolved_state_not_rendered`, because the topology in `commentsExtended` is not read: a
   reply is drawn as an independent comment and a resolved comment is indistinguishable from an open
-  one. `final` and `original` need none of the revision warnings — they apply the projection and
-  then assert no revision survived it, so an unrenderable family fails the projection instead of
-  passing through unseen. All four route through the `unsupportedContent` policy, so **an existing
-  caller passing `unsupportedContent: "strict"` now gets a closed `resource_policy_failure` where
-  such a document previously exported**; pass `"warn"` to keep the old outcome. Warnings count only
-  what is actually missing: `rPrChange` and tracked cell insert/delete/merge are drawn, so neither
-  is reported, and the package manifest gains `revisions.runPropertyChanges` so the property count
-  can be split without a second inventory pass. The profile contract is now also pinned where it
+  one. (#444 also introduced revision warnings — `revision_family_not_rendered` and
+  `revision_property_change_not_rendered` — but #538 and #539 below draw those families in this
+  same cycle, so neither warning ships.) Both route through the `unsupportedContent` policy, so
+  **an existing caller passing `unsupportedContent: "strict"` now gets a closed
+  `resource_policy_failure` where such a document previously exported**; pass `"warn"` to keep the
+  old outcome. The package manifest gains `revisions.runPropertyChanges`, splitting run-level from
+  block-level property revisions in the inventory without a second pass. The profile contract is now also pinned where it
   was previously asserted without evidence: PDF text extraction per profile (deleted content
   extracts in document order under `markup` and never under `final`; inserted content never under
   `original`), revision rendering inside headers, footers, footnotes and endnotes, a comment range
@@ -50,6 +45,19 @@ All notable changes to this project will be documented in this file.
   fingerprint, fingerprints from before this change do not compare equal to ones after it.
 
 ### Added
+- **The converter draws block-level property revisions (#539).** A tracked change to
+  paragraph, numbering, table, row, cell or section properties (`w:pPrChange`,
+  `w:numberingChange`, `w:tblPrChange`, `w:tblGridChange`, `w:trPrChange`, `w:tblPrExChange`,
+  `w:tcPrChange`, `w:sectPrChange`) previously passed through `WmlToHtmlConverter` untouched,
+  leaving no mark a reader could see under tracked-changes rendering. Each family now marks
+  its block — a titled goldenrod change bar on the paragraph
+  (`rev-para-format-change` / `rev-section-format-change`), a dotted outline on the table, row
+  or cell (`rev-table-format-change`, `rev-row-format-change`, `rev-cell-format-change`), and
+  a marker div where a trailing body `w:sectPr` records a section-property change — with the
+  author and date under `IncludeRevisionMetadata`. Outside tracked-changes rendering nothing
+  is emitted. The standalone export's `revision_property_change_not_rendered` warning is
+  retired with the gap it disclosed; `revisions.runPropertyChanges` in the package manifest
+  remains as inventory.
 - **The converter draws custom XML revision ranges (#538).** `w:customXmlInsRangeStart`/
   `End`, `Del`, `MoveFrom`, and `MoveTo` — a reviewer's tracked add/remove/move of a custom
   XML structural wrapper — previously passed through `WmlToHtmlConverter` untouched, leaving

--- a/Docxodus.Tests/HtmlConverterTests.cs
+++ b/Docxodus.Tests/HtmlConverterTests.cs
@@ -4746,6 +4746,120 @@ namespace OxPt
             }
         }
 
+        private static byte[] BuildDocWithBlockPropertyRevisions()
+        {
+            const string w = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+            var body =
+                $"<w:body xmlns:w=\"{w}\">" +
+                // Paragraph whose properties changed with tracking on (was centered, now default).
+                "<w:p><w:pPr>" +
+                "<w:pPrChange w:id=\"501\" w:author=\"Reviewer\" w:date=\"2026-01-01T00:00:00Z\">" +
+                "<w:pPr><w:jc w:val=\"center\"/></w:pPr></w:pPrChange>" +
+                "</w:pPr><w:r><w:t>Re-aligned paragraph.</w:t></w:r></w:p>" +
+                // Paragraph whose numbering changed.
+                "<w:p><w:pPr>" +
+                "<w:numberingChange w:id=\"502\" w:author=\"Reviewer\" w:date=\"2026-01-01T00:00:00Z\"/>" +
+                "</w:pPr><w:r><w:t>Renumbered paragraph.</w:t></w:r></w:p>" +
+                // Table with tracked table-level, grid, row, row-exception, and cell property changes.
+                "<w:tbl>" +
+                "<w:tblPr><w:tblPrChange w:id=\"503\" w:author=\"Reviewer\" w:date=\"2026-01-01T00:00:00Z\">" +
+                "<w:tblPr/></w:tblPrChange></w:tblPr>" +
+                "<w:tblGrid><w:gridCol w:w=\"4000\"/>" +
+                "<w:tblGridChange w:id=\"504\"><w:tblGrid><w:gridCol w:w=\"5000\"/></w:tblGrid></w:tblGridChange>" +
+                "</w:tblGrid>" +
+                "<w:tr><w:trPr>" +
+                "<w:trPrChange w:id=\"505\" w:author=\"Reviewer\" w:date=\"2026-01-01T00:00:00Z\"><w:trPr/></w:trPrChange>" +
+                "</w:trPr>" +
+                "<w:tblPrEx><w:tblPrExChange w:id=\"506\" w:author=\"Reviewer\" w:date=\"2026-01-01T00:00:00Z\">" +
+                "<w:tblPrEx/></w:tblPrExChange></w:tblPrEx>" +
+                "<w:tc><w:tcPr>" +
+                "<w:tcPrChange w:id=\"507\" w:author=\"Reviewer\" w:date=\"2026-01-01T00:00:00Z\"><w:tcPr/></w:tcPrChange>" +
+                "</w:tcPr><w:p><w:r><w:t>Restyled cell.</w:t></w:r></w:p></w:tc></w:tr>" +
+                "</w:tbl>" +
+                "<w:p><w:r><w:t>Tail paragraph.</w:t></w:r></w:p>" +
+                // Trailing section properties changed with tracking on.
+                "<w:sectPr><w:sectPrChange w:id=\"508\" w:author=\"Reviewer\" w:date=\"2026-01-01T00:00:00Z\">" +
+                "<w:sectPr/></w:sectPrChange></w:sectPr>" +
+                "</w:body>";
+
+            using (MemoryStream ms = new MemoryStream())
+            {
+                using (WordprocessingDocument wDoc = WordprocessingDocument.Create(
+                    ms, DocumentFormat.OpenXml.WordprocessingDocumentType.Document))
+                {
+                    var main = wDoc.AddMainDocumentPart();
+                    main.Document = new Document(new Body());
+                    main.Document.Save();
+                    var xd = main.GetXDocument();
+                    xd.Root.Element(XName.Get("body", w))
+                        .ReplaceWith(XElement.Parse(body));
+                    main.PutXDocument();
+                }
+                return ms.ToArray();
+            }
+        }
+
+        [Fact]
+        public void HC067_BlockPropertyRevisions_DrawPerceivableMarks()
+        {
+            // Issue #539: Word records a tracked formatting change by storing the previous
+            // properties beside the current ones. The block renders in its CURRENT state, so
+            // without a mark the reviewer's re-indent, table restyle, or section change is
+            // invisible under markup — each family must leave a perceivable, kind-addressable
+            // trace with the author metadata the other families expose.
+            byte[] docBytes = BuildDocWithBlockPropertyRevisions();
+            using (MemoryStream ms = new MemoryStream())
+            {
+                ms.Write(docBytes, 0, docBytes.Length);
+                using (WordprocessingDocument wDoc = WordprocessingDocument.Open(ms, true))
+                {
+                    var settings = new WmlToHtmlConverterSettings()
+                    {
+                        RenderTrackedChanges = true,
+                        IncludeRevisionMetadata = true,
+                    };
+
+                    string htmlString = WmlToHtmlConverter.ConvertToHtml(wDoc, settings).ToString();
+
+                    Assert.Contains("rev-para-format-change", htmlString);   // pPrChange + numberingChange
+                    Assert.Contains("rev-table-format-change", htmlString);  // tblPrChange / tblGridChange
+                    Assert.Contains("rev-row-format-change", htmlString);    // trPrChange / tblPrExChange
+                    Assert.Contains("rev-cell-format-change", htmlString);   // tcPrChange
+                    Assert.Contains("rev-section-format-change", htmlString); // sectPrChange
+                    Assert.Contains("data-author=\"Reviewer\"", htmlString);
+                    // The stylesheet ships the marks it references.
+                    Assert.Contains("format-change", GetCssText(htmlString));
+                }
+            }
+        }
+
+        private static string GetCssText(string htmlString)
+        {
+            var html = XElement.Parse(htmlString);
+            return string.Concat(html.Descendants()
+                .Where(e => e.Name.LocalName == "style")
+                .Select(e => e.Value));
+        }
+
+        [Fact]
+        public void HC068_BlockPropertyRevisions_InvisibleWhenNotRenderingTrackedChanges()
+        {
+            byte[] docBytes = BuildDocWithBlockPropertyRevisions();
+            using (MemoryStream ms = new MemoryStream())
+            {
+                ms.Write(docBytes, 0, docBytes.Length);
+                using (WordprocessingDocument wDoc = WordprocessingDocument.Open(ms, true))
+                {
+                    string htmlString = WmlToHtmlConverter.ConvertToHtml(
+                        wDoc, new WmlToHtmlConverterSettings()).ToString();
+
+                    Assert.DoesNotContain("format-change", htmlString);
+                    Assert.Contains("Re-aligned paragraph.", htmlString);
+                    Assert.Contains("Restyled cell.", htmlString);
+                }
+            }
+        }
+
         private static byte[] BuildDocWithCommentSpanningRevisions()
         {
             using (MemoryStream ms = new MemoryStream())

--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -1810,6 +1810,30 @@ namespace Docxodus
             sb.AppendLine("    color: #4b0082;");
             sb.AppendLine("}");
 
+            // Block-level property revisions (issue #539) — a goldenrod change bar / outline
+            // in place of markup the block cannot strike or underline. Titles carry the detail.
+            sb.AppendLine($".{prefix}para-format-change {{");
+            sb.AppendLine("    border-left: 3px dotted #b8860b;");
+            sb.AppendLine("    padding-left: 4px;");
+            sb.AppendLine("}");
+            sb.AppendLine($"table.{prefix}table-format-change {{");
+            sb.AppendLine("    outline: 2px dotted #b8860b;");
+            sb.AppendLine("    outline-offset: 1px;");
+            sb.AppendLine("}");
+            sb.AppendLine($"tr.{prefix}row-format-change {{");
+            sb.AppendLine("    outline: 1px dotted #b8860b;");
+            sb.AppendLine("}");
+            sb.AppendLine($"td.{prefix}cell-format-change {{");
+            sb.AppendLine("    outline: 1px dotted #b8860b;");
+            sb.AppendLine("    outline-offset: -1px;");
+            sb.AppendLine("}");
+            sb.AppendLine($".{prefix}section-format-change {{");
+            sb.AppendLine("    border-left: 3px dotted #b8860b;");
+            sb.AppendLine("    padding-left: 4px;");
+            sb.AppendLine("    color: #b8860b;");
+            sb.AppendLine("    font-size: 0.85em;");
+            sb.AppendLine("}");
+
             // Table row inserted
             sb.AppendLine($"tr.{prefix}row-ins {{");
             sb.AppendLine("    background-color: #e6ffe6;");
@@ -3059,6 +3083,32 @@ namespace Docxodus
             if (element.Name == W.endnoteReference)
             {
                 return ProcessEndnoteReference(wordDoc, settings, element);
+            }
+
+            // A trailing body-level w:sectPr renders no content of its own, but a tracked
+            // section-property change recorded on it (w:sectPrChange) must still leave a mark
+            // (issue #539): emit a titled marker div where the section metadata sits.
+            if (element.Name == W.sectPr)
+            {
+                var sectPrChange = element.Element(W.sectPrChange);
+                if (!settings.RenderTrackedChanges || sectPrChange == null)
+                    return null;
+                var sectPrefix = settings.RevisionCssClassPrefix ?? "rev-";
+                var sectionMarker = new XElement(Xhtml.div,
+                    new XAttribute("class", sectPrefix + "section-format-change"),
+                    new XAttribute("title", "Section properties changed"),
+                    new XText("Section properties changed"));
+                if (settings.IncludeRevisionMetadata)
+                {
+                    var changeAuthor = (string)sectPrChange.Attribute(W.author);
+                    var changeDate = (string)sectPrChange.Attribute(W.date);
+                    if (changeAuthor != null)
+                        sectionMarker.Add(new XAttribute("data-author", changeAuthor));
+                    if (changeDate != null)
+                        sectionMarker.Add(new XAttribute("data-date", changeDate));
+                }
+
+                return sectionMarker;
             }
 
             // Custom XML revision range boundaries (issue #538): a reviewer added, removed, or
@@ -5050,6 +5100,49 @@ namespace Docxodus
                 var paraIns = rPr?.Element(W.ins);
                 var paraDel = rPr?.Element(W.del);
 
+                // Block-level property revisions (issue #539): the paragraph renders in its
+                // CURRENT state, so the recorded previous-properties marker is the only trace
+                // a reviewer's re-format, renumber, or section change leaves. Draw it as a
+                // kind-classed change bar the stylesheet styles, titled with what changed.
+                var pPrChange = pPr?.Element(W.pPrChange);
+                var numberingChange = pPr?.Element(W.numberingChange);
+                var inlineSectPrChange = pPr?.Element(W.sectPr)?.Element(W.sectPrChange);
+                if (pPrChange != null || numberingChange != null || inlineSectPrChange != null)
+                {
+                    var prefix = settings.RevisionCssClassPrefix ?? "rev-";
+                    var classes = new List<string>();
+                    var described = new List<string>();
+                    if (pPrChange != null || numberingChange != null)
+                    {
+                        classes.Add(prefix + "para-format-change");
+                        if (pPrChange != null) described.Add("Paragraph formatting changed");
+                        if (numberingChange != null) described.Add("Numbering changed");
+                    }
+                    if (inlineSectPrChange != null)
+                    {
+                        classes.Add(prefix + "section-format-change");
+                        described.Add("Section properties changed");
+                    }
+
+                    var existingClass = (string)paragraph.Attribute("class");
+                    var combined = string.Join(" ", classes);
+                    paragraph.SetAttributeValue("class",
+                        existingClass != null ? existingClass + " " + combined : combined);
+                    if (paragraph.Attribute("title") == null)
+                        paragraph.Add(new XAttribute("title", string.Join("; ", described)));
+
+                    var marker = pPrChange ?? numberingChange ?? inlineSectPrChange;
+                    if (settings.IncludeRevisionMetadata)
+                    {
+                        var changeAuthor = (string)marker.Attribute(W.author);
+                        var changeDate = (string)marker.Attribute(W.date);
+                        if (changeAuthor != null && paragraph.Attribute("data-author") == null)
+                            paragraph.Add(new XAttribute("data-author", changeAuthor));
+                        if (changeDate != null && paragraph.Attribute("data-date") == null)
+                            paragraph.Add(new XAttribute("data-date", changeDate));
+                    }
+                }
+
                 if (paraIns != null)
                 {
                     // Paragraph mark was inserted (paragraph was split from another)
@@ -5291,6 +5384,35 @@ namespace Docxodus
                 CreateColGroup(element),
                 element.Elements().Select(e => ConvertToHtmlTransform(wordDoc, settings, e, false, currentMarginLeft)));
             table.AddAnnotation(style);
+
+            // Tracked table-property / grid revisions (issue #539).
+            if (settings.RenderTrackedChanges)
+            {
+                var tblPrChange = element.Elements(W.tblPr).Elements(W.tblPrChange).FirstOrDefault();
+                var tblGridChange = element.Elements(W.tblGrid).Elements(W.tblGridChange).FirstOrDefault();
+                if (tblPrChange != null || tblGridChange != null)
+                {
+                    var revisionPrefix = settings.RevisionCssClassPrefix ?? "rev-";
+                    var existingClass = (string)table.Attribute("class");
+                    var className = revisionPrefix + "table-format-change";
+                    table.SetAttributeValue("class",
+                        existingClass != null ? existingClass + " " + className : className);
+                    if (table.Attribute("title") == null)
+                        table.Add(new XAttribute("title", tblGridChange != null && tblPrChange == null
+                            ? "Table column widths changed"
+                            : "Table properties changed"));
+                    var marker = tblPrChange ?? tblGridChange;
+                    if (settings.IncludeRevisionMetadata)
+                    {
+                        var changeAuthor = (string)marker.Attribute(W.author);
+                        var changeDate = (string)marker.Attribute(W.date);
+                        if (changeAuthor != null && table.Attribute("data-author") == null)
+                            table.Add(new XAttribute("data-author", changeAuthor));
+                        if (changeDate != null && table.Attribute("data-date") == null)
+                            table.Add(new XAttribute("data-date", changeDate));
+                    }
+                }
+            }
             var jc = (string)element.Elements(W.tblPr).Elements(W.jc).Attributes(W.val).FirstOrDefault() ?? "left";
             XAttribute dir = null;
             XAttribute jcToUse = null;
@@ -5549,6 +5671,29 @@ namespace Docxodus
                             cell.Add(new XAttribute("data-date", date));
                     }
                 }
+
+                // Tracked cell-property revision (issue #539): w:tcPrChange. Composes with the
+                // structural cell revisions above by appending to whatever class they set.
+                var tcPrChange = tcPr.Element(W.tcPrChange);
+                if (tcPrChange != null)
+                {
+                    var revisionPrefix = settings.RevisionCssClassPrefix ?? "rev-";
+                    var existingClass = (string)cell.Attribute("class");
+                    var className = revisionPrefix + "cell-format-change";
+                    cell.SetAttributeValue("class",
+                        existingClass != null ? existingClass + " " + className : className);
+                    if (cell.Attribute("title") == null)
+                        cell.Add(new XAttribute("title", "Cell properties changed"));
+                    if (settings.IncludeRevisionMetadata)
+                    {
+                        var changeAuthor = (string)tcPrChange.Attribute(W.author);
+                        var changeDate = (string)tcPrChange.Attribute(W.date);
+                        if (changeAuthor != null && cell.Attribute("data-author") == null)
+                            cell.Add(new XAttribute("data-author", changeAuthor));
+                        if (changeDate != null && cell.Attribute("data-date") == null)
+                            cell.Add(new XAttribute("data-date", changeDate));
+                    }
+                }
             }
 
             return cell;
@@ -5574,6 +5719,32 @@ namespace Docxodus
                 var trPr = element.Element(W.trPr);
                 var rowIns = trPr?.Element(W.ins);
                 var rowDel = trPr?.Element(W.del);
+
+                // Tracked row-property revisions (issue #539): w:trPrChange, and the row's
+                // table-property exceptions via w:tblPrExChange.
+                var trPrChange = trPr?.Element(W.trPrChange);
+                var tblPrExChange = element.Elements(W.tblPrEx)
+                    .Elements(W.tblPrExChange).FirstOrDefault();
+                if (trPrChange != null || tblPrExChange != null)
+                {
+                    var revisionPrefix = settings.RevisionCssClassPrefix ?? "rev-";
+                    var existingClass = (string)htmlRow.Attribute("class");
+                    var className = revisionPrefix + "row-format-change";
+                    htmlRow.SetAttributeValue("class",
+                        existingClass != null ? existingClass + " " + className : className);
+                    if (htmlRow.Attribute("title") == null)
+                        htmlRow.Add(new XAttribute("title", "Row properties changed"));
+                    var marker = trPrChange ?? tblPrExChange;
+                    if (settings.IncludeRevisionMetadata)
+                    {
+                        var changeAuthor = (string)marker.Attribute(W.author);
+                        var changeDate = (string)marker.Attribute(W.date);
+                        if (changeAuthor != null && htmlRow.Attribute("data-author") == null)
+                            htmlRow.Add(new XAttribute("data-author", changeAuthor));
+                        if (changeDate != null && htmlRow.Attribute("data-date") == null)
+                            htmlRow.Add(new XAttribute("data-date", changeDate));
+                    }
+                }
 
                 if (rowIns != null)
                 {

--- a/docs/architecture/standalone_paginated_export.md
+++ b/docs/architecture/standalone_paginated_export.md
@@ -725,27 +725,27 @@ browser-observed environment can never satisfy it.
 
 ### Revision and comment families that are not drawn
 
-`markup` draws insertions, deletions, moves, run-level format changes, tracked cell
-insert/delete/merge — the last as tinted, struck-through or dashed cells — and, since issue
-#538, custom XML revision ranges: each range boundary renders as a bracket marker in the
-family's revision color, titled with the change and its author, because the revision has no
-text of its own to strike or underline. One family still travels through the projection
-untouched and leaves no mark a reader can see, so it is reported rather than approximated:
-the block-level property revisions — paragraph, table, section and numbering — raise
-`revision_property_change_not_rendered`.
+`markup` draws every tracked-revision family: insertions, deletions, moves, run-level format
+changes, tracked cell insert/delete/merge — as tinted, struck-through or dashed cells — custom
+XML revision ranges (issue #538: each range boundary renders as a bracket marker in the family's
+revision color, titled with the change and its author, because the revision has no text of its
+own to strike or underline), and, since issue #539, the block-level property revisions:
+paragraph, table, row, cell and section property changes each mark their block with a titled
+goldenrod change bar or outline. No revision family warns anymore —
+`revision_property_change_not_rendered` and its predecessor `revision_family_not_rendered` are
+retired, and their specs now pin the drawing and the silence together so neither warning can
+come back without the render evidence going with it.
 
-That second warning counts only what is missing. `rPrChange` is a property revision the converter
-does draw, so the manifest counts it separately as `runPropertyChanges` and the warning reports
-`propertyChanges - runPropertyChanges`. Splitting the count in the inventory rather than
-approximating it in the export is what keeps `unsupportedContent: "strict"` honest: a document
-whose only property revisions are run-level format changes is drawn in full and must not fail
-closed. The split costs no extra work — it is one more counter in the pass the manifest already
-makes, not a second inventory pass over the package.
+The manifest still counts `runPropertyChanges` separately from `propertyChanges`. The split is
+kept as inventory — it costs one counter in a pass the manifest already makes, and callers who
+told the two families apart by it keep that visibility even though nothing warns on the
+difference anymore.
 
-`final` and `original` need no such warnings. They apply the projection and then assert the derived
-package retains no revisions at all, so a family that cannot be applied fails the projection instead
-of passing through unseen. This is also what keeps the source package intact: the projection derives
-a new package and the original bytes are never accepted, rejected, or rewritten in place.
+`final` and `original` never needed the warnings. They apply the projection and then assert the
+derived package retains no revisions at all, so a family that cannot be applied fails the
+projection instead of passing through unseen. This is also what keeps the source package intact:
+the projection derives a new package and the original bytes are never accepted, rejected, or
+rewritten in place.
 
 Any visible comment profile renders comment bodies, ranges and authors, but not the topology
 recorded in `commentsExtended`: a reply is drawn as an independent comment
@@ -755,7 +755,7 @@ they are reported instead of approximated. Comments survive the `final`/`origina
 unchanged, so these two are raised against the source package only; the derived preflight would
 otherwise report each of them twice.
 
-All four warnings route through the `unsupportedContent` policy, so `strict` turns the first one
+Both comment warnings route through the `unsupportedContent` policy, so `strict` turns the first one
 raised into a closed `resource_policy_failure` in `package_preflight` rather than a warning a
 caller has to notice. As everywhere else in preflight, a strict export reports the first policy
 breach and stops; `warn` is what enumerates every one of them in a single pass.

--- a/npm/src/export-browser.ts
+++ b/npm/src/export-browser.ts
@@ -1624,48 +1624,12 @@ async function preflightManifest(
       fail("resource_policy_failure", "package_preflight", warning.message, warning.remediation);
     }
   }
+  // Every tracked-revision family now draws under the markup profile — insertions, deletions,
+  // moves, run and block property changes (issue #539), tracked cell revisions, and custom XML
+  // revision ranges (issue #538) — so there is no longer a revision warning to raise here.
+  // Comment topology (threading, resolved state) is still flattened; that warning remains.
   if (isSourcePackage) {
-    warnUnrenderedRevisionFamilies(manifest, state, options);
     warnUnrenderedCommentTopology(manifest, state, options);
-  }
-}
-
-/**
- * Warns for tracked-revision families the markup profile cannot draw.
- *
- * The converter draws insertions, deletions, moves, run-level format changes, tracked cell
- * insert/delete/merge (as tinted, struck-through or dashed cells), and — since issue #538 —
- * custom XML revision ranges (as bracket boundary markers). What it still never draws is the
- * block-level property revisions — paragraph, table, section and numbering — which travel
- * through the projection untouched but leave no mark a reader can see.
- *
- * Only `markup` needs this. `final` and `original` apply the projection and then assert the
- * derived package has no revisions left at all, so an unrenderable family cannot survive them
- * silently — it fails the projection instead.
- */
-function warnUnrenderedRevisionFamilies(
-  manifest: PackageManifest,
-  state: ExecutionState,
-  options: NormalizedOptions,
-): void {
-  if (options.reviewProfile !== "markup") return;
-  const revisions = manifest.facts.revisions;
-  // rPrChange is the one property revision the converter draws (as a marked format change), so
-  // only the remainder is unrepresented. The manifest counts that subset for exactly this reason;
-  // reporting the combined figure would fail a strict export whose content is fully drawn.
-  const blockPropertyChanges = revisions.propertyChanges - revisions.runPropertyChanges;
-  if (blockPropertyChanges > 0) {
-    policyWarning(state, options, {
-      code: "revision_property_change_not_rendered",
-      phase: "package_preflight",
-      message: blockPropertyChanges === 1
-        ? "1 paragraph, table, section, or numbering property revision is present but is not drawn as markup."
-        : `${blockPropertyChanges} paragraph, table, section, and numbering property revisions are `
-          + "present but are not drawn as markup.",
-      remediation: "Use the final or original profile when block-level property revisions must be reflected in the output.",
-      detail: "numberingChange, pPrChange, sectPrChange, tblGridChange, tblPrChange, "
-        + "tblPrExChange, tcPrChange, trPrChange",
-    });
   }
 }
 

--- a/npm/tests/docx-review-topology-fixture.ts
+++ b/npm/tests/docx-review-topology-fixture.ts
@@ -89,19 +89,19 @@ function minimalPackage({
 }
 
 /**
- * A document carrying both sides of the property-revision split plus a custom XML range.
+ * A document carrying every property-revision shape the markup profile draws.
  *
- * Two `w:pPrChange` are unrepresentable; the `w:rPrChange`, the `w:ins`, and (since issue
- * #538) the `w:customXmlInsRangeStart`/`End` pair beside them are drawn, and exist so the
- * warnings can be shown to count only what is actually missing. Manifest counts:
+ * Two `w:pPrChange` draw as titled paragraph change bars (issue #539); the `w:rPrChange`,
+ * the `w:ins`, and the `w:customXmlInsRangeStart`/`End` pair (issue #538) beside them draw
+ * as well, so no revision warning may fire for any of it. Manifest counts:
  * `propertyChanges` 3, `runPropertyChanges` 1, `otherChanges` 1, `insertions` 1.
  */
-export function generateUnrenderableRevisionDocx(): Uint8Array {
+export function generateBlockPropertyRevisionDocx(): Uint8Array {
   return minimalPackage({
     body: `<w:p>
     <w:pPr>
       <w:jc w:val="center"/>
-      <!-- Word records the previous paragraph properties; markup cannot draw this. -->
+      <!-- Word records the previous paragraph properties; markup draws a change bar. -->
       <w:pPrChange w:id="10" ${AUTHORED}>
         <w:pPr><w:jc w:val="left"/></w:pPr>
       </w:pPrChange>
@@ -123,7 +123,7 @@ export function generateUnrenderableRevisionDocx(): Uint8Array {
       <w:ind w:left="720"/>
       <w:pPrChange w:id="13" ${AUTHORED}><w:pPr/></w:pPrChange>
     </w:pPr>
-    <!-- A custom XML revision range; the converter has no handling for these at all. -->
+    <!-- A custom XML revision range; drawn as bracket boundary markers since #538. -->
     <w:customXmlInsRangeStart w:id="14" ${AUTHORED}/>
     <w:r><w:t>Indented, and wrapped in custom XML by a reviewer.</w:t></w:r>
     <w:customXmlInsRangeEnd w:id="14"/>

--- a/npm/tests/standalone-export.spec.ts
+++ b/npm/tests/standalone-export.spec.ts
@@ -9,7 +9,7 @@ import {
   generateCellRevisionDocx,
   generateCommentTopologyDocx,
   generateRenderedRevisionOnlyDocx,
-  generateUnrenderableRevisionDocx,
+  generateBlockPropertyRevisionDocx,
 } from './docx-review-topology-fixture.js';
 import { generateUndecodableImageDocx } from './docx-undecodable-image-fixture.js';
 import { R_NS, storedZip, W_NS, xml } from './docx-zip.js';
@@ -814,29 +814,31 @@ test.describe('standalone paginated HTML', () => {
       }
     });
 
-  test('warns only for the revision families the markup profile cannot draw', async ({ page }) => {
-    const source = generateUnrenderableRevisionDocx();
+  test('draws block property revisions rather than warning about them', async ({ page }) => {
+    // The premise of the retired revision warnings was "the converter does not draw this".
+    // Since issue #539 the block-level property revisions draw too — a paragraph whose
+    // properties changed carries a titled goldenrod change bar — so every revision family
+    // renders and no revision warning may fire. Asserting the drawing and the silence
+    // together means the warning cannot come back without the render evidence going with it.
+    const source = generateBlockPropertyRevisionDocx();
     const markup = await convert(page, source, false, { reviewProfile: 'markup' });
-    const warnings = markup.renderReport.warnings;
 
-    // The custom XML range is DRAWN since issue #538 (bracket boundary markers), so the old
-    // revision_family_not_rendered warning must never fire for it. Of the three property
-    // revisions, only two warn: the rPrChange beside them is drawn as a marked format change,
-    // so the count must exclude it.
-    expect(warnings.map((warning) => warning.code))
-      .not.toContain('revision_family_not_rendered');
-    expect(warnings).toContainEqual(expect.objectContaining({
-      code: 'revision_property_change_not_rendered',
-      severity: 'warning',
-      phase: 'package_preflight',
-      message: '2 paragraph, table, section, and numbering property revisions are present but are '
-        + 'not drawn as markup.',
-    }));
-    // No remediation may point at a profile that shows less than the one being warned about.
-    for (const warning of warnings) expect(warning.remediation).not.toContain('commentProfile: hidden');
+    const drawn = await page.evaluate((html: string) => {
+      const parsed = new DOMParser().parseFromString(html, 'text/html');
+      const styles = Array.from(parsed.querySelectorAll('style'), (node) => node.textContent).join('');
+      return {
+        paraMarks: parsed.querySelectorAll('.rev-para-format-change').length,
+        styled: styles.includes('.rev-para-format-change'),
+      };
+    }, markup.html);
+    expect(drawn).toEqual({ paraMarks: 2, styled: true });
+
+    const codes = markup.renderReport.warnings.map((warning) => warning.code);
+    expect(codes).not.toContain('revision_family_not_rendered');
+    expect(codes).not.toContain('revision_property_change_not_rendered');
 
     // final applies the projection and then asserts no revision survives it, so no family can
-    // pass through silently and neither warning applies.
+    // pass through silently and neither retired warning may reappear there either.
     const final = await convert(page, source, false, { reviewProfile: 'final' });
     const finalCodes = final.renderReport.warnings.map((warning) => warning.code);
     expect(finalCodes).not.toContain('revision_family_not_rendered');
@@ -888,19 +890,18 @@ test.describe('standalone paginated HTML', () => {
     expect(strict.pageCount).toBeGreaterThan(0);
   });
 
-  test('fails closed under strict for a revision family it cannot draw', async ({ page }) => {
-    const source = generateUnrenderableRevisionDocx();
-    const failure = await page.evaluate(async (bytes) => (window as any).DocxodusStandalone
-      .convertFailure(bytes, {
-        reviewProfile: 'markup',
-        commentProfile: 'hidden',
-        unsupportedContent: 'strict',
-      }), Array.from(source));
-
-    expect(failure.unexpectedSuccess).toBeUndefined();
-    expect(failure.code).toBe('resource_policy_failure');
-    expect(failure.phase).toBe('package_preflight');
-    expect(failure.report.status).toBe('failed');
+  test('survives strict now that every revision family is drawn', async ({ page }) => {
+    // This document used to fail closed under strict: its pPrChange pair raised
+    // revision_property_change_not_rendered and strict escalated it. With the family drawn
+    // (issue #539) the warning is retired, so the same document must export cleanly under
+    // the strictest policy.
+    const source = generateBlockPropertyRevisionDocx();
+    const strict = await convert(page, source, false, {
+      reviewProfile: 'markup',
+      commentProfile: 'hidden',
+      unsupportedContent: 'strict',
+    });
+    expect(strict.pageCount).toBeGreaterThan(0);
   });
 
   test('warns exactly once that comment threading and resolved state are not drawn',


### PR DESCRIPTION
Closes #539

## What this fixes

Word records a tracked change to *properties* — a paragraph re-centered, a table re-bordered, a row re-sized, a cell re-shaded, a section's margins altered — as a property-change element (`w:pPrChange`, `w:numberingChange`, `w:tblPrChange`, `w:tblGridChange`, `w:trPrChange`, `w:tblPrExChange`, `w:tcPrChange`, `w:sectPrChange`) holding the previous values. The HTML converter drew every *content* revision family (insertions, deletions, moves, run format changes, tracked cell structure, custom XML ranges) but let all eight block-level property families pass through invisibly: a reviewer's change was in the file, and a reader of the rendered markup could not see that anything had happened.

## How it works

Unlike a run format change, a block property change has no text of its own to strike or underline, so each family marks the block that carries it:

- **Paragraph** (`pPrChange`, `numberingChange`, and a paragraph-level `sectPrChange` on a section-break paragraph): the paragraph's `div` gains a titled class (`rev-para-format-change` / `rev-section-format-change`) drawn as a goldenrod dotted change bar on the left edge — the same visual grammar as the existing insertion/deletion change bars.
- **Table** (`tblPrChange`, `tblGridChange`): the `table` gains `rev-table-format-change`, a dotted outline.
- **Row** (`trPrChange`, `tblPrExChange`): the `tr` gains `rev-row-format-change`.
- **Cell** (`tcPrChange`): the `td` gains `rev-cell-format-change`, composing with the existing tracked cell insert/delete/merge classes.
- **Trailing section properties**: a body-level `w:sectPr` renders no content at all, so a `sectPrChange` there emits a small titled marker `div` where the section metadata sits.

Every mark carries a human-readable `title` naming what changed, and `data-author`/`data-date` under `IncludeRevisionMetadata`. With tracked-changes rendering off, nothing is emitted — the document renders exactly as before.

## The export warning this retires

The standalone paginated export warned `revision_property_change_not_rendered` for exactly this gap, and `unsupportedContent: "strict"` escalated it to a closed failure. With the family drawn, the warning (and the now-empty warning pass) is removed, and the export spec pins the drawing and the silence together — the warning cannot come back without the render evidence going with it. A document whose only revisions are block property changes now exports cleanly under the strictest policy. The package manifest's `revisions.runPropertyChanges` counter stays, as inventory: callers keep the run-level/block-level split even though nothing warns on it anymore.

## Validation

- New converter tests: a fixture carrying all eight property-change elements asserts every class, the metadata attributes, and the CSS; a second test asserts total invisibility with tracked-changes rendering off.
- Reworked export specs assert the drawn markers, the absence of both retired warning codes under `markup` and `final`, and a clean strict export of the formerly fail-closed fixture.
- Full .NET suite: 4406 passed / 0 failed. Full Playwright suite: 654 passed / 0 failed.