### PR TITLE
Skip claude-review on fork PRs that can never authenticate

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,15 @@ on:
 
 jobs:
   claude-review:
-    # Dependabot PRs never get repository secrets (including
-    # CLAUDE_CODE_OAUTH_TOKEN) on pull_request-triggered runs — that's a
-    # GitHub security restriction, not something this workflow can work
-    # around. Skip the job there instead of showing a permanently-red,
-    # unfixable check on every dependency-bump PR.
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    # Dependabot and fork PRs never get repository secrets (including
+    # CLAUDE_CODE_OAUTH_TOKEN) or an OIDC id-token on pull_request-triggered
+    # runs — that's a GitHub security restriction, not something this
+    # workflow can work around (fork runs die in seconds on "Unable to get
+    # ACTIONS_ID_TOKEN_REQUEST_URL", issue #338). Skip the job there instead
+    # of showing a permanently-red check the contributor cannot fix.
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Closes #338.

## Why

The `claude-review` check failed in ~24 seconds on the only fork-originated PR in its run history (#337), dying during authentication on `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL`. That's GitHub's security model at work: a `pull_request`-triggered run from a fork gets a read-only token, no repository secrets (so no `CLAUDE_CODE_OAUTH_TOKEN`), and no OIDC id-token, regardless of what `permissions:` the workflow declares. The workflow cannot request its way around it, so an external contributor sees a permanently-red check they have no way to fix — the exact situation the workflow's existing dependabot guard already documents and avoids.

## How

The dependabot guard gains a same-repo condition:

```yaml
if: >-
  github.event.pull_request.user.login != 'dependabot[bot]' &&
  github.event.pull_request.head.repo.full_name == github.repository
```

Fork PRs now skip the job cleanly (a neutral "skipped" instead of a red "failed"); same-repo PRs are unaffected — this PR's own run demonstrates that.

## The other half of the issue

#338 also documented a cluster of seven consecutive *same-repo* OIDC failures on Aug 2–3, which the fork restriction cannot explain. That cluster self-resolved within the same window and has not recurred: the 15 most recent `Claude Code Review` runs (all same-repo, through 2026-08-26) are uniformly green. With nothing reproducible left to fix there, the fork skip closes out the one remaining actionable cause.