### PR TITLE
Enable nullable reference types as the project default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- **Nullable reference types are enabled project-wide (#13).** The core library now compiles
+  with `<Nullable>enable</Nullable>`: every file is null-checked by default, and the inherited
+  OpenXmlPowerTools core opts out through an explicit `#nullable disable` header in each of its
+  32 files instead of an invisible project default. Nine previously-oblivious legacy files were
+  already clean and are now fully checked, and the small remainder (the culture-specific
+  `GetListItemText_*` providers, `SmlCellFormatter`, `SmlToHtmlConverter`, `UnicodeMapper`,
+  `SpreadsheetDocumentManager`, and a few one-warning files) gained honest annotations —
+  behavior-preserving `?` returns and locals, plus flow-proven `!` where a null was already
+  guarded. Callers compiling with nullable enabled now see accurate nullability metadata for
+  those APIs (for example `SmlCellFormatter.FormatCell` declares its nullable `formatCode`
+  and `out color`, and the `GetListItemText_*` providers declare their nullable returns), which
+  may surface new — correct — warnings at call sites that previously compiled silently.
 - **`ReplaceTextRange` with a needle that matches nothing now fails with the new
   `TextNotFound` error code (#490)** — `text_not_found` on the wire — carrying the anchor id
   and the needle, instead of returning an empty list a caller could not distinguish from a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,19 +22,16 @@ duplicated description is one that will go stale.
 
 ### Nullable Reference Types
 
-The project sets `<Nullable>disable</Nullable>` globally: enabling it today produces
-**~4,800 warnings** in the legacy core. New code should still be annotated.
-
-- **New files**: add `#nullable enable` at the top.
-- **Substantial refactors**: consider adding `#nullable enable` and fixing that file's warnings.
-- **Use proper annotations**: mark nullable parameters/returns with `?`; use null checks or `!`.
-
-About 60% of files in `Docxodus/` already carry `#nullable enable` — everything written for
-this fork. The un-annotated remainder is the inherited OpenXmlPowerTools core
-(`WmlComparer`, `WmlToHtmlConverter`, the `HtmlToWml*` family, `FormattingAssembler`,
-`DocumentBuilder`, `RevisionProcessor`, `PtOpenXmlUtil`, `PtUtil`, `ListItemRetriever`).
-
-See [Issue #13](https://github.com/JSv4/Docxodus/issues/13) for the migration plan.
+`Docxodus.csproj` sets `<Nullable>enable</Nullable>` (issue #13): every file is
+nullable-checked by default, so a new file needs no directive. The exception is the
+inherited OpenXmlPowerTools core — 32 legacy files (`WmlComparer`, `WmlToHtmlConverter`,
+the `HtmlToWml*` family, `FormattingAssembler`, `DocumentBuilder`, `RevisionProcessor`,
+`PtOpenXmlUtil`, …) carry an explicit `#nullable disable` header holding back ~4,600
+warnings. `grep -l "^#nullable disable" Docxodus/*.cs` lists the remaining debt; when
+substantially refactoring one of those files, consider removing its header and fixing
+that file's warnings. CS8632 stays in `NoWarn` deliberately: with the project context
+enabled it can only fire inside the opted-out files, where some inert `?` annotations
+are kept for the day each file migrates.
 
 ### Warnings
 

--- a/Docxodus/AnnotationManager.cs
+++ b/Docxodus/AnnotationManager.cs
@@ -1,3 +1,6 @@
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 

--- a/Docxodus/ChartUpdater.cs
+++ b/Docxodus/ChartUpdater.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/Docxodus/DocumentAnnotation.cs
+++ b/Docxodus/DocumentAnnotation.cs
@@ -1,3 +1,6 @@
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 

--- a/Docxodus/DocumentAssembler.cs
+++ b/Docxodus/DocumentAssembler.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/Docxodus/DocumentBuilder.cs
+++ b/Docxodus/DocumentBuilder.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #define TestForUnsupportedDocuments

--- a/Docxodus/Docxodus.csproj
+++ b/Docxodus/Docxodus.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>disable</Nullable>
+    <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
 
     <!-- Enable packaging for NuGet -->

--- a/Docxodus/FieldRetriever.cs
+++ b/Docxodus/FieldRetriever.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/Docxodus/FormattingAssembler.cs
+++ b/Docxodus/FormattingAssembler.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/Docxodus/GetListItemText_fr_FR.cs
+++ b/Docxodus/GetListItemText_fr_FR.cs
@@ -38,7 +38,7 @@ namespace Docxodus
             "soixante", "", "quatre-vingt", ""
         };
 
-        public static string GetListItemText(string languageCultureName, int levelNumber, string numFmt)
+        public static string? GetListItemText(string languageCultureName, int levelNumber, string numFmt)
         {
             if (numFmt == "cardinalText")
             {

--- a/Docxodus/GetListItemText_ru_RU.cs
+++ b/Docxodus/GetListItemText_ru_RU.cs
@@ -35,7 +35,7 @@ namespace Docxodus
 
         // TODO this is not correct for values above 99
 
-        public static string GetListItemText(string languageCultureName, int levelNumber, string numFmt)
+        public static string? GetListItemText(string languageCultureName, int levelNumber, string numFmt)
         {
             if (numFmt == "cardinalText")
             {

--- a/Docxodus/GetListItemText_sv_SE.cs
+++ b/Docxodus/GetListItemText_sv_SE.cs
@@ -28,7 +28,7 @@ namespace Docxodus
             "artonde", "nittonde"
         };
 
-		public static string GetListItemText(string languageCultureName, int levelNumber, string numFmt)
+		public static string? GetListItemText(string languageCultureName, int levelNumber, string numFmt)
 		{
 			switch (numFmt)
 			{

--- a/Docxodus/GetListItemText_zh_CN.cs
+++ b/Docxodus/GetListItemText_zh_CN.cs
@@ -10,7 +10,7 @@ namespace Docxodus
 {
     public class ListItemTextGetter_zh_CN
     {
-        public static string GetListItemText(string languageCultureName, int levelNumber, string numFmt)
+        public static string? GetListItemText(string languageCultureName, int levelNumber, string numFmt)
         {
             string[] ccTDigitCharacters = new[] {
                 "",

--- a/Docxodus/HtmlToWmlConverter.cs
+++ b/Docxodus/HtmlToWmlConverter.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/Docxodus/HtmlToWmlConverterCore.cs
+++ b/Docxodus/HtmlToWmlConverterCore.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 /***************************************************************************

--- a/Docxodus/HtmlToWmlCssApplier.cs
+++ b/Docxodus/HtmlToWmlCssApplier.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/Docxodus/HtmlToWmlCssParser.cs
+++ b/Docxodus/HtmlToWmlCssParser.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 /***************************************************************************

--- a/Docxodus/ListItemRetriever.cs
+++ b/Docxodus/ListItemRetriever.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/Docxodus/MarkupSimplifier.cs
+++ b/Docxodus/MarkupSimplifier.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/Docxodus/MetricsGetter.cs
+++ b/Docxodus/MetricsGetter.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/Docxodus/OpenXmlRegex.cs
+++ b/Docxodus/OpenXmlRegex.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/Docxodus/OxPtHelpers.cs
+++ b/Docxodus/OxPtHelpers.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/Docxodus/PowerToolsBlock.cs
+++ b/Docxodus/PowerToolsBlock.cs
@@ -41,7 +41,7 @@ namespace Docxodus
     /// <seealso cref="PowerToolsBlockExtensions.EndPowerToolsBlock"/>
     public class PowerToolsBlock : IDisposable
     {
-        private OpenXmlPackage _package;
+        private OpenXmlPackage? _package;
 
         public PowerToolsBlock(OpenXmlPackage package)
         {

--- a/Docxodus/PresentationBuilder.cs
+++ b/Docxodus/PresentationBuilder.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/Docxodus/PtOpenXmlDocument.cs
+++ b/Docxodus/PtOpenXmlDocument.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 /*

--- a/Docxodus/PtOpenXmlUtil.cs
+++ b/Docxodus/PtOpenXmlUtil.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/Docxodus/PtUtil.cs
+++ b/Docxodus/PtUtil.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/Docxodus/ReferenceAdder.cs
+++ b/Docxodus/ReferenceAdder.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/Docxodus/RevisionProcessor.cs
+++ b/Docxodus/RevisionProcessor.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/Docxodus/ScalarTypes.cs
+++ b/Docxodus/ScalarTypes.cs
@@ -12,7 +12,7 @@ namespace Docxodus
         private static readonly Hashtable defaultScalarTypesHash;
         internal static bool IsTypeInList(Collection<string> typeNames)
         {
-            string text = PSObjectIsOfExactType(typeNames);
+            string? text = PSObjectIsOfExactType(typeNames);
             return !string.IsNullOrEmpty(text) && (PSObjectIsEnum(typeNames) || DefaultScalarTypes.defaultScalarTypesHash.ContainsKey(text));
         }
 
@@ -37,7 +37,7 @@ namespace Docxodus
             DefaultScalarTypes.defaultScalarTypesHash.Add("System.Security.SecureString", null);
         }
 
-        internal static string PSObjectIsOfExactType(Collection<string> typeNames)
+        internal static string? PSObjectIsOfExactType(Collection<string> typeNames)
         {
             if (typeNames.Count != 0)
             {

--- a/Docxodus/SmlCellFormatter.cs
+++ b/Docxodus/SmlCellFormatter.cs
@@ -25,7 +25,7 @@ namespace Docxodus
         private class FormatConfig
         {
             public CellType CellType;
-            public string FormatCode;
+            public required string FormatCode;
         }
 
         private static Dictionary<string, FormatConfig> ExcelFormatCodeToNetFormatCodeExceptionMap = new Dictionary<string, FormatConfig>()
@@ -53,7 +53,7 @@ namespace Docxodus
         // specified, the first is used for positive numbers and zeros, and the second is used for negative numbers. If only
         // one section is specified, it is used for all numbers. To skip a section, the ending semicolon for that section shall
         // be written.
-        public static string FormatCell(string formatCode, string value, out string color)
+        public static string FormatCell(string? formatCode, string value, out string? color)
         {
             color = null;
 
@@ -162,7 +162,7 @@ namespace Docxodus
             "Yellow",
         };
 
-        private static string FormatDouble(string formatCode, double dv, out string color)
+        private static string FormatDouble(string formatCode, double dv, out string? color)
         {
             color = null;
             var trimmed = formatCode.Trim();

--- a/Docxodus/SmlDataRetriever.cs
+++ b/Docxodus/SmlDataRetriever.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/Docxodus/SmlToHtmlConverter.cs
+++ b/Docxodus/SmlToHtmlConverter.cs
@@ -131,7 +131,7 @@ namespace Docxodus
                     {
                         p.Element,
                         p.Styles,
-                        StylesString = p.Element.Name.LocalName + "|" + p.Styles.OrderBy(k => k.Key).Select(s => string.Format("{0}: {1};", s.Key, s.Value)).StringConcatenate(),
+                        StylesString = p.Element.Name.LocalName + "|" + p.Styles!.OrderBy(k => k.Key).Select(s => string.Format("{0}: {1};", s.Key, s.Value)).StringConcatenate(),
                     })
                     .GroupBy(p => p.StylesString)
                     .ToList();
@@ -142,7 +142,7 @@ namespace Docxodus
                 {
                     string classNameToUse;
                     var firstOne = grp.First();
-                    var styles = firstOne.Styles;
+                    var styles = firstOne.Styles!;
                     if (styles.ContainsKey("PtStyleName"))
                     {
                         classNameToUse = htmlConverterSettings.CssClassPrefix + styles["PtStyleName"];
@@ -162,7 +162,7 @@ namespace Docxodus
                     }
                     usedCssClassNames.Add(classNameToUse);
                     sb.Append(firstOne.Element.Name.LocalName + "." + classNameToUse + " {" + Environment.NewLine);
-                    foreach (var st in firstOne.Styles.Where(s => s.Key != "PtStyleName"))
+                    foreach (var st in firstOne.Styles!.Where(s => s.Key != "PtStyleName"))
                     {
                         var s = "    " + st.Key + ": " + st.Value + ";" + Environment.NewLine;
                         sb.Append(s);
@@ -194,8 +194,9 @@ namespace Docxodus
                         .Select(e => string.Format("{0}: {1};", e.Key, e.Value))
                         .StringConcatenate();
                     XAttribute st = new XAttribute("style", styleValue);
-                    if (d.Attribute("style") != null)
-                        d.Attribute("style").Value += styleValue;
+                    var existingStyle = d.Attribute("style");
+                    if (existingStyle != null)
+                        existingStyle.Value += styleValue;
                     else
                         d.Add(st);
                 }
@@ -218,7 +219,7 @@ namespace Docxodus
             }
         }
 
-        private static object ConvertToHtmlTransform(WordprocessingDocument wordDoc,
+        private static object? ConvertToHtmlTransform(WordprocessingDocument wordDoc,
             WmlToHtmlConverterSettings settings, XNode node)
         {
             // Ignore element.

--- a/Docxodus/SpreadsheetDocumentManager.cs
+++ b/Docxodus/SpreadsheetDocumentManager.cs
@@ -73,18 +73,18 @@ namespace Docxodus
         private static string GetSheetName(WorksheetPart worksheet, SpreadsheetDocument document)
         {
             //Gets the id of worksheet part
-            string partId = document.WorkbookPart.GetIdOfPart(worksheet);
+            string partId = document.WorkbookPart!.GetIdOfPart(worksheet);
             XDocument workbookDocument = document.WorkbookPart.GetXDocument();
             //Gets the name from sheet tag related to worksheet
             string sheetName =
-                workbookDocument.Root
-                .Element(ns + "sheets")
+                workbookDocument.Root!
+                .Element(ns + "sheets")!
                 .Elements(ns + "sheet")
                 .Where(
                     t =>
-                        t.Attribute(relationshipsns + "id").Value == partId
+                        t.Attribute(relationshipsns + "id")!.Value == partId
                 ).First()
-                .Attribute("name").Value;
+                .Attribute("name")!.Value;
             return sheetName;
         }
         /// <summary>

--- a/Docxodus/SpreadsheetWriter.cs
+++ b/Docxodus/SpreadsheetWriter.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #undef DisplayWorkingSet

--- a/Docxodus/StronglyTypedBlock.cs
+++ b/Docxodus/StronglyTypedBlock.cs
@@ -40,7 +40,7 @@ namespace Docxodus
     /// <seealso cref="PowerToolsBlockExtensions.EndPowerToolsBlock"/>
     public class StronglyTypedBlock : IDisposable
     {
-        private OpenXmlPackage _package;
+        private OpenXmlPackage? _package;
 
         public StronglyTypedBlock(OpenXmlPackage package)
         {

--- a/Docxodus/TestUtil.cs
+++ b/Docxodus/TestUtil.cs
@@ -27,7 +27,7 @@ namespace Docxodus
             }
         }
 
-        private static DirectoryInfo s_TempDir = null;
+        private static DirectoryInfo? s_TempDir = null;
         public static DirectoryInfo TempDir
         {
             get

--- a/Docxodus/TextReplacer.cs
+++ b/Docxodus/TextReplacer.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/Docxodus/UnicodeMapper.cs
+++ b/Docxodus/UnicodeMapper.cs
@@ -75,8 +75,8 @@ namespace Docxodus
             // unicode characters.
             if (element.Name == W.br)
             {
-                XAttribute typeAttribute = element.Attribute(W.type);
-                string type = typeAttribute != null ? typeAttribute.Value : null;
+                XAttribute? typeAttribute = element.Attribute(W.type);
+                string? type = typeAttribute != null ? typeAttribute.Value : null;
                 if (type == null || type == "textWrapping")
                     return CarriageReturn.ToString();
                 if (type == "page")
@@ -210,13 +210,13 @@ namespace Docxodus
             if (sym.Name != W.sym)
                 throw new ArgumentException(string.Format("Not a w:sym: {0}", sym.Name), "sym");
 
-            XAttribute fontAttribute = sym.Attribute(W.font);
-            string fontAttributeValue = fontAttribute != null ? fontAttribute.Value : null;
+            XAttribute? fontAttribute = sym.Attribute(W.font);
+            string? fontAttributeValue = fontAttribute != null ? fontAttribute.Value : null;
             if (fontAttributeValue == null)
                 throw new ArgumentException("w:sym element has no w:font attribute.", "sym");
 
-            XAttribute charAttribute = sym.Attribute(W._char);
-            string charAttributeValue = charAttribute != null ? charAttribute.Value : null;
+            XAttribute? charAttribute = sym.Attribute(W._char);
+            string? charAttributeValue = charAttribute != null ? charAttribute.Value : null;
             if (charAttributeValue == null)
                 throw new ArgumentException("w:sym element has no w:char attribute.", "sym");
 
@@ -253,9 +253,9 @@ namespace Docxodus
         {
             return textValue
                 .Select(CharToRunChild)
-                .GroupAdjacent(e => e.Name == W.t)
+                .GroupAdjacent(e => e!.Name == W.t)
                 .SelectMany(grouping => grouping.Key
-                    ? StringToSingleRunList(grouping.Select(t => (string) t).StringConcatenate(), runProperties)
+                    ? StringToSingleRunList(grouping.Select(t => (string) t!).StringConcatenate(), runProperties)
                     : grouping.Select(e => new XElement(W.r, runProperties, e)))
                 .ToList();
         }
@@ -305,7 +305,7 @@ namespace Docxodus
         /// </summary>
         /// <param name="character">The character.</param>
         /// <returns>The Open XML element or null, if the character equals <see cref="StartOfHeading" /> (U+0001).</returns>
-        public static XElement CharToRunChild(char character)
+        public static XElement? CharToRunChild(char character)
         {
             // Ignore the special character that represents the Open XML elements we
             // wanted to ignore.

--- a/Docxodus/WmlComparer.cs
+++ b/Docxodus/WmlComparer.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // TODO Line 1202 there are inefficient calls to PutXDocument() for footnotes and endnotes

--- a/Docxodus/WmlDocument.cs
+++ b/Docxodus/WmlDocument.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/Docxodus/WmlToHtmlConverter.Charts.cs
+++ b/Docxodus/WmlToHtmlConverter.Charts.cs
@@ -1,3 +1,6 @@
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 

--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/Docxodus/WmlToXml.cs
+++ b/Docxodus/WmlToXml.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // Portions Copyright (c) Eric White Inc. All rights reserved.

--- a/Docxodus/WorksheetAccessor.cs
+++ b/Docxodus/WorksheetAccessor.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/Docxodus/XlsxTables.cs
+++ b/Docxodus/XlsxTables.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
+#nullable disable
+
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;


### PR DESCRIPTION
Closes #13.

## Why

#13 tracked enabling nullable reference types since the fork began. The strategy so far was a convention: the project compiled with `<Nullable>disable</Nullable>` and every fork-era file had to remember to start with `#nullable enable`. That leaves two problems: a new file that forgets the directive silently gets no null checking, and the ~4,800-warning legacy debt is invisible — nothing in any file says whether it is checked or not.

## How

The default is inverted, which turns out to be a small change:

- **`Docxodus.csproj` now sets `<Nullable>enable</Nullable>`** — the last project in the solution still on `disable` (every tool, the WASM bridge, and the test project were already on `enable`). New files are checked automatically; the convention can no longer be forgotten.
- **The 32 inherited OpenXmlPowerTools files that hold the legacy warnings each carry an explicit `#nullable disable` header** with a one-line comment pointing at the debt. The opt-out is now a grep-able marker in the file itself (`grep -l "^#nullable disable" Docxodus/*.cs`), and removing a header is the natural first step of any future per-file migration.
- **Nine previously-oblivious legacy files were already warning-free** (`RevisionAccepter`, `DocumentStructure`, `ColorParser`, `AnnotationTarget`, `SkiaSharpHelpers`, two `GetListItemText` providers, and others) and simply flip to fully checked.
- **The small remainder (~30 warnings in 10 files) was annotated honestly instead of opted out**: the culture-specific `GetListItemText_*` providers and `UnicodeMapper.CharToRunChild` declare their nullable returns, `SmlCellFormatter.FormatCell` declares its nullable `formatCode` and `out color`, nullable locals gain `?`, `FormatConfig.FormatCode` becomes `required`, and the few dereferences the compiler cannot see are guarded upstream use flow-proven `!`. One three-line spot in `SmlToHtmlConverter` stores `d.Attribute("style")` in a local instead of calling it twice — the compiler-recommended shape, same behavior.

No runtime behavior changes anywhere: every edit is an annotation, a `!`, or the one local-variable hoist. Consumers compiling with nullable enabled now get accurate metadata for the newly-annotated APIs, which can surface new — correct — warnings at their call sites.

CS8632 ("`?` used outside a nullable context") stays in `NoWarn` deliberately. With the project context enabled it can only fire inside the opted-out files, where 22 existing inert `?` annotations are kept as documentation for the day each file migrates.

## Validation

- Library build warning set is **byte-identical** to the pre-change baseline (diffed sorted unique warning lines), and the WASM-mode build (`-p:WASM_BUILD=true`) is identical to that same baseline.
- Release solution build: 0 errors, and zero nullable (`CS86xx`) warnings in any project outside the library — the changed metadata introduces no new warnings in the tools, bridges, or tests.
- Full .NET suite: 4413 passed, 0 failed.