### PR TITLE
Smooth three agent-facing paper cuts (DX round from the complex-form run)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Agent-facing DX round (#596).** `DocxDiffRevision` now renders a self-describing
+  one-liner from `ToString()` (type, move role, changed format property names, quoted
+  text, anchors, author) instead of the bare type name; the two tracked-changes knobs —
+  `DocxSession.SetTrackedChanges` (how mutations are *recorded*) and
+  `WmlToMarkdownConverterSettings.TrackedChanges` (how projections *render*) — now
+  cross-reference each other in their XML docs so a clean projection after a tracked edit
+  is no longer misread as "the edit wasn't tracked"; and a `docxodus_mutations` step may
+  be written flat (action and arguments directly beside `tool`, the standalone-tool
+  shape) — the MCP server lifts it into `args`, and a step with neither `args` nor
+  `action` gets an error that spells out the nested shape.
+
 ### Fixed
 - **Markdown-authored headings no longer carry an inert `numId=0` numbering suppressor
   (#572).** The suppressor exists for legal-outline templates whose Heading styles attach

--- a/Docxodus.Tests/DocxDiffTests.cs
+++ b/Docxodus.Tests/DocxDiffTests.cs
@@ -380,6 +380,38 @@ public class DocxDiffTests
     }
 
     [Fact]
+    public void DocxDiffRevision_ToString_IsSelfDescribing()
+    {
+        // Issue #596: the revision record a caller most wants to eyeball while debugging must
+        // not print as the bare type name in logs/interpolation.
+        var left = Doc("first para", "second para", "third para");
+        var right = Doc("first para", "third para");
+
+        var del = Assert.Single(DocxDiff.GetRevisions(left, right),
+            r => r.Type == DocxDiffRevisionType.Deleted);
+        var rendered = del.ToString();
+
+        Assert.StartsWith("Deleted", rendered);
+        Assert.Contains("\"second para\"", rendered);
+        Assert.Contains(del.LeftAnchor!, rendered);
+        Assert.EndsWith($"({del.Author})", rendered);
+        Assert.DoesNotContain(nameof(DocxDiffRevision), rendered);
+    }
+
+    [Fact]
+    public void DocxDiffRevision_ToString_NamesChangedFormatProperties()
+    {
+        var fc = Assert.Single(
+            DocxDiff.GetRevisions(Doc("identical text"), BoldDoc("identical text")),
+            r => r.Type == DocxDiffRevisionType.FormatChanged);
+        var rendered = fc.ToString();
+
+        Assert.StartsWith("FormatChanged [", rendered);
+        Assert.Contains("bold", rendered);
+        Assert.Contains(" ↔ ", rendered); // a format change always carries both anchors
+    }
+
+    [Fact]
     public void GetRevisions_StampsAuthorFromSettings()
     {
         var left = Doc("one two three");

--- a/Docxodus.Tests/McpMutationTransactionTests.cs
+++ b/Docxodus.Tests/McpMutationTransactionTests.cs
@@ -1014,6 +1014,53 @@ public sealed class McpMutationTransactionTests : IDisposable
         },
     });
 
