### PR TITLE
Formatting-only edits crossing a field envelope now redline as rPrChange, not del+ins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **A formatting-only edit crossing a complex-field envelope no longer redlines as a
+  delete+insert pair (#593).** The field-envelope digest recorded each field's raw modeled
+  inline index, and run segmentation is formatting-sensitive — so a formatting span
+  boundary falling mid-run before the field shifted that index, flipped the digest, and
+  demoted a content-equal format-only alignment to a whole-paragraph replace: a human
+  reviewer in Word saw the field region re-typed although nothing textual changed. Field
+  positions are now format-neutral (consecutive text runs collapse to one position), so the
+  change renders as `w:rPrChange` on the affected runs; genuine instruction, begin-state,
+  and reorder differences still take the reversible whole-carrier fallback. The semantic
+  changeset's field-envelope digest tag advanced to `docxodus-ir-field-envelope-v2`, and it
+  no longer reports a `field_envelope` modify for such formatting-only splits.
 - **Markdown-authored headings no longer carry an inert `numId=0` numbering suppressor
   (#572).** The suppressor exists for legal-outline templates whose Heading styles attach
   numbering — `numId=0` keeps the authored text unnumbered — but it was written

--- a/Docxodus.Tests/Ir/Diff/IrFieldEnvelopeMarkupRendererTests.cs
+++ b/Docxodus.Tests/Ir/Diff/IrFieldEnvelopeMarkupRendererTests.cs
@@ -37,6 +37,94 @@ public class IrFieldEnvelopeMarkupRendererTests
     }
 
     [Fact]
+    public void Read_FieldEnvelopeDigest_IgnoresFormattingOnlyRunSplit()
+    {
+        // Run segmentation is formatting-sensitive (CoalesceRuns merges only format-equal
+        // neighbors), so a formatting-only span boundary inside the text BEFORE a field must
+        // not move the field's recorded structural position (issue #593).
+        var joined = Paragraph(Doc(
+            "<w:p><w:r><w:t xml:space=\"preserve\">See </w:t></w:r>"
+            + ComplexFieldInner(" REF _Ref12345 \\h ", "Section 2.1")
+            + "<w:r><w:t xml:space=\"preserve\"> for details.</w:t></w:r></w:p>"));
+        var split = Paragraph(Doc(
+            "<w:p><w:r><w:t>S</w:t></w:r>"
+            + "<w:r><w:rPr><w:i/></w:rPr><w:t xml:space=\"preserve\">ee </w:t></w:r>"
+            + ComplexFieldInner(" REF _Ref12345 \\h ", "Section 2.1")
+            + "<w:r><w:t xml:space=\"preserve\"> for details.</w:t></w:r></w:p>"));
+
+        Assert.Equal(joined.ContentHash, split.ContentHash);
+        Assert.Equal(joined.FieldEnvelopeDigest, split.FieldEnvelopeDigest);
+
+        // Guard: genuinely MOVING the field relative to its text neighbors still flips the digest.
+        var moved = Paragraph(Doc(
+            "<w:p>" + ComplexFieldInner(" REF _Ref12345 \\h ", "Section 2.1")
+            + "<w:r><w:t xml:space=\"preserve\">See  for details.</w:t></w:r></w:p>"));
+        Assert.NotEqual(joined.FieldEnvelopeDigest, moved.FieldEnvelopeDigest);
+    }
+
+    [Fact]
+    public void Render_FormattingOnlySpanAcrossComplexField_StaysFormatOnly()
+    {
+        // Italicizing a span that starts mid-run before the field and covers the whole
+        // envelope: content is identical, only run properties differ. This must survive as a
+        // FormatOnly alignment and render as w:rPrChange — not a whole-paragraph del+ins pair
+        // that re-types the field region (issue #593).
+        var left = Doc(
+            "<w:p><w:r><w:t xml:space=\"preserve\">See </w:t></w:r>"
+            + ComplexFieldInner(" REF _Ref12345 \\h ", "Section 2.1")
+            + "<w:r><w:t xml:space=\"preserve\"> for details.</w:t></w:r></w:p>");
+        var right = Doc(
+            "<w:p><w:r><w:t>S</w:t></w:r>"
+            + "<w:r><w:rPr><w:i/></w:rPr><w:t xml:space=\"preserve\">ee </w:t></w:r>"
+            + ItalicComplexFieldInner(" REF _Ref12345 \\h ", "Section 2.1")
+            + "<w:r><w:rPr><w:i/></w:rPr><w:t xml:space=\"preserve\"> for</w:t></w:r>"
+            + "<w:r><w:t xml:space=\"preserve\"> details.</w:t></w:r></w:p>");
+
+        var script = IrEditScriptBuilder.Build(IrReader.Read(left), IrReader.Read(right), new IrDiffSettings());
+        var op = Assert.Single(script.Operations);
+        Assert.Equal(IrEditOpKind.FormatOnlyBlock, op.Kind);
+
+        var redline = DocxDiff.Compare(left, right);
+        AssertSchemaValid(redline);
+        var root = MainXml(redline).Root!;
+        Assert.Empty(root.Descendants(W + "ins"));
+        Assert.Empty(root.Descendants(W + "del"));
+        Assert.Single(root.Descendants(W + "fldChar")
+            .Where(f => (string?)f.Attribute(W + "fldCharType") == "begin"));
+        Assert.NotEmpty(root.Descendants(W + "rPrChange"));
+
+        var accepted = RevisionProcessor.AcceptRevisions(redline);
+        var rejected = RevisionProcessor.RejectRevisions(redline);
+        AssertNoRevisionMarkup(accepted);
+        AssertNoRevisionMarkup(rejected);
+        Assert.Equal(Paragraph(right).FieldEnvelopeDigest, Paragraph(accepted).FieldEnvelopeDigest);
+        Assert.Equal(Paragraph(left).FieldEnvelopeDigest, Paragraph(rejected).FieldEnvelopeDigest);
+        Assert.NotEmpty(MainXml(accepted).Root!.Descendants(W + "i"));
+        Assert.Empty(MainXml(rejected).Root!.Descendants(W + "i"));
+    }
+
+    [Fact]
+    public void Revisions_FormattingOnlySpanAcrossComplexField_SurfaceAsFormatChanged()
+    {
+        var left = Doc(
+            "<w:p><w:r><w:t xml:space=\"preserve\">See </w:t></w:r>"
+            + ComplexFieldInner(" REF _Ref12345 \\h ", "Section 2.1")
+            + "<w:r><w:t xml:space=\"preserve\"> for details.</w:t></w:r></w:p>");
+        var right = Doc(
+            "<w:p><w:r><w:t>S</w:t></w:r>"
+            + "<w:r><w:rPr><w:i/></w:rPr><w:t xml:space=\"preserve\">ee </w:t></w:r>"
+            + ItalicComplexFieldInner(" REF _Ref12345 \\h ", "Section 2.1")
+            + "<w:r><w:rPr><w:i/></w:rPr><w:t xml:space=\"preserve\"> for</w:t></w:r>"
+            + "<w:r><w:t xml:space=\"preserve\"> details.</w:t></w:r></w:p>");
+
+        var revisions = DocxDiff.GetRevisions(left, right);
+
+        Assert.DoesNotContain(revisions, r => r.Type == DocxDiffRevisionType.Deleted);
+        Assert.DoesNotContain(revisions, r => r.Type == DocxDiffRevisionType.Inserted);
+        Assert.Contains(revisions, r => r.Type == DocxDiffRevisionType.FormatChanged);
+    }
+
+    [Fact]
     public void Render_ComplexFieldCodeAndStateChange_RoundTripsBothFieldVariants()
     {
         var left = Doc(ComplexField(" PAGE ", "7", "w:dirty=\"true\""));
@@ -665,6 +753,13 @@ public class IrFieldEnvelopeMarkupRendererTests
         "<w:r><w:fldChar w:fldCharType=\"separate\"/></w:r>" +
         "<w:r><w:t>" + result + "</w:t></w:r>" +
         "<w:r><w:fldChar w:fldCharType=\"end\"/></w:r>";
+
+    private static string ItalicComplexFieldInner(string instruction, string result) =>
+        "<w:r><w:rPr><w:i/></w:rPr><w:fldChar w:fldCharType=\"begin\"/></w:r>" +
+        "<w:r><w:rPr><w:i/></w:rPr><w:instrText xml:space=\"preserve\">" + instruction + "</w:instrText></w:r>" +
+        "<w:r><w:rPr><w:i/></w:rPr><w:fldChar w:fldCharType=\"separate\"/></w:r>" +
+        "<w:r><w:rPr><w:i/></w:rPr><w:t>" + result + "</w:t></w:r>" +
+        "<w:r><w:rPr><w:i/></w:rPr><w:fldChar w:fldCharType=\"end\"/></w:r>";
 
     private static string SimpleField(string instruction, string result, string dirty, string locked, string fieldData) =>
         "<w:p>" + SimpleFieldInner(instruction, result, dirty, locked, fieldData) + "</w:p>";

--- a/Docxodus/Ir/IrReader.cs
+++ b/Docxodus/Ir/IrReader.cs
@@ -985,11 +985,23 @@ internal static class IrReader
     private static void AppendFieldEnvelopeEntries(
         IReadOnlyList<IrInline> inlines, string prefix, List<XElement> fields)
     {
+        // Format-neutral structural position: consecutive text runs collapse to ONE position.
+        // Run segmentation is formatting-sensitive (CoalesceRuns merges only format-equal
+        // neighbors), so a formatting-only span boundary inside a text stretch would otherwise
+        // shift the raw inline index of every following field, flip this digest, and lower a
+        // content-equal FormatOnly alignment to a whole-paragraph del+ins pair (issue #593).
+        // Non-text inlines always advance the position, so genuinely reordering a field
+        // relative to its neighbors is still a structural difference.
+        int position = -1;
+        bool previousWasText = false;
         for (int i = 0; i < inlines.Count; i++)
         {
+            bool isText = inlines[i] is IrTextRun;
+            if (!(isText && previousWasText)) position++;
+            previousWasText = isText;
             string path = prefix.Length == 0
-                ? i.ToString(CultureInfo.InvariantCulture)
-                : prefix + "/" + i.ToString(CultureInfo.InvariantCulture);
+                ? position.ToString(CultureInfo.InvariantCulture)
+                : prefix + "/" + position.ToString(CultureInfo.InvariantCulture);
             switch (inlines[i])
             {
                 case IrFieldRun field:

--- a/Docxodus/Verification/SemanticDiff.cs
+++ b/Docxodus/Verification/SemanticDiff.cs
@@ -734,8 +734,8 @@ internal static class SemanticDiffEngine
                 Add(SemanticChangeOperation.Modify, SemanticChangeFamily.Field, part,
                     "paragraph.field_envelope", la, ra,
                     left.Anchor.Scope, right.Anchor.Scope, null,
-                    Digest(left.FieldEnvelopeDigest, "docxodus-ir-field-envelope-v1"),
-                    Digest(right.FieldEnvelopeDigest, "docxodus-ir-field-envelope-v1"));
+                    Digest(left.FieldEnvelopeDigest, "docxodus-ir-field-envelope-v2"),
+                    Digest(right.FieldEnvelopeDigest, "docxodus-ir-field-envelope-v2"));
             }
 
             EmitTokenChanges(left, right, op.TokenDiff, part);


### PR DESCRIPTION
Closes #593.

## Why

Italicizing a span that intersects a complex-field (cross-reference) envelope and comparing with `DocxDiff` yielded a **Deleted + Inserted pair with identical text** for the field region in the native tracked-changes markup, instead of a formatting revision (`w:rPrChange`). Correct OOXML, but a human reviewer in Word sees a re-typed field region where nothing textual changed — noise that invites "what changed here?" questions in a legal review. The semantic changeset already classified the change correctly; only the redline shape was wrong.

## Root cause

The trigger is narrower than "the span crosses the envelope": it is a formatting-span boundary falling **mid-run in text before the field**. The engine's field-envelope digest (the structural signal that protects field instruction/state changes with a reversible whole-paragraph fallback) recorded each field's raw modeled inline index as its position. Run segmentation is formatting-sensitive — the reader coalesces only format-equal neighboring runs — so the mid-run split turned one pre-field text run into two, shifted the field's index from 1 to 2, and flipped the digest even though instruction, scaffold, and result were all identical. `StructuralCarrierDiffers` then demoted the content-equal format-only alignment to a whole-paragraph replace, and both renderers dutifully emitted the full del+ins pair.

## The fix

Field-envelope positions are now **format-neutral**: consecutive text runs collapse to a single position when the digest entries are built, so run splits cannot move a field's recorded place. Non-text inlines still advance the position, so every genuine structural difference keeps flipping the digest and taking the reversible whole-carrier fallback:

- instruction and begin-state (dirty/lock/fldData) changes — entry body, unchanged;
- reordering a field relative to its neighbors — pinned by a new guard assertion;
- zero-width-result, nested, and hyperlink fields — the separate `HasUnsliceableFieldCarrier` path, untouched.

The `/result` and `/link` recursions and textbox propagation inherit the new encoding automatically. Because digest **values** change for field paragraphs with mixed formatting, the semantic changeset's digest tag advances to `docxodus-ir-field-envelope-v2` — and the changeset correctly stops reporting a `field_envelope` modify for formatting-only splits.

## Validation

- New tests in the field-envelope battery: digest invariance under a formatting-only run split (with a field-moved counter-guard), the end-to-end redline shape (single `FormatOnlyBlock` op, zero `w:ins`/`w:del`, one field scaffold, `w:rPrChange` present, accept→italic / reject→left round-trip, schema-valid), and the `GetRevisions` surface (`FormatChanged`, no Deleted/Inserted). All three fail before the fix with exactly the reported del+ins pair.
- All 30 pre-existing field-envelope tests (instruction/state/nested/hyperlink/textbox true positives) still pass.
- Constraint suites green: redline reversibility proofs, IR parity + markup parity + consolidate scoreboards, edit-script corpus, semantic-diff battery, workflow evals (293 tests).
- Full .NET suite: 4430 passed / 0 failed (3 skipped).

A sibling latent gap — the inline-envelope digest (inline SDT/smartTag carriers) uses raw XML sibling indices and can degrade the same way — is deliberately not touched here; it is a separate digest with its own battery and will be filed as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)