### PR TITLE
Assert the release packaging contract on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,14 @@ jobs:
       - name: TypeScript type check
         run: cd npm && npx tsc --noEmit
 
+      # Asserts the packaging contract publish.yml relies on. Runs here so a broken
+      # package boundary fails a pull request instead of a release: publish.yml only
+      # triggers on a `v*` tag, and two bugs reached the v10.0.0 tag precisely because
+      # nothing exercised its steps before then. Browser-free (`npm pack --dry-run`),
+      # so it costs well under a minute.
+      - name: Release preflight (package boundaries)
+        run: RELEASE_PREFLIGHT_SKIP_INSTALL=1 ./scripts/release-preflight.sh
+
   # The docx-scalpel (python/) suite is a client of the .NET core: pyhost.csproj
   # project-references Docxodus.csproj, so a core change that breaks a DocxSession
   # op fails here. That is the point of running it on every PR rather than

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -343,7 +343,11 @@ jobs:
           npm ci
           npx playwright-core install-deps chromium
           npm test
-          npm run test:package-boundary
+
+      # Same script ci.yml runs on every pull request, so the packaging contract has one
+      # definition rather than two that drift apart between releases.
+      - name: Release preflight (package boundaries)
+        run: RELEASE_PREFLIGHT_SKIP_INSTALL=1 ./scripts/release-preflight.sh
 
       - name: Publish browser/WASM package
         run: |

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Runs the packaging validation that publish.yml performs at release time, without
+# publishing anything.
+#
+# Why this exists: publish.yml only triggers on a `v*` tag, so nothing exercised its
+# steps until release day — the most expensive moment to discover breakage. Two bugs
+# reached the v10.0.0 tag that way, both latent for weeks:
+#
+#   * @docxodus/export's package-boundary check assumed a flat dist/. The verified font
+#     runtime (#529) added dist/fonts/, which index.js imports, so the check rejected a
+#     package that was correct.
+#   * publish.yml never set kernel.apparmor_restrict_unprivileged_userns=0, so Chromium
+#     could not start its sandbox and npm-export's tests failed.
+#
+# publish.yml and ci.yml both call this script, so the packaging contract is asserted on
+# every pull request and there is one definition of it rather than two that drift.
+#
+# Deliberately browser-free: both boundary checks are `npm pack --dry-run`, so this adds
+# well under a minute to a PR. npm-export's browser suite is covered by playwright.yml,
+# which already installs Chromium and permits its user-namespace sandbox.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Skip `npm ci` when node_modules is already present and the caller asked us to
+# (CI installs separately; a local run usually has one).
+SKIP_INSTALL="${RELEASE_PREFLIGHT_SKIP_INSTALL:-0}"
+
+install_if_needed() {
+  local dir="$1"
+  if [ "$SKIP_INSTALL" = "1" ] && [ -d "$dir/node_modules" ]; then
+    echo "  (using existing node_modules)"
+    return
+  fi
+  (cd "$dir" && npm ci)
+}
+
+echo "==> docxodus (npm/)"
+install_if_needed "$REPO_ROOT/npm"
+# The boundary check inspects dist/, so the bundles have to exist first. A tag build
+# rebuilds anyway; this keeps the script correct when run on its own.
+if [ ! -f "$REPO_ROOT/npm/dist/index.js" ]; then
+  echo "  dist/ missing — building"
+  (cd "$REPO_ROOT/npm" && npm run build)
+fi
+(cd "$REPO_ROOT/npm" && npm run test:package-boundary)
+
+echo "==> @docxodus/export (npm-export/)"
+install_if_needed "$REPO_ROOT/npm-export"
+(cd "$REPO_ROOT/npm-export" && npm run build && npm run test:package-boundary)
+
+echo
+echo "Release preflight passed: both packages pack within their declared boundaries."


### PR DESCRIPTION
The v10.0.0 release took four publish runs. Two of the three failures were bugs that
had been sitting in the tree for weeks, and neither could have been caught before the
tag, because **`publish.yml` only triggers on `v*`** — nothing exercises its steps
between releases.

Both bugs are already fixed on `main`. This PR is about why they were not caught.

## What went wrong

- **`@docxodus/export`'s package-boundary check allowed only flat `dist/*.js`.** Turning
  on the verified font runtime (#529, 2026-08-22) added `npm-export/src/fonts/`, which
  compiles to `dist/fonts/` and is imported by `src/index.ts:18` — the published package
  is broken without it. The check rejected a package that was correct, and the npm
  publish never ran.
- **`publish.yml` never permitted Chromium's user-namespace sandbox.** `@docxodus/export`
  refuses to launch Chromium without it (#602), and Ubuntu 24.04 restricts unprivileged
  user namespaces through AppArmor. `playwright.yml` and `visual-parity.yml` had always
  set `kernel.apparmor_restrict_unprivileged_userns=0`; `publish.yml` was missed when the
  sandbox requirement landed.

Different symptoms, one cause: a release-only workflow accumulating drift no pull request
could see.

## The fix

`scripts/release-preflight.sh` runs the packaging validation without publishing — build
and pack-audit both `npm/` and `npm-export/`. `ci.yml`'s `build-npm` job runs it on every
pull request, and `publish.yml` runs **the same script**, so the packaging contract has
one definition rather than two that drift apart between releases.

It is deliberately browser-free: both boundary checks are `npm pack --dry-run`, so this
adds well under a minute to a PR. `npm-export`'s browser suite stays in `playwright.yml`,
which already installs Chromium and permits its sandbox — duplicating it here would cost
several minutes per PR for coverage that already exists.

Step ordering matters and is deliberate: `npm-export` declares `docxodus` as
`file:../npm`, so the preflight runs after `npm/`'s build in both workflows.

## Validation

The important check is not that the preflight passes — it is that it **fails on the bug
it exists for**. With the pre-fix flat-`dist` pattern restored, the script fails; with the
fix in place it passes:

```
npm package boundary: 192 runtime/license files; no demo or test machinery
@docxodus/export package boundary: 63 runtime/license files
Release preflight passed: both packages pack within their declared boundaries.
```

So a future PR that adds a `dist/` subdirectory, or ships something that should not be in
the tarball, fails at review time rather than at the tag.

## What this does not cover

The third v10.0.0 failure was `@docxodus/export`'s first publish returning `404` on `PUT`.
That is an npm account matter — the package has never been published and the `@docxodus`
scope holds nothing — so no CI change can catch or fix it. Tracked separately.
