### PR TITLE
Default the DOCX Arcade to Freedoom's E1M1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ All notable changes to this project will be documented in this file.
   the raycasters' HUD readable. The landing page's arcade card also hugs the game screen
   after boot instead of stretching 80dvh of blank paper, so the thumb D-pad and FIRE land
   directly under the action. Demo-content change (`docs/demo/`), not npm surface.
+- **The arcade now opens on Freedoom's E1M1 by default**, on both the landing page and the
+  full-screen cabinet — a visitor's first coin drop is the real Doom-format level rather
+  than the platformer. `?cart=quest|dungeon` still pick the other two cartridges explicitly.
+  Demo-content change (`docs/demo/`), not npm surface.
 
 ## [10.0.0] - 2026-08-27
 

--- a/docs/demo/arcade.html
+++ b/docs/demo/arcade.html
@@ -150,7 +150,7 @@
         const controller = startArcade({
           editor,
           session,
-          cart: params.get("cart") ?? "quest",
+          cart: params.get("cart") ?? "e1m1",
           // ?intro=0 skips the attract screen (specs use it; humans get the
           // full "OS LEGAL presents DOCXODUS" title card).
           intro: params.get("intro") !== "0",

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -522,7 +522,7 @@
         const controller = startArcade({
           editor,
           session,
-          cart: params.get("cart") ?? "quest",
+          cart: params.get("cart") ?? "e1m1",
           intro: params.get("intro") !== "0",
           ui: dock.ui,
         });

--- a/npm/tests/demo-arcade.spec.ts
+++ b/npm/tests/demo-arcade.spec.ts
@@ -181,7 +181,10 @@ test.describe('THE DOCX ARCADE page', () => {
   }
 
   test('boots the shipped surface, animates incrementally, and steers with the keyboard', async ({ page }) => {
-    await page.goto(`/demo-arcade.html?${OVERRIDE}`);
+    // Pinned to the platformer: this test exercises PILCROW's-quest-specific
+    // mechanics (the ArrowRight side-scroll), not whichever cart ships as the
+    // page's default.
+    await page.goto(`/demo-arcade.html?${OVERRIDE}&cart=quest`);
     await waitForBoot(page);
 
     await page.waitForFunction(() => (window as any).__arcade.frames() >= 4, { timeout: 30000 });
@@ -225,7 +228,9 @@ test.describe('THE DOCX ARCADE page', () => {
   });
 
   test('pause → type terrain into the document → resume makes it real; save yields a real DOCX', async ({ page }) => {
-    await page.goto(`/demo-arcade.html?${OVERRIDE}`);
+    // Pinned to the platformer: the row-6-is-open-sky / § coin-tile assertions
+    // below are quest-specific, not a property of whichever cart is default.
+    await page.goto(`/demo-arcade.html?${OVERRIDE}&cart=quest`);
     await waitForBoot(page);
     await page.waitForFunction(() => (window as any).__arcade.frames() >= 2, { timeout: 30000 });
 


### PR DESCRIPTION
## Summary

Both places the arcade boots — `docs/demo/arcade.html` (the full-screen cabinet) and `docs/demo/index.html` (the phone-frame mount on the landing page) — picked the cartridge to open with via `params.get("cart") ?? "quest"`, i.e. the platformer whenever a visitor didn't pass `?cart=`. This changes that fallback to `"e1m1"`, Freedoom's E1M1 — the real Doom-format level rasterized from the WAD — so that's what a first-time visitor's coin drop lands on. `?cart=quest` and `?cart=dungeon` still select the other two cartridges explicitly, and nothing about cartridge selection, the dock's button highlighting, or the level itself changed — only which one loads with no query string.

Also updated `CHANGELOG.md` under `[Unreleased]` to record the change as demo content, not an npm/library surface change.

## Why the test change

`npm/tests/demo-arcade.spec.ts` had two specs that navigated to the arcade page with no `?cart=` at all, relying on the old implicit default to land on the platformer — one exercises the platformer's ArrowRight side-scroll physics, the other types terrain into a level row and expects the platformer's `§` coin-tile aliasing. Neither test is actually about "whatever cartridge is default"; they're platformer regression tests that happened to piggyback on the default. Pinned both to `&cart=quest` explicitly so they keep covering the platformer regardless of which cartridge the page defaults to. Every other spec file (`demo-arcade-freedoom.spec.ts`, `demo-arcade-libreoffice.spec.ts`, `demo-arcade-mobile.spec.ts`, `social-demo.spec.ts`) already either passes `cart=` explicitly where the assertions are cartridge-specific, or only checks cartridge-agnostic properties (attract-screen grid geometry, font tilt, generic boot), so they needed no changes.

## Test plan

- [x] `node docs/demo/tools/ascii-arcade.test.mjs` — the headless cartridge/level logic tests — pass unchanged (this change doesn't touch cartridge logic, only which one is selected by default).
- [ ] `npm run pretest && npx playwright test demo-arcade.spec.ts demo-arcade-freedoom.spec.ts demo-arcade-mobile.spec.ts` — not run in this sandbox (no local `dotnet`/WASM toolchain available to build `dist/wasm/`); please run in CI or locally to confirm.


---
_Generated by [Claude Code](https://claude.ai/code/session_016gLg8E5fCebSadWup4VE1i)_