+    [Fact]
+    public void MCP596_FlatMutationStep_IsLiftedIntoArgs()
+    {
+        // Issue #596: a step written by symmetry with the standalone tool call — action and
+        // arguments directly beside "tool" instead of nested under "args" — must work.
+        var sessionId = OpenSession(_store, _path);
+        var anchor = FirstAnchor(_store, sessionId);
+
+        var result = J(Dispatcher.Call(_store, "docxodus_mutations", J(JsonSerializer.Serialize(new
+        {
+            sessionId,
+            steps = new object[]
+            {
+                new
+                {
+                    tool = "docxodus_edit",
+                    action = "insert_paragraph",
+                    anchorId = anchor,
+                    position = "after",
+                    markdown = "flat step landed",
+                },
+            },
+        }))));
+
+        Assert.Equal("ok", result.GetProperty("status").GetString());
+        var step = Assert.Single(result.GetProperty("steps").EnumerateArray());
+        Assert.Equal("insert_paragraph", step.GetProperty("action").GetString());
+        Assert.Contains("flat step landed", GetMarkdown(_store, sessionId));
+    }
+
+    [Fact]
+    public void MCP596_StepWithNeitherArgsNorAction_GetsTeachingError()
+    {
+        var sessionId = OpenSession(_store, _path);
+
+        var ex = Assert.Throws<McpToolException>(() => Dispatcher.Call(_store, "docxodus_mutations",
+            J(JsonSerializer.Serialize(new
+            {
+                sessionId,
+                steps = new object[] { new { tool = "docxodus_edit" } },
+            }))));
+
+        // The error must teach the nested shape, not just name the missing key.
+        Assert.Contains("must be nested", ex.Message);
+        Assert.Contains("\"args\"", ex.Message);
+    }
+
     private static string OpenSession(SessionStore store, string path)
     {
         var opened = J(Dispatcher.Call(store, "docxodus_open",

--- a/Docxodus/DocxDiff.cs
+++ b/Docxodus/DocxDiff.cs
@@ -1115,4 +1115,35 @@ public sealed class DocxDiffRevision
         formatChange: r.FormatChange is { } fc ? new DocxDiffFormatChange(fc) : null,
         leftAnchor: r.LeftAnchor,
         rightAnchor: r.RightAnchor);
+
+    /// <summary>
+    /// Self-describing one-line rendering — type, move role, changed format property names,
+    /// quoted (truncated) text, anchors, and author — so a revision prints usefully in logs
+    /// and string interpolation instead of as the bare type name (issue #596). For example:
+    /// <c>Deleted "[8]%" @ p:body:abca8bfa ↔ p:body:dad1d7ec (Open-Xml-PowerTools)</c>.
+    /// </summary>
+    public override string ToString()
+    {
+        var sb = new System.Text.StringBuilder(Type.ToString());
+        if (Type == DocxDiffRevisionType.Moved)
+        {
+            sb.Append(IsMoveSource == true ? " (source" : " (destination");
+            if (MoveGroupId is { } group) sb.Append(" #").Append(group);
+            sb.Append(')');
+        }
+        if (FormatChange is { } change && change.ChangedPropertyNames.Count > 0)
+            sb.Append(" [").Append(string.Join(", ", change.ChangedPropertyNames)).Append(']');
+        var text = Text.ReplaceLineEndings(" ");
+        if (text.Length > 60) text = text[..59] + "…";
+        sb.Append(" \"").Append(text).Append('"');
+        if (LeftAnchor is not null || RightAnchor is not null)
+        {
+            sb.Append(" @ ");
+            if (LeftAnchor is not null && RightAnchor is not null)
+                sb.Append(LeftAnchor).Append(" ↔ ").Append(RightAnchor);
+            else
+                sb.Append(LeftAnchor ?? RightAnchor);
+        }
+        return sb.Append(" (").Append(Author).Append(')').ToString();
+    }
 }

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -2179,6 +2179,17 @@ public sealed partial class DocxSession : IDisposable
     /// already-applied markup — switching to <see cref="TrackedChangeMode.Accept"/> does not
     /// accept existing revisions, and switching to <see cref="TrackedChangeMode.RenderInline"/>
     /// does not retroactively wrap prior direct edits.
+    /// <para>
+    /// This is the RECORDING knob. It is distinct from the RENDERING knob,
+    /// <see cref="WmlToMarkdownConverterSettings.TrackedChanges"/> (reached via
+    /// <see cref="DocxSessionSettings.ProjectionSettings"/>), which controls how existing
+    /// markup is projected by <see cref="Project"/>/<see cref="ProjectAnchor"/>. With the
+    /// projection knob at its <see cref="TrackedChangeMode.Accept"/> default, a projection
+    /// taken after a tracked edit shows the clean accepted text with no inline
+    /// <c>{+ins+}</c>/<c>{-del-}</c> markers — that does NOT mean the edit was recorded
+    /// untracked. Set the projection knob to <see cref="TrackedChangeMode.RenderInline"/>
+    /// to see revision markup in projections (issue #596).
+    /// </para>
     /// </summary>
     public void SetTrackedChanges(TrackedChangeMode mode)
     {

--- a/Docxodus/WmlToMarkdownConverter.cs
+++ b/Docxodus/WmlToMarkdownConverter.cs
@@ -95,7 +95,13 @@ public class WmlToMarkdownConverterSettings
     /// </summary>
     public int TableInlineCellMax { get; set; } = 80;
 
-    /// <summary>How tracked changes (<c>w:ins</c>, <c>w:del</c>) are projected.</summary>
+    /// <summary>
+    /// How tracked changes (<c>w:ins</c>, <c>w:del</c>) are projected. Rendering only —
+    /// distinct from <see cref="DocxSession.SetTrackedChanges"/>, which controls how session
+    /// mutations are RECORDED: an edit recorded as a tracked change still projects as clean
+    /// accepted text under this knob's <see cref="TrackedChangeMode.Accept"/> default
+    /// (issue #596).
+    /// </summary>
     public TrackedChangeMode TrackedChanges { get; set; } = TrackedChangeMode.Accept;
 
     /// <summary>

--- a/docs/architecture/docx_agent_server.md
+++ b/docs/architecture/docx_agent_server.md
@@ -545,7 +545,10 @@ session mutations, and this mutates no session.
 `docxodus_create`/`docxodus_table`/`docxodus_list`/`docxodus_comment`/`docxodus_links`/
 `docxodus_images`/`docxodus_content_controls`/`docxodus_track_changes` (their `undo`/`redo` and
 read-only actions — e.g. `get_membership`, comment `list` — are rejected as steps; a batch is a
-sequence of *mutations*).
+sequence of *mutations*). A step may also be written flat — the action and its arguments
+directly beside `tool`, the same shape as the standalone tool call — and the server lifts the
+non-envelope keys into `args` (issue #596); a step with neither `args` nor `action` gets an
+error that spells out the nested shape.
 
 `mode: atomic` is the recommended default. The server preflights every supported
 action, required argument/enum, and step precondition against the batch-start state

--- a/tools/mcp-server/Dispatcher.cs
+++ b/tools/mcp-server/Dispatcher.cs
@@ -1277,7 +1277,9 @@ internal static class Dispatcher
             var stepTool = step.TryGetProperty("tool", out var toolEl) && toolEl.ValueKind == JsonValueKind.String
                 ? toolEl.GetString()! : throw new McpToolException("mutation step missing string \"tool\"");
             var stepArgs = step.TryGetProperty("args", out var a) && a.ValueKind == JsonValueKind.Object
-                ? a : throw new McpToolException("mutation step missing object \"args\"");
+                ? a : LiftFlatStepArgs(step) ?? throw new McpToolException(
+                    "mutation step missing object \"args\" — step arguments must be nested, e.g. "
+                    + "{\"tool\":\"docxodus_edit\",\"args\":{\"action\":\"replace_text_range\",\"anchorId\":\"…\",\"find\":\"…\",\"replace\":\"…\"}}");
             var action = stepArgs.TryGetProperty("action", out var actEl) && actEl.ValueKind == JsonValueKind.String
                 ? actEl.GetString()! : throw new McpToolException("mutation step args missing string \"action\"");
 
@@ -1310,6 +1312,32 @@ internal static class Dispatcher
                 () => ValidateMutationBatchStep(session, stepTool, action, stepArgs)));
         }
         return result;
