### PR TITLE
Note-body edits commit again: the backref separator was poisoning the offset baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **Footnote/endnote body edits no longer vanish on commit (#583).** The editor's note
+  renderer appended the backref separator as a bare text node (`" "` before the `↩`), so the
+  block's committed-text baseline carried a phantom trailing character the session's flat
+  run text does not have. Every later span-based commit of a note body then computed offsets
+  one past the session text and failed with `offset_out_of_range` — at which point the editor
+  re-rendered the block from session truth, silently reverting the user's typing. The
+  separator now lives inside the chrome element the serializer already excludes, so the
+  baseline matches the session and note edits commit like any block edit.
 - **Typed leading block markers no longer vanish on commit (#571).** The editor's
   blur-commit serializer escaped inline markdown (`*`, `_`, backticks, brackets) but not
   block-level markers, so typing `## 2.1 Termination`, `> see clause 4`, `- deliverables`,

--- a/npm/src/editor.ts
+++ b/npm/src/editor.ts
@@ -3775,8 +3775,14 @@ export class DocxEditor {
       const backref = document.createElement("a");
       backref.setAttribute("class", `${prefix}-backref`);
       backref.setAttribute("contenteditable", "false");
-      backref.textContent = "↩";
-      last.append(" ", backref);
+      // The separator space must live INSIDE the chrome element. As a bare text
+      // node in the paragraph it was counted by blockContentText, giving the
+      // committed baseline a phantom trailing character the session's flat text
+      // does not have — every later span commit then computed offsets one past
+      // the session text and died with offset_out_of_range, silently reverting
+      // the user's note edit (#583).
+      backref.textContent = " ↩";
+      last.append(backref);
     }
     li.querySelectorAll<HTMLElement>("[data-anchor]").forEach((b) => this.wireBlock(b));
     return li;

--- a/npm/tests/editor-note-body-commit.spec.ts
+++ b/npm/tests/editor-note-body-commit.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect, Page } from '@playwright/test';
+
+async function waitForDocxodus(page: Page) {
+  await page.waitForFunction(() => (window as any).DocxodusReady === true, { timeout: 30000 });
+}
+
+// #583 — editing a footnote's body must commit like any block edit.
+//
+// Repro found by playing DOCX GOLF's footnote hole by hand: type into the
+// note body at the bottom of the document, click away, and the session still
+// holds the old note text; the next interaction reverts the DOM, silently
+// discarding the user's edit. Body-paragraph edits through the identical
+// gestures commit fine.
+test.describe('DocxEditor — footnote body edits commit', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/test-harness.html');
+    await waitForDocxodus(page);
+  });
+
+  test('typing into a footnote body and blurring reaches the session', async ({ page }) => {
+    const out = await page.evaluate(async () => {
+      const D = (window as any).Docxodus;
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const blank: Uint8Array = D.DocxSessionBridge.CreateBlankDocx();
+      const editor = D.DocxEditor.open(container, blank, D, {});
+
+      // Seed a body paragraph, then a footnote through the editor's own command
+      // (the ribbon's Footnote button calls this).
+      const body = container.querySelector('p[data-anchor][contenteditable="true"]') as HTMLElement;
+      body.focus();
+      const sel = window.getSelection()!;
+      let r = document.createRange();
+      r.selectNodeContents(body);
+      sel.removeAllRanges(); sel.addRange(r);
+      document.execCommand('insertText', false, 'The Lender may rely on the opinions.');
+      body.dispatchEvent(new Event('blur'));
+
+      const fresh = container.querySelector('p[data-anchor][contenteditable="true"]') as HTMLElement;
+      fresh.focus();
+      r = document.createRange();
+      r.selectNodeContents(fresh); r.collapse(false);
+      sel.removeAllRanges(); sel.addRange(r);
+      editor.insertFootnote();
+      await new Promise((res) => setTimeout(res, 300));
+
+      // Find the rendered note body and retype its text — the human gesture.
+      const blocks = Array.from(
+        container.querySelectorAll<HTMLElement>('[data-anchor][contenteditable="true"]'),
+      );
+      const note = blocks.find((b) => (b.textContent || '').includes('New footnote'));
+      if (!note) {
+        editor.close(); container.remove();
+        return { err: 'note body not rendered as an editable block' };
+      }
+      note.focus();
+      const walker = document.createTreeWalker(note, NodeFilter.SHOW_TEXT);
+      let target: Text | null = null;
+      for (let n = walker.nextNode(); n; n = walker.nextNode()) {
+        if ((n as Text).data.includes('New footnote')) { target = n as Text; break; }
+      }
+      if (!target) {
+        editor.close(); container.remove();
+        return { err: 'note text node not found' };
+      }
+      r = document.createRange();
+      r.setStart(target, 0); r.setEnd(target, target.data.length);
+      sel.removeAllRanges(); sel.addRange(r);
+      document.execCommand('insertText', false, 'As defined in the Master Agreement.');
+      note.dispatchEvent(new Event('blur'));
+      await new Promise((res) => setTimeout(res, 300));
+
+      // Session truth: what does the footnote hold now?
+      const proj = JSON.parse(D.DocxSessionBridge.Project(editor.sessionHandle));
+      const fn = Object.entries(proj.anchorIndex as Record<string, any>)
+        .filter(([id]) => id.startsWith('p:fn:'))
+        .map(([, t]) => t.textPreview as string);
+      const domNow = (container.querySelector('[data-anchor][contenteditable="true"]:last-child') as HTMLElement)?.textContent;
+      editor.close(); container.remove();
+      return { fn, domNow };
+    });
+
+    expect(out.err, out.err).toBeUndefined();
+    expect(
+      out.fn!.some((t: string) => t.includes('As defined in the Master Agreement')),
+      `the typed note text must reach the session; footnotes held: ${JSON.stringify(out.fn)}`,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #583.

## The bug

Typing into a footnote/endnote body and clicking away silently discarded the edit: the session kept the old note text, and the next interaction reverted the DOM. Body paragraphs committed fine through identical gestures — the loss was note-specific and invisible (no error anywhere).

## Root cause (one character)

`buildNoteLi` appended the backref as `last.append(" ", backref)`. The `↩` anchor is `contenteditable=false` chrome the serializer excludes — but the separator **space was a bare text node** that `blockContentText` counts. Every note body's committed-text baseline therefore carried a phantom trailing character the session's flat run text doesn't have. On commit, the old/next diff computed a span one past the session's text, and `ReplaceTextAtSpan` failed with `offset_out_of_range` (`span 0+15 out of [0, 14]` in the instrumented trace); `commitBlock`'s failure path then re-rendered the block from session truth — i.e., reverted the user's typing.

## The fix

The separator now lives inside the chrome element (`backref.textContent = " ↩"`), so the baseline matches the session's offset space. `renumberNoteChrome` only patches the backref's `href`, never its text, so renumbering keeps the space.

## How it surfaced

Playing DOCX GOLF's footnote hole by hand: Insert → Footnote leaves a "New footnote." placeholder, and no amount of retyping could ever change it — the hole was unwinnable. (The hole's CI honesty spec passes via the reference solution, which authors the note with its final text in one call — exactly the blind spot a human play-through exists to catch.)

## Testing

- New spec `editor-note-body-commit.spec.ts`: inserts a footnote through the editor command, retypes the body with real gestures, blurs, asserts the text reached the session. Failed before the fix with the session still holding the placeholder.
- Editor family + golf specs: **100/100**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)