### PR TITLE
Add complex-form-document benchmark harness with first findings

### DIFF
--- a/benchmarks/complex-form-doc/ComplexFormBenchmark.csproj
+++ b/benchmarks/complex-form-doc/ComplexFormBenchmark.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- Standalone benchmark harness; deliberately NOT part of Docxodus.sln so it never
+       affects CI, packaging, or the warning baselines. See README.md for how to run it. -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Docxodus/Docxodus.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="edits/**" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/complex-form-doc/FINDINGS.md
+++ b/benchmarks/complex-form-doc/FINDINGS.md
@@ -1,0 +1,61 @@
+# Findings from the 2026-08-26 run (NVCA Model COI, Oct 2025)
+
+Measured at commit c8e13d2 on .NET 10.0.400, single container, cold process per phase.
+Timings are indicative, not benchmarks-grade.
+
+## Headline results
+
+| Measurement | Result |
+|---|---|
+| HTML (footnotes + headers rendered) | 0.8–2.1 s |
+| Markdown projection | 364–459 ms, 214,469 chars, 462 anchors, all 94 footnotes projected inline |
+| No-edit session round-trip | 401–535 ms, text-exact, part inventory identical |
+| Tracked session, 8-edit counsel script | all edits succeed; 11 native revisions, correct author; single accept/reject verified |
+| `DocxDiff.Compare` | 1.5–2.4 s, 18 word-level revisions with both-side anchors |
+| Accept-all / reject-all round-trip | exact in both directions |
+| Schema findings added by any output | 0 (source baseline 80 → outputs 80) |
+| Edit-script / semantic-changes JSON | 46.6 KB / ~50 KB, 24 typed changes with SHA-256 content+format digests |
+| Redline → HTML (tracked markup) | 0.7–0.8 s, semantic `<ins>`/`<del>` |
+| `@docxodus/export` PDF | 51 pages in 17.3 s cold (Chromium launch included), render report `complete`; redline with `reviewProfile: "markup"` renders as Word-style strikeout/underline markup |
+| `docxodus-mcp` end-to-end (open → search → tracked edit → revision list → sessionless compare) | first-try success; compare 3.8 s with per-author revision summary |
+
+## Issues discovered (Docxodus)
+
+1. **`WmlComparer` (legacy engine) fails its round-trip invariants on this document.**
+   Accept-all and reject-all both diverge from the expected text: the engine silently
+   drops an empty paragraph inside a footnote (adjacent to the *Kumar v. Racing Corp.*
+   footnote), and it rewrites the package wholesale (validator findings drop 80 → 29,
+   i.e. it normalizes markup it should preserve). It is also ~3× slower than `DocxDiff`
+   (6.3–7.5 s vs 1.5–2.4 s). The benchmark keeps the legacy engine as a tracked
+   known-gap: the two `[check] legacy ... FAIL` lines are expected until this is fixed
+   or the engine's documentation explicitly scopes it away from footnote-heavy
+   documents. `DocxDiff` on the identical inputs passes both invariants exactly.
+
+2. **`DocxSession.DeleteBlock` leaves orphaned footnote definitions.** Deleting a
+   paragraph whose text carries a footnote reference removes the reference but leaves
+   the footnote body in `word/footnotes.xml`. Word renders nothing (the note is
+   unreferenced), but the text still ships inside the file — for legal workflows this is
+   a confidentiality-adjacent leak: "deleted" drafting commentary survives in the
+   package. Options: prune unreferenced notes on delete, prune on `Save()`, or expose a
+   `CompactFootnotes`-style op; whichever is chosen should be revision-aware (a tracked
+   delete must keep the note until the revision is accepted).
+
+3. **Formatting-only edits that cross a field envelope surface as delete+insert pairs
+   in the native redline.** Italicizing a span that intersects a cross-reference field
+   produces a full del+ins of the field region rather than a formatting revision —
+   correct OOXML, but noisy for a human reviewer. The semantic changeset already
+   classifies it precisely (`run_formatting` modify on the exact token span plus a
+   `field` envelope change), so this is a markup-shaping improvement, not a diff bug.
+
+4. **PDF export's sandbox posture will surprise container deployments.**
+   `@docxodus/export` (correctly) refuses to launch Chromium without its OS sandbox: it
+   fails when run as root and needs unprivileged user namespaces enabled. The error and
+   remediation text are good; the README warning deserves to be louder, and a
+   preflight `checkEnvironment()` helper would turn the first failed conversion into a
+   configuration message.
+
+5. **Small DX nits.** `DocxDiffRevision` has no useful `ToString()` (logging a revision
+   prints the type name); the projection-side tracked-changes knob
+   (`ProjectionSettings.TrackedChanges`) is separate from the mutation-recording knob
+   (`SetTrackedChanges`) and easy to conflate — an agent that records tracked edits and
+   then projects sees clean text unless it also sets the projection mode.

