### PR TITLE
Make the demo surfaces work on phones: ribbon fades, golf bottom sheet, arcade game-first card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ All notable changes to this project will be documented in this file.
   Reset/Show me/Next) raises as a bottom sheet over the document, with a grab handle and
   a scrim. Clearing a hole raises the sheet so the banner and the unlocked Next hole are
   never celebrated off-screen. Demo-content change (`docs/demo/`), not npm surface.
+- **The arcade presents the game, not the paper, on a phone** — Freedoom E1M1 included.
+  On the landing page and the cabinet the letter page's white side margins are cropped at
+  phone widths (the fit-to-width zoom measures the surface element, so widening it by the
+  margins' share lands the 6.5in game bezel edge-to-edge — presentation only, the document
+  and its Save keep their margins), which makes every cartridge's screen ~30% larger and
+  the raycasters' HUD readable. The landing page's arcade card also hugs the game screen
+  after boot instead of stretching 80dvh of blank paper, so the thumb D-pad and FIRE land
+  directly under the action. Demo-content change (`docs/demo/`), not npm surface.
 
 ## [10.0.0] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **The ribbon's strips signal their overflow instead of hard-clipping.** On a narrow
+  surface the compact chrome keeps every command by scrolling its strips (title bar, tab
+  strip, ribbon panels, anchor rail) — but the clipped edge read as a squashed, broken
+  layout on a phone. Each strip now dissolves its content at whichever edge hides more
+  controls (a scroll-position-driven fade mask, the horizontal twin of the document
+  scroller's gradient veils), and the fade lifts as soon as the strip fits.
+- **DOCX Golf is playable on a phone.** The caddie no longer collapses into a hidden
+  sidebar strip: in compact mode it docks as a fixed bottom scorecard bar — live
+  strokes/par/diffs plus a one-line hole brief, so the objective is readable without
+  opening anything — and the full caddie (holes, how-to, score, target/redline views,
+  Reset/Show me/Next) raises as a bottom sheet over the document, with a grab handle and
+  a scrim. Clearing a hole raises the sheet so the banner and the unlocked Next hole are
+  never celebrated off-screen. Demo-content change (`docs/demo/`), not npm surface.
+
 ## [10.0.0] - 2026-08-27
 
 ### Removed

--- a/docs/architecture/editor_ui_surface.md
+++ b/docs/architecture/editor_ui_surface.md
@@ -470,6 +470,12 @@ page rather than a narrower one whose lines break where Word's never would.
 **No command is removed in compact** — the strip scrolls instead. That is the one rule the previous
 hand-rolled mini toolbar broke, and the reason the compact player kept falling behind the editor.
 
+A strip that scrolls must also *say so*: every scrolling strip (title bar, tab strip, panels, rail)
+stamps `data-fade` with the edges that hide more content, and the stylesheet dissolves content at
+exactly those edges — the horizontal twin of the document scroller's gradient veils. Without it the
+clipped edge reads as a squashed layout, which is precisely how it was reported from phones. The
+fade lifts the moment a strip fits, so nothing is faded unless there is more behind it.
+
 `chrome: "compact"` or `"full"` pins the density (what `player.html` does, since a host site may
 size its iframe wide enough to trip the roomy layout); `"auto"` is the default.
 

--- a/docs/demo/arcade.html
+++ b/docs/demo/arcade.html
@@ -52,6 +52,19 @@
     body:has(.dxr[data-state="loading"]) #home,
     body:has(.dxr[data-state="error"]) #home { display: none; }
 
+    /* Phone: crop the letter page's white side margins so the game screen
+       runs edge-to-edge. The editor's fit-to-width zoom measures the surface
+       element, so widening it by the margins' share of the page (2 × 1in of
+       the 8.5in blank doc the arcade seeds ≈ 15.4% per side) lands the 6.5in
+       text column — the game bezel — exactly on the screen width, with the
+       white margins hanging clipped off both edges. Presentation only: the
+       document keeps its margins, and Save ships them untouched. */
+    @media (max-width: 640px) {
+      #app .dxr-scroll { overflow-x: hidden; }
+      #app .dxr-surface { margin-left: -15.4%; margin-right: -15.4%;
+        padding-left: 0; padding-right: 0; }
+    }
+
     /* The dock, the "⋯" sheet and the thumb pad are styled by arcade-dock.js
        (`.dxa-*`), which owns both its layouts. Nothing about them is page-local
        any more — the landing page mounts the identical controls. */

