### PR TITLE
Correct the arcade's social-meta copy: rasterized from the WAD, not a live WAD parser

### DIFF
--- a/docs/demo/arcade.html
+++ b/docs/demo/arcade.html
@@ -6,7 +6,7 @@
   <meta name="color-scheme" content="light" />
   <title>Docxodus — THE DOCX ARCADE: a video game inside a Word document</title>
   <link rel="icon" href="../favicon.svg" type="image/svg+xml" />
-  <meta name="description" content="A platformer, a Doom-style raycaster, and a REAL Doom-format level (Freedoom's E1M1) rendered as colored runs in a live Word paragraph, playable in the in-browser Docxodus editor. Pause anywhere: it is only a document — type new terrain into the level, resume, and it is real. Save mid-jump as .docx." />
+  <meta name="description" content="A platformer, a Doom-style raycaster, and Freedoom's E1M1 — real Doom level geometry, rasterized from the WAD — rendered as colored runs in a live Word paragraph, playable in the in-browser Docxodus editor. Pause anywhere: it is only a document — type new terrain into the level, resume, and it is real. Save mid-jump as .docx." />
 
   <!-- Share THIS page's URL. Social platforms link through to the live game. -->
   <meta property="og:type" content="website" />
@@ -16,7 +16,7 @@
   <meta property="og:image" content="https://raw.githubusercontent.com/JSv4/Docxodus/main/docs/images/arcade-social.png" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="THE DOCX ARCADE — a video game running inside a Word document" />
-  <meta name="twitter:description" content="A platformer, a Doom-style raycaster, and a real Doom-format level (Freedoom E1M1) whose screen is a live Word paragraph. Pause, type terrain into the document, resume — you wrote the level." />
+  <meta name="twitter:description" content="A platformer, a Doom-style raycaster, and Freedoom's E1M1 rasterized from the real WAD, whose screen is a live Word paragraph. Pause, type terrain into the document, resume — you wrote the level." />
   <meta name="twitter:image" content="https://raw.githubusercontent.com/JSv4/Docxodus/main/docs/images/arcade-social.png" />
 
   <style>


### PR DESCRIPTION
Closes #575.

The arcade page's `description` and `twitter:description` meta describe the Freedoom cartridge as "a REAL Doom-format level … rendered / whose screen is a live Word paragraph", which reads as though the browser parses a WAD at runtime. It does not: `tools/wad2cart.mjs` rasterizes E1M1's linedef geometry at build time and the page ships static grid data — `freedoom-e1m1.js` already says so accurately; only the social copy oversold it.

Two lines change, both to "rasterized from the (real) WAD" phrasing. This is the one surviving piece of PR #475, whose batch primitive and puzzle eval main has since independently superseded (details in #575); #475 will be closed as superseded once this lands.

No code paths touched — meta tags only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)