### PR TITLE
Golf: last-click-wins hole navigation

### DIFF
--- a/docs/demo/docx-golf.js
+++ b/docs/demo/docx-golf.js
@@ -609,6 +609,7 @@ export function startGolf({ editor, session, engine, ui, course = COURSE }) {
   let assisted = false;
   let revisionsLeft = -1;
   let loading = false;
+  let pendingHole = null;
   let scoring = false;
   let scoreQueued = false;
   let scoreTimer = 0;
@@ -782,7 +783,11 @@ export function startGolf({ editor, session, engine, ui, course = COURSE }) {
 
   // ── hole lifecycle ───────────────────────────────────────────────
   async function loadHole(i) {
-    if (loading || i < 0 || i >= course.length) return;
+    if (i < 0 || i >= course.length) return;
+    // Last click wins: a request arriving while a load is in flight is queued
+    // (replacing any earlier queued request) and honored when the load settles,
+    // instead of being silently dropped (#588).
+    if (loading) { pendingHole = i; return; }
     loading = true;
     ui.error.dataset.on = 'false';
     banner(null);
@@ -821,6 +826,13 @@ export function startGolf({ editor, session, engine, ui, course = COURSE }) {
       fail(err);
     } finally {
       loading = false;
+      if (pendingHole !== null && pendingHole !== holeIndex) {
+        const next = pendingHole;
+        pendingHole = null;
+        void loadHole(next);
+      } else {
+        pendingHole = null;
+      }
     }
   }
 

--- a/npm/tests/demo-golf.spec.ts
+++ b/npm/tests/demo-golf.spec.ts
@@ -161,6 +161,22 @@ test.describe('DOCX GOLF', () => {
     expect(await page.evaluate(() => (window as any).__golf.scorecard()[0])).toBeNull();
   });
 
+  test('rapid hole-nav clicks land on the LAST clicked hole', async ({ page }) => {
+    test.setTimeout(180000);
+    await bootCourse(page);
+
+    // Six fast clicks while loads are in flight — the last one must win.
+    await page.evaluate(() => {
+      const buttons = document.querySelectorAll<HTMLButtonElement>('[data-dxg="holes"] button');
+      for (const n of [2, 3, 4, 5, 1, 6]) buttons[n - 1].click();
+    });
+    await page.waitForFunction(
+      () => (window as any).__golf.holeIndex() === 5 && (window as any).__golf.revisionsLeft() >= 0,
+      { timeout: 60000 },
+    );
+    expect(await page.evaluate(() => (window as any).__golf.hole().id)).toBe('footnote-drill');
+  });
+
   test('reset re-tees the hole: strokes and diffs return to the start', async ({ page }) => {
     test.setTimeout(180000);
     await bootCourse(page);


### PR DESCRIPTION
Closes #588.

`loadHole`'s `loading` guard silently dropped every request arriving while a load was in flight — six rapid taps across the hole nav landed on the *first* hole clicked. A mid-load request is now queued (later requests replace earlier ones) and honored when the current load settles, so the last click wins, which is what a fast tapper means.

New spec fires six rapid nav clicks and asserts the course lands on the last one (failed before with the run stuck on hole 2). Full golf suite: 8/8; headless 12/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)