--- a/benchmarks/complex-form-doc/Program.cs
+++ b/benchmarks/complex-form-doc/Program.cs
@@ -1,0 +1,305 @@
+// Complex-form-document benchmark harness.
+//
+// Exercises the surfaces an agentic caller leans on hardest — markdown/HTML projection,
+// tracked-change session editing, DocxDiff/WmlComparer redlining — against a single
+// heavyweight .docx and verifies the invariants that matter for legal work:
+//
+//   * no-edit open→save round-trip is text-exact and part-preserving
+//   * accept-all on a redline reproduces the revised document's text exactly
+//   * reject-all on a redline reproduces the baseline document's text exactly
+//   * outputs add zero OOXML schema findings over the source document's own baseline
+//
+// The reference document class is an NVCA-style model legal form (dense footnotes,
+// hundreds of bookmarks and cross-reference fields, multilevel numbering, multiple
+// sections and header/footer variants). The document itself is not committed — pass any
+// comparable .docx on the command line. See README.md and FINDINGS.md.
+
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
+using Docxodus;
+
+if (args.Length < 1)
+{
+    Console.Error.WriteLine("usage: ComplexFormBenchmark <document.docx> [edits.json] [--out <dir>]");
+    Console.Error.WriteLine("       edits.json defaults to edits/nvca-coi.json next to this program");
+    return 1;
+}
+
+var docPath = args[0];
+var editsPath = args.Length > 1 && !args[1].StartsWith("--")
+    ? args[1]
+    : Path.Combine(AppContext.BaseDirectory, "edits", "nvca-coi.json");
+var outIx = Array.IndexOf(args, "--out");
+var outDir = outIx >= 0 && outIx + 1 < args.Length ? args[outIx + 1] : Path.Combine(Path.GetTempPath(), "complex-form-benchmark");
+Directory.CreateDirectory(outDir);
+
+var bytes = File.ReadAllBytes(docPath);
+var edits = JsonSerializer.Deserialize<EditScript>(File.ReadAllText(editsPath), new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+Console.WriteLine($"document: {docPath} ({bytes.Length:N0} bytes)");
+Console.WriteLine($"edit script: {editsPath} ({edits.Replacements.Count} replacements + delete/insert/format/comment)");
+Console.WriteLine($"outputs: {outDir}");
+Console.WriteLine();
+
+var baselineErrors = ValidateCount(bytes);
+Console.WriteLine($"source schema findings baseline: {baselineErrors}");
+
+// ---------- 1. Projections ----------
+var doc = new WmlDocument(Path.GetFileName(docPath), bytes);
+Bench("html (footnotes+headers rendered)", () =>
+{
+    var html = WmlToHtmlConverter.ConvertToHtml(doc, new WmlToHtmlConverterSettings
+    {
+        FabricateCssClasses = true,
+        RenderFootnotesAndEndnotes = true,
+        RenderHeadersAndFooters = true,
+    });
+    File.WriteAllText(Path.Combine(outDir, "document.html"), WmlToHtmlConverter.ToHtmlString(html, indent: false));
+});
+Bench("markdown projection", () =>
+{
+    var projection = WmlToMarkdownConverter.Convert(doc, new WmlToMarkdownConverterSettings());
+    File.WriteAllText(Path.Combine(outDir, "document.md"), projection.Markdown);
+    Console.WriteLine($"    {projection.Markdown.Length:N0} chars, {projection.AnchorIndex.Count} anchors");
+});
+Bench("DocxDiff compatibility probe", () =>
+{
+    var report = DocxDiff.InspectCompatibility(doc);
+    Console.WriteLine($"    warnings: {report.Warnings.Count}");
+});
+
+// ---------- 2. No-edit round-trip ----------
+Bench("no-edit session round-trip", () =>
+{
+    byte[] rt;
+    using (var s = new DocxSession(bytes)) rt = s.Save();
+    Check("round-trip text exact", ExtractText(rt) == ExtractText(bytes));
+    Check("round-trip parts identical", SamePartNames(bytes, rt));
+});
+
+// ---------- 3. Tracked-change session (the agentic redline path) ----------
+byte[] trackedDocx = [];
+Bench("tracked session: full edit script", () =>
+{
+    using var s = new DocxSession(bytes, new DocxSessionSettings { RevisionAuthor = edits.Author });
+    s.SetTrackedChanges(TrackedChangeMode.RenderInline);
+    var applied = ApplyEdits(s, edits, out var failures);
+    Console.WriteLine($"    edits applied: {applied}, failed: {failures}");
+    var revs = s.ListRevisions();
+    Console.WriteLine($"    native revisions recorded: {revs.Count} (author \"{edits.Author}\")");
+    if (revs.Count >= 2)
+    {
+        Check("accept single revision", s.AcceptRevision(revs[0].Id).Success);
+        Check("reject single revision", s.RejectRevision(revs[^1].Id).Success);
+    }
+    trackedDocx = s.Save();
+    File.WriteAllBytes(Path.Combine(outDir, "tracked-session.docx"), trackedDocx);
+    Check("tracked save adds no schema findings", ValidateCount(trackedDocx) <= baselineErrors);
+});
+
+// ---------- 4. Clean edits + DocxDiff redline ----------
+byte[] modified = [];
+Bench("clean session: same edit script untracked", () =>
+{
+    using var s = new DocxSession(bytes);
+    ApplyEdits(s, edits, out _);
+    modified = s.Save();
+    File.WriteAllBytes(Path.Combine(outDir, "modified.docx"), modified);
+});
+
+var left = new WmlDocument("baseline.docx", bytes);
+var right = new WmlDocument("modified.docx", modified);
+WmlDocument? redline = null;
+Bench("DocxDiff.Compare", () =>
+{
+    redline = DocxDiff.Compare(left, right);
+    File.WriteAllBytes(Path.Combine(outDir, "redline-docxdiff.docx"), redline.DocumentByteArray);
+});
+Bench("DocxDiff.GetRevisions", () =>
+{
+    Console.WriteLine($"    revisions: {DocxDiff.GetRevisions(left, right).Count}");
+});
+Bench("DocxDiff edit script + semantic changes", () =>
+{
+    var editScript = DocxDiff.GetEditScriptJson(left, right);
+    var semantic = DocxDiff.GetSemanticChangesJson(left, right);
+    File.WriteAllText(Path.Combine(outDir, "editscript.json"), editScript);
+    File.WriteAllText(Path.Combine(outDir, "semantic-changes.json"), semantic);
+    Console.WriteLine($"    edit script {editScript.Length:N0} chars, semantic changes {semantic.Length:N0} chars");
+});
+Bench("DocxDiff round-trip invariants", () =>
+{
+    var acceptAll = RevisionProcessor.AcceptRevisions(redline!);
+    var rejectAll = RevisionProcessor.RejectRevisions(redline!);
+    Check("accept-all == modified text", ExtractText(acceptAll.DocumentByteArray) == ExtractText(modified));
+    Check("reject-all == baseline text", ExtractText(rejectAll.DocumentByteArray) == ExtractText(bytes));
+    Check("redline adds no schema findings", ValidateCount(redline!.DocumentByteArray) <= baselineErrors);
+});
+Bench("redline -> HTML with tracked-change markup", () =>
+{
+    var html = WmlToHtmlConverter.ConvertToHtml(redline!, new WmlToHtmlConverterSettings
+    {
+        FabricateCssClasses = true,
+        RenderTrackedChanges = true,
+        RenderFootnotesAndEndnotes = true,
+    });
+    File.WriteAllText(Path.Combine(outDir, "redline.html"), WmlToHtmlConverter.ToHtmlString(html, indent: false));
+});
+
+// ---------- 5. Legacy engine, for regression tracking ----------
+Bench("WmlComparer.Compare (legacy engine)", () =>
+{
+    var settings = new WmlComparerSettings { AuthorForRevisions = edits.Author };
+    var legacy = WmlComparer.Compare(left, right, settings);
+    File.WriteAllBytes(Path.Combine(outDir, "redline-wmlcomparer.docx"), legacy.DocumentByteArray);
+    Console.WriteLine($"    revisions: {WmlComparer.GetRevisions(legacy, settings).Count}");
+    var acceptAll = RevisionProcessor.AcceptRevisions(legacy);
+    var rejectAll = RevisionProcessor.RejectRevisions(legacy);
+    Check("legacy accept-all == modified text", ExtractText(acceptAll.DocumentByteArray) == ExtractText(modified));
+    Check("legacy reject-all == baseline text", ExtractText(rejectAll.DocumentByteArray) == ExtractText(bytes));
+});
+
+Console.WriteLine();
+Console.WriteLine(FailedChecks == 0
+    ? "ALL CHECKS PASSED"
+    : $"{FailedChecks} CHECK(S) FAILED (see [check] lines above)");
+return FailedChecks == 0 ? 0 : 2;
+
+// ---------- helpers ----------
+
+static void Bench(string label, Action act)
+{
+    var sw = Stopwatch.StartNew();
+    try
+    {
+        act();
+        sw.Stop();
+        Console.WriteLine($"[bench] {label}: {sw.ElapsedMilliseconds} ms");
+    }
+    catch (Exception ex)
+    {
+        sw.Stop();
+        Console.WriteLine($"[bench] {label}: FAILED after {sw.ElapsedMilliseconds} ms :: {ex.GetType().Name}: {ex.Message}");
+        FailedChecks++;
+    }
+}
+
+static int ApplyEdits(DocxSession s, EditScript edits, out int failures)
+{
+    int ok = 0, bad = 0;
+    void Run(string what, Func<EditResult?> op)
+    {
+        var r = op();
+        if (r is { Success: true }) ok++;
+        else { bad++; Console.WriteLine($"    [edit failed] {what}: {r?.Error?.Code.ToString() ?? "no match"}"); }
+    }
+
+    foreach (var rep in edits.Replacements)
+        Run($"replace \"{rep.Find}\"", () =>
+        {
+            var m = s.Grep(System.Text.RegularExpressions.Regex.Escape(rep.Find)).FirstOrDefault();
+            return m is null ? null : s.ReplaceMatch(m, rep.Replace);
+        });
+
+    if (edits.DeleteBlockContaining is { } del)
+        Run("delete block", () =>
+        {
+            var m = s.Grep(System.Text.RegularExpressions.Regex.Escape(del)).FirstOrDefault();
+            return m is null ? null : s.DeleteBlock(m.EnclosingAnchor.Anchor.Id);
+        });
+
+    if (edits.InsertAfterBlockContaining is { } ins)
+        Run("insert paragraph", () =>
+        {
+            var m = s.Grep(System.Text.RegularExpressions.Regex.Escape(ins.Needle)).FirstOrDefault();
+            return m is null ? null : s.InsertParagraph(m.EnclosingAnchor.Anchor.Id, Position.After, ins.Markdown);
+        });
+
+    if (edits.Italicize is { } ital)
+        Run("italicize span", () =>
+        {
+            var m = s.Grep(System.Text.RegularExpressions.Regex.Escape(ital)).FirstOrDefault();
+            return m is null ? null : s.ApplyFormat(m, new FormatOp { Italic = true });
+        });
+
+    if (edits.Comment is { } com)
+        Run("add comment", () =>
+        {
+            var m = s.Grep(System.Text.RegularExpressions.Regex.Escape(com.Needle)).FirstOrDefault();
+            return m is null ? null : s.AddComment(m.EnclosingAnchor.Anchor.Id, m.Span, edits.Author, com.Text);
+        });
+
+    failures = bad;
+    return ok;
+}
+
+static string ExtractText(byte[] docx)
+{
+    XNamespace w = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+    var sb = new StringBuilder();
+    using var ms = new MemoryStream(docx);
+    using var zip = new ZipArchive(ms, ZipArchiveMode.Read);
+    foreach (var partName in new[] { "word/document.xml", "word/footnotes.xml", "word/endnotes.xml" })
+    {
+        var entry = zip.GetEntry(partName);
+        if (entry is null) continue;
+        var xdoc = XDocument.Load(entry.Open());
+        foreach (var p in xdoc.Descendants(w + "p"))
+        {
+            foreach (var t in p.Descendants())
+            {
+                if (t.Name == w + "t") sb.Append(t.Value);
+                else if (t.Name == w + "tab") sb.Append('\t');
+            }
+            sb.Append('\n');
+        }
+    }
+    return sb.ToString();
+}
+
+static bool SamePartNames(byte[] a, byte[] b)
+{
+    static HashSet<string> Names(byte[] docx)
+    {
+        using var ms = new MemoryStream(docx);
+        using var zip = new ZipArchive(ms, ZipArchiveMode.Read);
+        return zip.Entries.Select(e => e.FullName).ToHashSet();
+    }
+    return Names(a).SetEquals(Names(b));
+}
+
+static int ValidateCount(byte[] docx)
+{
+    using var ms = new MemoryStream(docx);
+    using var word = WordprocessingDocument.Open(ms, false);
+    return new OpenXmlValidator().Validate(word).Count();
+}
+
+static void Check(string label, bool pass)
+{
+    Console.WriteLine($"    [check] {label}: {(pass ? "PASS" : "FAIL")}");
+    if (!pass) FailedChecks++;
+}
+
+internal sealed record EditScript
+{
+    public string Author { get; init; } = "Benchmark Reviewer";
+    public List<Replacement> Replacements { get; init; } = [];
+    public string? DeleteBlockContaining { get; init; }
+    public InsertSpec? InsertAfterBlockContaining { get; init; }
+    public string? Italicize { get; init; }
+    public CommentSpec? Comment { get; init; }
+}
+
+internal sealed record Replacement(string Find, string Replace);
+internal sealed record InsertSpec(string Needle, string Markdown);
+internal sealed record CommentSpec(string Needle, string Text);
+
+internal static partial class Program
+{
+    internal static int FailedChecks;
+}

--- a/benchmarks/complex-form-doc/README.md
+++ b/benchmarks/complex-form-doc/README.md
@@ -1,0 +1,47 @@
+# Complex-form-document benchmark
+
+A standalone harness that runs Docxodus's agent-facing surfaces against one heavyweight
+legal .docx and verifies the invariants that matter for redline work. It is deliberately
+**not** part of `Docxodus.sln`, so it never affects CI, packaging, or the warning
+baselines.
+
+## What it measures
+
+| Stage | Surface | Checks |
+|---|---|---|
+| Projections | `WmlToHtmlConverter`, `WmlToMarkdownConverter`, `DocxDiff.InspectCompatibility` | timing, anchor count, compatibility warnings |
+| Round-trip | `DocxSession` open → save with no edits | text-exact, part inventory identical |
+| Tracked session | `DocxSession` with `TrackedChangeMode.RenderInline` | every scripted edit succeeds, native revisions recorded with the configured author, single accept/reject works, no schema findings added |
+| Redline | `DocxDiff.Compare` + revision list + edit-script JSON + semantic changeset | **accept-all ≡ revised text**, **reject-all ≡ baseline text**, no schema findings added |
+| Rendering | redline → HTML with tracked-change markup | timing |
+| Legacy engine | `WmlComparer.Compare` | same round-trip invariants, tracked as a known-gap regression signal (see FINDINGS.md) |
+
+"No schema findings added" is measured against the *source document's own* validator
+baseline — real Word documents ship with schema findings of their own (the reference
+document carries 80), so zero is the wrong yardstick; parity is the invariant.
+
+## Reference document class
+
+The harness was written against the NVCA Model Certificate of Incorporation
+(October 2025): ~51 pages, 234 paragraphs, 94 footnotes, 392 bookmarks, 201
+cross-reference field instructions, 16 abstract numbering definitions, 4 sections,
+8 headers and 10 footers. The document is publicly available from the NVCA and is not
+committed here — pass any comparable form document on the command line.
+
+## Running
+
+```bash
+dotnet run --project benchmarks/complex-form-doc -- path/to/document.docx [edits.json] [--out DIR]
+```
+
+The edit script defaults to `edits/nvca-coi.json`, which encodes a realistic Series A
+counsel pass over the NVCA charter (placeholder fills, a liquidation-preference and
+dividend-rate change, a notice-period change, deletion of an optional bracketed
+provision, an inserted negotiated paragraph, a formatting-only change that crosses a
+cross-reference field, and a span-anchored comment). For a different document, supply an
+edits JSON with the same shape: the needles are literal substrings located via
+`DocxSession.Grep`.
+
+Exit code 0 means every check passed; 2 means at least one `[check] ... FAIL` line —
+including the two legacy-engine failures that are currently expected on footnote-heavy
+documents (FINDINGS.md).

--- a/benchmarks/complex-form-doc/edits/nvca-coi.json
+++ b/benchmarks/complex-form-doc/edits/nvca-coi.json
@@ -1,0 +1,19 @@
+{
+  "author": "Series A Counsel",
+  "replacements": [
+    { "find": "[specify percentage]", "replace": "a majority" },
+    { "find": "[__ times] the applicable Original Issue Price", "replace": "one times (1x) the applicable Original Issue Price" },
+    { "find": "[8]% of the Original Issue Price", "replace": "6% of the Original Issue Price" },
+    { "find": "at least 10 days prior to the effective date", "replace": "at least 20 days prior to the effective date" }
+  ],
+  "deleteBlockContaining": "bona fide equity financing of the Corporation, in and of itself",
+  "insertAfterBlockContaining": {
+    "needle": "pro rata based on the number of shares of Common Stock held by each such holder",
+    "markdown": "Notwithstanding the foregoing, the aggregate amount payable to the holders of Preferred Stock pursuant to this Section 2 shall be reduced by the amount of any indebtedness of the Corporation held by such holders that is repaid at or prior to the closing of such Deemed Liquidation Event."
+  },
+  "italicize": "the “Available Proceeds”",
+  "comment": {
+    "needle": "one times (1x) the applicable Original Issue Price",
+    "text": "Confirm the fund's model assumes a 1x non-participating preference here."
+  }
+}


### PR DESCRIPTION
## Why

Docxodus's agent-facing surfaces (markdown projection, `DocxSession` tracked editing, `DocxDiff` redlining) are exhaustively unit-tested, but there was no single harness that runs them end-to-end against a genuinely heavyweight legal form document and checks the invariants a redline workflow actually depends on. This PR adds one, and records what its first run found.

## What it does

`benchmarks/complex-form-doc/` is a standalone console app (deliberately **not** added to `Docxodus.sln`, so CI, packaging, and the warning baselines are untouched). Given any complex `.docx` and a JSON edit script of counsel-style changes, it:

1. Times HTML and markdown projections and the `DocxDiff` compatibility probe.
2. Verifies a no-edit `DocxSession` open→save round-trip is text-exact with an identical part inventory.
3. Applies the edit script with tracked changes on, verifies every edit lands, revisions carry the configured author, and single accept/reject work.
4. Applies the same script untracked, runs `DocxDiff.Compare`, and asserts the invariants: **accept-all reproduces the revised text exactly, reject-all reproduces the baseline exactly**, and the redline adds **zero** OOXML validator findings over the source document's own baseline (real Word documents ship with findings of their own, so parity — not zero — is the yardstick).
5. Runs the legacy `WmlComparer` on the same inputs with the same checks, as a known-gap regression signal.

The default edit script encodes a realistic Series A counsel pass over the NVCA Model Certificate of Incorporation (Oct 2025) — placeholder fills, liquidation-preference and dividend changes, deletion of an optional bracketed provision, an inserted paragraph, a formatting change crossing a cross-reference field, and a span-anchored comment. The NVCA document itself is publicly available and is not committed; the harness takes any comparable document by path.

## What the first run found

`FINDINGS.md` records full timings plus real defects surfaced by the run:

- **`WmlComparer` fails both round-trip invariants on this document**: it silently drops an empty footnote paragraph and normalizes markup wholesale (validator findings 80 → 29), while `DocxDiff` passes both invariants exactly on identical inputs. The harness intentionally reports these as failing checks until the gap is fixed or documented.
- **`DocxSession.DeleteBlock` orphans footnote definitions**: deleting a paragraph that references a footnote removes the reference but leaves the note body in `footnotes.xml` — invisible in Word, but "deleted" drafting commentary still ships inside the file, which matters for legal use.
- Smaller items: formatting-only edits crossing a field envelope render as del+ins pairs in the native redline (the semantic changeset classifies them correctly), the PDF exporter's Chromium-sandbox requirement deserves a louder deployment warning, and a couple of DX nits.

## How it was validated

Built and run against the NVCA charter in this branch's session: all Docxodus-engine checks pass (`ALL CHECKS PASSED` minus the two intentionally-failing legacy-engine checks described above); output shown in `FINDINGS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YCwVEXa53jCdcYf7rv19G

---
_Generated by [Claude Code](https://claude.ai/code/session_017YCwVEXa53jCdcYf7rv19G)_