### PR TITLE
Prune footnote/endnote definitions orphaned by structural deletes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **Structural deletes no longer orphan footnote/endnote definitions (#591).**
+  `DeleteBlock`, `DeleteRange`, `DeleteSection`, `DeleteTableRow`, and `DeleteTableColumn`
+  removed a note's body-side reference but left its full definition — often substantive
+  commentary — shipping invisibly inside `word/footnotes.xml`/`word/endnotes.xml`. The
+  delete family now runs the same Word-faithful pruner revision resolution has used since
+  #516: a definition whose *last* reference the op removed is deleted (and reported in
+  `EditResult.Removed`), while definitions still referenced elsewhere, pre-existing
+  danglers, the Word-reserved separator notes, and the notes part itself all survive.
+  Tracked-mode deletes are unaffected — the reference lives on inside `w:del`, and the
+  definition is pruned when the revision is accepted, as before.
 - **Markdown-authored headings no longer carry an inert `numId=0` numbering suppressor
   (#572).** The suppressor exists for legal-outline templates whose Heading styles attach
   numbering — `numId=0` keeps the authored text unnumbered — but it was written

--- a/Docxodus.Tests/DocxSessionNotePruneTests.cs
+++ b/Docxodus.Tests/DocxSessionNotePruneTests.cs
@@ -1,0 +1,305 @@
+#nullable enable
+
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
+using Docxodus;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+/// <summary>
+/// Structural deletes must not orphan footnote/endnote definitions (issue #591). Deleting the
+/// body content that carried a note's LAST reference removes the definition from the notes
+/// part via the same Word-faithful pruner revision resolution has used since issue #516 —
+/// scoped strictly to ids the op itself unreferenced, so a pre-existing dangling note is
+/// untouched and the part (with its Word-reserved separator notes) always survives.
+/// Test IDs use the DS64x range.
+/// </summary>
+public class DocxSessionNotePruneTests
+{
+    private static readonly XNamespace W =
+        "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+
+    private static XElement PartXml(byte[] docxBytes, System.Func<MainDocumentPart, OpenXmlPart?> pick)
+    {
+        using var ms = new MemoryStream(docxBytes);
+        using var doc = WordprocessingDocument.Open(ms, false);
+        var part = pick(doc.MainDocumentPart!);
+        Assert.NotNull(part);
+        return part!.GetXDocument().Root!;
+    }
+
+    private static int[] UserNoteIds(XElement notesRoot, XName noteName) =>
+        notesRoot.Elements(noteName)
+            .Where(n => n.Attribute(W + "type") is null)
+            .Select(n => (int)n.Attribute(W + "id")!)
+            .OrderBy(id => id).ToArray();
+
+    private static string AnchorByPreview(DocxSession session, string contains) =>
+        session.Project().AnchorIndex.Values
+            .First(t => t.Anchor.Scope == "body" && t.Anchor.Kind is "p" or "h"
+                && t.TextPreview.Contains(contains)).Anchor.Id;
+
+    private static void AssertSchemaValid(byte[] bytes)
+    {
+        using var ms = new MemoryStream(bytes);
+        using var wDoc = WordprocessingDocument.Open(ms, false);
+        var errors = new OpenXmlValidator().Validate(wDoc)
+            .Select(e => $"{e.Path?.XPath}: {e.Description}").ToList();
+        Assert.True(errors.Count == 0, "OOXML schema errors:\n" + string.Join("\n", errors));
+    }
+
+    /// <summary>
+    /// Five paragraphs: one cites footnote 2 alone, two share footnote 1, one cites endnote 1,
+    /// one is plain. Footnote 7 exists but is referenced by nothing (a pre-existing dangler).
+    /// </summary>
+    private static byte[] BuildMultiNoteDoc()
+    {
+        using var ms = new MemoryStream();
+        using (var doc = WordprocessingDocument.Create(ms, DocumentFormat.OpenXml.WordprocessingDocumentType.Document))
+        {
+            var main = doc.AddMainDocumentPart();
+            main.Document = new DocumentFormat.OpenXml.Wordprocessing.Document(
+                new DocumentFormat.OpenXml.Wordprocessing.Body(
+                    new DocumentFormat.OpenXml.Wordprocessing.Paragraph(
+                        new DocumentFormat.OpenXml.Wordprocessing.Run(
+                            new DocumentFormat.OpenXml.Wordprocessing.Text("Solo cite."),
+                            new DocumentFormat.OpenXml.Wordprocessing.FootnoteReference { Id = 2 })),
+                    new DocumentFormat.OpenXml.Wordprocessing.Paragraph(
+                        new DocumentFormat.OpenXml.Wordprocessing.Run(
+                            new DocumentFormat.OpenXml.Wordprocessing.Text("Shared cite one."),
+                            new DocumentFormat.OpenXml.Wordprocessing.FootnoteReference { Id = 1 })),
+                    new DocumentFormat.OpenXml.Wordprocessing.Paragraph(
+                        new DocumentFormat.OpenXml.Wordprocessing.Run(
+                            new DocumentFormat.OpenXml.Wordprocessing.Text("Shared cite two."),
+                            new DocumentFormat.OpenXml.Wordprocessing.FootnoteReference { Id = 1 })),
+                    new DocumentFormat.OpenXml.Wordprocessing.Paragraph(
+                        new DocumentFormat.OpenXml.Wordprocessing.Run(
+                            new DocumentFormat.OpenXml.Wordprocessing.Text("Endnote cite."),
+                            new DocumentFormat.OpenXml.Wordprocessing.EndnoteReference { Id = 1 })),
+                    new DocumentFormat.OpenXml.Wordprocessing.Paragraph(
+                        new DocumentFormat.OpenXml.Wordprocessing.Run(
+                            new DocumentFormat.OpenXml.Wordprocessing.Text("Plain paragraph.")))));
+
+            var fnPart = main.AddNewPart<FootnotesPart>();
+            var fnXml = """
+                <w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                  <w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>
+                  <w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>
+                  <w:footnote w:id="1"><w:p><w:r><w:t>Shared note.</w:t></w:r></w:p></w:footnote>
+                  <w:footnote w:id="2"><w:p><w:r><w:t>Solo note.</w:t></w:r></w:p></w:footnote>
+                  <w:footnote w:id="7"><w:p><w:r><w:t>Dangling note.</w:t></w:r></w:p></w:footnote>
+                </w:footnotes>
+                """;
+            using (var s = fnPart.GetStream(FileMode.Create))
+            using (var w = new StreamWriter(s)) w.Write(fnXml);
+
+            var enPart = main.AddNewPart<EndnotesPart>();
+            var enXml = """
+                <w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                  <w:endnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:endnote>
+                  <w:endnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:endnote>
+                  <w:endnote w:id="1"><w:p><w:r><w:t>The endnote.</w:t></w:r></w:p></w:endnote>
+                </w:endnotes>
+                """;
+            using (var s = enPart.GetStream(FileMode.Create))
+            using (var w = new StreamWriter(s)) w.Write(enXml);
+        }
+        return ms.ToArray();
+    }
+
+    /// <summary>A 2×2 table whose first cell cites footnote 2, plus an intro paragraph.</summary>
+    private static byte[] BuildTableNoteDoc()
+    {
+        using var ms = new MemoryStream();
+        using (var doc = WordprocessingDocument.Create(ms, DocumentFormat.OpenXml.WordprocessingDocumentType.Document))
+        {
+            var main = doc.AddMainDocumentPart();
+            main.Document = new DocumentFormat.OpenXml.Wordprocessing.Document(
+                new DocumentFormat.OpenXml.Wordprocessing.Body(
+                    new DocumentFormat.OpenXml.Wordprocessing.Paragraph(
+                        new DocumentFormat.OpenXml.Wordprocessing.Run(
+                            new DocumentFormat.OpenXml.Wordprocessing.Text("Intro paragraph."))),
+                    new DocumentFormat.OpenXml.Wordprocessing.Table(
+                        new DocumentFormat.OpenXml.Wordprocessing.TableProperties(
+                            new DocumentFormat.OpenXml.Wordprocessing.TableWidth { Type = DocumentFormat.OpenXml.Wordprocessing.TableWidthUnitValues.Auto, Width = "0" }),
+                        new DocumentFormat.OpenXml.Wordprocessing.TableGrid(
+                            new DocumentFormat.OpenXml.Wordprocessing.GridColumn { Width = "2400" },
+                            new DocumentFormat.OpenXml.Wordprocessing.GridColumn { Width = "2400" }),
+                        new DocumentFormat.OpenXml.Wordprocessing.TableRow(
+                            new DocumentFormat.OpenXml.Wordprocessing.TableCell(
+                                new DocumentFormat.OpenXml.Wordprocessing.Paragraph(
+                                    new DocumentFormat.OpenXml.Wordprocessing.Run(
+                                        new DocumentFormat.OpenXml.Wordprocessing.Text("Cell with note."),
+                                        new DocumentFormat.OpenXml.Wordprocessing.FootnoteReference { Id = 2 }))),
+                            new DocumentFormat.OpenXml.Wordprocessing.TableCell(
+                                new DocumentFormat.OpenXml.Wordprocessing.Paragraph(
+                                    new DocumentFormat.OpenXml.Wordprocessing.Run(
+                                        new DocumentFormat.OpenXml.Wordprocessing.Text("Plain cell."))))),
+                        new DocumentFormat.OpenXml.Wordprocessing.TableRow(
+                            new DocumentFormat.OpenXml.Wordprocessing.TableCell(
+                                new DocumentFormat.OpenXml.Wordprocessing.Paragraph(
+                                    new DocumentFormat.OpenXml.Wordprocessing.Run(
+                                        new DocumentFormat.OpenXml.Wordprocessing.Text("Second row a.")))),
+                            new DocumentFormat.OpenXml.Wordprocessing.TableCell(
+                                new DocumentFormat.OpenXml.Wordprocessing.Paragraph(
+                                    new DocumentFormat.OpenXml.Wordprocessing.Run(
+                                        new DocumentFormat.OpenXml.Wordprocessing.Text("Second row b."))))))));
+
+            var fnPart = main.AddNewPart<FootnotesPart>();
+            var fnXml = """
+                <w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                  <w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>
+                  <w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>
+                  <w:footnote w:id="2"><w:p><w:r><w:t>Table note.</w:t></w:r></w:p></w:footnote>
+                </w:footnotes>
+                """;
+            using (var s = fnPart.GetStream(FileMode.Create))
+            using (var w = new StreamWriter(s)) w.Write(fnXml);
+        }
+        return ms.ToArray();
+    }
+
+    [Fact]
+    public void DS640_DeleteBlock_PrunesTheOrphanedFootnoteDefinition()
+    {
+        using var session = new DocxSession(BuildMultiNoteDoc());
+        var result = session.DeleteBlock(AnchorByPreview(session, "Solo cite."));
+        Assert.True(result.Success, result.Error?.Message);
+
+        var saved = session.Save();
+        var footnotes = PartXml(saved, m => m.FootnotesPart);
+        // Footnote 2 lost its only reference and is pruned; the shared note and the
+        // pre-existing dangler survive, as do the two Word-reserved separator notes.
+        Assert.Equal(new[] { 1, 7 }, UserNoteIds(footnotes, W + "footnote"));
+        Assert.Contains(footnotes.Elements(W + "footnote"),
+            n => (string?)n.Attribute(W + "type") == "separator");
+        Assert.Contains(footnotes.Elements(W + "footnote"),
+            n => (string?)n.Attribute(W + "type") == "continuationSeparator");
+
+        // The pruned definition is reported as removed alongside the paragraph.
+        Assert.Contains(result.Removed, a => a.Kind == "fn");
+        AssertSchemaValid(saved);
+    }
+
+    [Fact]
+    public void DS641_DeleteBlock_KeepsADefinitionStillReferencedElsewhere()
+    {
+        using var session = new DocxSession(BuildMultiNoteDoc());
+        var result = session.DeleteBlock(AnchorByPreview(session, "Shared cite one."));
+        Assert.True(result.Success, result.Error?.Message);
+
+        var footnotes = PartXml(session.Save(), m => m.FootnotesPart);
+        Assert.Equal(new[] { 1, 2, 7 }, UserNoteIds(footnotes, W + "footnote"));
+    }
+
+    [Fact]
+    public void DS642_DeleteBlock_PrunesWhenTheLastSharedReferenceGoes()
+    {
+        using var session = new DocxSession(BuildMultiNoteDoc());
+        Assert.True(session.DeleteBlock(AnchorByPreview(session, "Shared cite one.")).Success);
+        var second = session.DeleteBlock(AnchorByPreview(session, "Shared cite two."));
+        Assert.True(second.Success, second.Error?.Message);
+
+        var footnotes = PartXml(session.Save(), m => m.FootnotesPart);
+        Assert.Equal(new[] { 2, 7 }, UserNoteIds(footnotes, W + "footnote"));
+    }
+
+    [Fact]
+    public void DS643_DeleteBlock_LeavesAPreexistingDanglingNoteAlone()
+    {
+        using var session = new DocxSession(BuildMultiNoteDoc());
+        var result = session.DeleteBlock(AnchorByPreview(session, "Plain paragraph."));
+        Assert.True(result.Success, result.Error?.Message);
+
+        var footnotes = PartXml(session.Save(), m => m.FootnotesPart);
+        Assert.Equal(new[] { 1, 2, 7 }, UserNoteIds(footnotes, W + "footnote"));
+    }
+
+    [Fact]
+    public void DS644_DeleteBlock_PrunesTheOrphanedEndnoteDefinition()
+    {
+        using var session = new DocxSession(BuildMultiNoteDoc());
+        var result = session.DeleteBlock(AnchorByPreview(session, "Endnote cite."));
+        Assert.True(result.Success, result.Error?.Message);
+
+        var endnotes = PartXml(session.Save(), m => m.EndnotesPart);
+        Assert.Empty(UserNoteIds(endnotes, W + "endnote"));
+        Assert.Contains(result.Removed, a => a.Kind == "en");
+    }
+
+    [Fact]
+    public void DS645_TrackedDelete_KeepsTheDefinitionUntilTheRevisionIsAccepted()
+    {
+        using var session = new DocxSession(BuildMultiNoteDoc());
+        session.SetTrackedChanges(TrackedChangeMode.RenderInline);
+        var tracked = session.DeleteBlock(AnchorByPreview(session, "Solo cite."));
+        Assert.True(tracked.Success, tracked.Error?.Message);
+
+        // The reference is only marked deleted, so the definition must survive.
+        var footnotes = PartXml(session.Save(), m => m.FootnotesPart);
+        Assert.Equal(new[] { 1, 2, 7 }, UserNoteIds(footnotes, W + "footnote"));
+
+        var accept = session.AcceptAllRevisions();
+        Assert.True(accept.Success, accept.Error?.Message);
+        footnotes = PartXml(session.Save(), m => m.FootnotesPart);
+        Assert.Equal(new[] { 1, 7 }, UserNoteIds(footnotes, W + "footnote"));
+    }
+
+    [Fact]
+    public void DS646_DeleteRange_PrunesEveryNoteTheRangeUnreferenced()
+    {
+        using var session = new DocxSession(BuildMultiNoteDoc());
+        var result = session.DeleteRange(
+            AnchorByPreview(session, "Solo cite."),
+            AnchorByPreview(session, "Endnote cite."));
+        Assert.True(result.Success, result.Error?.Message);
+
+        var saved = session.Save();
+        var footnotes = PartXml(saved, m => m.FootnotesPart);
+        Assert.Equal(new[] { 7 }, UserNoteIds(footnotes, W + "footnote"));
+        // The endnote's citing paragraph was the exclusive end — untouched.
+        var endnotes = PartXml(saved, m => m.EndnotesPart);
+        Assert.Equal(new[] { 1 }, UserNoteIds(endnotes, W + "endnote"));
+    }
+
+    [Fact]
+    public void DS647_DeleteTableRow_PrunesTheCellsOrphanedNote()
+    {
+        using var session = new DocxSession(BuildTableNoteDoc());
+        var cellAnchor = AnchorByPreview(session, "Cell with note.");
+        var result = session.DeleteTableRow(cellAnchor);
+        Assert.True(result.Success, result.Error?.Message);
+
+        var footnotes = PartXml(session.Save(), m => m.FootnotesPart);
+        Assert.Empty(UserNoteIds(footnotes, W + "footnote"));
+    }
+
+    [Fact]
+    public void DS648_DeleteTableColumn_PrunesTheCellsOrphanedNote()
+    {
+        using var session = new DocxSession(BuildTableNoteDoc());
+        var cellAnchor = AnchorByPreview(session, "Cell with note.");
+        var result = session.DeleteTableColumn(cellAnchor);
+        Assert.True(result.Success, result.Error?.Message);
+
+        var footnotes = PartXml(session.Save(), m => m.FootnotesPart);
+        Assert.Empty(UserNoteIds(footnotes, W + "footnote"));
+    }
+
+    [Fact]
+    public void DS649_Undo_RestoresAPrunedDefinition()
+    {
+        using var session = new DocxSession(BuildMultiNoteDoc());
+        Assert.True(session.DeleteBlock(AnchorByPreview(session, "Solo cite.")).Success);
+        Assert.True(session.Undo());
+
+        var footnotes = PartXml(session.Save(), m => m.FootnotesPart);
+        Assert.Equal(new[] { 1, 2, 7 }, UserNoteIds(footnotes, W + "footnote"));
+        Assert.Contains("Solo note.",
+            footnotes.Descendants(W + "t").Select(t => (string)t));
+    }
+}

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -2785,7 +2785,7 @@ public sealed partial class DocxSession : IDisposable
             }
             if (!accept && rejectedNumberingIds.Length > 0)
                 PruneUnreferencedDocxodusNumbering(rejectedNumberingIds);
