### PR TITLE
Emit comment marker links only in the mode that renders their target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -807,6 +807,16 @@ All notable changes to this project will be documented in this file.
   version bump at release time.
 
 ### Fixed
+- **Inline and margin comment markers are no longer links to nowhere (#563).** The `[n]`
+  comment marker always carried `href="#comment-{id}"`, but only `endnotes` mode renders that
+  target — inline mode has no comments section, and margin mode's note ids are stripped when
+  pagination clones notes into the page margin. Every commented document therefore failed a
+  strict (`unsupportedContent: "strict"`) inline/margin standalone export on a
+  `fragment_target_unavailable` dangling link, and quietly degraded to an inert marker under
+  the default `warn`. The converter now emits the `href` only in `endnotes` mode; in inline
+  and margin modes the marker keeps its element name, id, classes and metadata but is not an
+  anchor, so nothing downstream has to repair a link the converter knew was dangling.
+
 - **`PreserveInputRevisions` now carries a modified block's own tracked changes through the
   redline (#517).** A comparison whose right side already contained tracked changes silently
   lost them from a *modified* block — the fine renderers emit the accepted view, so accepting

--- a/Docxodus.Tests/HtmlConverterTests.cs
+++ b/Docxodus.Tests/HtmlConverterTests.cs
@@ -5179,6 +5179,57 @@ namespace OxPt
             }
         }
 
+        [Fact]
+        public void HC073_CommentMarkers_LinkOnlyWhereTheTargetRenders()
+        {
+            // Only EndnoteStyle renders the `#comment-N` targets the marker links point at.
+            // In Inline and Margin modes the marker must not be a link to nowhere, while
+            // keeping its identity (id, class, element name) for downstream selectors
+            // (issue #563).
+            byte[] docBytes = BuildDocWithThreadedComments();
+            foreach (var mode in new[]
+            {
+                CommentRenderMode.EndnoteStyle,
+                CommentRenderMode.Inline,
+                CommentRenderMode.Margin,
+            })
+            {
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    ms.Write(docBytes, 0, docBytes.Length);
+                    using (WordprocessingDocument wDoc = WordprocessingDocument.Open(ms, true))
+                    {
+                        var settings = new WmlToHtmlConverterSettings()
+                        {
+                            RenderComments = true,
+                            CommentRenderMode = mode,
+                            IncludeCommentMetadata = true,
+                        };
+                        XElement xhtml = WmlToHtmlConverter.ConvertToHtml(wDoc, settings);
+
+                        var marker = ById(xhtml, "comment-ref-1");
+                        Assert.Equal("a", marker.Name.LocalName);
+                        Assert.Contains("comment-marker", (string)marker.Attribute("class"));
+
+                        if (mode == CommentRenderMode.EndnoteStyle)
+                        {
+                            Assert.Equal("#comment-1", (string)marker.Attribute("href"));
+                            Assert.NotNull(ById(xhtml, "comment-1"));
+                        }
+                        else
+                        {
+                            Assert.Null(marker.Attribute("href"));
+                        }
+
+                        // The reply's marker keeps its metadata in every mode — dropping the
+                        // href must not cost the thread relationship.
+                        var marker2 = ById(xhtml, "comment-ref-2");
+                        Assert.Equal("1", (string)marker2.Attribute("data-parent-id"));
+                    }
+                }
+            }
+        }
+
         #endregion
     }
 }

--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -4682,8 +4682,13 @@ namespace Docxodus
             var prefix = settings.CommentCssClassPrefix ?? "comment-";
             tracker.Comments.TryGetValue(id.Value, out var comment);
 
+            // Only EndnoteStyle renders the `#comment-{id}` targets (RenderCommentsSection);
+            // in Inline and Margin modes the marker stays an anchor-free <a> so it is not a
+            // link to nowhere, while `a[data-comment-id]` selectors keep matching (issue #563).
             var marker = new XElement(Xhtml.a,
-                new XAttribute("href", $"#comment-{id}"),
+                settings.CommentRenderMode == CommentRenderMode.EndnoteStyle
+                    ? new XAttribute("href", $"#comment-{id}")
+                    : null,
                 new XAttribute("id", $"comment-ref-{id}"),
                 new XAttribute("class", prefix + "marker"));
 