--- a/docs/demo/docx-golf.js
+++ b/docs/demo/docx-golf.js
@@ -456,25 +456,73 @@ const PANEL_CSS = `
   font: 13px/1.5 system-ui, sans-serif; color: #1c2733; background: #f4f7f5;
   border-left: 1px solid #d7dfd9; }
 .dxg * { box-sizing: border-box; }
-.dxg-head { padding: 12px 14px 10px; border-bottom: 1px solid #d7dfd9; }
-.dxg-headrow { display: flex; align-items: center; gap: 10px; }
-.dxg-brand { font: 700 15px/1 "SF Mono", Consolas, monospace; letter-spacing: .08em; color: #14532d; }
+.dxg-head { flex: none; padding: 12px 14px 10px; border-bottom: 1px solid #d7dfd9; }
+.dxg-headrow { display: flex; align-items: center; gap: 10px; min-width: 0; }
+.dxg-brand { font: 700 15px/1 "SF Mono", Consolas, monospace; letter-spacing: .08em;
+  color: #14532d; white-space: nowrap; }
 .dxg-mini { display: none; font: 600 11.5px/1 "SF Mono", Consolas, monospace; color: #45524b;
-  margin-left: auto; white-space: nowrap; }
-.dxg-toggle { display: none; font: 600 11.5px/1 system-ui, sans-serif; padding: 6px 10px;
-  border: 1px solid #c3cfc6; border-radius: 8px; background: #fff; color: #33413a; cursor: pointer; }
-.dxg-toggle[aria-expanded="true"] { background: #14532d; border-color: #14532d; color: #fff; }
-/* Compact (phone) mode: the panel collapses to its head — brand, mini score,
-   toggle, hole nav — and the body/foot appear only while the toggle is open,
-   so the document keeps the screen. Driver sets data-compact from a media
-   query and data-open from the toggle. */
+  margin-left: auto; white-space: nowrap; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+.dxg-toggle { display: none; font: 600 11.5px/1 system-ui, sans-serif; padding: 7px 12px;
+  border: 1px solid #14532d; border-radius: 8px; background: #14532d; color: #fff;
+  cursor: pointer; white-space: nowrap; }
+.dxg-toggle[aria-expanded="true"] { background: #fff; color: #14532d; }
+/* The sheet is an invisible wrapper on a desk (holes, body, foot flow as one
+   column) and becomes the phone bottom sheet in compact mode below. */
+.dxg-sheet { display: flex; flex-direction: column; flex: 1; min-height: 0; }
+.dxg-minibrief, .dxg-grab, .dxg-scrim { display: none; }
+.dxg-holesrow { display: flex; align-items: baseline; gap: 8px; flex: none;
+  padding: 10px 14px; border-bottom: 1px solid #d7dfd9; }
+
+/* ── Compact (phone) mode ─────────────────────────────────────────────────────
+   The caddie docks as a fixed scorecard bar along the bottom edge — brand,
+   live mini score, a one-line hole brief, and the Caddie button — so the
+   document keeps the whole screen and the objective stays readable without
+   opening anything. The toggle raises the full panel as a bottom sheet OVER
+   the document (grab handle, rounded top, scrim behind), the pattern a thumb
+   already knows, instead of squeezing the editor into a sliver. Driver sets
+   data-compact from a media query and data-open from the toggle/scrim/grab;
+   it also opens the sheet itself when a hole clears, so the banner and the
+   unlocked Next hole are never celebrated off-screen. */
+.dxg[data-compact="true"] { position: fixed; left: 0; right: 0; bottom: 0; top: auto;
+  z-index: 60; height: auto;
+  max-height: calc(100vh - 16px); max-height: calc(100dvh - 16px);
+  background: transparent; border-left: 0; }
 .dxg[data-compact="true"] .dxg-mini { display: inline; }
 .dxg[data-compact="true"] .dxg-toggle { display: inline-block; }
-.dxg[data-compact="true"]:not([data-open="true"]) .dxg-body,
-.dxg[data-compact="true"]:not([data-open="true"]) .dxg-foot { display: none; }
-.dxg[data-compact="true"] .dxg-view { max-height: 30vh; }
-.dxg[data-compact="true"] .dxg-view iframe { height: 28vh; }
-.dxg-holesrow { display: flex; align-items: baseline; gap: 8px; margin-top: 10px; }
+.dxg[data-compact="true"] .dxg-brand { font-size: 13px; }
+.dxg[data-compact="true"] .dxg-head { order: 2; position: relative; z-index: 1;
+  padding: 9px 12px calc(9px + env(safe-area-inset-bottom));
+  background: rgba(244, 247, 245, .96);
+  -webkit-backdrop-filter: blur(8px); backdrop-filter: blur(8px);
+  border-top: 1px solid #d7dfd9; border-bottom: 0;
+  box-shadow: 0 -6px 18px rgba(16, 42, 26, .08); }
+.dxg[data-compact="true"]:not([data-open="true"]) .dxg-minibrief { display: block;
+  width: 100%; margin: 7px 0 0; padding: 0; border: 0; background: none;
+  cursor: pointer; text-align: left; font: 12px/1.4 system-ui, sans-serif;
+  color: #45524b; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dxg-minibrief b { color: #14532d; font-weight: 700; }
+.dxg[data-compact="true"] .dxg-sheet { display: none; order: 1; position: relative;
+  z-index: 1; min-height: 0; margin-bottom: -1px; max-height: 76vh; max-height: 76dvh;
+  background: #f4f7f5; border: 1px solid #d7dfd9; border-bottom: 0;
+  border-radius: 16px 16px 0 0; overflow: hidden;
+  box-shadow: 0 -18px 44px rgba(16, 42, 26, .2); }
+.dxg[data-compact="true"][data-open="true"] .dxg-sheet { display: flex;
+  animation: dxg-rise .28s cubic-bezier(.32, .72, .28, 1); }
+.dxg[data-compact="true"][data-open="true"] .dxg-scrim { display: block;
+  position: fixed; inset: 0; z-index: 0; background: rgba(16, 42, 26, .35);
+  -webkit-tap-highlight-color: transparent; }
+.dxg[data-compact="true"] .dxg-grab { display: grid; place-items: center; flex: none;
+  width: 100%; height: 24px; margin: 4px 0 0; padding: 0; border: 0;
+  background: none; cursor: pointer; }
+.dxg-grab i { display: block; width: 44px; height: 5px; border-radius: 999px;
+  background: #c3cfc6; }
+.dxg[data-compact="true"] .dxg-holesrow { padding: 4px 14px 10px; }
+.dxg[data-compact="true"] .dxg-view { max-height: 38vh; max-height: 38dvh; }
+.dxg[data-compact="true"] .dxg-view iframe { height: 36vh; height: 36dvh; }
+@keyframes dxg-rise { from { transform: translateY(26px); opacity: .4; }
+  to { transform: translateY(0); opacity: 1; } }
+@media (prefers-reduced-motion: reduce) {
+  .dxg[data-compact="true"][data-open="true"] .dxg-sheet { animation: none; } }
 .dxg-holeslabel { font: 600 10.5px/1 "SF Mono", Consolas, monospace; letter-spacing: .07em;
   text-transform: uppercase; color: #6b7a71; }
 .dxg-holes { display: flex; gap: 5px; flex-wrap: wrap; }
@@ -540,17 +588,23 @@ export function mountGolfPanel(root) {
 
   root.classList.add('dxg');
   root.innerHTML = `