-            var prunedNotes = PruneNotesOrphanedByResolution(referencedNotesBefore);
+            var prunedNotes = PruneOrphanedNotes(referencedNotesBefore);
 
             var removed = new List<Anchor>();
             var seenRemoved = new HashSet<string>(StringComparer.Ordinal);
@@ -2800,16 +2800,7 @@ public sealed partial class DocxSession : IDisposable
                 }
             }
 
-            foreach (var (note, notePartUri) in prunedNotes)
-            {
-                foreach (var d in note.DescendantsAndSelf())
-                {
-                    var unid = (string?)d.Attribute(PtOpenXml.Unid);
-                    if (unid is null) continue;
-                    if (AnchorForUnid(unid, notePartUri) is { } anch && seenRemoved.Add(anch.Id))
-                        removed.Add(anch);
-                }
-            }
+            AppendPrunedNoteAnchors(prunedNotes, removed, seenRemoved);
 
             // Selective revision resolution must not normalize unrelated package state. The
             // relationship sweep above is deliberately limited to ids carried by this group;
@@ -2890,7 +2881,7 @@ public sealed partial class DocxSession : IDisposable
             }
             if (!accept && rejectedNumberingIds.Length > 0)
                 PruneUnreferencedDocxodusNumbering(rejectedNumberingIds);