+    }
+
+    /// <summary>
+    /// Accepts the flat step shape a caller writes by symmetry with the standalone tools —
+    /// <c>{"tool":"docxodus_edit","action":"replace_text_range", …}</c> — by lifting every
+    /// non-envelope property into the args object the batch machinery expects (issue #596).
+    /// Returns null when the step carries no string "action", i.e. it is not recognizably
+    /// the flat shape and the caller should get the missing-args guidance instead.
+    /// </summary>
+    private static JsonElement? LiftFlatStepArgs(JsonElement step)
+    {
+        if (!step.TryGetProperty("action", out var action) || action.ValueKind != JsonValueKind.String)
+            return null;
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartObject();
+            foreach (var property in step.EnumerateObject())
+            {
+                if (property.NameEquals("tool")) continue;
+                property.WriteTo(writer);
+            }
+            writer.WriteEndObject();
+        }
+        using var lifted = JsonDocument.Parse(buffer.ToArray());
+        return lifted.RootElement.Clone();
     }
 
     private static EditError? ValidateMutationBatchAction(string tool, string action)

--- a/tools/mcp-server/ToolCatalog.cs
+++ b/tools/mcp-server/ToolCatalog.cs
@@ -560,9 +560,9 @@ internal static class ToolCatalog
                     "type": "object",
                     "properties": {
                       "tool": { "type": "string", "enum": ["docxodus_edit", "docxodus_format", "docxodus_create", "docxodus_table", "docxodus_list", "docxodus_comment", "docxodus_links", "docxodus_images", "docxodus_content_controls", "docxodus_track_changes"] },
-                      "args": { "type": "object", "description": "The same arguments that tool's action takes, minus sessionId (inherited from the batch). transactionId is forbidden here; it belongs only at the batch root." }
+                      "args": { "type": "object", "description": "The same arguments that tool's action takes, minus sessionId (inherited from the batch). transactionId is forbidden here; it belongs only at the batch root. May be omitted by writing the action and its arguments directly beside \"tool\" (the same flat shape as the standalone tool call); the server lifts them into args." }
                     },