+    <div class="dxg-scrim" data-dxg="scrim" aria-hidden="true"></div>
     <div class="dxg-head">
       <div class="dxg-headrow">
         <div class="dxg-brand">⛳ DOCX GOLF</div>
-        <span class="dxg-mini" data-dxg="mini"></span>
+        <span class="dxg-mini" data-dxg="mini" title="Strokes / par · diffs left"></span>
         <button class="dxg-toggle" data-dxg="toggle" aria-expanded="false"
           title="Show the caddie">☰ Caddie</button>
       </div>
-      <div class="dxg-holesrow">
-        <span class="dxg-holeslabel">Holes</span>
-        <div class="dxg-holes" data-dxg="holes" role="group" aria-label="Pick a hole"></div>
-      </div>
+      <button class="dxg-minibrief" data-dxg="minibrief"
+        title="Open the caddie"></button>
+    </div>
+    <div class="dxg-sheet" data-dxg="sheet">
+    <button class="dxg-grab" data-dxg="grab" aria-label="Close the caddie"
+      title="Close the caddie"><i></i></button>
+    <div class="dxg-holesrow">
+      <span class="dxg-holeslabel">Holes</span>
+      <div class="dxg-holes" data-dxg="holes" role="group" aria-label="Pick a hole"></div>
     </div>
     <div class="dxg-body">
       <div class="dxg-banner" data-dxg="banner"></div>