-            var prunedNotes = PruneNotesOrphanedByResolution(referencedNotesBefore);
+            var prunedNotes = PruneOrphanedNotes(referencedNotesBefore);
             var removed = new List<Anchor>();
             var seenRemoved = new HashSet<string>(StringComparer.Ordinal);
             foreach (var element in removedElements)
@@ -2909,16 +2900,7 @@ public sealed partial class DocxSession : IDisposable
                 }
             }
 
-            foreach (var (note, notePartUri) in prunedNotes)
-            {
-                foreach (var descendant in note.DescendantsAndSelf())
-                {
-                    var unid = (string?)descendant.Attribute(PtOpenXml.Unid);
-                    if (unid is null) continue;
-                    if (AnchorForUnid(unid, notePartUri) is { } anchor && seenRemoved.Add(anchor.Id))
-                        removed.Add(anchor);
-                }
-            }
+            AppendPrunedNoteAnchors(prunedNotes, removed, seenRemoved);
 
             // ResolveAll has already swept only relationships referenced by the groups it
             // resolved. Preserve every unrelated relationship for exact package semantics.
@@ -3033,18 +3015,19 @@ public sealed partial class DocxSession : IDisposable
     }
 
     /// <summary>
-    /// Word-faithful note cleanup after revision resolution (issue #516). A note whose LAST
-    /// reference was removed by the resolution is deleted from its part — Word removes the
-    /// note when the rejected insertion (or accepted deletion) carries its reference away,
-    /// and without this the note survived as an empty reference-less husk. The PART itself
-    /// always stays: Word never prunes a notes part (the RP050-Deleted-Footnote oracle
-    /// keeps its separator-only footnotes.xml after accepting the only note's deletion),
-    /// and a separator-only part is exactly what Word ships in every fresh document.
-    /// Scoped strictly to ids referenced before and unreferenced after THIS resolution:
-    /// a note that was already dangling is pre-existing document state and stays untouched.
+    /// Word-faithful note cleanup after an op that removes body content (issues #516, #591).
+    /// A note whose LAST reference was removed — by revision resolution carrying the reference
+    /// away, or by a structural delete removing the block that held it — is deleted from its
+    /// part; without this the note survived as a reference-less husk still shipping its full
+    /// text inside the package. The PART itself always stays: Word never prunes a notes part
+    /// (the RP050-Deleted-Footnote oracle keeps its separator-only footnotes.xml after
+    /// accepting the only note's deletion), and a separator-only part is exactly what Word
+    /// ships in every fresh document. Scoped strictly to ids referenced before and
+    /// unreferenced after THIS op: a note that was already dangling is pre-existing
+    /// document state and stays untouched.
     /// </summary>
     /// <returns>The removed note elements with their part uri, for removed-anchor reporting.</returns>