-                    "required": ["tool", "args"]
+                    "required": ["tool"]
                   }
                 }
               },


### PR DESCRIPTION
Closes #596.

Three small ergonomics fixes observed while driving the library end-to-end against a heavyweight legal form document (#590). Individually trivial; together they are the first paper cuts a new integrator hits.

## 1. `DocxDiffRevision` prints usefully now

`Console.WriteLine(revision)` used to print `Docxodus.DocxDiffRevision`. The new `ToString()` renders a self-describing one-liner — type, move role, changed format property names, quoted (truncated, newline-flattened) text, left/right anchors, and author:

```
Deleted "[8]%" @ p:body:abca8bfa ↔ p:body:dad1d7ec (Open-Xml-PowerTools)
FormatChanged [bold] "identical text" @ p:body:11aa22bb ↔ p:body:33cc44dd (Open-Xml-PowerTools)
```

## 2. The two tracked-changes knobs cross-reference each other

`DocxSession.SetTrackedChanges(...)` controls how mutations are **recorded**; `DocxSessionSettings.ProjectionSettings.TrackedChanges` controls how projections **render**. An agent that switches the session to `RenderInline`, edits, then projects sees clean final text (the projection knob is still at its `Accept` default) and reasonably concludes its edits weren't tracked. Both members' XML docs now name the other knob explicitly and spell out this exact trap. Documentation only — no behavior change, so no bridge/client ripple.

## 3. MCP `docxodus_mutations` accepts the flat step shape

Individual tools take flat arguments (`docxodus_edit {action, anchorId, …}`), but a `mutations` step required them nested under `args`; a step written by symmetry with the single-tool call failed with `mutation step missing object "args"`. The dispatcher now lifts a flat step (recognized by a top-level string `action`) into `args` server-side, the tool schema documents both shapes, and a step with *neither* `args` nor `action` gets an error that shows the nested shape rather than only naming the missing key.

## Validation

- New tests: `DocxDiffRevision_ToString_IsSelfDescribing`, `DocxDiffRevision_ToString_NamesChangedFormatProperties`, `MCP596_FlatMutationStep_IsLiftedIntoArgs`, `MCP596_StepWithNeitherArgsNorAction_GetsTeachingError` — each fails without its fix (bare type name / missing-args rejection).
- Full .NET suite: 4431 passed / 0 failed (3 skipped); MCP server builds clean in Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)