@@ -594,6 +648,7 @@ export function mountGolfPanel(root) {
       <button data-dxg="reset" title="Re-tee this hole: the document and your strokes go back to the start">↻ Reset</button>
       <button data-dxg="showme" title="Concede: the caddie makes the edits for you — the hole clears but is not scored">🏳 Show me</button>
       <button class="dxg-next" data-dxg="next" disabled title="Clear the hole to unlock">Next hole ▶</button>
+    </div>
     </div>`;
 
   const grab = (name) => root.querySelector(`[data-dxg="${name}"]`);
@@ -607,7 +662,8 @@ export function mountGolfPanel(root) {
       view: grab('view'), hints: grab('hints'),
       reset: grab('reset'), next: grab('next'),
       showme: grab('showme'), toggle: grab('toggle'), mini: grab('mini'),
-      howto: grab('howto'),
+      howto: grab('howto'), sheet: grab('sheet'), scrim: grab('scrim'),
+      grabber: grab('grab'), minibrief: grab('minibrief'),
     },
   };
 }
@@ -670,6 +726,12 @@ export function startGolf({ editor, session, engine, ui, course = COURSE }) {
     ui.parchip.textContent = `par ${hole.par}`;
     ui.surface.textContent = hole.surface ?? 'document';
     ui.brief.textContent = hole.brief;
+    // The bar's one-line brief: on a phone the objective must be readable
+    // without opening the sheet, or the course reads as a bare document.
+    ui.minibrief.replaceChildren();
+    const miniTitle = document.createElement('b');
+    miniTitle.textContent = `Hole ${holeIndex + 1} · ${hole.title}`;
+    ui.minibrief.append(miniTitle, ` — ${hole.brief}`);
     ui.par.textContent = String(hole.par);
     ui.strokes.textContent = String(counter.strokes());
     ui.score.dataset.cleared = String(cleared);
@@ -690,8 +752,9 @@ export function startGolf({ editor, session, engine, ui, course = COURSE }) {
     revisionsLeft = revisions.length;
     ui.diffs.textContent = String(revisionsLeft);
     ui.strokes.textContent = String(counter.strokes());
+    // Scorecard notation, same as the clear banner: strokes/par, then work left.
     ui.mini.textContent =
-      `${counter.strokes()} strokes · par ${course[holeIndex]?.par ?? '–'} · ${revisionsLeft} left`;
+      `${counter.strokes()}/${course[holeIndex]?.par ?? '–'} · ${revisionsLeft} left`;
     ui.hints.innerHTML = '';
     if (revisionsLeft === 0) {
       const li = document.createElement('li');
@@ -849,6 +912,9 @@ export function startGolf({ editor, session, engine, ui, course = COURSE }) {
         : `Running total ${totalText}${assistedNote} · next hole when you are ready.`,
     );
     paintChrome();
+    // On a phone the banner and the unlocked Next hole live in the sheet —
+    // raise it so the clear is never celebrated off-screen.
+    if (isCompact()) setOpen(true);
   }
 
   // ── hole lifecycle ───────────────────────────────────────────────
@@ -924,22 +990,34 @@ export function startGolf({ editor, session, engine, ui, course = COURSE }) {
     }
   });
 
-  // Compact (phone) mode: collapse the panel to its head behind a toggle.
+  // Compact (phone) mode: the caddie docks as a bottom scorecard bar and the
+  // toggle raises it as a bottom sheet over the document. The scrim, the grab
+  // handle, Escape, and the toggle itself all lower it again.
   const compactQuery = typeof window.matchMedia === 'function'
     ? window.matchMedia('(max-width: 640px)')
     : null;
+  const isCompact = () => ui.panel.dataset.compact === 'true';
+  const setOpen = (open) => {
+    ui.panel.dataset.open = String(open);
+    ui.toggle.setAttribute('aria-expanded', String(open));
+    ui.toggle.textContent = open ? '✕ Close' : '☰ Caddie';
+    ui.toggle.title = open ? 'Close the caddie' : 'Show the caddie';
+  };
   const applyCompact = () => {
     const compact = Boolean(compactQuery?.matches);
     ui.panel.dataset.compact = String(compact);
-    if (!compact) delete ui.panel.dataset.open;
+    setOpen(false); // a density flip never strands an open sheet
   };
   compactQuery?.addEventListener('change', applyCompact);
   applyCompact();
-  ui.toggle.addEventListener('click', () => {
-    const open = ui.panel.dataset.open === 'true';
-    ui.panel.dataset.open = String(!open);
-    ui.toggle.setAttribute('aria-expanded', String(!open));
-  });
+  ui.toggle.addEventListener('click', () => setOpen(ui.panel.dataset.open !== 'true'));
+  ui.minibrief.addEventListener('click', () => setOpen(true));
+  ui.scrim.addEventListener('click', () => setOpen(false));
+  ui.grabber.addEventListener('click', () => setOpen(false));
+  const onKeydown = (event) => {
+    if (event.key === 'Escape' && isCompact() && ui.panel.dataset.open === 'true') setOpen(false);
+  };
+  document.addEventListener('keydown', onKeydown);
 
   const controller = {
     course,
@@ -970,6 +1048,7 @@ export function startGolf({ editor, session, engine, ui, course = COURSE }) {
     dispose: () => {
       clearInterval(pollTimer);
       clearTimeout(scoreTimer);
+      document.removeEventListener('keydown', onKeydown);
     },
   };
 

--- a/docs/demo/golf.html
+++ b/docs/demo/golf.html
@@ -25,7 +25,9 @@
     html, body { height: 100%; }
     body { margin: 0; background: #e8ecf2; }
     html, body * { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
-    #layout { display: flex; height: 100%; min-height: 0; }
+    /* dvh tracks the browser chrome's dynamic collapse on phones; 100% is the
+       fallback for engines without it. */
+    #layout { display: flex; height: 100%; height: 100dvh; min-height: 0; }
     #app { flex: 1; min-width: 0; height: 100%; }
     #caddie { width: 340px; flex: none; height: 100%; }
     @media (max-width: 900px) {
@@ -33,11 +35,16 @@
       #app { height: 58%; }
       #caddie { width: auto; height: 42%; border-left: 0; border-top: 1px solid #d7dfd9; }
     }
-    /* Phone: the caddie collapses to its head strip (the panel's compact mode);
-       the document keeps the screen, and the expanded sheet is capped. */
+    /* Phone: the caddie (docx-golf.js) docks itself as a fixed scorecard bar
+       with a bottom sheet, so the document takes the whole column and only
+       reserves the bar's height at the bottom. */
     @media (max-width: 640px) {
-      #app { flex: 1; height: auto; min-height: 0; }
-      #caddie { height: auto; max-height: 62%; overflow: auto; }
+      #app { flex: 1; height: auto; min-height: 0;
+        padding-bottom: calc(84px + env(safe-area-inset-bottom)); }
+      #caddie { width: auto; height: auto; max-height: none; overflow: visible; border-top: 0; }
+      /* The ribbon's compact table picker docks to the viewport bottom, which
+         the caddie bar now owns — lift it above the bar. */
+      #app .dxr-pop[data-open] { bottom: calc(96px + env(safe-area-inset-bottom)); }
     }
     #home {
       position: fixed; top: 10px; right: 356px; z-index: 50;

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -265,9 +265,25 @@
       /* The arcade also spends its bottom ~190px on the thumb controls, so it
          gets the taller frame — a letterboxed 92 × 26 game screen is unplayable.
          Sized in dvh where that exists: vh on a phone is the tall viewport with
-         the browser chrome hidden, which would push the controls under it. */
+         the browser chrome hidden, which would push the controls under it.
+         (After boot the script below shrinks this to hug the game screen, so
+         the thumb controls land under the action instead of over blank paper.) */
       [data-demo="arcade"] #workspace { height: min(86vh, 720px); }
       [data-demo="arcade"] #workspace { height: min(80dvh, 720px); }
+      /* Crop the letter page's white side margins so the game screen runs
+         edge-to-edge on a phone. The editor's fit-to-width zoom measures the
+         surface element, so widening it by the margins' share of the page
+         (2 × 1in of 8.5in ≈ 15.4% per side, the blank doc the arcade seeds)
+         lands the 6.5in text column — the game bezel — exactly on the card's
+         visible width, with the margins hanging clipped off both edges. The
+         document itself is untouched; this is presentation, like a word
+         processor hiding whitespace. Arcade only: in the editor demo the
+         margins are part of the document being edited. */
+      [data-demo="arcade"] #workspace .dxr-scroll { overflow-x: hidden; }
+      [data-demo="arcade"] #workspace .dxr-surface {
+        margin-left: -15.4%; margin-right: -15.4%;
+        padding-left: 0; padding-right: 0;
+      }
     }
     @media (prefers-reduced-motion: reduce) {
       *, *::before, *::after { scroll-behavior: auto !important; animation-duration: .01ms !important;
@@ -511,6 +527,35 @@
           ui: dock.ui,
         });
         dock.show();
+
+        // On a phone the CSS default keeps the card 80dvh tall — mostly blank
+        // paper below the game, with the thumb controls floating over it far
+        // from the action. Once the arcade is live the card hugs the game
+        // instead: the canvas paragraph's bottom edge plus room for the pad
+        // and dock, so the thumbs land directly under the screen they steer.
+        // Re-measured on resize (rotation, browser-chrome collapse).
+        const workspace = $("workspace");
+        const hugCard = () => {
+          if (!window.matchMedia("(max-width: 620px)").matches) {
+            workspace.style.removeProperty("height");
+            return;
+          }
+          const canvas = controller.canvasElement();
+          if (!canvas) return;
+          const bottom = canvas.getBoundingClientRect().bottom
+            - workspace.getBoundingClientRect().top;
+          // 240px ≈ the caption's first lines + the pad cluster + the dock.
+          const hugged = Math.ceil(bottom + 240);
+          workspace.style.height =
+            `${Math.max(430, Math.min(hugged, Math.round(innerHeight * 0.8)))}px`;
+        };
+        requestAnimationFrame(hugCard);
+        let hugTimer = 0;
+        addEventListener("resize", () => {
+          clearTimeout(hugTimer);
+          hugTimer = setTimeout(hugCard, 160);
+        });
+
         window.__arcade = { ...controller, editor, ribbon, session, bridge, dock };
         window.__ribbon = ribbon;
         setStatus(`Live — the arcade booted in ${Math.round(performance.now() - started)} ms.`, "ready");

--- a/npm/src/ribbon-chrome.ts
+++ b/npm/src/ribbon-chrome.ts
@@ -23,7 +23,7 @@
  */
 
 /** Bumped whenever RIBBON_CSS changes, so a stale injected stylesheet is replaced. */
-export const RIBBON_STYLE_VERSION = "8";
+export const RIBBON_STYLE_VERSION = "9";
 export const RIBBON_STYLE_ATTR = "data-docxodus-ribbon-styles";
 
 /**
@@ -93,6 +93,27 @@ export const RIBBON_CSS = `
 /* Touch devices get bigger hit targets everywhere the token is used. */
 @media (pointer: coarse) { .dxr { --dxr-tap: 40px; } }
 
+/* ── Scroll-edge affordances ──────────────────────────────────────────────────
+   The chrome's strips (title bar, tabs, panels, rail) scroll horizontally
+   rather than squashing or wrapping — the compact rule is "no command is
+   removed, the strip scrolls". But a hard clip mid-control reads as a broken
+   layout, especially on a phone, so ribbon.ts measures every strip and stamps
+   data-fade with the edges that hide more content ("l", "r", or both). The
+   mask dissolves content at exactly those edges — the horizontal twin of
+   .dxr-scroll's gradient veils — and lifts entirely once the strip fits, so
+   nothing is ever faded unless there is more behind it. */
+.dxr-titlebar, .dxr-tabs, .dxr-panel, .dxr-rail { --dxr-fade-l: 0px; --dxr-fade-r: 0px; }
+.dxr [data-fade] {
+  -webkit-mask-image: linear-gradient(to right,
+    transparent, #000 var(--dxr-fade-l),
+    #000 calc(100% - var(--dxr-fade-r)), transparent);
+  mask-image: linear-gradient(to right,
+    transparent, #000 var(--dxr-fade-l),
+    #000 calc(100% - var(--dxr-fade-r)), transparent);
+}
+.dxr [data-fade~="l"] { --dxr-fade-l: 28px; }
+.dxr [data-fade~="r"] { --dxr-fade-r: 28px; }
+
 /* ── Chrome shell ─────────────────────────────────────────────────────────── */
 .dxr-chrome {
   position: sticky;
@@ -103,12 +124,17 @@ export const RIBBON_CSS = `
   border-bottom: 1px solid var(--dxr-rule);
 }
 
+/* Scrolls in EVERY density (compact just tightens it): the fade affordance
+   marks any overflowing strip as scrollable, so it must actually be. */
 .dxr-titlebar {
   display: flex;
   align-items: center;
   gap: 10px;
   padding: 6px 10px 0;
+  overflow-x: auto;
+  scrollbar-width: none;
 }
+.dxr-titlebar::-webkit-scrollbar { display: none; }
 .dxr-brand {
   display: flex;
   align-items: baseline;
@@ -538,10 +564,7 @@ export const RIBBON_CSS = `
 .dxr[data-chrome="compact"] .dxr-titlebar {
   gap: 6px;
   padding: 5px 8px 0;
-  overflow-x: auto;
-  scrollbar-width: none;
 }
-.dxr[data-chrome="compact"] .dxr-titlebar::-webkit-scrollbar { display: none; }
 .dxr[data-chrome="compact"] .dxr-brandname { display: none; }
 .dxr[data-chrome="compact"] .dxr-brand { flex: 0 1 auto; }
 /* A filename clipped to "do..." tells you less than no filename at all, so it keeps a

--- a/npm/src/ribbon.ts
+++ b/npm/src/ribbon.ts
@@ -296,6 +296,8 @@ class RibbonSurface implements RibbonEditor {
   private featureTimer: ReturnType<typeof setInterval> | null = null;
   private featureIndex = 0;
   private resizeObserver: ResizeObserver | null = null;
+  private strips: HTMLElement[] = [];
+  private stripObserver: ResizeObserver | null = null;
   private lastAnchorText = "";
   private selectionFrame: number | null = null;
   private readonly onSelectionChange: () => void;
@@ -339,6 +341,7 @@ class RibbonSurface implements RibbonEditor {
     this.applyStaticOptions();
     this.buildGrid();
     this.wire();
+    this.wireScrollFades();
     this.applyChrome();
 
     this.loader = this.createLoaderController();
@@ -440,6 +443,48 @@ class RibbonSurface implements RibbonEditor {
     this.element.dataset.chrome = next;
     // The picker's absolute position is meaningless after a density flip.
     this.closePicker();
+    // A density flip relays out every strip; re-measure without waiting for
+    // the observer so the fades never lag a frame behind the new layout.
+    this.syncAllStripFades();
+  }
+
+  // ── scroll-edge affordances ─────────────────────────────────────────────────
+
+  /**
+   * The chrome's strips scroll horizontally instead of squashing ("no command
+   * is removed in compact"), so each one reports which edges hide more content
+   * via `data-fade` and the stylesheet dissolves content at exactly those
+   * edges. Without this a strip hard-clips mid-control and reads as broken.
+   */
+  private syncStripFade(strip: HTMLElement): void {
+    const max = strip.scrollWidth - strip.clientWidth;
+    const tokens =
+      max <= 1 ? "" : `${strip.scrollLeft > 1 ? "l " : ""}${strip.scrollLeft < max - 1 ? "r" : ""}`.trim();
+    if (tokens) strip.setAttribute("data-fade", tokens);
+    else strip.removeAttribute("data-fade");
+  }
+
+  private syncAllStripFades(): void {
+    for (const strip of this.strips) this.syncStripFade(strip);
+  }
+
+  private wireScrollFades(): void {
+    this.strips = Array.from(
+      this.element.querySelectorAll<HTMLElement>(".dxr-titlebar, .dxr-tabs, .dxr-panel, .dxr-rail"),
+    );
+    if (typeof ResizeObserver !== "undefined") {
+      // One observer for all strips. It also fires when a panel becomes the
+      // active one (display flips from none), which is what keeps a freshly
+      // selected tab's fades honest without per-tab wiring.
+      this.stripObserver = new ResizeObserver((entries) => {
+        for (const entry of entries) this.syncStripFade(entry.target as HTMLElement);
+      });
+    }
+    for (const strip of this.strips) {
+      strip.addEventListener("scroll", () => this.syncStripFade(strip), { passive: true });
+      this.stripObserver?.observe(strip);
+      this.syncStripFade(strip);
+    }
   }
 
   // ── status ──────────────────────────────────────────────────────────────────
@@ -547,6 +592,8 @@ class RibbonSurface implements RibbonEditor {
     doc.removeEventListener("mousedown", this.onDocumentMouseDown);
     this.resizeObserver?.disconnect();
     this.resizeObserver = null;
+    this.stripObserver?.disconnect();
+    this.stripObserver = null;
     if (this.selectionFrame != null) cancelAnimationFrame(this.selectionFrame);
     this.selectionFrame = null;
     this.stopRotation();
@@ -887,6 +934,10 @@ class RibbonSurface implements RibbonEditor {
       }
       host.appendChild(row);
     }
+    // The thread list is the one strip content that grows while its panel is
+    // already visible, which a ResizeObserver on the panel cannot see.
+    const panel = this.element.querySelector<HTMLElement>('.dxr-panel[data-panel="review"]');
+    if (panel) this.syncStripFade(panel);
   }
 
   // ── selection-driven state ──────────────────────────────────────────────────

--- a/npm/tests/demo-arcade-mobile.spec.ts
+++ b/npm/tests/demo-arcade-mobile.spec.ts
@@ -53,24 +53,58 @@ async function waitForBoot(page: Page) {
   expect(err, `arcade boot failed: ${err}`).toBeUndefined();
 }
 
-/** Distinct line-box tops inside the canvas paragraph. The frame is 26 rows
- * joined by `w:br`, so an intact render is exactly 26 line boxes; every
- * over-wide row that wraps adds one more. Fragments on the same line share
- * their top (same font size throughout the canvas), while the paragraph's
- * exact 10pt line pitch is ≥ ~5px even under the phone's fit-to-width zoom,
- * so a small fixed tolerance separates lines reliably — including when the
- * inflated glyph boxes are TALLER than the line pitch. */
+/** Visual line boxes inside the canvas paragraph. The frame is 26 rows
+ * joined by `w:br`, so an intact render is exactly 26; every over-wide row
+ * that WRAPS adds one more. Rows are read from the `<br>` structure (the
+ * same segmentation `rowWidthSpreadInCells` uses) and each row contributes
+ * 1 + how many full LINE PITCHES its own fragments' tops span: a real fold
+ * displaces fragments by a whole pitch, while sub-pitch offsets are
+ * rendering artifacts, not wraps — inflated glyph boxes overflow the exact
+ * 10pt line box by half a leading, and mixed fallback faces differ in
+ * ascent, offsets that scale with the fit zoom and so cannot be separated
+ * from real folds by any fixed pixel tolerance (the margin-cropped phone
+ * presentation zooms ~40% past where 2px was safe). The pitch is measured
+ * from the rows themselves: the median gap between consecutive row tops. */
 async function canvasLineBoxes(page: Page): Promise<number> {
   return page.evaluate(() => {
     const el = (window as any).__arcade.canvasElement() as HTMLElement;
-    const range = document.createRange();
-    range.selectNodeContents(el);
-    const rects = Array.from(range.getClientRects()).filter((r) => r.height >= 2);
-    const tops: number[] = [];
-    for (const r of rects) {
-      if (!tops.some((t) => Math.abs(t - r.top) < 2)) tops.push(r.top);
-    }
-    return tops.length;
+    const rows: Text[][] = [];
+    let current: Text[] = [];
+    const walk = (node: Node) => {
+      for (const child of Array.from(node.childNodes)) {
+        if (child.nodeName === 'BR') { rows.push(current); current = []; }
+        else if (child.nodeType === Node.TEXT_NODE) current.push(child as Text);
+        else walk(child);
+      }
+    };
+    walk(el);
+    rows.push(current);
+
+    const measured = rows
+      .map((nodes) => {
+        let first = Infinity;
+        let last = -Infinity;
+        for (const text of nodes) {
+          const range = document.createRange();
+          range.selectNodeContents(text);
+          for (const r of Array.from(range.getClientRects())) {
+            if (r.height < 2) continue;
+            first = Math.min(first, r.top);
+            last = Math.max(last, r.top);
+          }
+        }
+        return first === Infinity ? null : { top: first, spread: last - first };
+      })
+      .filter((row): row is { top: number; spread: number } => row !== null);
+
+    const gaps = measured
+      .slice(1)
+      .map((row, i) => row.top - measured[i].top)
+      .filter((gap) => gap > 0)
+      .sort((a, b) => a - b);
+    const pitch = gaps[Math.floor(gaps.length / 2)] || 1;
+
+    return measured.reduce((total, row) => total + 1 + Math.round(row.spread / pitch), 0);
   });
 }
 

--- a/npm/tests/demo-golf.spec.ts
+++ b/npm/tests/demo-golf.spec.ts
@@ -212,24 +212,44 @@ test.describe('DOCX GOLF', () => {
 test.describe('DOCX GOLF on a phone', () => {
   test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
 
-  test('the caddie collapses to a strip and expands on demand', async ({ page }) => {
+  test('the caddie docks as a scorecard bar and raises as a bottom sheet', async ({ page }) => {
     test.setTimeout(180000);
     await bootCourse(page);
 
-    // Compact: the panel body starts collapsed behind a toggle, with a mini
-    // score strip keeping strokes/par/diffs visible, and the document keeps
-    // the bulk of the screen.
+    // Compact: the caddie starts lowered — a bottom scorecard bar with the
+    // live mini score AND the hole's one-line brief, so the objective is
+    // readable without opening anything and the document keeps the screen.
     const panel = page.locator('#caddie.dxg');
     await expect(panel).toHaveAttribute('data-compact', 'true');
     await expect(page.locator('[data-dxg="brief"]')).not.toBeVisible();
     await expect(page.locator('[data-dxg="mini"]')).toBeVisible();
     await expect(page.locator('[data-dxg="mini"]')).toContainText('2'); // hole 1 tees with 2 diffs
+    await expect(page.locator('[data-dxg="minibrief"]')).toBeVisible();
+    await expect(page.locator('[data-dxg="minibrief"]')).toContainText('First tee');
 
+    // The toggle raises the full caddie as a bottom sheet over the document.
     await page.locator('[data-dxg="toggle"]').click();
     await expect(page.locator('[data-dxg="brief"]')).toBeVisible();
     await expect(page.locator('[data-dxg="hints"]')).toBeVisible();
 
+    // Tapping the scrim above the sheet lowers it again…
+    await page.locator('[data-dxg="scrim"]').click({ position: { x: 20, y: 20 } });
+    await expect(page.locator('[data-dxg="brief"]')).not.toBeVisible();
+
+    // …and the toggle keeps working both ways.
+    await page.locator('[data-dxg="toggle"]').click();
+    await expect(page.locator('[data-dxg="brief"]')).toBeVisible();
     await page.locator('[data-dxg="toggle"]').click();
     await expect(page.locator('[data-dxg="brief"]')).not.toBeVisible();
+  });
+
+  test('clearing a hole raises the sheet, so the banner and Next are seen', async ({ page }) => {
+    test.setTimeout(180000);
+    await bootCourse(page);
+
+    await page.evaluate(async () => { await (window as any).__golf.playReference(); });
+    await expect(page.locator('#caddie.dxg')).toHaveAttribute('data-open', 'true');
+    await expect(page.locator('[data-dxg="banner"]')).toBeVisible();
+    await expect(page.locator('[data-dxg="banner"]')).toContainText('HOLE CLEAR');
   });
 });

--- a/npm/tests/social-demo.spec.ts
+++ b/npm/tests/social-demo.spec.ts
@@ -418,6 +418,29 @@ test.describe('The landing page on a phone', () => {
     expect(geometry.tapTargets).toBeGreaterThanOrEqual(40);
     expect(geometry.clearOfCentre).toBe(true);
 
+    // The phone card presents the game, not the paper: the page's white side
+    // margins are cropped so the bezel spans (nearly) the whole card, and the
+    // card hugs the game screen instead of stretching 80dvh of blank paper
+    // with the controls floating far below the action.
+    const presentation = await page.evaluate(() => {
+      const frame = document.querySelector('#frame')!.getBoundingClientRect();
+      const canvas = ((window as any).__arcade.canvasElement() as HTMLElement)
+        .getBoundingClientRect();
+      const dpad = document.querySelector('.dxa-dpad')!.getBoundingClientRect();
+      return {
+        canvasShare: canvas.width / frame.width,
+        cardHeight: frame.height,
+        padGap: dpad.top - canvas.bottom,
+      };
+    });
+    expect(presentation.canvasShare,
+      'the margins are cropped — the bezel fills the card').toBeGreaterThan(0.9);
+    expect(presentation.cardHeight,
+      'the card hugs the game instead of stretching to 80dvh').toBeLessThan(720);
+    expect(presentation.padGap,
+      'the D-pad sits just under the game screen, near the action').toBeLessThan(160);
+    expect(presentation.padGap, 'and clear of the bezel itself').toBeGreaterThan(0);
+
     // Holding ▶ runs the pilcrow right, through the same input the keyboard
     // feeds — the control is wired to the simulation, not to a stub.
     const before = await page.evaluate(() => (window as any).__arcade.game().player.x as number);


### PR DESCRIPTION
Three mobile complaints from the live demo pages, with one shared root cause: overflow (or blank space) that hid itself.

## The ribbon looked squashed on phones (all demos)

The compact chrome deliberately keeps every command by letting its strips scroll sideways — but nothing *said* they scroll. On a phone the Layout panel simply cut the "Start at" field in half at the screen edge, and the tab strip cut off "Review" entirely, which reads as a broken, squashed toolbar rather than a scrollable one.

**Mechanism:** `ribbon.ts` now watches every horizontally scrolling strip (title bar, tab strip, each ribbon panel, the anchor rail) with one shared `ResizeObserver` plus a passive scroll listener, and stamps `data-fade` on the strip with the edges that currently hide more content (`l`, `r`, or both). The stylesheet applies a `mask-image` gradient that dissolves content at exactly those edges — the horizontal twin of the document scroller's existing gradient veils, so it reads as the same design language. The fade lifts the moment a strip fits its content, so nothing is faded unless there really is more behind it. The title bar also gains `overflow-x: auto` in *every* density (it previously scrolled only in compact), so the affordance never marks a strip scrollable that isn't. `RIBBON_STYLE_VERSION` bumped so hosts replace the injected stylesheet.

## DOCX Golf was unplayable on phones

The caddie collapsed to a head strip that hid the hole brief, the score detail, the target/redline views and every button — so the game read as a bare document with a mystery bar at the bottom.

**Mechanism** (all demo content in `docs/demo/`, no npm surface change): in compact mode the caddie now docks as a fixed scorecard bar along the bottom edge — the brand, the live score in golf notation (`strokes/par · N left`), a one-line hole brief, and a prominent Caddie button — so the objective is readable without opening anything and the document keeps the whole screen. The toggle (or tapping the brief) raises the full caddie as a bottom sheet **over** the document: grab handle, rounded top, dimming scrim, holes row, how-to, score tiles, view tabs, and the Reset / Show me / Next buttons pinned at the sheet foot. The scrim, the grab handle, Escape, and the toggle all lower it. Clearing a hole raises the sheet automatically so the HOLE CLEAR banner and the unlocked Next button are never celebrated off-screen. `golf.html` sizes the layout in `dvh` (with a `%` fallback), reserves only the bar's height under the document, and lifts the ribbon's bottom-docked table picker above the bar. Every existing `data-dxg` hook is kept; the phone Playwright spec is extended to pin the new contract.

## The arcade (Freedoom E1M1 included) was a postage stamp on the phone landing page

On the index page's phone arcade, the 92-column game screen shrank to fit the whole 8.5in page — a quarter of the phone's width went to white page margins and the Doom HUD was unreadable — while the card stretched to 80dvh of blank paper with the thumb controls floating far below the action.

**Mechanism** (page-level presentation in `docs/demo/index.html` + `arcade.html`; the document and its Save keep their margins):
- **Margin crop.** The editor's fit-to-width zoom measures the surface element, so at phone widths the page widens the surface by the margins' share of the page (2 × 1in of the 8.5in blank doc the arcade seeds ≈ 15.4% per side) and hides the horizontal overflow. The 6.5in game bezel then lands exactly edge-to-edge: every cartridge's screen grows ~30% and the raycasters' HUD line becomes readable.
- **A card that hugs the game.** After boot the landing page sizes the card to the canvas paragraph's bottom edge plus room for the caption's key lines, the D-pad/FIRE cluster and the dock (re-measured on resize), so the thumbs land directly under the screen they steer instead of over blank paper.

The phone landing spec (`social-demo.spec.ts`) now pins this: the bezel spans >90% of the card, the card stays under 720px, and the D-pad sits just below the game screen.

## A follow-up the crop surfaced: the Pixel 5 grid guard was zoom-fragile

The first CI run failed five `demo-arcade-mobile.spec.ts` tests: `canvasLineBoxes` counted distinct client-rect tops with a fixed 2px tolerance, calibrated for the old full-page fit zoom. The crop raises the zoom ~40%, which pushed always-present sub-pitch offsets (inflated glyph boxes overflowing the exact 10pt line box, and the `<br>` elements' own rects) past 2px — every intact row double-counted (51 vs 26) while the grid was provably intact (`white-space: pre` held; the same tests' row-width-spread assertions passed). The helper now reads rows from the `<br>` structure (the same segmentation `rowWidthSpreadInCells` uses, which also drops the `<br>` rects from the measurement) and counts a fold only when a row's own fragments are displaced by a full line pitch, measured as the median gap between consecutive row tops. A real fold moves fragments exactly one pitch at any zoom.

## Validation

- `npm run typecheck` (src + tests) and the headless golf logic tests pass; the full CI suite is green on the current head, including the previously failing Pixel 5 project.
- The arcade changes were validated **against the real published engine**: the landing page was booted in a phone-sized Chromium (390×844) with docxodus pulled from the npm registry and served locally, on both the quest and Freedoom E1M1 cartridges, before and after — the after screenshots show a readable HUD, an edge-to-edge bezel, and the controls docked under the game.
- The grid-guard rewrite was validated the same way, Pixel 5-shaped: the failing case (margin-cropped cabinet + 175% text inflation) measures 26; injecting genuine wrapping (`white-space: pre-wrap` on the canvas) measures 52 — the historical garble number — so the guard still fires; all three cartridges measure 26 under the Android font-coverage emulation; the un-cropped baseline page still measures 26.
- The ribbon fades and the caddie bar/sheet were verified visually via a static harness mounting the real chrome at 390×844 and at desktop width. Desktop layouts are unchanged.

Note: `main`'s re-pin of the demos to `docxodus@10.0.0` is merged in. The golf and arcade halves are `docs/` content and deploy with Pages immediately; the ribbon-fade half reaches the live pages at the next release + pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBfWH5cv8qLwBc59zV1hXV