### PR TITLE
Document what a release tag publishes, and the npm scope bootstrap it still needs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,6 +294,50 @@ changes for a caller who passes nothing, and how to pin the old behaviour.
 
 Reference commits: `#206`, `#209`; reference tags: `v6.1.0`, `v6.2.0`.
 
+### What the tag actually publishes
+
+Pushing `vX.Y.Z` fires `publish.yml`, which derives the version from the tag and publishes
+**four NuGet packages** (`Docxodus`, `Redline`, `Docx2Html`, `Docx2OC`), **two npm packages**
+(`docxodus`, then `@docxodus/export`), and twelve self-contained CLI binaries (three tools ×
+four RIDs) as workflow artifacts. Release assets stay empty — the binaries are artifacts, not
+attachments, and have
+been for every release; an empty asset list is not a failed run.
+
+**`docx-scalpel` does not ship from a `vX.Y.Z` tag.** PyPI is driven by
+`python-publish.yml` on a separate `docx-scalpel-v<PEP440>` tag. That decoupling is
+deliberate (see the header comment in that workflow): a Python-only point release should not
+drag core/npm/binaries along, and a core release should not force a PyPI bump. Cut a
+`docx-scalpel-v*` tag when the wheel needs to move — not as part of every release.
+
+**The run can partially succeed, and the order matters.** Each registry is published by a
+different job. NuGet goes first and independently; `docxodus` and `@docxodus/export` publish
+in that order in one job, because the companion peer-depends on the exact matching
+`docxodus` version, so it *cannot* go first. A failure in the companion step therefore
+leaves NuGet and `docxodus` published while `@docxodus/export` is not. Re-run with
+`gh workflow run publish.yml --ref main -f version=X.Y.Z` after fixing: NuGet pushes use
+`--skip-duplicate`, and an already-published npm version fails loudly rather than silently
+overwriting.
+
+**One-time bootstrap for `@docxodus/export`.** The companion publishes through npm OIDC
+trusted publishing, which is configured *per package* and therefore cannot be configured for
+a package that does not exist yet. Its first-ever publish fails with
+`404 Not Found - PUT https://registry.npmjs.org/@docxodus%2fexport`, which reads like a
+permissions bug and is not one. Bootstrap it once by hand — create the `@docxodus` scope,
+publish one version with a token, then configure trusted publishing on the package — after
+which CI owns it. Until that is done, expect every release to publish everything except the
+companion.
+
+### Post-release: re-pin the demos
+
+`docs/demo/` loads the library from jsDelivr, so its `docxodus@X.Y.Z` pins can only move
+*after* npm publishes and the CDN serves the new bundle. Confirm with a real fetch
+(`curl -I https://cdn.jsdelivr.net/npm/docxodus@X.Y.Z/dist/embed.bundle.js`), then update the
+demo pages, `docs/demo/README.md`, `docs/npm-package.md`, `npm/README.md`,
+`npm/examples/embed.html`, and the `RELEASE_ENGINE` constant in
+`npm/tests/social-demo.spec.ts` — that spec is the guard that proves the demos load the pin
+rather than a 404, so run it. One reference in `docs/demo/README.md` is prose recounting a
+past pin-ahead-of-release; leave it alone.
+
 ## Dependencies
 
 - **DocumentFormat.OpenXml** 3.5.1


### PR DESCRIPTION
The v10.0.0 release took four publish runs. Two of the failures were real bugs, fixed
separately (#609 addresses why they went uncaught). This PR covers the rest of the
friction, which was not a bug at all: nothing wrote down how the release pipeline
actually behaves, so every surprise had to be diagnosed from scratch under time pressure.

Documentation only — no behaviour change.

## What it adds to the Release Process section

**What a `vX.Y.Z` tag actually publishes.** Four NuGet packages (`Docxodus`, `Redline`,
`Docx2Html`, `Docx2OC`), two npm packages, and twelve self-contained CLI binaries (three
tools × four RIDs) as *workflow artifacts*. Also that release assets are empty on every
release by design — the binaries are artifacts, not attachments. I checked v9.9.0, v9.8.0
and v9.7.0: all zero. Worth stating, because an empty asset list on a fresh release looks
exactly like something failed.

**`docx-scalpel` deliberately does not ship from a `vX.Y.Z` tag.** PyPI is driven by
`python-publish.yml` on a separate `docx-scalpel-v<PEP440>` tag. The workflow header
explains the reasoning — a Python-only point release shouldn't drag core/npm/binaries
along, and a core release shouldn't force a PyPI bump. I initially read this as a gap in
the pipeline and was wrong; it is a deliberate decision that deserves to be visible from
the release instructions rather than only from the workflow it governs.

**The run can partially succeed, and the ordering is not negotiable.** Each registry is a
different job. `@docxodus/export` peer-depends on the exact matching `docxodus` version, so
it *cannot* publish first — which means a failure in the companion step leaves NuGet and
`docxodus` published while the companion is not. That is what v10.0.0 ended up in. Adds the
re-run command and why it is safe to repeat (NuGet pushes use `--skip-duplicate`; an
already-published npm version fails loudly rather than silently overwriting).

**The one-time bootstrap `@docxodus/export` still needs.** npm OIDC trusted publishing is
configured *per package*, so it cannot be configured for a package that does not exist yet.
The first-ever publish therefore fails with:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@docxodus%2fexport
```

which reads like a permissions bug and is not one. **This is still outstanding.** Until
someone creates the `@docxodus` scope and publishes one version by hand, every release will
ship everything except the companion. No CI change can fix it, which is why this is
documentation rather than code.

**The post-release demo re-pin.** `docs/demo/` loads from jsDelivr, so its pins can only
move after the CDN actually serves the new bundle. Records the verification fetch, the full
list of files carrying a pin, and the one reference in `docs/demo/README.md` to leave alone
because it is prose about a past pin-ahead-of-release rather than a live one.

## A correction

I had twice reported "nine CLI binaries" while walking through this release. It is twelve —
I had eyeballed a truncated job list. Counted properly from the matrix and from the run:
three tools × four RIDs. The doc says twelve.