-    private List<(XElement Note, string PartUri)> PruneNotesOrphanedByResolution(
+    private List<(XElement Note, string PartUri)> PruneOrphanedNotes(
         (HashSet<int> Footnotes, HashSet<int> Endnotes) before)
     {
         var removed = new List<(XElement, string)>();
@@ -3085,6 +3068,27 @@ public sealed partial class DocxSession : IDisposable
 
     private static bool IsSeparatorNote(XElement note) =>
         (string?)note.Attribute(W.type) is "separator" or "continuationSeparator";
+
+    /// <summary>Appends the anchors of pruned note definitions (with their descendants) to
+    /// <paramref name="removed"/>, deduplicated through <paramref name="seenRemoved"/> — the
+    /// shared removed-anchor reporting for every op that calls
+    /// <see cref="PruneOrphanedNotes"/>.</summary>
+    private void AppendPrunedNoteAnchors(
+        List<(XElement Note, string PartUri)> prunedNotes,
+        List<Anchor> removed,
+        HashSet<string> seenRemoved)
+    {
+        foreach (var (note, notePartUri) in prunedNotes)
+        {
+            foreach (var descendant in note.DescendantsAndSelf())
+            {
+                var unid = (string?)descendant.Attribute(PtOpenXml.Unid);
+                if (unid is null) continue;
+                if (AnchorForUnid(unid, notePartUri) is { } anchor && seenRemoved.Add(anchor.Id))
+                    removed.Add(anchor);
+            }
+        }
+    }
 
     internal IReadOnlyList<int> DefinedNumberingIds()
     {
@@ -6818,6 +6822,7 @@ public sealed partial class DocxSession : IDisposable
         if (structurallyDeletes && ValidateBookmarkRemoval(new[] { element }, anchorId) is { } bookmarkError)
             return bookmarkError;
 
+        var referencedNotesBefore = ReferencedNoteIds();
         _history.RecordPreOp(TakeSnapshot());
         try
         {
@@ -6877,6 +6882,10 @@ public sealed partial class DocxSession : IDisposable
                 }
             }
             element.Remove();
+            AppendPrunedNoteAnchors(
+                PruneOrphanedNotes(referencedNotesBefore),
+                removed,
+                new HashSet<string>(removed.Select(a => a.Id), StringComparer.Ordinal));
             if (hyperlinkOwner is { } owner)
                 SweepOrphanedStoryRelationships(owner.Part);
             InvalidateProjectionCache();
@@ -7044,6 +7053,7 @@ public sealed partial class DocxSession : IDisposable
         if (ValidateBookmarkRemoval(structuralRoots, anchorForPatchScope.Anchor.Id) is { } bookmarkError)
             return bookmarkError;
 
+        var referencedNotesBefore = ReferencedNoteIds();
         _history.RecordPreOp(TakeSnapshot());
         try
         {
@@ -7091,6 +7101,8 @@ public sealed partial class DocxSession : IDisposable
                         el.Remove();
                     }
                 }
+                AppendPrunedNoteAnchors(
+                    PruneOrphanedNotes(referencedNotesBefore), trackedRemoved, trackedRemovedIds);
                 if (hyperlinkOwner is { } trackedOwner)
                     SweepOrphanedStoryRelationships(trackedOwner.Part);
                 InvalidateProjectionCache();
@@ -7111,6 +7123,7 @@ public sealed partial class DocxSession : IDisposable
                 CollectAnchors(el, includeDescendants: true, index, removed, removedIds);
                 el.Remove();
             }