--- a/docs/architecture/comment_rendering.md
+++ b/docs/architecture/comment_rendering.md
@@ -238,36 +238,17 @@ private static object ProcessCommentRangeEnd(XElement element, WmlToHtmlConverte
 
 #### ProcessCommentReference
 
-Creates the superscript marker linking to the comment:
+Creates the superscript `[n]` marker for every render mode: an `<a>` with
+`id="comment-ref-{id}"` and class `{prefix}marker`, plus the metadata each mode needs
+(`data-comment-id` for point comments, `data-parent-id`/`data-resolved`/reply body text
+under `IncludeCommentMetadata` — see issue #540).
 
-```csharp
-private static object ProcessCommentReference(XElement element, WmlToHtmlConverterSettings settings)
-{
-    var tracker = element.Ancestors().First().Annotation<CommentTracker>();
-    var id = (int?)element.Attribute(W.id);
-    var prefix = settings.CommentCssClassPrefix ?? "comment-";
-
-    if (tracker != null && id.HasValue && tracker.Comments.ContainsKey(id.Value))
-    {
-        tracker.ReferencedCommentIds.Add(id.Value);
-
-        // EndnoteStyle: Create anchor link
-        if (settings.CommentRenderMode == CommentRenderMode.EndnoteStyle)
-        {
-            return new XElement(Xhtml.sup,
-                new XAttribute("class", prefix + "marker"),
-                new XAttribute("id", prefix + "ref-" + id.Value),
-                new XElement(Xhtml.a,
-                    new XAttribute("href", "#" + prefix.TrimEnd('-') + "-" + id.Value),
-                    "[" + (tracker.ReferencedCommentIds.Count) + "]"
-                )
-            );
-        }
-    }
-
-    return null;
-}
-```
+The marker carries `href="#comment-{id}"` **only in EndnoteStyle mode**, because only
+`RenderCommentsSection` renders that target. Inline mode has no comments section at all,
+and margin mode's note registry loses its ids when pagination clones notes into the page
+margin — so in those modes the marker is an anchor-free `<a>` rather than a link to
+nowhere (issue #563). The standalone export's fragment-target validation stays as defense
+in depth for genuinely broken documents.
 
 ### 5. Text Highlighting
 
@@ -391,7 +372,8 @@ In margin mode, the entire document body is wrapped in a flexbox container with 
       <span class="comment-highlight" data-comment-id="0">
         This text has a comment
       </span>
-      <sup><a href="#comment-0" class="comment-marker" id="comment-ref-0">[0]</a></sup>
+      <!-- no href: pagination strips the note ids the link would point at (#563) -->
+      <sup><a class="comment-marker" id="comment-ref-0">[0]</a></sup>
     </p>
   </div>
 

--- a/npm/tests/standalone-export.spec.ts
+++ b/npm/tests/standalone-export.spec.ts
@@ -927,16 +927,36 @@ test.describe('standalone paginated HTML', () => {
     expect(codes).not.toContain('comment_resolved_state_not_rendered');
 
     // This document used to fail closed under strict through those warnings; the same input
-    // must now export cleanly under the strictest policy. (endnotes, not inline: an inline
-    // comment marker links to a section that mode does not render, a pre-existing dangling
-    // fragment target that strict fails on and that the retired preflight warnings used to
-    // mask by failing first — tracked separately.)
+    // must now export cleanly under the strictest policy. (Inline and margin strict exports
+    // are proven separately below — issue #563.)
     const strict = await convert(page, source, false, {
       reviewProfile: 'final',
       commentProfile: 'endnotes',
       unsupportedContent: 'strict',
     });
     expect(strict.pageCount).toBeGreaterThan(0);
+  });
+
+  test('strict inline and margin exports survive commented documents', async ({ page }) => {
+    // Issue #563: the [n] comment marker carried href="#comment-N" in every mode, but only
+    // endnotes renders that target, so strict failed any commented inline/margin export on a
+    // dangling fragment target. The marker is now anchor-free outside endnotes; assert the
+    // markup change and the strict outcome together so the href cannot quietly return.
+    const source = generateCommentTopologyDocx();
+    for (const commentProfile of ['inline', 'margin'] as const) {
+      const strict = await convert(page, source, false, {
+        commentProfile,
+        unsupportedContent: 'strict',
+      });
+      expect(strict.pageCount, `${commentProfile} strict export`).toBeGreaterThan(0);
+
+      const marker = await page.evaluate((html: string) => {
+        const parsed = new DOMParser().parseFromString(html, 'text/html');
+        const el = parsed.querySelector('[id^="comment-ref-"]');
+        return el ? { tag: el.tagName, hasHref: el.hasAttribute('href') } : null;
+      }, strict.html);
+      expect(marker, `${commentProfile} marker`).toEqual({ tag: 'A', hasHref: false });
+    }
   });
 
   test('renders comment bodies per visible profile and none for hidden', async ({ page }) => {


### PR DESCRIPTION
Closes #563.

## Why

Every comment reference is rendered as a superscript `[n]` marker, and until now that marker was always a link to `#comment-{id}`. But only the endnote-style comment mode actually renders an element with that id (the comments section at the end of the document). In inline mode there is no comments section at all, and in margin mode the pagination engine strips ids from the note clones it places in the page margin. So in both of those modes, every comment marker was a link pointing at nothing.

The practical consequence showed up in the standalone paginated export, which validates that every in-page fragment link has a live target. A dangling marker meant:

- under the default `unsupportedContent: "warn"` policy, the link was downgraded to an inert label with a `fragment_target_unavailable` warning;
- under `"strict"`, the export failed closed — **any commented document could not be exported strictly in inline or margin mode**.

This was previously masked for threaded/resolved comments by earlier preflight warnings; once #540 taught the renderer to draw comment topology and retired those warnings, the dangling marker became the first thing a strict export tripped over.

## How

One mechanism-level change in `WmlToHtmlConverter.ProcessCommentReference`: the `href` attribute is added only when the render mode is `EndnoteStyle` — the mode whose output contains the target. In inline and margin modes the marker keeps everything else it had (its element name, `comment-ref-{id}` id, `comment-marker` class, and the metadata attributes added for #540) but is an anchor-free `<a>` rather than a link.

Keeping the element an `<a>` (instead of switching to `<span>`) matters: the pagination engine selects point-comment markers with `a[data-comment-id]`, and an `<a>` without `href` is non-interactive per HTML — exactly the wanted presentation. The export's inert-link downgrade stays in place as defense in depth for documents with genuinely broken internal links.

## Validation

- New .NET test `HC073_CommentMarkers_LinkOnlyWhereTheTargetRenders` converts the same commented document in all three modes and asserts the marker carries `href` (and the target exists) in endnote mode, and carries no `href` — while keeping its identity and reply metadata — in inline and margin modes. Watched fail before the fix (inline marker still had `href="#comment-1"`), passes after.
- New Playwright spec `strict inline and margin exports survive commented documents` runs a strict standalone export of a commented document in both modes and asserts it succeeds and the rendered markers are anchor-free `<a>`s. Watched fail against the pre-fix engine with `Fragment target #comment-1 is unavailable in the final page tree`, passes after rebuild.
- The existing `draws comment topology` spec's comment explaining why it could only assert strict under endnote mode is updated to point at the new spec.
- Full .NET suite 4414/0; full Playwright suite 640 passed (the 5 tabs-visual screenshot failures are the known host-font environment issue, and `editor-block-drag` passes in isolation — a load flake).