### PR TITLE
Formatting-only edits before an inline content control now redline as rPrChange, not del+ins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,18 @@ All notable changes to this project will be documented in this file.
   `action` gets an error that spells out the nested shape.
 
 ### Fixed
+- **A formatting-only edit before an inline content control no longer redlines as a
+  delete+insert pair (#600).** The inline-envelope digest — the structural signal protecting
+  inline SDT/smartTag wrappers with a reversible whole-paragraph fallback — recorded each
+  carrier's raw XML sibling index, so a formatting span boundary splitting a text run before
+  the carrier shifted that index, flipped the digest, and demoted a content-equal
+  format-only alignment to a whole-paragraph replace, exactly the #593 shape on a different
+  digest. Carrier positions are now format-neutral (consecutive plain text runs collapse to
+  one position; runs holding structural content still advance it), so the change renders as
+  `w:rPrChange`; wrapper metadata changes, carrier reorders against structural neighbors,
+  and edits inside the control keep the whole-carrier fallback, and a carrier moved across a
+  merged text stretch is owned by the content hash with the round-trip invariant pinned. The
+  semantic changeset's tag advanced to `docxodus-ir-inline-envelope-v2`.
 - **A formatting-only edit crossing a complex-field envelope no longer redlines as a
   delete+insert pair (#593).** The field-envelope digest recorded each field's raw modeled
   inline index, and run segmentation is formatting-sensitive — so a formatting span

--- a/Docxodus.Tests/Ir/Diff/IrInlineEnvelopeMarkupRendererTests.cs
+++ b/Docxodus.Tests/Ir/Diff/IrInlineEnvelopeMarkupRendererTests.cs
@@ -37,6 +37,110 @@ public class IrInlineEnvelopeMarkupRendererTests
         "w:element=\"country-region\"><w:r><w:t>" + text +
         "</w:t></w:r></w:smartTag></w:p>";
 
+    private static string SdtInner(string tag, string text = "controlled") =>
+        "<w:sdt><w:sdtPr><w:tag w:val=\"" + tag + "\"/></w:sdtPr>" +
+        "<w:sdtContent><w:r><w:t>" + text + "</w:t></w:r></w:sdtContent></w:sdt>";
+
+    private static IrParagraph Paragraph(WmlDocument doc) =>
+        IrReader.Read(doc).Body.Blocks.OfType<IrParagraph>().Single();
+
+    [Fact]
+    public void Read_InlineEnvelopeDigest_IgnoresFormattingOnlyRunSplit()
+    {
+        // Run segmentation is formatting-sensitive, so a formatting-only span boundary in the
+        // text BEFORE an inline carrier must not move the carrier's recorded position
+        // (issue #600 — the inline-envelope sibling of the field-envelope fix in #593).
+        var joined = Paragraph(Doc(
+            "<w:p><w:r><w:t xml:space=\"preserve\">See </w:t></w:r>"
+            + SdtInner("stable")
+            + "<w:r><w:t xml:space=\"preserve\"> for details.</w:t></w:r></w:p>"));
+        var split = Paragraph(Doc(
+            "<w:p><w:r><w:t>S</w:t></w:r>"
+            + "<w:r><w:rPr><w:i/></w:rPr><w:t xml:space=\"preserve\">ee </w:t></w:r>"
+            + SdtInner("stable")
+            + "<w:r><w:t xml:space=\"preserve\"> for details.</w:t></w:r></w:p>"));
+
+        Assert.Equal(joined.ContentHash, split.ContentHash);
+        Assert.Equal(joined.InlineEnvelopeDigest, split.InlineEnvelopeDigest);
+
+        // Guard: swapping the carrier with its text neighbor is still a structural difference.
+        var swapped = Paragraph(Doc(
+            "<w:p>" + SdtInner("stable")
+            + "<w:r><w:t xml:space=\"preserve\">See </w:t></w:r>"
+            + "<w:r><w:t xml:space=\"preserve\"> for details.</w:t></w:r></w:p>"));
+        Assert.NotEqual(joined.InlineEnvelopeDigest, swapped.InlineEnvelopeDigest);
+    }
+
+    [Fact]
+    public void Render_FormattingOnlySpanBeforeInlineSdt_StaysFormatOnly()
+    {
+        // Italicizing a span that starts mid-run BEFORE the carrier and does not touch the
+        // carrier itself: content is identical, only run properties differ. This must survive
+        // as a FormatOnly alignment and render as w:rPrChange — not a whole-paragraph del+ins
+        // pair re-typing the controlled region (issue #600). A formatting change reaching INTO
+        // the sdtContent still takes the whole-carrier fallback, because the envelope entry
+        // embeds the carrier XML — that conservatism is pinned by
+        // Render_InlineSdtInnerTextChange_UsesWholeParagraphFallback.
+        var left = Doc(
+            "<w:p><w:r><w:t xml:space=\"preserve\">See </w:t></w:r>"
+            + SdtInner("stable")
+            + "<w:r><w:t xml:space=\"preserve\"> for details.</w:t></w:r></w:p>");
+        var right = Doc(
+            "<w:p><w:r><w:t>S</w:t></w:r>"
+            + "<w:r><w:rPr><w:i/></w:rPr><w:t xml:space=\"preserve\">ee </w:t></w:r>"
+            + SdtInner("stable")
+            + "<w:r><w:rPr><w:i/></w:rPr><w:t xml:space=\"preserve\"> for</w:t></w:r>"
+            + "<w:r><w:t xml:space=\"preserve\"> details.</w:t></w:r></w:p>");
+
+        var script = IrEditScriptBuilder.Build(IrReader.Read(left), IrReader.Read(right), new IrDiffSettings());
+        var op = Assert.Single(script.Operations);
+        Assert.Equal(IrEditOpKind.FormatOnlyBlock, op.Kind);
+
+        var redline = DocxDiff.Compare(left, right);
+        AssertSchemaValid(redline);
+        var root = MainXml(redline);
+        Assert.Empty(root.Descendants(W + "ins"));
+        Assert.Empty(root.Descendants(W + "del"));
+        Assert.Single(root.Descendants(W + "sdt"));
+        Assert.NotEmpty(root.Descendants(W + "rPrChange"));
+
+        // Reject legitimately keeps the right side's run segmentation with the left formats
+        // restored (modeled-semantic, not byte, equivalence — the #532-#534 convention), so
+        // assert the semantics: text, carrier structure, and the formatting delta itself.
+        var accepted = RevisionProcessor.AcceptRevisions(redline);
+        var rejected = RevisionProcessor.RejectRevisions(redline);
+        AssertNoRevisionMarkup(accepted);
+        AssertNoRevisionMarkup(rejected);
+        Assert.NotEmpty(MainXml(accepted).Descendants(W + "i"));
+        Assert.Empty(MainXml(rejected).Descendants(W + "i"));
+        Assert.Single(MainXml(accepted).Descendants(W + "sdt"));
+        Assert.Single(MainXml(rejected).Descendants(W + "sdt"));
+        Assert.Equal(Paragraph(left).ContentHash, Paragraph(rejected).ContentHash);
+        Assert.Equal(Paragraph(left).InlineEnvelopeDigest, Paragraph(rejected).InlineEnvelopeDigest);
+        Assert.Equal(Paragraph(right).InlineEnvelopeDigest, Paragraph(accepted).InlineEnvelopeDigest);
+    }
+
+    [Fact]
+    public void Render_InlineSdtMovedAcrossATextStretch_StillRoundTrips()
+    {
+        // Moving the carrier past one of two adjacent text runs merges a text stretch, which a
+        // format-neutral position encoding cannot distinguish from a formatting split in
+        // reverse — so this move is caught by the CONTENT hash instead of the envelope digest.
+        // Whatever path renders it, the package invariant must hold: accept keeps the right
+        // inline tree, reject restores the left one.
+        var left = Doc(
+            "<w:p><w:r><w:t xml:space=\"preserve\">alpha </w:t></w:r>"
+            + SdtInner("stable")
+            + "<w:r><w:t xml:space=\"preserve\"> omega</w:t></w:r></w:p>");
+        var right = Doc(
+            "<w:p><w:r><w:t xml:space=\"preserve\">alpha </w:t></w:r>"
+            + "<w:r><w:t xml:space=\"preserve\"> omega</w:t></w:r>"
+            + SdtInner("stable") + "</w:p>");
+
+        AssertRoundTrips(left, right);
+        AssertRoundTrips(right, left);
+    }
+
     [Fact]
     public void Render_InlineSdtAdditionAndRemoval_RoundTripsExactInlineShape()
     {

--- a/Docxodus/Ir/IrReader.cs
+++ b/Docxodus/Ir/IrReader.cs
@@ -893,11 +893,19 @@ internal static class IrReader
     private static void AppendTextboxInlineEnvelopeEntries(
         IReadOnlyList<IrInline> inlines, string prefix, XElement stream)
     {
+        // Format-neutral positions, for the same reason as AppendFieldEnvelopeEntries and
+        // InlineElementPath: consecutive text runs collapse so a formatting-only run split
+        // cannot shift a following carrier's recorded place (issues #593/#600).
+        int position = -1;
+        bool previousWasText = false;
         for (int i = 0; i < inlines.Count; i++)
         {
+            bool isText = inlines[i] is IrTextRun;
+            if (!(isText && previousWasText)) position++;
+            previousWasText = isText;
             string path = prefix.Length == 0
-                ? i.ToString(CultureInfo.InvariantCulture)
-                : prefix + "/" + i.ToString(CultureInfo.InvariantCulture);
+                ? position.ToString(CultureInfo.InvariantCulture)
+                : prefix + "/" + position.ToString(CultureInfo.InvariantCulture);
             switch (inlines[i])
             {
                 case IrTextbox textbox:
@@ -1063,8 +1071,17 @@ internal static class IrReader
         }
     }
 
-    /// <summary>Path segments include the actual sibling index, not merely the wrapper ordinal: moving one
-    /// carrier past a plain run is structural even if the carrier XML itself is byte-identical.</summary>
+    /// <summary>
+    /// Path segments carry a FORMAT-NEUTRAL sibling position, not merely the wrapper ordinal:
+    /// consecutive plain text runs collapse to one position (run segmentation is
+    /// formatting-sensitive, so a formatting-only span boundary splitting a run before the
+    /// carrier must not move the carrier's recorded place — issue #600, the inline sibling of
+    /// the field-envelope fix in #593), while every non-plain sibling advances the position, so
+    /// reordering a carrier against another carrier or a structural run stays a digest
+    /// difference. The one rearrangement this cannot see — a carrier moved across a plain-run
+    /// stretch boundary, which merges two stretches — changes the visible token order, so the
+    /// content hash owns it and the pinned round-trip invariant still holds on the fine path.
+    /// </summary>
     private static string InlineElementPath(XElement paragraph, XElement element)
     {
         var segments = new Stack<string>();
@@ -1073,10 +1090,36 @@ internal static class IrReader
         {
             if (current.Parent is not XElement)
                 return string.Join("/", segments);
-            int siblingIndex = current.ElementsBeforeSelf().Count();
-            segments.Push($"{current.Name.NamespaceName}:{current.Name.LocalName}[{siblingIndex}]");
+            int position = FormatNeutralSiblingPosition(current);
+            segments.Push($"{current.Name.NamespaceName}:{current.Name.LocalName}[{position}]");
         }
         return string.Join("/", segments);
+    }
+
+    // Run children that carry only text-grade content. A run holding anything else (a drawing,
+    // field plumbing, a note reference, …) is structural and always occupies its own position.
+    private static readonly HashSet<XName> PlainRunChildNames = new()
+    {
+        W + "rPr", W + "t", W + "tab", W + "br", W + "cr", W + "noBreakHyphen",
+        W + "softHyphen", W + "sym", W + "lastRenderedPageBreak",
+    };
+
+    private static bool IsPlainTextRun(XElement element) =>
+        element.Name == W + "r" &&
+        element.Elements().All(child => PlainRunChildNames.Contains(child.Name));
+
+    private static int FormatNeutralSiblingPosition(XElement element)
+    {
+        int position = -1;
+        bool previousWasPlainRun = false;
+        foreach (var sibling in element.Parent!.Elements())
+        {
+            bool plain = IsPlainTextRun(sibling);
+            if (!(plain && previousWasPlainRun)) position++;
+            previousWasPlainRun = plain;
+            if (ReferenceEquals(sibling, element)) return position;
+        }
+        return position;
     }
 
     /// <summary>

--- a/Docxodus/Verification/SemanticDiff.cs
+++ b/Docxodus/Verification/SemanticDiff.cs
@@ -726,8 +726,8 @@ internal static class SemanticDiffEngine
                 Add(SemanticChangeOperation.Modify, SemanticChangeFamily.ContentControl, part,
                     "paragraph.inline_content_control", la, ra,
                     left.Anchor.Scope, right.Anchor.Scope, null,
-                    Digest(left.InlineEnvelopeDigest, "docxodus-ir-inline-envelope-v1"),
-                    Digest(right.InlineEnvelopeDigest, "docxodus-ir-inline-envelope-v1"));
+                    Digest(left.InlineEnvelopeDigest, "docxodus-ir-inline-envelope-v2"),
+                    Digest(right.InlineEnvelopeDigest, "docxodus-ir-inline-envelope-v2"));
             }
             if (left.FieldEnvelopeDigest != right.FieldEnvelopeDigest)
             {


### PR DESCRIPTION
Closes #600 — the inline-envelope sibling of #593 (PR #599), found during that root-cause analysis.

## Root cause

The inline-envelope digest — the structural signal that protects inline SDT/smartTag wrappers with a reversible whole-paragraph fallback — encoded each carrier's position via `InlineElementPath`, which used **raw XML sibling indices** at every level. Run segmentation is formatting-sensitive, so a formatting-only span boundary that splits a `w:r` before an inline content control shifted the carrier's sibling index, flipped the digest, and `StructuralCarrierDiffers` demoted a content-equal FormatOnly alignment to a whole-paragraph del+ins pair: a reviewer in Word saw the controlled region re-typed although nothing changed but run properties.

## The fix

Mirrors #599: carrier positions are now **format-neutral**. Consecutive *plain* text runs — runs whose only children are text-grade (`w:t`, `w:tab`, `w:br`, `w:sym`, …) — collapse to a single position, so run splits cannot move a carrier's recorded place. Any other sibling still advances the position: another carrier, or a run holding a drawing or field plumbing. Every existing true positive keeps flipping the digest and taking the whole-carrier fallback, each pinned by the pre-existing battery:

- wrapper metadata changes (`w:tag` etc.) — the entry embeds the carrier XML, unchanged;
- edits *inside* the control — same embedding (`Render_InlineSdtInnerTextChange_UsesWholeParagraphFallback`);
- reordering a carrier against a structural neighbor — positions still shift.

The previous doc comment pinned "moving one carrier past a plain run is structural." The one rearrangement the new encoding genuinely cannot see is a carrier moved across a *merged* plain-run stretch — formally indistinguishable from a formatting split in reverse (this is exactly the trade #599 made for fields). That move changes visible token order, so the **content hash** owns it; the fine markup path keeps sdt containers atomic and claim-tracked, and a new test pins that its accept/reject round-trip invariant holds either way. The outer-paragraph textbox recursion gets the same collapse over modeled inlines, and the semantic changeset's digest tag advances to `docxodus-ir-inline-envelope-v2` because digest values change for mixed-formatting carrier paragraphs.

## Validation

- New tests in the inline-envelope battery: digest invariance under a formatting-only run split (with a carrier-swap counter-guard); the end-to-end redline shape (single `FormatOnlyBlock` op, zero `w:ins`/`w:del`, the carrier emitted once, `w:rPrChange` present, accept→italic / reject→left at modeled-semantic level with carrier digests matching each side, schema-valid); and the moved-carrier round-trip pin. The two formatting tests fail before the fix with the reported del+ins demotion; the move pin passes before and after, guarding the hand-off to the content hash.
- All pre-existing inline-envelope, field-envelope, and note/image SDT digest tests pass unchanged (75 tests across the envelope batteries).
- Constraint suites green: redline reversibility proofs, IR parity + markup parity + consolidate scoreboards, edit-script corpus, semantic-diff battery, workflow evals, content-control batteries (335 tests).
- Full .NET suite: 4457 passed / 0 failed (3 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)