+            AppendPrunedNoteAnchors(PruneOrphanedNotes(referencedNotesBefore), removed, removedIds);
             if (hyperlinkOwner is { } owner)
                 SweepOrphanedStoryRelationships(owner.Part);
             InvalidateProjectionCache();
@@ -10821,6 +10834,7 @@ public sealed partial class DocxSession : IDisposable
                 "DeleteTableRow across a vertical-merge restart", cellAnchorId);
 
         var before = CaptureTableMetadata(tbl!);
+        var referencedNotesBefore = ReferencedNoteIds();
         _history.RecordPreOp(TakeSnapshot());
         try
         {
@@ -10839,6 +10853,11 @@ public sealed partial class DocxSession : IDisposable
                 tr.Remove();
             }
 
+            var prunedNoteAnchors = new List<Anchor>();
+            AppendPrunedNoteAnchors(
+                PruneOrphanedNotes(referencedNotesBefore),
+                prunedNoteAnchors,
+                new HashSet<string>(StringComparer.Ordinal));
             if (hyperlinkOwner is { } owner)
                 SweepOrphanedStoryRelationships(owner.Part);
 
@@ -10847,7 +10866,7 @@ public sealed partial class DocxSession : IDisposable
             return new EditResult
             {
                 Success = true,
-                Removed = InvalidatedCellAnchors(mapping),
+                Removed = InvalidatedCellAnchors(mapping).Concat(prunedNoteAnchors).ToList(),
                 TableAnchors = mapping,
                 Patch = PatchFor(target!),
             };
@@ -10884,6 +10903,7 @@ public sealed partial class DocxSession : IDisposable
             return bookmarkError;
 
         var before = CaptureTableMetadata(tbl!);
+        var referencedNotesBefore = ReferencedNoteIds();
         _history.RecordPreOp(TakeSnapshot());
         try
         {
@@ -10924,6 +10944,11 @@ public sealed partial class DocxSession : IDisposable
                 if (cols is not null && doomed < cols.Count) cols[doomed].Remove();
             }
 
+            var prunedNoteAnchors = new List<Anchor>();
+            AppendPrunedNoteAnchors(
+                PruneOrphanedNotes(referencedNotesBefore),
+                prunedNoteAnchors,
+                new HashSet<string>(StringComparer.Ordinal));
             if (hyperlinkOwner is { } owner)
                 SweepOrphanedStoryRelationships(owner.Part);
 
@@ -10932,7 +10957,7 @@ public sealed partial class DocxSession : IDisposable
             return new EditResult
             {
                 Success = true,
-                Removed = InvalidatedCellAnchors(mapping),
+                Removed = InvalidatedCellAnchors(mapping).Concat(prunedNoteAnchors).ToList(),
                 TableAnchors = mapping,
                 Patch = PatchFor(target!),
             };

--- a/docs/architecture/docx_mutation_api.md
+++ b/docs/architecture/docx_mutation_api.md
@@ -267,7 +267,7 @@ Each mutation reports which anchors it created, removed, or modified. This table
 | Op | Created | Removed | Modified | Patch scope |
 |---|---|---|---|---|
 | `ReplaceText(p, md)` | — (markdown subset can't introduce inline anchors in v1) | descendant inline anchors that no longer exist (rare) | `p` | `p` |
-| `DeleteBlock(p)` (or `h`/`li`/`tbl`) | — | `p` + all descendant anchors | — | nearest stable ancestor |
+| `DeleteBlock(p)` (or `h`/`li`/`tbl`) | — | `p` + all descendant anchors, plus any `fn`/`en` definition whose last reference the delete removed (issue #591 — the same Word-faithful prune revision resolution performs; shared notes, pre-existing danglers, and the separator notes survive; likewise for `DeleteRange`/`DeleteSection`/`DeleteTableRow`/`DeleteTableColumn`) | — | nearest stable ancestor |
 | `DeleteBlock(fn)` / `DeleteBlock(en)` / `DeleteBlock(cmt)` | — | the definition anchor (and any cross-references it pointed at — those become "gone" but aren't separately addressed) | — | nearest stable ancestor in the body |
 | `InsertParagraph(p, pos, md)` | one anchor per new block | — | — | smallest enclosing common parent |
 | `SplitParagraph(p, offset)` | the **second** half | — | `p` (first half — convention) | enclosing parent |


### PR DESCRIPTION
Closes #591.

## Why

Deleting a paragraph whose text carries a `w:footnoteReference` removed the reference from `document.xml` but left the footnote's full body in `word/footnotes.xml`. Word renders nothing for an unreferenced note, so the document *looks* correct — but the \"deleted\" note text still ships inside the package. For legal form documents, where footnotes carry substantive commentary, that is confidentiality-adjacent: a user who deletes a provision reasonably believes its annotation is gone, yet anyone unzipping the file or walking `footnotes.xml` with a text extractor still sees it.

## How it works

The session already had the right mechanism: since #516, revision resolution diffs the set of referenced note ids before and after the operation and deletes any definition whose **last** reference the operation itself removed (`PruneNotesOrphanedByResolution`). This PR renames that pruner to `PruneOrphanedNotes` and runs it from the five structural-delete operations too: `DeleteBlock`, `DeleteRange`, `DeleteSection` (via their shared core), `DeleteTableRow`, and `DeleteTableColumn`.

The before/after scoping preserves the library's conservatism:

- a note still referenced from another paragraph survives (last-reference semantics);
- a note that was **already** dangling before the op is pre-existing document state and stays untouched;
- the Word-reserved separator/continuation notes and the notes part itself always survive — a separator-only `footnotes.xml` is exactly what Word ships in every fresh document;
- tracked-mode deletes are unaffected: the reference is only wrapped in `w:del`, so the definition survives until the revision is accepted, at which point the existing resolution-side prune (unchanged) cleans it up — matching Word's behavior.

Pruned definitions are reported in `EditResult.Removed` (through a small shared helper also adopted by the two revision resolvers, which previously had this loop duplicated inline), so editor callers learn the note anchor died. Undo restores the definition — the prune happens inside the op's normal snapshot.

No public API surface changed, so no bridge/client ripple is needed.

## Validation

- New `DocxSessionNotePruneTests` (DS640–DS649): solo-reference prune, shared-reference survival, last-shared-reference prune, pre-existing-dangler survival, endnote symmetry, tracked-delete-then-accept end-to-end, `DeleteRange`, `DeleteTableRow`, `DeleteTableColumn`, and undo restoration; DS640 also schema-validates the pruned package. The six structural-delete tests fail without the fix.
- Full .NET suite: 4437 passed / 0 failed (3 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)