### PR TITLE
Stress-test DocxDiff on a heavyweight legal document, and stop it reading each file four times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- **`DocxDiff` no longer reads each document four times per comparison.** On a heavyweight
+  legal document (the NVCA model certificate of incorporation: 574 KB of `document.xml`,
+  15,360 elements, 97 footnotes) about 72% of a `Compare` was spent inside `IrReader`,
+  reading each side twice — once to build the edit script, once again inside the markup
+  renderer for the source elements it clones from — and each of those reads opened and
+  parsed the whole package twice, because deciding the accepted-revision view scanned a
+  second package and then discarded the parse. The comparison now reads once per side and
+  hands that snapshot to the renderer, and the revision-view scan runs against the package
+  the walk is about to use. The two sides' pre-accept and IR reads run concurrently, and
+  `GetRevisions` on byte-identical packages takes the same shortcut `Compare` already had
+  instead of running the whole pipeline to prove there is nothing to report. The N-way
+  `Consolidate` carried the same duplication multiplied by reviewer count (`2*(N+1)` reads
+  to compare `N+1` documents) and is fixed the same way. Supporting cuts: `ContentSignature`
+  walks each subtree once instead of three times, its repeated hash inputs (about seven in
+  eight on a real document) are served from a per-call cache, canonical-XML hashing no
+  longer materializes a byte array per call, and attribute canonicalization skips the sort
+  for the elements that carry none or one. Measured medians: `Compare` 821 → 351 ms on a
+  scattered-edit pass, 1279 → 868 ms on a whole-document rewrite; `GetRevisions` 395 →
+  216 ms and 371 → 0 ms on identical inputs; a four-reviewer `Consolidate` 1870 → 675 ms;
+  allocation per comparison 528 → 276 MB. **Output is unchanged** — the new
+  `benchmarks/docxdiff-stress` harness digests the redline package, revision list, edit
+  script and all four consolidate products across eight generated edit shapes, and all 36
+  digests are byte-identical before and after.
 - **The ribbon's strips signal their overflow instead of hard-clipping.** On a narrow
   surface the compact chrome keeps every command by scrolling its strips (title bar, tab
   strip, ribbon panels, anchor rail) — but the clipped edge read as a squashed, broken

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ All notable changes to this project will be documented in this file.
   hands that snapshot to the renderer, and the revision-view scan runs against the package
   the walk is about to use. The two sides' pre-accept and IR reads run concurrently
   where the runtime has threads to run them on — the browser build keeps the sequential
-  schedule, its WASM project does not set `WasmEnableThreads`, so a blocking join there
-  would hang the page rather than speed it up; it still gets the read-sharing win, which is the larger
+  schedule, its WASM project does not set `WasmEnableThreads`, so blocking on a queued
+  task there throws `PlatformNotSupportedException: Cannot wait on monitors on this runtime`
+  and fails the comparison outright; it still gets the read-sharing win, which is the larger
   half (roughly 1.4-1.6x with no parallelism at all). `GetRevisions` on byte-identical packages takes the same shortcut `Compare` already had
   instead of running the whole pipeline to prove there is nothing to report. The N-way
   `Consolidate` carried the same duplication multiplied by reviewer count (`2*(N+1)` reads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@ All notable changes to this project will be documented in this file.
   parsed the whole package twice, because deciding the accepted-revision view scanned a
   second package and then discarded the parse. The comparison now reads once per side and
   hands that snapshot to the renderer, and the revision-view scan runs against the package
-  the walk is about to use. The two sides' pre-accept and IR reads run concurrently, and
-  `GetRevisions` on byte-identical packages takes the same shortcut `Compare` already had
+  the walk is about to use. The two sides' pre-accept and IR reads run concurrently
+  where the runtime has threads to run them on — the browser build keeps the sequential
+  schedule, its WASM project does not set `WasmEnableThreads`, so a blocking join there
+  would hang the page rather than speed it up; it still gets the read-sharing win, which is the larger
+  half (roughly 1.4-1.6x with no parallelism at all). `GetRevisions` on byte-identical packages takes the same shortcut `Compare` already had
   instead of running the whole pipeline to prove there is nothing to report. The N-way
   `Consolidate` carried the same duplication multiplied by reviewer count (`2*(N+1)` reads
   to compare `N+1` documents) and is fixed the same way. Supporting cuts: `ContentSignature`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@ All notable changes to this project will be documented in this file.
   task there throws `PlatformNotSupportedException: Cannot wait on monitors on this runtime`
   and fails the comparison outright; it still gets the read-sharing win, which is the larger
   half (roughly 1.4-1.6x with no parallelism at all). `GetRevisions` on byte-identical packages takes the same shortcut `Compare` already had
-  instead of running the whole pipeline to prove there is nothing to report. The N-way
+  instead of running the whole pipeline to prove there is nothing to report — the shortcut
+  skips the work, not the compatibility pre-flight, so
+  `OnCompatibilityWarning`/`ThrowOnCompatibilityWarning` still report on the inputs whether
+  or not the two sides happen to match. The N-way
   `Consolidate` carried the same duplication multiplied by reviewer count (`2*(N+1)` reads
   to compare `N+1` documents) and is fixed the same way. Supporting cuts: `ContentSignature`
   walks each subtree once instead of three times, its repeated hash inputs (about seven in
@@ -30,8 +33,9 @@ All notable changes to this project will be documented in this file.
   216 ms and 371 → 0 ms on identical inputs; a four-reviewer `Consolidate` 1870 → 675 ms;
   allocation per comparison 528 → 276 MB. **Output is unchanged** — the new
   `benchmarks/docxdiff-stress` harness digests the redline package, revision list, edit
-  script and all four consolidate products across eight generated edit shapes, and all 36
-  digests are byte-identical before and after.
+  script, all four consolidate products and the compatibility report across eight generated
+  edit shapes and every one of the 678 documents in `TestFiles/`, and every digest is
+  byte-identical before and after.
 - **The ribbon's strips signal their overflow instead of hard-clipping.** On a narrow
   surface the compact chrome keeps every command by scrolling its strips (title bar, tab
   strip, ribbon panels, anchor rail) — but the clipped edge read as a squashed, broken

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ usually ripple through all of it.
 | Export package | `npm-export/` | `@docxodus/export` — deterministic standalone HTML + PDF through a pinned Chromium. Has its own `dist/`, tests, and `docxodus doctor` preflight. See `standalone_paginated_export.md`. |
 | Workflow evals | `eval/` + `Docxodus.Tests/Eval/` | Deterministic document-workflow scenarios scored on task completion, target precision, and collateral change. Corpus and contract in `eval/README.md`. |
 | Pages demo | `docs/demo/` | Static pages hosting the **shipped** surface via `createRibbonEditor`. They contain no editor UI of their own — change `npm/src/ribbon.ts`, not these files. |
-| Out-of-solution tools | `tools/diffharness/`, `tools/manifest-fuzz/`, `tools/screenshots/`, `benchmarks/` | Not in `Docxodus.sln`; build them by path. LibreOffice-backed diff verification, AFL manifest fuzzing, README screenshot capture, and a form-document edit benchmark. |
+| Out-of-solution tools | `tools/diffharness/`, `tools/manifest-fuzz/`, `tools/screenshots/`, `benchmarks/` | Not in `Docxodus.sln`; build them by path. LibreOffice-backed diff verification, AFL manifest fuzzing, README screenshot capture, a form-document edit benchmark, and a `DocxDiff` perf/output-parity stress harness. |
 
 ### The single-owner rule
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ nullable-checked by default, so a new file needs no directive. The exception is 
 inherited OpenXmlPowerTools core — 21 legacy files (`WmlComparer`, `WmlToHtmlConverter`,
 the `HtmlToWml*` family, `FormattingAssembler`, `DocumentBuilder`, `RevisionProcessor`,
 `PtOpenXmlUtil`, …) carry an explicit `#nullable disable` header. They hold back a lot:
-stripping all 21 takes the library from 131 warnings to **3,659**.
+stripping all 21 takes the library from its baseline to **3,659**.
 `grep -l "^#nullable disable" Docxodus/*.cs` lists the remaining debt; when
 substantially refactoring one of those files, consider removing its header and fixing
 that file's warnings. CS8632 stays in `NoWarn` deliberately: with the project context
@@ -40,9 +40,15 @@ are kept for the day each file migrates.
 **`Docxodus.csproj` and `Docxodus.Tests.csproj` both override it to `false`**, so the core
 library and the test project do *not* fail on warnings. The CLI tools, MCP server,
 python-host and WASM project do inherit it. Current baseline: the library builds with
-**131 warnings**, the test project with **774** (mostly StyleCop `SA1633`/`SA1636` file
+**132 warnings**, the test project with **775** (mostly StyleCop `SA1633`/`SA1636` file
 headers and `SA1206` using-order). Don't add to either baseline. Measure with
 `--no-incremental` — a warm incremental build reports zero because nothing recompiles.
+
+The one movement that is not a regression: no file in the library carries a StyleCop file
+header, so `SA1633` fires once per file and **every new `.cs` file under `Docxodus/` moves
+both counts by exactly one** (the test build compiles the library through its project
+reference). A change that adds one file and one warning is at baseline; anything more is not.
+Update the two numbers here in the same commit rather than leaving them stale.
 
 ## Repository Layout
 

--- a/Docxodus.Tests/DocxDiffCompatibilityTests.cs
+++ b/Docxodus.Tests/DocxDiffCompatibilityTests.cs
@@ -74,6 +74,79 @@ public class DocxDiffCompatibilityTests
         Assert.Contains(captured!.Warnings, w => w.Feature.Id == "contentControls");
     }
 
+    // ---- the identical-bytes shortcuts must not swallow the pre-flight ------------------------
+    //
+    // Compare and GetRevisions both short-circuit byte-identical packages. The shortcut skips the
+    // WORK; the pre-flight is a property of the INPUTS, so a caller who asked to be warned about an
+    // under-tested construct still has to be. These pin every product on the shortcut path, because
+    // a shortcut added to one product and not wired to the pre-flight is invisible to output-parity
+    // evidence: the answer (nothing changed) is right, and the warning simply never arrives.
+
+    [Fact]
+    public void GetRevisions_IdenticalPackages_StillThrowsOnCompatibilityWarning()
+    {
+        var doc = Math();
+        var ex = Assert.Throws<DocxDiffCompatibilityException>(() =>
+            DocxDiff.GetRevisions(doc, new WmlDocument(doc),
+                new DocxDiffSettings { ThrowOnCompatibilityWarning = true }));
+        Assert.Contains(ex.Report.Warnings, w => w.Feature.Id == "math");
+    }
+
+    [Fact]
+    public void GetRevisions_IdenticalPackages_StillFiresCompatibilityCallback()
+    {
+        var doc = Math();
+        DocxDiffCompatibilityReport? captured = null;
+        var revisions = DocxDiff.GetRevisions(doc, new WmlDocument(doc),
+            new DocxDiffSettings { OnCompatibilityWarning = r => captured = r });
+        Assert.Empty(revisions);
+        Assert.NotNull(captured);
+        Assert.Contains(captured!.Warnings, w => w.Feature.Id == "math");
+    }
+
+    [Fact]
+    public void Compare_IdenticalPackages_StillThrowsOnCompatibilityWarning()
+    {
+        var doc = Math();
+        var ex = Assert.Throws<DocxDiffCompatibilityException>(() =>
+            DocxDiff.Compare(doc, new WmlDocument(doc),
+                new DocxDiffSettings { ThrowOnCompatibilityWarning = true }));
+        Assert.Contains(ex.Report.Warnings, w => w.Feature.Id == "math");
+    }
+
+    /// <summary>One comparison, every product: the pre-flight fires on whichever product is asked for
+    /// first, so a shortcut on any one of them cannot be the reason a warning goes missing.</summary>
+    [Theory]
+    [InlineData("revisions")]
+    [InlineData("redline")]
+    [InlineData("editscript")]
+    public void Comparison_IdenticalPackages_EveryProductPreflights(string product)
+    {
+        var doc = Math();
+        DocxDiffCompatibilityReport? captured = null;
+        var comparison = DocxDiff.CreateComparison(doc, new WmlDocument(doc),
+            new DocxDiffSettings { OnCompatibilityWarning = r => captured = r });
+
+        switch (product)
+        {
+            case "revisions": Assert.Empty(comparison.GetRevisions()); break;
+            case "redline": Assert.NotNull(comparison.ToRedline()); break;
+            default: Assert.NotNull(comparison.GetEditScriptJson()); break;
+        }
+
+        Assert.NotNull(captured);
+        Assert.Contains(captured!.Warnings, w => w.Feature.Id == "math");
+    }
+
+    /// <summary>The shortcut is still a shortcut: with the pre-flight not engaged, an identical pair
+    /// reports nothing and never opens either package.</summary>
+    [Fact]
+    public void GetRevisions_IdenticalPackages_DefaultSettings_ReportNothing()
+    {
+        var doc = Math();
+        Assert.Empty(DocxDiff.GetRevisions(doc, new WmlDocument(doc)));
+    }
+
     /// <summary>A minimal valid DOCX whose body is <paramref name="bodyInner"/>. The document element declares the
     /// w/m/v/o namespaces so any construct in bodyInner parses under the right namespace. extraParts can add a
     /// footnotes/header/etc. part for multi-part tests.</summary>

--- a/Docxodus.Tests/Ir/IrHasherTests.cs
+++ b/Docxodus.Tests/Ir/IrHasherTests.cs
@@ -72,6 +72,43 @@ public class IrHasherTests
         Assert.NotEqual(IrHasher.CanonicalHash(bare), IrHasher.CanonicalHash(Drawing(null, null, "99", cx: "101")));
     }
 
+    // The stripping rules consult attribute.Parent (wp:docPr/@id), so canonicalization must decide an
+    // attribute's fate while it is still attached to its element. Elements carrying exactly ONE attribute
+    // take a separate no-sort path, and this is the shape that catches it stripping too late: a lone
+    // wp:docPr/@id, with no sibling attribute to force the general path.
+    [Fact]
+    public void Canonicalize_LoneDocPrId_StillStripped()
+    {
+        XElement Drawing(string docPrId) =>
+            new(W + "drawing",
+                new XElement(Wp + "inline",
+                    new XElement(Wp + "docPr", new XAttribute("id", docPrId)),
+                    new XElement(Wp + "extent", new XAttribute("cx", "100"), new XAttribute("cy", "200"))));
+
+        Assert.Equal(IrHasher.CanonicalHash(Drawing("1")), IrHasher.CanonicalHash(Drawing("4823")));
+        Assert.Equal(IrHasher.Canonicalize(Drawing("1")), IrHasher.Canonicalize(Drawing("4823")));
+    }
+
+    // The one-attribute path must also keep an attribute it should not strip, and keep its value.
+    [Fact]
+    public void Canonicalize_LoneKeptAttribute_Survives()
+    {
+        var a = new XElement(W + "p", new XAttribute(W + "val", "left"));
+        var b = new XElement(W + "p", new XAttribute(W + "val", "right"));
+
+        Assert.NotEqual(IrHasher.CanonicalHash(a), IrHasher.CanonicalHash(b));
+        Assert.Equal(IrHasher.CanonicalHash(a), IrHasher.CanonicalHash(new XElement(W + "p", new XAttribute(W + "val", "left"))));
+    }
+
+    // A lone strippable attribute in the pt14/rsid families takes the same path.
+    [Fact]
+    public void Canonicalize_LoneStrippableAttribute_Removed()
+    {
+        var bare = new XElement(W + "p");
+        Assert.Equal(IrHasher.CanonicalHash(bare), IrHasher.CanonicalHash(new XElement(W + "p", new XAttribute(W + "rsidR", "00AB12CD"))));
+        Assert.Equal(IrHasher.CanonicalHash(bare), IrHasher.CanonicalHash(new XElement(W + "p", new XAttribute(Pt + "Unid", "deadbeef"))));
+    }
+
     [Fact]
     public void Canonicalize_ContentChange_Detected()
     {

--- a/Docxodus/DocxDiff.cs
+++ b/Docxodus/DocxDiff.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Threading.Tasks;
+using Docxodus.Internal;
 using Docxodus.Ir;
 using Docxodus.Ir.Diff;
 using Docxodus.Verification;
@@ -490,18 +490,18 @@ public static class DocxDiff
     private static (IrDocument BaseIr, List<(string Author, IrDocument Ir)> ReviewerIrs) ReadReviewerSet(
         WmlDocument baseDocument, IReadOnlyList<DocxDiffReviewer> reviewers, IrReaderOptions opts)
     {
-        var baseTask = Task.Run(() => IrReader.Read(baseDocument, opts));
-        var reviewerTasks = new Task<IrDocument>[reviewers.Count];
+        var reads = new Func<IrDocument>[reviewers.Count];
         for (var i = 0; i < reviewers.Count; i++)
         {
             var doc = reviewers[i].Document;
-            reviewerTasks[i] = Task.Run(() => IrReader.Read(doc, opts));
+            reads[i] = () => IrReader.Read(doc, opts);
         }
 
-        var baseIr = baseTask.GetAwaiter().GetResult();
+        var (baseIr, reviewerIrs) = ParallelWork.Fan(() => IrReader.Read(baseDocument, opts), reads);
+
         var revIr = new List<(string Author, IrDocument Ir)>(reviewers.Count);
         for (var i = 0; i < reviewers.Count; i++)
-            revIr.Add((reviewers[i].Author, reviewerTasks[i].GetAwaiter().GetResult()));
+            revIr.Add((reviewers[i].Author, reviewerIrs[i]));
         return (baseIr, revIr);
     }
 

--- a/Docxodus/DocxDiff.cs
+++ b/Docxodus/DocxDiff.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using Docxodus.Ir;
 using Docxodus.Ir.Diff;
 using Docxodus.Verification;
@@ -241,11 +242,14 @@ public static class DocxDiff
         baseDocument = PreAccept(s.Diff, baseDocument);
         reviewers = PreAccept(s.Diff, reviewers);
         PreflightCompatibility(s.Diff, new[] { baseDocument }.Concat(reviewers.Select(r => r.Document)).ToArray());
-        var baseIr = IrReader.Read(baseDocument, ReadOpts);
-        var revIr = reviewers.Select(r => (r.Author, IrReader.Read(r.Document, ReadOpts))).ToList();
+        // ONE read per document, with provenance, serving both the merge and the renderer's
+        // clone-from-provenance pass — the renderer used to re-read all of them, so an N-reviewer
+        // consolidate read 2*(N+1) packages to compare N+1.
+        var (baseIr, revIr) = ReadReviewerSet(baseDocument, reviewers, RenderReadOpts);
         var script = IrCompositeMerger.Merge(baseIr, revIr, s.ConflictResolution, diff);
         return IrCompositeMarkupRenderer.Render(
-            script, baseDocument, reviewers.Select(r => (r.Author, r.Document)).ToList(), diff);
+            script, baseDocument, reviewers.Select(r => (r.Author, r.Document)).ToList(), diff,
+            baseIr, revIr.Select(x => x.Ir).ToList());
     }
 
     /// <summary>
@@ -292,8 +296,7 @@ public static class DocxDiff
         if (reviewers.Count == 0) return System.Array.Empty<DocxDiffConflict>();
         baseDocument = PreAccept(s.Diff, baseDocument);
         reviewers = PreAccept(s.Diff, reviewers);
-        var baseIr = IrReader.Read(baseDocument, ReadOpts);
-        var revIr = reviewers.Select(r => (r.Author, IrReader.Read(r.Document, ReadOpts))).ToList();
+        var (baseIr, revIr) = ReadReviewerSet(baseDocument, reviewers, ReadOpts);
         var script = IrCompositeMerger.Merge(baseIr, revIr, s.ConflictResolution, diff);
         return script.Conflicts.Select(DocxDiffConflict.FromIr).ToList();
     }
@@ -334,8 +337,7 @@ public static class DocxDiff
         if (reviewers.Count == 0) return System.Array.Empty<DocxDiffConsolidatedRevision>();
         baseDocument = PreAccept(s.Diff, baseDocument);
         reviewers = PreAccept(s.Diff, reviewers);
-        var baseIr = IrReader.Read(baseDocument, ReadOpts);
-        var revIr = reviewers.Select(r => (r.Author, IrReader.Read(r.Document, ReadOpts))).ToList();
+        var (baseIr, revIr) = ReadReviewerSet(baseDocument, reviewers, ReadOpts);
         var script = IrCompositeMerger.Merge(baseIr, revIr, s.ConflictResolution, diff);
         var rendered = IrCompositeRevisionRenderer.Render(script, baseIr, revIr, diff);
         return rendered.Select(x => new DocxDiffConsolidatedRevision(
@@ -391,8 +393,7 @@ public static class DocxDiff
                 IrNodeList.From(System.Array.Empty<IrConflict>())));
         baseDocument = PreAccept(s.Diff, baseDocument);
         reviewers = PreAccept(s.Diff, reviewers);
-        var baseIr = IrReader.Read(baseDocument, ReadOpts);
-        var revIr = reviewers.Select(r => (r.Author, IrReader.Read(r.Document, ReadOpts))).ToList();
+        var (baseIr, revIr) = ReadReviewerSet(baseDocument, reviewers, ReadOpts);
         var script = IrCompositeMerger.Merge(baseIr, revIr, s.ConflictResolution, diff);
         return IrCompositeScriptJson.Write(script);
     }
@@ -479,6 +480,29 @@ public static class DocxDiff
                     $"reviewers[{i}].Document is null (author '{reviewers[i].Author}').", nameof(reviewers));
         }
         return s;
+    }
+
+    /// <summary>
+    /// Read the base document and every reviewer's document into IR. The reads are independent pure
+    /// functions of their inputs, so they run concurrently; reviewer order in the result matches
+    /// <paramref name="reviewers"/>, which is significant for conflict competitor order.
+    /// </summary>
+    private static (IrDocument BaseIr, List<(string Author, IrDocument Ir)> ReviewerIrs) ReadReviewerSet(
+        WmlDocument baseDocument, IReadOnlyList<DocxDiffReviewer> reviewers, IrReaderOptions opts)
+    {
+        var baseTask = Task.Run(() => IrReader.Read(baseDocument, opts));
+        var reviewerTasks = new Task<IrDocument>[reviewers.Count];
+        for (var i = 0; i < reviewers.Count; i++)
+        {
+            var doc = reviewers[i].Document;
+            reviewerTasks[i] = Task.Run(() => IrReader.Read(doc, opts));
+        }
+
+        var baseIr = baseTask.GetAwaiter().GetResult();
+        var revIr = new List<(string Author, IrDocument Ir)>(reviewers.Count);
+        for (var i = 0; i < reviewers.Count; i++)
+            revIr.Add((reviewers[i].Author, reviewerTasks[i].GetAwaiter().GetResult()));
+        return (baseIr, revIr);
     }
 
     /// <summary>

--- a/Docxodus/DocxDiff.cs
+++ b/Docxodus/DocxDiff.cs
@@ -51,6 +51,14 @@ public static class DocxDiff
     internal static readonly IrReaderOptions ReadOpts =
         new() { RetainSources = false, RevisionView = RevisionView.Accept };
 
+    // The same read WITH provenance. DocxDiffComparison uses this one so a single pass per side feeds both
+    // the edit-script build and the markup renderer's clone-from-provenance pass; provenance is
+    // equality-neutral (see IrProvenance), so the script built over it is identical to one built over
+    // ReadOpts. ReadOpts stays for the paths that genuinely never clone source XML and want the lower
+    // footprint (the consolidate scoreboard, compatibility probes).
+    internal static readonly IrReaderOptions RenderReadOpts =
+        new() { RetainSources = true, RevisionView = RevisionView.Accept };
+
     /// <summary>
     /// Compare <paramref name="left"/> and <paramref name="right"/> and produce a tracked-changes
     /// <see cref="WmlDocument"/> carrying native Word revision markup

--- a/Docxodus/DocxDiffComparison.cs
+++ b/Docxodus/DocxDiffComparison.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Docxodus.Ir;
 using Docxodus.Ir.Diff;
 using Docxodus.Verification;
@@ -61,18 +62,30 @@ public sealed class DocxDiffComparison
         _originalRight = right;
         _settings = settings ?? new DocxDiffSettings();
 
+        // PreAccept re-reads and can rewrite the whole package (strict-namespace normalization,
+        // mc:AlternateContent resolution, optional accept-flatten). The two sides never look at each
+        // other, so they run concurrently; the preflight that DOES span both runs after the join.
         _preflighted = new(() =>
         {
-            var preLeft = DocxDiff.PreAccept(_settings, _originalLeft);
+            var leftTask = Task.Run(() => DocxDiff.PreAccept(_settings, _originalLeft));
             var preRight = DocxDiff.PreAccept(_settings, _originalRight);
+            var preLeft = leftTask.GetAwaiter().GetResult();
             DocxDiff.PreflightCompatibility(_settings, preLeft, preRight);
             return (preLeft, preRight);
         }, LazyThreadSafetyMode.ExecutionAndPublication);
 
+        // ONE read per side serves every product, including the markup renderer's clone-from-provenance
+        // pass — hence DocxDiff.RenderReadOpts (RetainSources ON) rather than DocxDiff.ReadOpts. Provenance
+        // is equality-neutral (see IrProvenance), so this snapshot is node-for-node value-equal to the
+        // retention-off one and the edit script built over it is unchanged; what it buys is the renderer's
+        // two full re-reads of these same documents, which on a heavyweight document dominate the compare.
+        // The two sides are independent pure reads, so they run concurrently.
         _ir = new(() =>
         {
             var (preLeft, preRight) = _preflighted.Value;
-            return (IrReader.Read(preLeft, DocxDiff.ReadOpts), IrReader.Read(preRight, DocxDiff.ReadOpts));
+            var leftTask = Task.Run(() => IrReader.Read(preLeft, DocxDiff.RenderReadOpts));
+            var irRight = IrReader.Read(preRight, DocxDiff.RenderReadOpts);
+            return (leftTask.GetAwaiter().GetResult(), irRight);
         }, LazyThreadSafetyMode.ExecutionAndPublication);
 
         // The DATA script: CrossParagraphTokenDiff forced off, exactly as GetRevisions and
@@ -88,6 +101,15 @@ public sealed class DocxDiffComparison
 
         _revisions = new(() =>
         {
+            // Byte-identical packages have nothing to report, and proving that by running the whole
+            // pipeline costs as much as a real comparison. This is the same guard ToRedline uses, for
+            // the same reason and with the same exception: an explicit accept-all request rewrites the
+            // input even when the two sides match, so it is not a no-op. Note the edit script has no
+            // equivalent shortcut — its all-Equal operations are the answer callers asked for.
+            if (DocxCompare.HasIdenticalPackageBytes(_originalLeft, _originalRight) &&
+                !(_settings.PreAcceptInputRevisions && !_settings.PreserveInputRevisions))
+                return Array.Empty<DocxDiffRevision>();
+
             var diff = _settings.ToIrDiffSettings() with { CrossParagraphTokenDiff = false };
             var (irLeft, irRight) = _ir.Value;
             return IrRevisionRenderer.Render(_dataScript.Value, irLeft, irRight, diff)
@@ -175,7 +197,8 @@ public sealed class DocxDiffComparison
         var script = diff.CrossParagraphTokenDiff
             ? BuildFusedScript(diff)
             : _dataScript.Value;
-        return IrMarkupRenderer.Render(script, left, right, diff);
+        var (irLeft, irRight) = _ir.Value;
+        return IrMarkupRenderer.Render(script, left, right, diff, irLeft, irRight);
     }
 
     private IrEditScript BuildFusedScript(IrDiffSettings diff)

--- a/Docxodus/DocxDiffComparison.cs
+++ b/Docxodus/DocxDiffComparison.cs
@@ -34,10 +34,16 @@ namespace Docxodus;
 /// <see cref="DocxDiffSettings"/> flow into the semantic pass (as
 /// <see cref="SemanticDiffOptions.DiffSettings"/>) and the result is memoized. Passing explicit
 /// <see cref="SemanticDiffOptions"/> bypasses the memo and runs the semantic pipeline with those
-/// options verbatim. The semantic pipeline keeps its own package-preflighted read (its reader
-/// retains sources, the diff read does not), so it shares the snapshot but not the IR pass.</para>
+/// options verbatim. The semantic pipeline keeps its own package-preflighted read, so it shares the
+/// snapshot but not the IR pass.</para>
 /// <para><b>Memory.</b> The instance retains the input packages and every materialized product
-/// for its lifetime; scope it to the pipeline run that needs the products.</para>
+/// for its lifetime; scope it to the pipeline run that needs the products. What it retains includes
+/// the two IR snapshots, once a product has forced them. Those are read with provenance retained, so
+/// that the markup renderer can clone source elements out of them rather than re-reading both
+/// documents — which means they pin the parsed <c>XDocument</c> of every story on both sides, not
+/// only the IR values. That is the price of reading each input once instead of four times: bounded
+/// by the inputs, but not small, and one more reason not to hold a comparison beyond the run that
+/// uses it.</para>
 /// <para><b>Thread-safety.</b> All memoization is <see cref="LazyThreadSafetyMode.ExecutionAndPublication"/>;
 /// concurrent product calls are safe.</para>
 /// </remarks>
@@ -107,9 +113,20 @@ public sealed class DocxDiffComparison
             // the same reason and with the same exception: an explicit accept-all request rewrites the
             // input even when the two sides match, so it is not a no-op. Note the edit script has no
             // equivalent shortcut — its all-Equal operations are the answer callers asked for.
+            //
+            // The shortcut skips the WORK, never the compatibility preflight. That preflight is a
+            // property of the inputs, not of whether they differ: a caller who asked to be told about
+            // an under-tested construct is asking about THIS document, and gets the same answer
+            // whether or not the other side happens to be byte-identical. ToRedline's identical-bytes
+            // path runs it for exactly that reason, and this class documents the preflight as firing
+            // on the first product call; dropping it here would silently make GetRevisions the one
+            // product that never warns.
             if (DocxCompare.HasIdenticalPackageBytes(_originalLeft, _originalRight) &&
                 !(_settings.PreAcceptInputRevisions && !_settings.PreserveInputRevisions))
+            {
+                RunGatedPreflight();
                 return Array.Empty<DocxDiffRevision>();
+            }
 
             var diff = _settings.ToIrDiffSettings() with { CrossParagraphTokenDiff = false };
             var (irLeft, irRight) = _ir.Value;
@@ -180,13 +197,7 @@ public sealed class DocxDiffComparison
         if (DocxCompare.HasIdenticalPackageBytes(_originalLeft, _originalRight) &&
             !(s.PreAcceptInputRevisions && !s.PreserveInputRevisions))
         {
-            if (s.OnCompatibilityWarning != null || s.ThrowOnCompatibilityWarning)
-            {
-                var preflightLeft = DocxDiff.PreAccept(s, _originalLeft);
-                var preflightRight = DocxDiff.PreAccept(s, _originalRight);
-                DocxDiff.PreflightCompatibility(s, preflightLeft, preflightRight);
-            }
-
+            RunGatedPreflight();
             return new WmlDocument(_originalLeft);
         }
 
@@ -200,6 +211,23 @@ public sealed class DocxDiffComparison
             : _dataScript.Value;
         var (irLeft, irRight) = _ir.Value;
         return IrMarkupRenderer.Render(script, left, right, diff, irLeft, irRight);
+    }
+
+    /// <summary>
+    /// The compatibility preflight a product's identical-bytes shortcut still owes its caller, run
+    /// only when the caller actually asked for it. Both shortcuts (<see cref="BuildRedline"/> and the
+    /// revision list) route through here so they cannot drift apart again: the pre-accept pair is
+    /// built the same way <c>_preflighted</c> builds it, but nothing else on the shortcut path needs
+    /// those documents, so they are not memoized.
+    /// </summary>
+    private void RunGatedPreflight()
+    {
+        var s = _settings;
+        if (s.OnCompatibilityWarning == null && !s.ThrowOnCompatibilityWarning)
+            return;
+        var preflightLeft = DocxDiff.PreAccept(s, _originalLeft);
+        var preflightRight = DocxDiff.PreAccept(s, _originalRight);
+        DocxDiff.PreflightCompatibility(s, preflightLeft, preflightRight);
     }
 
     private IrEditScript BuildFusedScript(IrDiffSettings diff)

--- a/Docxodus/DocxDiffComparison.cs
+++ b/Docxodus/DocxDiffComparison.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
+using Docxodus.Internal;
 using Docxodus.Ir;
 using Docxodus.Ir.Diff;
 using Docxodus.Verification;
@@ -64,12 +64,13 @@ public sealed class DocxDiffComparison
 
         // PreAccept re-reads and can rewrite the whole package (strict-namespace normalization,
         // mc:AlternateContent resolution, optional accept-flatten). The two sides never look at each
-        // other, so they run concurrently; the preflight that DOES span both runs after the join.
+        // other, so they run concurrently where the runtime has threads (see ParallelWork); the
+        // preflight that DOES span both runs after the join.
         _preflighted = new(() =>
         {
-            var leftTask = Task.Run(() => DocxDiff.PreAccept(_settings, _originalLeft));
-            var preRight = DocxDiff.PreAccept(_settings, _originalRight);
-            var preLeft = leftTask.GetAwaiter().GetResult();
+            var (preLeft, preRight) = ParallelWork.Pair(
+                () => DocxDiff.PreAccept(_settings, _originalLeft),
+                () => DocxDiff.PreAccept(_settings, _originalRight));
             DocxDiff.PreflightCompatibility(_settings, preLeft, preRight);
             return (preLeft, preRight);
         }, LazyThreadSafetyMode.ExecutionAndPublication);
@@ -83,9 +84,9 @@ public sealed class DocxDiffComparison
         _ir = new(() =>
         {
             var (preLeft, preRight) = _preflighted.Value;
-            var leftTask = Task.Run(() => IrReader.Read(preLeft, DocxDiff.RenderReadOpts));
-            var irRight = IrReader.Read(preRight, DocxDiff.RenderReadOpts);
-            return (leftTask.GetAwaiter().GetResult(), irRight);
+            return ParallelWork.Pair(
+                () => IrReader.Read(preLeft, DocxDiff.RenderReadOpts),
+                () => IrReader.Read(preRight, DocxDiff.RenderReadOpts));
         }, LazyThreadSafetyMode.ExecutionAndPublication);
 
         // The DATA script: CrossParagraphTokenDiff forced off, exactly as GetRevisions and

--- a/Docxodus/Docxodus.csproj
+++ b/Docxodus/Docxodus.csproj
@@ -63,6 +63,9 @@
     <InternalsVisibleTo Include="docxodus-pyhost" />
     <InternalsVisibleTo Include="docxodus-mcp" />
     <InternalsVisibleTo Include="Docxodus.Tests" />
+    <!-- Out-of-solution perf harness (benchmarks/docxdiff-stress); times internal
+         pipeline stages directly. Never referenced by shipped code. -->
+    <InternalsVisibleTo Include="DocxDiffStress" />
   </ItemGroup>
 
 </Project>

--- a/Docxodus/Internal/ParallelWork.cs
+++ b/Docxodus/Internal/ParallelWork.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 
 namespace Docxodus.Internal;
@@ -115,9 +116,27 @@ internal static class ParallelWork
             throw;
         }
 
+        // Collect in argument order so the FIRST failure in sequential order is the one that
+        // propagates — but drain every task before throwing. Rethrowing straight out of the loop
+        // would leave a later task's exception unobserved, which is the very thing the head-failure
+        // path above takes care to avoid.
         var results = new T[rest.Length];
+        Exception? failure = null;
         for (var i = 0; i < rest.Length; i++)
-            results[i] = tasks[i].GetAwaiter().GetResult();
+        {
+            try
+            {
+                results[i] = tasks[i].GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                failure ??= ex;
+            }
+        }
+
+        if (failure is not null)
+            ExceptionDispatchInfo.Capture(failure).Throw();
+
         return (headResult, results);
     }
 }

--- a/Docxodus/Internal/ParallelWork.cs
+++ b/Docxodus/Internal/ParallelWork.cs
@@ -14,11 +14,15 @@ namespace Docxodus.Internal;
 /// holds on a server. It does not hold in the browser.</para>
 ///
 /// <para><b>Why the guard exists.</b> <c>wasm/DocxodusWasm/DocxodusWasm.csproj</c> does not set
-/// <c>WasmEnableThreads</c>, so the browser runtime is single-threaded. There <c>Task.Run</c> does not
-/// start a second thread: it queues the delegate for the ONE thread — which is the very thread about to
-/// block on the result. A blocking join would then wait forever for work that cannot start, hanging the
-/// page rather than merely failing to be faster. The fan-out is therefore compiled out of the WASM
-/// assembly entirely, and gated at runtime besides, since a single-core host gains nothing from it.</para>
+/// <c>WasmEnableThreads</c>, so the browser runtime is single-threaded: <c>Task.Run</c> queues the
+/// delegate for the ONE thread, which is the very thread that would then block on the result. The
+/// runtime refuses rather than deadlocking — the blocking join throws
+/// <c>PlatformNotSupportedException: Cannot wait on monitors on this runtime</c>, so an unguarded
+/// fan-out does not merely fail to be faster, it fails every browser comparison outright. (Measured:
+/// with the guard forced open, all ten <c>npm/tests/docx-diff.spec.ts</c> cases fail with exactly that
+/// exception; those specs are this guard's regression test.) The fan-out is therefore compiled out of
+/// the WASM assembly entirely, and gated at runtime besides, since a single-core host gains nothing
+/// from it.</para>
 ///
 /// <para>Both paths compute the same values in the same order. This is a scheduling decision, never a
 /// semantic one.</para>

--- a/Docxodus/Internal/ParallelWork.cs
+++ b/Docxodus/Internal/ParallelWork.cs
@@ -1,0 +1,119 @@
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+
+namespace Docxodus.Internal;
+
+/// <summary>
+/// Fan independent, pure work out across threads — but only where the runtime actually has them.
+/// </summary>
+/// <remarks>
+/// <para>The diff engine reads its input documents concurrently: the reads share no state and are pure
+/// functions of their arguments, so running them together is a wall-clock win and nothing else. That
+/// holds on a server. It does not hold in the browser.</para>
+///
+/// <para><b>Why the guard exists.</b> <c>wasm/DocxodusWasm/DocxodusWasm.csproj</c> does not set
+/// <c>WasmEnableThreads</c>, so the browser runtime is single-threaded. There <c>Task.Run</c> does not
+/// start a second thread: it queues the delegate for the ONE thread — which is the very thread about to
+/// block on the result. A blocking join would then wait forever for work that cannot start, hanging the
+/// page rather than merely failing to be faster. The fan-out is therefore compiled out of the WASM
+/// assembly entirely, and gated at runtime besides, since a single-core host gains nothing from it.</para>
+///
+/// <para>Both paths compute the same values in the same order. This is a scheduling decision, never a
+/// semantic one.</para>
+/// </remarks>
+internal static class ParallelWork
+{
+    /// <summary>
+    /// Whether independent work should be fanned out. False in the browser (single-threaded runtime)
+    /// and on a single-core host, where the sequential path is both correct and no slower.
+    /// </summary>
+    internal static bool CanFanOut =>
+#if WASM_BUILD
+        false;
+#else
+        Environment.ProcessorCount > 1;
+#endif
+
+    /// <summary>
+    /// Evaluate <paramref name="first"/> and <paramref name="second"/>, concurrently where the runtime
+    /// allows it, and return their results in argument order.
+    /// </summary>
+    public static (T First, T Second) Pair<T>(Func<T> first, Func<T> second)
+    {
+        if (!CanFanOut)
+            return (first(), second());
+
+        // The caller's thread runs the second half rather than idling on two queued tasks.
+        var firstTask = Task.Run(first);
+        T secondResult;
+        try
+        {
+            secondResult = second();
+        }
+        catch
+        {
+            // Sequentially, first runs first, so ITS failure is the one a caller would have seen.
+            // Joining here both preserves that ordering and observes the task, so a concurrent
+            // failure never becomes an unobserved task exception.
+            firstTask.GetAwaiter().GetResult();
+            throw;
+        }
+
+        return (firstTask.GetAwaiter().GetResult(), secondResult);
+    }
+
+    /// <summary>
+    /// Evaluate <paramref name="head"/> and every element of <paramref name="rest"/>, concurrently where
+    /// the runtime allows it. Results keep their argument order, which callers rely on (reviewer order is
+    /// significant to consolidate conflict reporting).
+    /// </summary>
+    public static (T Head, T[] Others) Fan<T>(Func<T> head, Func<T>[] rest)
+    {
+        if (!CanFanOut)
+        {
+            var sequential = new T[rest.Length];
+            var headOnly = head();
+            for (var i = 0; i < rest.Length; i++)
+                sequential[i] = rest[i]();
+            return (headOnly, sequential);
+        }
+
+        var tasks = new Task<T>[rest.Length];
+        for (var i = 0; i < rest.Length; i++)
+        {
+            var work = rest[i];
+            tasks[i] = Task.Run(work);
+        }
+
+        T headResult;
+        try
+        {
+            headResult = head();
+        }
+        catch
+        {
+            // Head's failure is the one the sequential order would have surfaced; drain the rest so
+            // a concurrent failure is observed rather than left dangling, then rethrow it.
+            foreach (var task in tasks)
+            {
+                try
+                {
+                    _ = task.GetAwaiter().GetResult();
+                }
+                catch
+                {
+                    // Deliberately swallowed: head's exception is the one being propagated.
+                }
+            }
+
+            throw;
+        }
+
+        var results = new T[rest.Length];
+        for (var i = 0; i < rest.Length; i++)
+            results[i] = tasks[i].GetAwaiter().GetResult();
+        return (headResult, results);
+    }
+}

--- a/Docxodus/Ir/Diff/IrCompositeMarkupRenderer.cs
+++ b/Docxodus/Ir/Diff/IrCompositeMarkupRenderer.cs
@@ -43,7 +43,9 @@ internal static class IrCompositeMarkupRenderer
         IrCompositeScript script,
         WmlDocument baseDoc,
         IReadOnlyList<(string Author, WmlDocument Doc)> reviewers,
-        IrDiffSettings settings)
+        IrDiffSettings settings,
+        IrDocument? sourceBaseIr = null,
+        IReadOnlyList<IrDocument>? sourceReviewerIrs = null)
     {
         ArgumentNullException.ThrowIfNull(script);
         ArgumentNullException.ThrowIfNull(baseDoc);
@@ -57,11 +59,26 @@ internal static class IrCompositeMarkupRenderer
         // the table-shell/section slices stay OFF (B2). Mirrors IrCompositeMerger's forcing.
         settings = settings with { TrackBlockFormatChanges = false, TrackParagraphFormatChanges = true, TrackTableFormatChanges = true, TrackSectionFormatChanges = true };
 
-        // Re-read base + each reviewer WITH provenance (RetainSources=true) + Accept view — the SAME options the
-        // two-way renderer uses — so block anchors in the script resolve to source w:p/w:tbl elements to clone.
-        var readOpts = new IrReaderOptions { RetainSources = true, RevisionView = RevisionView.Accept };
-        var baseIr = IrReader.Read(baseDoc, readOpts);
-        var reviewerIrs = reviewers.Select(r => IrReader.Read(r.Doc, readOpts)).ToList();
+        // Base + each reviewer are needed WITH provenance (RetainSources=true) + Accept view — the SAME options
+        // the two-way renderer uses — so block anchors in the script resolve to source w:p/w:tbl elements to
+        // clone. A caller that already read these exact documents that way passes them in and the reads are
+        // skipped; that matters more here than in the two-way case, because re-reading meant 2*(N+1) reads of
+        // heavyweight packages for an N-reviewer consolidate. Provenance is equality-neutral (see
+        // IrProvenance), so a supplied snapshot renders identically to one read here. A partial or
+        // wrong-length hand-off is ignored rather than mixed with fresh reads.
+        IrDocument baseIr;
+        List<IrDocument> reviewerIrs;
+        if (sourceBaseIr is not null && sourceReviewerIrs is not null && sourceReviewerIrs.Count == reviewers.Count)
+        {
+            baseIr = sourceBaseIr;
+            reviewerIrs = sourceReviewerIrs.ToList();
+        }
+        else
+        {
+            var readOpts = new IrReaderOptions { RetainSources = true, RevisionView = RevisionView.Accept };
+            baseIr = IrReader.Read(baseDoc, readOpts);
+            reviewerIrs = reviewers.Select(r => IrReader.Read(r.Doc, readOpts)).ToList();
+        }
 
         // One shared RenderState (single ascending id counter, single move-name allocator). Left = base. The
         // RightSource / AuthorOverride / RightSourceId are switched per op below. RightSourcedClones are bucketed

--- a/Docxodus/Ir/Diff/IrMarkupRenderer.cs
+++ b/Docxodus/Ir/Diff/IrMarkupRenderer.cs
@@ -27,9 +27,12 @@ namespace Docxodus.Ir.Diff;
 /// just its IR. (2) <b>Provenance.</b> Building runs from provenance-cloned source XML preserves ALL run
 /// properties — including the UNMODELED rPr the <see cref="IrRunFormat"/> model does not capture. The
 /// adapter/scoreboard reads its IRs with <c>RetainSources=false</c> (no per-node <c>Source.Element</c>), so
-/// the renderer re-reads both documents internally with <c>RetainSources=true</c> + <c>RevisionView=Accept</c>
-/// to obtain the accept-clean source <c>w:p</c>/<c>w:tbl</c> elements it clones from. (Reading with Accept
-/// matches the IR the script was built over — the adapter reads Accept too — so anchors resolve identically.)</para>
+/// the renderer needs snapshots read with <c>RetainSources=true</c> + <c>RevisionView=Accept</c> to obtain the
+/// accept-clean source <c>w:p</c>/<c>w:tbl</c> elements it clones from. (Reading with Accept matches the IR the
+/// script was built over — the adapter reads Accept too — so anchors resolve identically.) It reads them
+/// itself unless the caller supplies them: <see cref="DocxDiffComparison"/> already holds provenance-bearing
+/// snapshots of the same inputs and hands them over, which is why <see cref="Render"/> takes the optional
+/// <c>sourceIrLeft</c>/<c>sourceIrRight</c> pair.</para>
 ///
 /// <para><b>Why clone from provenance, split at token boundaries.</b> For a Modified paragraph we must wrap
 /// only the changed runs in <c>w:ins</c>/<c>w:del</c> while leaving Equal runs untouched. The token diff
@@ -201,19 +204,37 @@ internal static class IrMarkupRenderer
     /// <c>RejectRevisions(result)</c> content-equals <paramref name="left"/> at the per-block text level.
     /// </summary>
     public static WmlDocument Render(
-        IrEditScript script, WmlDocument left, WmlDocument right, IrDiffSettings settings)
+        IrEditScript script, WmlDocument left, WmlDocument right, IrDiffSettings settings,
+        IrDocument? sourceIrLeft = null, IrDocument? sourceIrRight = null)
     {
         ArgumentNullException.ThrowIfNull(script);
         ArgumentNullException.ThrowIfNull(left);
         ArgumentNullException.ThrowIfNull(right);
         ArgumentNullException.ThrowIfNull(settings);
 
-        // Re-read both documents WITH provenance so we can clone source w:p/w:tbl elements. RevisionView is
-        // Accept to match the IR the script was built over (the adapter reads Accept), so every block anchor
-        // in the script resolves to a block in these snapshots' AnchorIndex.
-        var readOpts = new IrReaderOptions { RetainSources = true, RevisionView = RevisionView.Accept };
-        var irLeft = IrReader.Read(left, readOpts);
-        var irRight = IrReader.Read(right, readOpts);
+        // Both documents are needed WITH provenance so we can clone source w:p/w:tbl elements. RevisionView
+        // is Accept to match the IR the script was built over (the adapter reads Accept), so every block
+        // anchor in the script resolves to a block in these snapshots' AnchorIndex.
+        //
+        // A caller that already holds such a snapshot of these exact documents passes it in and the read is
+        // skipped: on a heavyweight document the two reads cost more than everything else this method does
+        // put together, and DocxDiffComparison holds provenance-bearing snapshots of precisely these inputs.
+        // Provenance is equality-neutral (see IrProvenance), so a RetainSources snapshot is node-for-node
+        // value-equal to the retention-off one the script was built over — passing it in cannot change what
+        // is rendered. When either side is absent both are re-read, so a partial hand-off is never mixed
+        // with a fresh read of the other side.
+        IrDocument irLeft, irRight;
+        if (sourceIrLeft is not null && sourceIrRight is not null)
+        {
+            irLeft = sourceIrLeft;
+            irRight = sourceIrRight;
+        }
+        else
+        {
+            var readOpts = new IrReaderOptions { RetainSources = true, RevisionView = RevisionView.Accept };
+            irLeft = IrReader.Read(left, readOpts);
+            irRight = IrReader.Read(right, readOpts);
+        }
 
         var state = new RenderState(irLeft, irRight, settings);
         state.LeftStyleIds = ReadStyleIds(left);

--- a/Docxodus/Ir/IrHash.cs
+++ b/Docxodus/Ir/IrHash.cs
@@ -40,6 +40,11 @@ internal readonly struct IrHash : IEquatable<IrHash>
             BinaryPrimitives.ReadUInt64BigEndian(digest.Slice(24, 8)));
     }
 
+    /// <summary>The largest buffer <see cref="ArrayPool{T}.Shared"/> actually pools (1 MiB). A rent
+    /// above it allocates a fresh array and a return discards it, so the pooled-buffer trade stops
+    /// paying and an exact size becomes the cheaper one.</summary>
+    private const int PooledCeiling = 1024 * 1024;
+
     /// <summary>Compute the SHA-256 digest of the UTF-8 encoding of <paramref name="text"/>.</summary>
     public static IrHash Compute(string text)
     {
@@ -57,7 +62,16 @@ internal readonly struct IrHash : IEquatable<IrHash>
         ArgumentNullException.ThrowIfNull(text);
 
         Span<byte> inline = stackalloc byte[1024];
+
+        // GetMaxByteCount is 3n+3, and ArrayPool.Shared stops pooling above 1 MB: renting the
+        // worst case for a large canonical subtree (a block content control, an opaque table) would
+        // allocate three times the string's actual UTF-8 length and then drop it, which is WORSE than
+        // the single exact-sized array this method exists to avoid. Past that threshold, pay one
+        // counting pass and rent the exact size instead.
         int maxBytes = Encoding.UTF8.GetMaxByteCount(text.Length);
+        if (maxBytes > PooledCeiling)
+            maxBytes = Encoding.UTF8.GetByteCount(text);
+
         byte[]? rented = maxBytes <= inline.Length ? null : ArrayPool<byte>.Shared.Rent(maxBytes);
         Span<byte> buffer = rented is null ? inline : rented;
 

--- a/Docxodus/Ir/IrHash.cs
+++ b/Docxodus/Ir/IrHash.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Security.Cryptography;
 using System.Text;
@@ -42,7 +43,34 @@ internal readonly struct IrHash : IEquatable<IrHash>
     /// <summary>Compute the SHA-256 digest of the UTF-8 encoding of <paramref name="text"/>.</summary>
     public static IrHash Compute(string text)
     {
-        return Compute(Encoding.UTF8.GetBytes(text));
+        return ComputeUtf8(text);
+    }
+
+    /// <summary>
+    /// The digest of <paramref name="text"/>'s UTF-8 encoding, computed without materializing that
+    /// encoding: short strings encode into a stack buffer, longer ones into a pooled array. Identical
+    /// bytes in, identical digest out — this is purely the allocation-free spelling of
+    /// <see cref="Compute(string)"/>, for the hot canonical-XML hashing paths.
+    /// </summary>
+    public static IrHash ComputeUtf8(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        Span<byte> inline = stackalloc byte[1024];
+        int maxBytes = Encoding.UTF8.GetMaxByteCount(text.Length);
+        byte[]? rented = maxBytes <= inline.Length ? null : ArrayPool<byte>.Shared.Rent(maxBytes);
+        Span<byte> buffer = rented is null ? inline : rented;
+
+        try
+        {
+            int written = Encoding.UTF8.GetBytes(text, buffer);
+            return Compute(buffer[..written]);
+        }
+        finally
+        {
+            if (rented is not null)
+                ArrayPool<byte>.Shared.Return(rented);
+        }
     }
 
     /// <summary>

--- a/Docxodus/Ir/IrHasher.cs
+++ b/Docxodus/Ir/IrHasher.cs
@@ -92,11 +92,20 @@ internal static class IrHasher
     }
 
     /// <summary>SHA-256 of <see cref="Canonicalize(XElement)"/>.</summary>
-    public static IrHash CanonicalHash(XElement element) => IrHash.Compute(Canonicalize(element, resolver: null));
+    public static IrHash CanonicalHash(XElement element) => CanonicalHash(element, resolver: null);
 
     /// <summary>Part-aware SHA-256 of <see cref="Canonicalize(XElement, IrRelResolver?)"/>.</summary>
-    public static IrHash CanonicalHash(XElement element, IrRelResolver? resolver) =>
-        IrHash.Compute(Canonicalize(element, resolver));
+    /// <remarks>
+    /// Hashes the same bytes <see cref="Canonicalize(XElement, IrRelResolver?)"/> returns without
+    /// materializing them: the canonical XML is encoded straight into a pooled buffer. Every paragraph,
+    /// run and section read takes this path, so the per-call array mattered.
+    /// </remarks>
+    public static IrHash CanonicalHash(XElement element, IrRelResolver? resolver)
+    {
+        var clone = new XElement(element);
+        Clean(clone, resolver);
+        return IrHash.ComputeUtf8(clone.ToString(SaveOptions.DisableFormatting));
+    }
 
     /// <summary>
     /// Canonical SHA-256 with a caller-supplied attribute rewriter. This keeps the shared XML-noise
@@ -118,13 +127,20 @@ internal static class IrHasher
         XElement element, IrRelResolver? resolver,
         Func<XAttribute, XAttribute>? attributeRewrite = null)
     {
-        // Remove noise child elements first (proofErr/noProof, anywhere in the subtree).
-        var toRemove = element
-            .Descendants()
-            .Where(d => d.Name == ProofErr || d.Name == NoProof)
-            .ToList();
-        foreach (var d in toRemove)
-            d.Remove();
+        // Remove noise child elements first (proofErr/noProof, anywhere in the subtree). Most subtrees
+        // carry none, so the removal list is allocated only once one is actually found.
+        List<XElement>? toRemove = null;
+        foreach (var d in element.Descendants())
+        {
+            if (d.Name == ProofErr || d.Name == NoProof)
+                (toRemove ??= new List<XElement>()).Add(d);
+        }
+
+        if (toRemove is not null)
+        {
+            foreach (var d in toRemove)
+                d.Remove();
+        }
 
         foreach (var el in element.DescendantsAndSelf())
             CleanAttributes(el, resolver, attributeRewrite);
@@ -134,6 +150,30 @@ internal static class IrHasher
         XElement element, IrRelResolver? resolver,
         Func<XAttribute, XAttribute>? attributeRewrite)
     {
+        // This runs on every element of every canonicalized subtree, and in WordprocessingML the
+        // overwhelming majority of elements carry no attributes or exactly one. Neither case can be
+        // reordered, so both skip the sort and its LINQ machinery entirely; only elements with two or
+        // more attributes take the ordering path below. All three produce the same attributes in the
+        // same order as the single LINQ chain they replace.
+        var first = element.FirstAttribute;
+        if (first is null)
+            return;
+
+        if (first.NextAttribute is null)
+        {
+            // Decide and rewrite while the attribute is still ATTACHED. ShouldStripAttribute consults
+            // attribute.Parent (the wp:docPr/@id rule) and a rewrite callback may too, so removing first
+            // would silently change the verdict — the LINQ chain below is likewise fully evaluated by
+            // ToList() before RemoveAttributes runs.
+            var replacement = ShouldStripAttribute(first)
+                ? null
+                : attributeRewrite is null ? RewriteRelAttribute(first, resolver) : attributeRewrite(first);
+            element.RemoveAttributes();
+            if (replacement is not null)
+                element.Add(replacement);
+            return;
+        }
+
         var kept = element.Attributes()
             .Where(a => !ShouldStripAttribute(a))
             .OrderBy(a => a.Name.NamespaceName, StringComparer.Ordinal)

--- a/Docxodus/Ir/IrReader.cs
+++ b/Docxodus/Ir/IrReader.cs
@@ -78,18 +78,48 @@ internal static class IrReader
         // 1. Work over a private copy so the caller's bytes are never mutated.
         var working = new WmlDocument(doc);
 
-        // 2. Normalize tracked revisions (rule N13).
-        working = ApplyRevisionView(working, options.RevisionView);
+        // 2. Normalize tracked revisions (rule N13), then walk the body — both over ONE open package.
+        // The revision-view decision needs every story parsed (see ApplyRevisionView), and so does the walk
+        // below; opening a second package to make that decision and then throwing the parse away doubled the
+        // XML parsing cost of every read. GetXDocument caches per part, so keeping this package alive means
+        // the walk reuses the very trees the scan already parsed. Only a document that genuinely needs a
+        // revision transform pays for a second open, and it pays it inside RevisionProcessor regardless.
+        var stream = new OpenXmlMemoryStreamDocument(working);
+        var wdoc = stream.GetWordprocessingDocument();
+        try
+        {
+            var transformed = ApplyRevisionView(working, wdoc, options.RevisionView);
+            if (transformed is not null)
+            {
+                wdoc.Dispose();
+                stream.Dispose();
+                working = transformed;
+                stream = new OpenXmlMemoryStreamDocument(working);
+                wdoc = stream.GetWordprocessingDocument();
+            }
+
+            return ReadOpenPackage(working, wdoc, options);
+        }
+        finally
+        {
+            wdoc.Dispose();
+            stream.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// The body of <see cref="Read"/> once the revision view is settled and <paramref name="wdoc"/> is the
+    /// open package for <paramref name="working"/>.
+    /// </summary>
+    private static IrDocument ReadOpenPackage(
+        WmlDocument working, WordprocessingDocument wdoc, IrReaderOptions options)
+    {
         // Only a graph that exceeds its normal inspection budget needs this package-level fallback. Keep the
         // SHA lazy so ordinary documents pay no whole-package hashing cost; when a cutoff occurs it prevents an
         // uninspected nested chart/SmartArt target from comparing Equal across distinct source packages.
         var normalizedDocumentBytes = working.DocumentByteArray;
         var drawingGraphFallbackDocumentHash =
             new Lazy<IrHash>(() => IrHash.Compute(normalizedDocumentBytes));
-
-        // 3. Open the copy, assign deterministic Unids, and walk the body.
-        using var stream = new OpenXmlMemoryStreamDocument(working);
-        using var wdoc = stream.GetWordprocessingDocument();
 
         var main = wdoc.MainDocumentPart
             ?? throw new DocxodusException("Document has no MainDocumentPart.");
@@ -497,7 +527,14 @@ internal static class IrReader
 
     // --- revisions --------------------------------------------------------
 
-    private static WmlDocument ApplyRevisionView(WmlDocument working, RevisionView view)
+    /// <summary>
+    /// Decide the revision view over the ALREADY-OPEN <paramref name="wdoc"/>: returns the transformed
+    /// document when a <see cref="RevisionProcessor"/> round-trip is required, or <c>null</c> when
+    /// <paramref name="working"/> is already its own accepted/rejected view and the caller should keep
+    /// reading the open package.
+    /// </summary>
+    private static WmlDocument? ApplyRevisionView(
+        WmlDocument working, WordprocessingDocument wdoc, RevisionView view)
     {
         switch (view)
         {
@@ -506,10 +543,10 @@ internal static class IrReader
                 // IrReaderTests.Read_UnknownElement_BecomesOpaque deliberately feeds a
                 // w:customXmlInsRangeStart under FailIfPresent expecting it to survive as an opaque
                 // block, i.e. it is intentionally NOT treated as "present revision markup" here.
-                if (HasRevisionMarkup(working, FailIfPresentNameSet))
+                if (HasRevisionMarkup(wdoc, FailIfPresentNameSet))
                     throw new DocxodusException(
                         "Document contains tracked revisions and RevisionView is FailIfPresent.");
-                return working;
+                return null;
 
             case RevisionView.Accept:
             case RevisionView.Reject:
@@ -521,14 +558,14 @@ internal static class IrReader
                 // consumes, so any document that actually needs a revision transform still takes that
                 // path.  See the masking analysis on ProcessorActsOnNameSet for why w:instrText/w:t are
                 // deliberately omitted (covered by their w:ins ancestor).
-                if (!HasRevisionMarkup(working, ProcessorActsOnNameSet))
-                    return working;
+                if (!HasRevisionMarkup(wdoc, ProcessorActsOnNameSet))
+                    return null;
                 return view == RevisionView.Accept
                     ? RevisionProcessor.AcceptRevisionsForIrReader(working)
                     : RevisionProcessor.RejectRevisions(working);
 
             default:
-                return working;
+                return null;
         }
     }
 
@@ -584,10 +621,8 @@ internal static class IrReader
     // A w:ins child of w:numPr (inserted numbering, RevisionProcessor.cs:96) is itself a w:ins element,
     // so the local-name "ins" scan above already catches it — no separate numPr probe is needed. The
     // scan matches by full XName via DescendantsAndSelf, which visits that nested w:ins like any other.
-    private static bool HasRevisionMarkup(WmlDocument working, HashSet<XName> names)
+    private static bool HasRevisionMarkup(WordprocessingDocument wdoc, HashSet<XName> names)
     {
-        using var stream = new OpenXmlMemoryStreamDocument(working);
-        using var wdoc = stream.GetWordprocessingDocument();
         var main = wdoc.MainDocumentPart;
         if (main is null)
             return false;

--- a/Docxodus/Ir/IrReader.cs
+++ b/Docxodus/Ir/IrReader.cs
@@ -84,15 +84,24 @@ internal static class IrReader
         // XML parsing cost of every read. GetXDocument caches per part, so keeping this package alive means
         // the walk reuses the very trees the scan already parsed. Only a document that genuinely needs a
         // revision transform pays for a second open, and it pays it inside RevisionProcessor regardless.
-        var stream = new OpenXmlMemoryStreamDocument(working);
-        var wdoc = stream.GetWordprocessingDocument();
+        // The pair is opened inside the try and the finally is null-tolerant, because
+        // GetWordprocessingDocument throws on a package that is not Wordprocessing (an .xlsx handed to
+        // the reader) or is structurally damaged. `using` used to cover that; a bare assignment before
+        // the try would leak the open package on exactly those inputs.
+        OpenXmlMemoryStreamDocument? stream = null;
+        WordprocessingDocument? wdoc = null;
         try
         {
+            stream = new OpenXmlMemoryStreamDocument(working);
+            wdoc = stream.GetWordprocessingDocument();
+
             var transformed = ApplyRevisionView(working, wdoc, options.RevisionView);
             if (transformed is not null)
             {
                 wdoc.Dispose();
+                wdoc = null;
                 stream.Dispose();
+                stream = null;
                 working = transformed;
                 stream = new OpenXmlMemoryStreamDocument(working);
                 wdoc = stream.GetWordprocessingDocument();
@@ -102,8 +111,8 @@ internal static class IrReader
         }
         finally
         {
-            wdoc.Dispose();
-            stream.Dispose();
+            wdoc?.Dispose();
+            stream?.Dispose();
         }
     }
 

--- a/Docxodus/UnidHelper.cs
+++ b/Docxodus/UnidHelper.cs
@@ -136,7 +136,14 @@ internal static class UnidHelper
         }
 
         var parentUnid = (string?)contentParent.Attribute(PtOpenXml.Unid) ?? contentParent.Name.LocalName;
-        AssignDescendantsDeterministic(contentParent, parentUnid, live);
+        // ContentSignature hashes a string built from an element's subtree, and in real OOXML those
+        // strings repeat heavily — on a 15k-element legal document roughly seven in eight are a
+        // duplicate of one already seen (identical rPr blobs, repeated empty runs, boilerplate
+        // properties). SHA-256 dominates this walk, so the repeats are worth remembering. The cache
+        // lives for one call only: it is keyed on the exact string that is hashed, so a hit returns
+        // precisely what a fresh hash would have, and nothing survives to leak between documents.
+        var sigCache = new Dictionary<string, string>(StringComparer.Ordinal);
+        AssignDescendantsDeterministic(contentParent, parentUnid, live, sigCache);
         ContentControlIdentity.AssignStableUnids(contentParent);
         return true;
     }
@@ -256,7 +263,8 @@ internal static class UnidHelper
 
     // ─── Deterministic derivation internals ──────────────────────────────
 
-    private static void AssignDescendantsDeterministic(XElement parent, string parentUnid, HashSet<XElement> live)
+    private static void AssignDescendantsDeterministic(
+        XElement parent, string parentUnid, HashSet<XElement> live, Dictionary<string, string> sigCache)
     {
         // Signature/dup-index bookkeeping is only needed when THIS parent has a child
         // to assign — for fully-assigned parents (the overwhelming majority after the
@@ -272,7 +280,7 @@ internal static class UnidHelper
         {
             if (child.Attribute(PtOpenXml.Unid) == null)
             {
-                var sig = ContentSignature(child);
+                var sig = ContentSignature(child, sigCache);
                 var key = (child.Name.LocalName, sig);
                 dup!.TryGetValue(key, out var dupIndex);
                 dup[key] = dupIndex + 1;
@@ -285,7 +293,7 @@ internal static class UnidHelper
                 // AssignToSelfAndDescendants). Still count it for dup-index of its
                 // same-content siblings so unassigned later siblings get a
                 // consistent index regardless of which subset already had Unids.
-                var sig = ContentSignature(child);
+                var sig = ContentSignature(child, sigCache);
                 var key = (child.Name.LocalName, sig);
                 dup!.TryGetValue(key, out var dupIndex);
                 dup[key] = dupIndex + 1;
@@ -298,7 +306,7 @@ internal static class UnidHelper
             if (live.Contains(child))
             {
                 var childUnid = (string?)child.Attribute(PtOpenXml.Unid)!;
-                AssignDescendantsDeterministic(child, childUnid, live);
+                AssignDescendantsDeterministic(child, childUnid, live, sigCache);
             }
         }
     }
@@ -320,31 +328,121 @@ internal static class UnidHelper
     /// fields get distinct sigs).
     /// </para>
     /// </summary>
-    private static string ContentSignature(XElement element)
+    private static string ContentSignature(XElement element) => ContentSignature(element, sigCache: null);
+
+    /// <summary>
+    /// The content signature of <paramref name="element"/>: a 16-hex-char digest of its own text,
+    /// paragraph style/numbering, and descendant element names. With <paramref name="sigCache"/>
+    /// supplied, digests are reused across elements whose signature input is identical — the digest
+    /// is a pure function of that string, so a cache hit is indistinguishable from a fresh hash.
+    /// </summary>
+    private static string ContentSignature(XElement element, Dictionary<string, string>? sigCache)
     {
         // Container elements (those that contain block-level descendants like
         // nested w:p or w:tbl) collapse to a tag-name-only signature. Their
         // Unid is used as parent_unid for the blocks inside; we don't want
         // editing/inserting one paragraph to invalidate every other paragraph
         // by shifting their parent's signature.
-        bool hasBlockDescendants = element.Descendants().Any(d => d.Name == W.p || d.Name == W.tbl);
-        if (hasBlockDescendants)
+        //
+        // The block-descendant test, the text concatenation and the descendant-name list all used to
+        // walk the subtree separately, with a string materialized per walk. One walk now feeds all
+        // three: the same characters land in the builder in the same order, so the hashed string —
+        // and therefore the signature — is unchanged.
+        var sb = AcquireSignatureBuilder();
+        try
         {
-            return ShortHash(element.Name.LocalName, hexChars: 16);
+            if (AppendSignatureInput(element, sb))
+                return Digest(element.Name.LocalName, sigCache);
+
+            return Digest(sb.ToString(), sigCache);
+        }
+        finally
+        {
+            ReleaseSignatureBuilder(sb);
         }
 
-        var text = string.Concat(element.Descendants(W.t).Select(t => (string)t));
-        var pPr = element.Element(W.pPr);
-        var styleId = pPr?.Element(W.pStyle)?.Attribute(W.val)?.Value ?? string.Empty;
-        var numId = pPr?.Element(W.numPr)?.Element(W.numId)?.Attribute(W.val)?.Value ?? string.Empty;
-        var sb2 = new StringBuilder(text.Length + 64);
-        sb2.Append(text).Append('|').Append(styleId).Append('|').Append(numId).Append('|');
-        foreach (var d in element.Descendants())
+        static string Digest(string input, Dictionary<string, string>? cache)
         {
-            if (d.Name == W.t) continue;
-            sb2.Append(d.Name.LocalName).Append(',');
+            if (cache is null)
+                return ShortHash(input, hexChars: 16);
+            if (cache.TryGetValue(input, out var hit))
+                return hit;
+            var computed = ShortHash(input, hexChars: 16);
+            cache[input] = computed;
+            return computed;
         }
-        return ShortHash(sb2.ToString(), hexChars: 16);
+    }
+
+    /// <summary>
+    /// Append <paramref name="element"/>'s signature input to <paramref name="sb"/> in the exact order
+    /// the original three-walk form produced — all descendant <c>w:t</c> text, <c>'|'</c>, the pStyle id,
+    /// <c>'|'</c>, the numId, <c>'|'</c>, then every non-<c>w:t</c> descendant's local name followed by a
+    /// comma. Returns <c>true</c> as soon as a block-level descendant (<c>w:p</c>/<c>w:tbl</c>) is seen,
+    /// in which case the caller discards the builder and uses the tag-name-only signature instead.
+    /// </summary>
+    private static bool AppendSignatureInput(XElement element, StringBuilder sb)
+    {
+        // Text first, bailing out the moment the element proves to be a block container.
+        if (AppendDescendantText(element, sb))
+            return true;
+
+        var pPr = element.Element(W.pPr);
+        sb.Append('|')
+          .Append(pPr?.Element(W.pStyle)?.Attribute(W.val)?.Value ?? string.Empty)
+          .Append('|')
+          .Append(pPr?.Element(W.numPr)?.Element(W.numId)?.Attribute(W.val)?.Value ?? string.Empty)
+          .Append('|');
+
+        AppendDescendantNames(element, sb);
+        return false;
+    }
+
+    /// <summary>Depth-first <c>w:t</c> text append; <c>true</c> if a <c>w:p</c>/<c>w:tbl</c> descendant exists.</summary>
+    private static bool AppendDescendantText(XElement element, StringBuilder sb)
+    {
+        foreach (var child in element.Elements())
+        {
+            if (child.Name == W.p || child.Name == W.tbl)
+                return true;
+            if (child.Name == W.t)
+                sb.Append(child.Value);
+            if (AppendDescendantText(child, sb))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Depth-first append of every non-<c>w:t</c> descendant's local name, comma-separated.</summary>
+    private static void AppendDescendantNames(XElement element, StringBuilder sb)
+    {
+        foreach (var child in element.Elements())
+        {
+            if (child.Name != W.t)
+                sb.Append(child.Name.LocalName).Append(',');
+            AppendDescendantNames(child, sb);
+        }
+    }
+
+    // One builder per thread, reused across the thousands of signatures a single walk computes.
+    // Oversized builders are dropped rather than parked so a pathological element cannot pin memory.
+    [ThreadStatic]
+    private static StringBuilder? t_signatureBuilder;
+
+    private static StringBuilder AcquireSignatureBuilder()
+    {
+        var sb = t_signatureBuilder;
+        if (sb is null)
+            return new StringBuilder(256);
+        t_signatureBuilder = null;
+        sb.Clear();
+        return sb;
+    }
+
+    private static void ReleaseSignatureBuilder(StringBuilder sb)
+    {
+        if (sb.Capacity <= 8192)
+            t_signatureBuilder = sb;
     }
 
     private static string DeriveUnid(string rootSeed, string tag, string sig, int dupIndex)

--- a/benchmarks/docxdiff-stress/Corpus.cs
+++ b/benchmarks/docxdiff-stress/Corpus.cs
@@ -1,0 +1,202 @@
+// Corpus-wide differential: run every document in a directory through the DocxDiff products and
+// digest the results, so two builds can be compared byte for byte.
+//
+// The eight generated variants of one reference document answer "did this change the diff of a
+// heavyweight legal form". They do NOT answer "did this change the diff of anything else", and the
+// reference document happens to carry no tracked revisions, no tables and no drawings — three of the
+// shapes the engine's riskiest code paths are keyed on. This mode closes that: point it at
+// TestFiles/ and it exercises every document the repository has.
+//
+// Failures are digested too. An exception is a result like any other, and a change in WHICH
+// exception a malformed document produces is exactly the kind of regression worth catching.
+
+using System.Collections.Concurrent;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Docxodus;
+
+namespace Docxodus.Stress;
+
+internal static class Corpus
+{
+    public static int Run(string root, string outPath, string? checkPath, int? limit, int threads)
+    {
+        var files = Directory.EnumerateFiles(root, "*.*", SearchOption.AllDirectories)
+            .Where(f => f.EndsWith(".docx", StringComparison.OrdinalIgnoreCase)
+                     || f.EndsWith(".docm", StringComparison.OrdinalIgnoreCase)
+                     || f.EndsWith(".dotx", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToList();
+        if (limit is > 0) files = files.Take(limit.Value).ToList();
+
+        Console.WriteLine($"corpus  : {root}");
+        Console.WriteLine($"documents: {files.Count:N0}");
+        Console.WriteLine($"threads : {threads}");
+        Console.WriteLine();
+
+        var digests = new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
+        var done = 0;
+        var errors = 0;
+
+        Parallel.ForEach(files, new ParallelOptions { MaxDegreeOfParallelism = threads }, path =>
+        {
+            var name = Path.GetRelativePath(root, path).Replace('\\', '/');
+            byte[] bytes;
+            try { bytes = File.ReadAllBytes(path); }
+            catch (Exception ex) { digests[$"{name}#read"] = $"READ-FAIL {ex.GetType().Name}"; return; }
+
+            // Every document is compared against a deterministically edited copy of itself, and
+            // against itself unchanged (the identical-bytes fast paths).
+            byte[] edited;
+            try { edited = CorpusVariant.Edit(bytes); }
+            catch (Exception ex) { digests[$"{name}#variant"] = $"VARIANT-FAIL {ex.GetType().Name}"; edited = bytes; }
+
+            var left = new WmlDocument("left.docx", bytes);
+            var right = new WmlDocument("right.docx", edited);
+            var same = new WmlDocument("same.docx", bytes);
+
+            // Default settings over the edited pair: the ordinary comparison path.
+            Record(digests, name, "edited", left, right, new DocxDiffSettings());
+
+            // The same document on both sides: the byte-identical shortcuts, including the one
+            // GetRevisions gained. Cheap, and it pins the shortcut against the full pipeline.
+            Record(digests, name, "identical", left, same, new DocxDiffSettings());
+
+            // The revision-view transform is only reached by a document that actually carries
+            // revision markup, and it is the path IrReader.Read was restructured around. Force both
+            // input-revision policies so the pre-accept flatten and the preserve renderer both run.
+            Record(digests, name, "preaccept", left, right,
+                new DocxDiffSettings { PreAcceptInputRevisions = true });
+            Record(digests, name, "preserve", left, right,
+                new DocxDiffSettings { PreserveInputRevisions = true });
+
+            var n = Interlocked.Increment(ref done);
+            if (n % 50 == 0) Console.WriteLine($"  {n,5}/{files.Count} ...");
+        });
+
+        foreach (var kv in digests)
+            if (kv.Value.Contains("FAIL", StringComparison.Ordinal)) errors++;
+
+        var sorted = new SortedDictionary<string, string>(digests, StringComparer.Ordinal);
+        File.WriteAllText(outPath, JsonSerializer.Serialize(sorted, new JsonSerializerOptions { WriteIndented = true }));
+        Console.WriteLine();
+        Console.WriteLine($"{sorted.Count:N0} digests over {files.Count:N0} documents written to {outPath}");
+        Console.WriteLine($"({errors:N0} of them record a thrown exception rather than a result — that is expected for");
+        Console.WriteLine(" malformed or unsupported fixtures, and a CHANGE in them is still a regression.)");
+
+        if (checkPath is null) return 0;
+
+        var expected = JsonSerializer.Deserialize<SortedDictionary<string, string>>(File.ReadAllText(checkPath))!;
+        var mismatches = 0;
+        foreach (var (k, want) in expected)
+        {
+            if (!sorted.TryGetValue(k, out var got)) { Console.WriteLine($"[parity] MISSING  {k}"); mismatches++; }
+            else if (got != want)
+            {
+                Console.WriteLine($"[parity] MISMATCH {k}");
+                Console.WriteLine($"           expected {want}");
+                Console.WriteLine($"           actual   {got}");
+                mismatches++;
+            }
+        }
+
+        foreach (var k in sorted.Keys.Where(k => !expected.ContainsKey(k)))
+        {
+            Console.WriteLine($"[parity] EXTRA    {k}");
+            mismatches++;
+        }
+
+        Console.WriteLine();
+        Console.WriteLine(mismatches == 0
+            ? $"[parity] OK - all {expected.Count:N0} digests identical across {files.Count:N0} documents"
+            : $"[parity] {mismatches:N0} MISMATCH(ES) of {expected.Count:N0}");
+        return mismatches == 0 ? 0 : 2;
+    }
+
+    private static void Record(
+        ConcurrentDictionary<string, string> sink, string name, string mode,
+        WmlDocument left, WmlDocument right, DocxDiffSettings settings)
+    {
+        sink[$"{name}#{mode}/redline"] = Try(() => StableRedlineDigest(DocxDiff.Compare(left, right, settings).DocumentByteArray));
+        sink[$"{name}#{mode}/revisions"] = Try(() =>
+        {
+            var revs = DocxDiff.GetRevisions(left, right, settings);
+            var sb = new StringBuilder().Append(revs.Count).Append('\n');
+            foreach (var r in revs)
+                sb.Append(r.Type).Append('|').Append(r.Author).Append('|').Append(r.Text).Append('|')
+                  .Append(r.LeftAnchor).Append('|').Append(r.RightAnchor).Append('|')
+                  .Append(r.MoveGroupId).Append('|').Append(r.IsMoveSource).Append('\n');
+            return Sha(Encoding.UTF8.GetBytes(sb.ToString()));
+        });
+        sink[$"{name}#{mode}/editscript"] = Try(() => Sha(Encoding.UTF8.GetBytes(DocxDiff.GetEditScriptJson(left, right, settings))));
+    }
+
+    // A thrown exception is a recorded outcome, not a crash: the type and message are digested so a
+    // build that throws something different, or stops throwing, shows up as a mismatch.
+    private static string Try(Func<string> f)
+    {
+        try { return f(); }
+        catch (Exception ex) { return $"FAIL {ex.GetType().Name}: {Truncate(ex.Message)}"; }
+    }
+
+    private static string Truncate(string s)
+    {
+        s = s.ReplaceLineEndings(" ").Trim();
+        return s.Length <= 160 ? s : s[..160];
+    }
+
+    private static string Sha(byte[] b) => Convert.ToHexString(SHA256.HashData(b));
+
+    // Media and diagram parts imported into a redline are named "P" + a fresh GUID, and the
+    // relationships pointing at them get ids of "R" + a fresh GUID. Two runs of the SAME comparison
+    // on the SAME build therefore emit packages that differ in those part names, in the relationship
+    // ids and targets, and in the r:embed/r:id references in the story parts — while the bytes they
+    // hold are identical. That is a real defect, but a PRE-EXISTING one:
+    // origin/main disagrees with itself on exactly the documents this affects. Digesting raw package
+    // bytes would therefore report 161 differences per run and drown any genuine regression on the
+    // 54 media-bearing documents in the corpus.
+    //
+    // So the redline is digested rename-invariantly: every generated part name is folded to a
+    // placeholder, in entry names AND inside XML content, and entries are hashed in canonical-name
+    // order. Content still has to match exactly — this hides only the naming churn, so a genuine
+    // change to any part's bytes, to the set of parts, or to which content sits under which
+    // canonical name still shows up as a mismatch.
+    // "P<32 hex>" for a generated part name, "R<32 hex>" for a generated relationship id.
+    private static readonly System.Text.RegularExpressions.Regex GeneratedPartName =
+        new("[PR][0-9a-f]{32}", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    private static string StableRedlineDigest(byte[] package)
+    {
+        var entries = new SortedDictionary<string, string>(StringComparer.Ordinal);
+        using (var ms = new MemoryStream(package))
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Read))
+        {
+            foreach (var entry in zip.Entries)
+            {
+                using var stream = entry.Open();
+                using var buffer = new MemoryStream();
+                stream.CopyTo(buffer);
+                var content = buffer.ToArray();
+
+                var canonicalName = GeneratedPartName.Replace(entry.FullName, "@");
+                var isXml = entry.FullName.EndsWith(".xml", StringComparison.OrdinalIgnoreCase)
+                         || entry.FullName.EndsWith(".rels", StringComparison.OrdinalIgnoreCase);
+                var digest = isXml
+                    ? Sha(Encoding.UTF8.GetBytes(GeneratedPartName.Replace(Encoding.UTF8.GetString(content), "@")))
+                    : Sha(content);
+
+                // Two parts can fold to one canonical name (P<guid1>.jpeg and P<guid2>.jpeg). Their
+                // content digests are combined in sorted order so the fold stays order-independent.
+                entries[canonicalName] = entries.TryGetValue(canonicalName, out var existing)
+                    ? string.Join(",", new[] { existing, digest }.OrderBy(x => x, StringComparer.Ordinal))
+                    : digest;
+            }
+        }
+
+        var sb = new StringBuilder();
+        foreach (var (k, v) in entries) sb.Append(k).Append('=').Append(v).Append('\n');
+        return Sha(Encoding.UTF8.GetBytes(sb.ToString()));
+    }
+}

--- a/benchmarks/docxdiff-stress/Corpus.cs
+++ b/benchmarks/docxdiff-stress/Corpus.cs
@@ -53,9 +53,16 @@ internal static class Corpus
             try { edited = CorpusVariant.Edit(bytes); }
             catch (Exception ex) { digests[$"{name}#variant"] = $"VARIANT-FAIL {ex.GetType().Name}"; edited = bytes; }
 
+            // A second, differently-offset edit of the same document: the N-way case needs two
+            // reviewers who actually disagree, or the merger never has a competitor to order.
+            byte[] editedAlt;
+            try { editedAlt = CorpusVariant.Edit(bytes, offset: 2); }
+            catch (Exception ex) { digests[$"{name}#variant-alt"] = $"VARIANT-FAIL {ex.GetType().Name}"; editedAlt = bytes; }
+
             var left = new WmlDocument("left.docx", bytes);
             var right = new WmlDocument("right.docx", edited);
             var same = new WmlDocument("same.docx", bytes);
+            var alt = new WmlDocument("alt.docx", editedAlt);
 
             // Default settings over the edited pair: the ordinary comparison path.
             Record(digests, name, "edited", left, right, new DocxDiffSettings());
@@ -71,6 +78,20 @@ internal static class Corpus
                 new DocxDiffSettings { PreAcceptInputRevisions = true });
             Record(digests, name, "preserve", left, right,
                 new DocxDiffSettings { PreserveInputRevisions = true });
+
+            // The compatibility pre-flight is a SECOND observable output, and it is invisible to
+            // everything above: with it disengaged, a product that never runs it and a product that
+            // runs it and finds nothing produce the same digest. Digest the report itself, so a
+            // shortcut that skips the pre-flight rather than the work shows up as a mismatch — on the
+            // identical pair as well, where a shortcut is most tempting and least observable.
+            RecordPreflight(digests, name, "edited", left, right);
+            RecordPreflight(digests, name, "identical", left, same);
+
+            // N-way. The consolidate path has its own reader fan-out, its own merger and its own
+            // markup renderer, and NONE of the three products above touches any of them. Two
+            // reviewers off the same base is the smallest shape that exercises reviewer ordering and
+            // conflict competitor order.
+            RecordConsolidate(digests, name, left, right, alt);
 
             var n = Interlocked.Increment(ref done);
             if (n % 50 == 0) Console.WriteLine($"  {n,5}/{files.Count} ...");
@@ -131,6 +152,80 @@ internal static class Corpus
             return Sha(Encoding.UTF8.GetBytes(sb.ToString()));
         });
         sink[$"{name}#{mode}/editscript"] = Try(() => Sha(Encoding.UTF8.GetBytes(DocxDiff.GetEditScriptJson(left, right, settings))));
+    }
+
+    // Every consolidate product, over two reviewers off one base. Reviewer order is significant to
+    // conflict reporting, so the digest carries the authors and the per-revision order as emitted.
+    private static void RecordConsolidate(
+        ConcurrentDictionary<string, string> sink, string name,
+        WmlDocument baseDoc, WmlDocument reviewerA, WmlDocument reviewerB)
+    {
+        var reviewers = new List<DocxDiffReviewer>
+        {
+            new() { Author = "Reviewer A", Document = reviewerA },
+            new() { Author = "Reviewer B", Document = reviewerB },
+        };
+        var settings = new DocxDiffConsolidateSettings();
+
+        sink[$"{name}#consolidate/redline"] = Try(() =>
+            StableRedlineDigest(DocxDiff.Consolidate(baseDoc, reviewers, settings).DocumentByteArray));
+
+        sink[$"{name}#consolidate/revisions"] = Try(() =>
+        {
+            var revs = DocxDiff.GetConsolidatedRevisions(baseDoc, reviewers, settings);
+            var sb = new StringBuilder().Append(revs.Count).Append('\n');
+            foreach (var r in revs)
+                sb.Append(r.Type).Append('|').Append(r.Author).Append('|').Append(r.Text).Append('|')
+                  .Append(r.LeftAnchor).Append('|').Append(r.RightAnchor).Append('|')
+                  .Append(r.ConflictId).Append('\n');
+            return Sha(Encoding.UTF8.GetBytes(sb.ToString()));
+        });
+
+        sink[$"{name}#consolidate/conflicts"] = Try(() =>
+        {
+            var conflicts = DocxDiff.GetConflicts(baseDoc, reviewers, settings);
+            var sb = new StringBuilder().Append(conflicts.Count).Append('\n');
+            foreach (var c in conflicts)
+                sb.Append(c.Id).Append('|').Append(c.BaseAnchor).Append('|')
+                  .Append(c.TokenStart).Append('-').Append(c.TokenEnd).Append('|')
+                  .Append(string.Join(",", c.Competitors.Select(x => x.Author + "=" + x.ResultText))).Append('\n');
+            return Sha(Encoding.UTF8.GetBytes(sb.ToString()));
+        });
+
+        sink[$"{name}#consolidate/editscript"] = Try(() =>
+            Sha(Encoding.UTF8.GetBytes(DocxDiff.GetConsolidatedEditScriptJson(baseDoc, reviewers, settings))));
+    }
+
+    // The compatibility report each product hands back through the OnCompatibilityWarning callback,
+    // digested per product. A product that stops running the pre-flight records "none" where it used
+    // to record a report — which no output digest can tell you, because the output was already right.
+    private static void RecordPreflight(
+        ConcurrentDictionary<string, string> sink, string name, string mode,
+        WmlDocument left, WmlDocument right)
+    {
+        foreach (var (product, run) in PreflightProducts(left, right))
+            sink[$"{name}#{mode}/preflight-{product}"] = Try(() =>
+            {
+                var seen = new List<string>();
+                var settings = new DocxDiffSettings
+                {
+                    OnCompatibilityWarning = report =>
+                    {
+                        foreach (var w in report.Warnings.OrderBy(w => w.Feature.Id, StringComparer.Ordinal))
+                            seen.Add(w.Feature.Id);
+                    },
+                };
+                run(settings);
+                return seen.Count == 0 ? "none" : string.Join(",", seen);
+            });
+    }
+
+    private static IEnumerable<(string Product, Action<DocxDiffSettings> Run)> PreflightProducts(
+        WmlDocument left, WmlDocument right)
+    {
+        yield return ("redline", s => DocxDiff.Compare(left, right, s));
+        yield return ("revisions", s => DocxDiff.GetRevisions(left, right, s));
+        yield return ("editscript", s => DocxDiff.GetEditScriptJson(left, right, s));
     }
 
     // A thrown exception is a recorded outcome, not a crash: the type and message are digested so a

--- a/benchmarks/docxdiff-stress/CorpusVariant.cs
+++ b/benchmarks/docxdiff-stress/CorpusVariant.cs
@@ -22,7 +22,12 @@ internal static class CorpusVariant
     /// zip entry directly rather than through the SDK, so a package the SDK rejects still produces a
     /// usable right-hand side instead of aborting the document's whole row.
     /// </summary>
-    public static byte[] Edit(byte[] source)
+    /// <param name="source">The document to edit.</param>
+    /// <param name="offset">Which of the four residues to edit. The default (0) is the ordinary
+    /// variant; a second reviewer built with a different offset edits DIFFERENT text nodes in the
+    /// same paragraphs, which is what gives an N-way consolidate real competitors to order and real
+    /// conflicts to report instead of one reviewer's edits applied unopposed.</param>
+    public static byte[] Edit(byte[] source, int offset = 0)
     {
         using var ms = new MemoryStream();
         ms.Write(source, 0, source.Length);
@@ -46,9 +51,9 @@ internal static class CorpusVariant
                 if (texts.Count == 0) return source;
 
                 var edits = 0;
-                for (var i = 0; i < texts.Count; i += 4)
+                for (var i = offset % 4; i < texts.Count; i += 4)
                 {
-                    texts[i].Value = MutateWord(texts[i].Value, i);
+                    texts[i].Value = MutateWord(texts[i].Value, i + offset);
                     edits++;
                 }
 

--- a/benchmarks/docxdiff-stress/CorpusVariant.cs
+++ b/benchmarks/docxdiff-stress/CorpusVariant.cs
@@ -1,0 +1,89 @@
+// A deterministic edit that works on an arbitrary .docx, however odd its contents.
+//
+// The generated variants in Variants.cs assume a document shaped like the reference legal form. A
+// corpus of 678 fixtures contains documents with no body text, no main part, deliberately malformed
+// XML, and packages that are not really Wordprocessing at all — so this one is written to degrade
+// rather than throw: anything it cannot edit comes back unchanged, which still exercises the
+// identical-bytes paths for that document.
+
+using System.IO.Compression;
+using System.Text;
+using System.Xml.Linq;
+
+namespace Docxodus.Stress;
+
+internal static class CorpusVariant
+{
+    private static readonly XNamespace W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+
+    /// <summary>
+    /// Edit every fourth non-trivial <c>w:t</c> in the main document part, by word substitution so
+    /// the surrounding tokens stay Equal and the token differ has real work to do. Operates on the
+    /// zip entry directly rather than through the SDK, so a package the SDK rejects still produces a
+    /// usable right-hand side instead of aborting the document's whole row.
+    /// </summary>
+    public static byte[] Edit(byte[] source)
+    {
+        using var ms = new MemoryStream();
+        ms.Write(source, 0, source.Length);
+
+        try
+        {
+            using (var zip = new ZipArchive(ms, ZipArchiveMode.Update, leaveOpen: true))
+            {
+                var entry = zip.GetEntry("word/document.xml");
+                if (entry is null) return source;
+
+                string xml;
+                using (var reader = new StreamReader(entry.Open(), Encoding.UTF8))
+                    xml = reader.ReadToEnd();
+
+                XDocument doc;
+                try { doc = XDocument.Parse(xml, LoadOptions.PreserveWhitespace); }
+                catch (System.Xml.XmlException) { return source; }
+
+                var texts = doc.Descendants(W + "t").Where(t => t.Value.Trim().Length > 3).ToList();
+                if (texts.Count == 0) return source;
+
+                var edits = 0;
+                for (var i = 0; i < texts.Count; i += 4)
+                {
+                    texts[i].Value = MutateWord(texts[i].Value, i);
+                    edits++;
+                }
+
+                if (edits == 0) return source;
+
+                using var writer = new StreamWriter(entry.Open(), new UTF8Encoding(false));
+                writer.BaseStream.SetLength(0);
+                writer.Write(doc.ToString(SaveOptions.DisableFormatting));
+            }
+
+            return ms.ToArray();
+        }
+        catch (InvalidDataException)
+        {
+            // Not a readable zip. Comparing it against itself is still a meaningful row.
+            return source;
+        }
+    }
+
+    private static string MutateWord(string value, int seed)
+    {
+        var words = value.Split(' ');
+        for (var i = 0; i < words.Length; i++)
+        {
+            if (words[i].Trim().Length <= 2) continue;
+            words[i] = Replacements[seed % Replacements.Length];
+            return string.Join(' ', words);
+        }
+
+        return value + " " + Replacements[seed % Replacements.Length];
+    }
+
+    private static readonly string[] Replacements =
+    [
+        "amended", "restated", "supplemental", "conditional", "irrevocable",
+        "notwithstanding", "reconciled", "superseded", "novated", "assigned",
+    ];
+}

--- a/benchmarks/docxdiff-stress/DocxDiffStress.csproj
+++ b/benchmarks/docxdiff-stress/DocxDiffStress.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- Standalone DocxDiff performance harness; deliberately NOT part of Docxodus.sln so it
+       never affects CI, packaging, or the warning baselines. See README.md for how to run it. -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>DocxDiffStress</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Docxodus/Docxodus.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/docxdiff-stress/FINDINGS.md
+++ b/benchmarks/docxdiff-stress/FINDINGS.md
@@ -1,0 +1,148 @@
+# Findings: where DocxDiff's time goes on a heavyweight legal document
+
+Measured on the NVCA Model Certificate of Incorporation (October 2025) — 147 KB packed,
+574 KB of `word/document.xml` holding 15,360 elements across 234 body paragraphs, plus 97
+footnotes in a 227 KB part (5,461 elements), 16 abstract numbering definitions, 4 sections,
+8 headers and 10 footers. Release build, .NET 10.0.11, 4 cores, server GC, single
+container. Medians of 9 timed iterations after 4 warm-ups, one process per column.
+
+Timings are indicative of *this* machine; the ratios and the stage attribution are the
+durable part.
+
+## What changed
+
+Every number below is from one before/after run of the same harness against the same
+document, with `--check` confirming all 36 output digests identical across the two.
+
+| Case | Before | After | |
+|---|---|---|---|
+| `light` — 8 scattered word edits | 821 ms | **351 ms** | 2.3× |
+| `heavy` — every fifth paragraph | 868 ms | **395 ms** | 2.2× |
+| `reorder` — 24 blocks relocated | 792 ms | **338 ms** | 2.3× |
+| `structural` — 20 deleted, 20 inserted | 803 ms | **334 ms** | 2.4× |
+| `footnotes` — half the footnote paragraphs | 959 ms | **510 ms** | 1.9× |
+| `churn` — every second text node | 1062 ms | **611 ms** | 1.7× |
+| `rewrite` — every paragraph replaced | 1279 ms | **868 ms** | 1.5× |
+| `GetRevisions` (light) | 395 ms | **216 ms** | 1.8× |
+| `GetEditScriptJson` (light) | 389 ms | **216 ms** | 1.8× |
+| all three products fused (light) | 852 ms | **387 ms** | 2.2× |
+| `GetRevisions` on identical packages | 371 ms | **0 ms** | — |
+| `Consolidate`, 4 reviewers | 1870 ms | **675 ms** | 2.8× |
+
+Allocation per `light` comparison: 528 MB → 276 MB. Per 4-reviewer consolidate: 1337 MB →
+710 MB.
+
+The gain tracks how much of a comparison is reading rather than diffing: `structural`, where
+the alignment does little work, is 2.4×; `rewrite`, where every block is modified and the
+token differ dominates, is 1.5×.
+
+## The finding that mattered: the same document was read four times
+
+A two-way `Compare` spent about 72% of its wall clock inside `IrReader`, reading each of the
+two documents **twice**, and each of those reads opened and parsed the package **twice**:
+
+1. `DocxDiffComparison` read both sides with `RetainSources` off to build the edit script.
+2. `IrMarkupRenderer` re-read the same two documents with `RetainSources` on, to get the
+   source `w:p`/`w:tbl` elements it clones from.
+3. Inside every read, deciding the revision view (`Accept`) opened a whole second package,
+   parsed every story to scan for revision markup, then threw that parse away and reopened
+   the document for the walk.
+
+None of it was needed. `RetainSources` only controls whether `IrProvenance` pins the source
+`XElement`, and `IrProvenance` is equality-neutral by construction, so the two snapshots are
+node-for-node value-equal — the renderer can be handed the snapshot the script was built
+over. And `GetXDocument` caches per part, so scanning the package the walk is about to use
+costs nothing extra.
+
+The N-way path had the same duplication multiplied by reviewer count: an N-reviewer
+`Consolidate` read `2*(N+1)` packages to compare `N+1`.
+
+## Where the remaining time goes
+
+Stage decomposition of the `light` case after the change (~330 ms), replicating
+`DocxDiffComparison`'s own steps:
+
+| Stage | Wall | Share |
+|---|---|---|
+| IR read, both sides, concurrent | ~134 ms | 41% |
+| markup render (excluding the reads it no longer does) | ~113 ms | 35% |
+| edit-script build | ~51 ms | 16% |
+| pre-accept normalizers, both sides, concurrent | ~25 ms | 8% |
+
+Inside one ~131 ms IR read:
+
+| | |
+|---|---|
+| `UnidHelper.AssignToAllElementsDeterministic` (main part) | ~51 ms |
+| IR walk, hashing, list-marker resolution, note/header scopes | ~60 ms |
+| package open + parse of every story the reader consumes | ~20 ms |
+
+Inside the markup render, sampled: 45% is `Buffer.MemmoveInternal` — the package clone and
+the deflate round-trip — and 13% is XLinq subtree enumeration. There is no algorithmic
+hotspot left there; it is I/O over a 574 KB part.
+
+Inside the edit-script build, sampled: 42% is `IrTokenDiffer.CharWeightedLcs`. That is the
+diff actually diffing.
+
+Two floors, for calibration: parsing every part the reader consumes costs ~13 ms, and
+opening a package and re-serializing it unchanged costs ~17 ms. So roughly 45 ms of a
+330 ms comparison is package I/O that no design avoids.
+
+## On the 10 comparisons/second target
+
+Not reached for a cold pairwise redline of a document this size, and worth being precise
+about why. At ~350 ms the `light` case is just under 3 per second; 10 per second means 100 ms.
+
+What that 100 ms would have to absorb: ~45 ms of unavoidable package I/O, plus the edit
+script, plus assembling and re-deflating an output package. The **data** products are much
+closer — `GetEditScriptJson` and `GetRevisions` are 216 ms and, with both documents already
+read, about 60 ms of that is the diff itself. **If the question is "10 analyses per second",
+that is reachable now with snapshot reuse; if it is "10 redlined .docx packages per second",
+the zip round-trip is a hard floor and the answer on this hardware is no.**
+
+Three levers remain, in descending value, none of them taken here:
+
+1. **Reuse reads across comparisons.** Nothing in the pipeline lets a caller say "I already
+   read this document." Every realistic bulk workload — one baseline against many
+   counterparties' markups, a version chain, an N-way consolidate — reads the same document
+   over and over. A snapshot type carrying the pre-accepted document plus its IR, accepted
+   by `CreateComparison`, removes the read from every comparison after the first. With both
+   sides pre-read, the `light` case would be roughly 165 ms — 6 per second — and the data
+   products would clear 10 per second comfortably. This is a public API addition and rippl-
+   es across every transport (see the ripple checklist in `CLAUDE.md`), which is why it was
+   left out of a change set whose remit was to not alter the surface.
+
+2. **Assign Unids only where they are read.** ~51 ms of every read hashes twice per element
+   for all 15,360 elements, but the IR reads a Unid back only on blocks, content controls
+   and `w:drawing`. A block's Unid derives from its ancestors, never its descendants, so
+   pruning the assignment would leave every anchor byte-identical. It was not taken because
+   `UnidHelper` is shared with `DocxSession` and the markdown projection, Unids persist into
+   saved packages, and "which elements carry an identity" is exactly the kind of contract
+   a green test suite can fail to protect.
+
+3. **Spend the other two cores.** Pre-accept and the two IR reads are concurrent now, which
+   uses about two of four cores; the build and the render are single-threaded. Per-block
+   token diffs are independent and the per-scope reads within one document are nearly so.
+   Worth perhaps 15-20% and a real risk of introducing order-dependence into a pipeline
+   whose determinism is a documented guarantee.
+
+## Notes for anyone re-running this
+
+- **Measure medians, and force a collection between cases.** A comparison here allocates
+  hundreds of megabytes; whichever case runs first after a quiet stretch absorbs the Gen2
+  collection for everything before it. Before the harness settled the heap between cases,
+  the same case reported 334 ms and 1048 ms in consecutive runs.
+- **Warm past tiered JIT before timing, not just twice.** An early draft of the sub-stage
+  probe reported `UnidHelper` at 108 ms and the package parse at 48 ms; with every stage
+  given the same promotion budget those became 51 ms and 13 ms. Stages measured first in a
+  series pay for code the later ones inherit already compiled.
+- **`--check` is the point.** A perf change to a diff engine is only interesting if the diff
+  is unchanged, and "the tests still pass" is a weaker claim than "all 36 output digests are
+  byte-identical across eight edit shapes and a four-way consolidate".
+- **Digest parity on one document is not coverage.** One optimization here — skipping the
+  attribute sort for elements carrying a single attribute — was briefly wrong: canonicalization
+  strips `wp:docPr/@id` by consulting `attribute.Parent`, so deciding an attribute's fate after
+  detaching it silently changes the verdict. Every digest still matched, because the reference
+  document contains no drawings. The rule was only pinned once a unit test gave `wp:docPr` a
+  lone `@id` — the existing one always paired it with `@name`, which took the sorted path. Read
+  the code an optimization touches for shapes the corpus does not contain.

--- a/benchmarks/docxdiff-stress/FINDINGS.md
+++ b/benchmarks/docxdiff-stress/FINDINGS.md
@@ -126,6 +126,34 @@ Three levers remain, in descending value, none of them taken here:
    Worth perhaps 15-20% and a real risk of introducing order-dependence into a pipeline
    whose determinism is a documented guarantee.
 
+## The concurrency is not available everywhere
+
+`wasm/DocxodusWasm/DocxodusWasm.csproj` does not set `WasmEnableThreads`, so the browser runtime is
+single-threaded. There `Task.Run` does not start a thread — it queues the delegate for the one thread
+that is about to block on the result, so an unguarded blocking join hangs the page rather than
+speeding anything up. `Docxodus.Internal.ParallelWork` compiles the fan-out out under `WASM_BUILD`
+and checks `Environment.ProcessorCount` besides.
+
+That matters for how the gain is attributed: **the read sharing is the larger half, and it does not
+depend on threads.** With the fan-out forced off (medians of nine, same box):
+
+| Case | `main` | sequential | concurrent |
+|---|---|---|---|
+| `light` | 821 ms | 575 ms | 351 ms |
+| `heavy` | 868 ms | 604 ms | 395 ms |
+| `reorder` | 792 ms | 514 ms | 338 ms |
+| `structural` | 803 ms | 531 ms | 334 ms |
+| `footnotes` | 959 ms | 717 ms | 510 ms |
+| `rewrite` | 1279 ms | 1025 ms | 868 ms |
+
+So roughly 1.4-1.6x from reading each document once, and the rest from reading the two of them at
+the same time. Treat the split as approximate — the two columns come from different runs and this
+box's medians move by 10-15% with load — but the ordering is stable and the mechanism is not in
+doubt: the stage decomposition puts the two reads at ~235 ms sequential against ~134 ms concurrent.
+
+All 36 output digests match on both schedules, which is the point: the schedule is not a semantic
+choice.
+
 ## Notes for anyone re-running this
 
 - **Measure medians, and force a collection between cases.** A comparison here allocates

--- a/benchmarks/docxdiff-stress/FINDINGS.md
+++ b/benchmarks/docxdiff-stress/FINDINGS.md
@@ -196,6 +196,12 @@ choice.
 - **`--check` is the point.** A perf change to a diff engine is only interesting if the diff
   is unchanged, and "the tests still pass" is a weaker claim than "all 36 output digests are
   byte-identical across eight edit shapes and a four-way consolidate".
+- **One negative control validates one half of a pipeline.** The first perturbation used to
+  prove the corpus check could fail — corrupting a content signature — moved 82-84% of the
+  revision and edit-script digests and **0%** of the redline digests, because Unids are stripped
+  from the rendered package. The redline column was entirely unvalidated until a second control
+  (swapping the snapshots handed to the renderer) moved 64% of it and none of the others. When a
+  check covers several products, perturb each one's inputs before believing any of them.
 - **Verify a suspected failure mode; do not infer it from timing.** The threading problem above was
   first blamed on a CI Playwright job that had run 51 minutes without finishing. That reasoning was
   wrong twice over: the job was cancelled by the next push rather than timing out, and the actual

--- a/benchmarks/docxdiff-stress/FINDINGS.md
+++ b/benchmarks/docxdiff-stress/FINDINGS.md
@@ -130,9 +130,12 @@ Three levers remain, in descending value, none of them taken here:
 
 `wasm/DocxodusWasm/DocxodusWasm.csproj` does not set `WasmEnableThreads`, so the browser runtime is
 single-threaded. There `Task.Run` does not start a thread — it queues the delegate for the one thread
-that is about to block on the result, so an unguarded blocking join hangs the page rather than
-speeding anything up. `Docxodus.Internal.ParallelWork` compiles the fan-out out under `WASM_BUILD`
-and checks `Environment.ProcessorCount` besides.
+that would then block on the result, and the runtime refuses rather than deadlocking: the join throws
+`PlatformNotSupportedException: Cannot wait on monitors on this runtime`. An unguarded fan-out
+therefore does not merely fail to be faster, it fails every browser comparison outright — measured,
+by forcing the guard open and watching all ten `npm/tests/docx-diff.spec.ts` cases fail with exactly
+that exception. `Docxodus.Internal.ParallelWork` compiles the fan-out out under `WASM_BUILD` and
+checks `Environment.ProcessorCount` besides.
 
 That matters for how the gain is attributed: **the read sharing is the larger half, and it does not
 depend on threads.** With the fan-out forced off (medians of nine, same box):
@@ -167,6 +170,12 @@ choice.
 - **`--check` is the point.** A perf change to a diff engine is only interesting if the diff
   is unchanged, and "the tests still pass" is a weaker claim than "all 36 output digests are
   byte-identical across eight edit shapes and a four-way consolidate".
+- **Verify a suspected failure mode; do not infer it from timing.** The threading problem above was
+  first blamed on a CI Playwright job that had run 51 minutes without finishing. That reasoning was
+  wrong twice over: the job was cancelled by the next push rather than timing out, and the actual
+  defect throws immediately rather than hanging. Building the WASM bundle with the guard forced open
+  and running one spec settled it in ten minutes and produced the exact exception text now quoted in
+  `ParallelWork`. A slow job is evidence of a slow job.
 - **Digest parity on one document is not coverage.** One optimization here — skipping the
   attribute sort for elements carrying a single attribute — was briefly wrong: canonicalization
   strips `wp:docPr/@id` by consulting `attribute.Parent`, so deciding an attribute's fate after

--- a/benchmarks/docxdiff-stress/FINDINGS.md
+++ b/benchmarks/docxdiff-stress/FINDINGS.md
@@ -188,6 +188,11 @@ choice.
   probe reported `UnidHelper` at 108 ms and the package parse at 48 ms; with every stage
   given the same promotion budget those became 51 ms and 13 ms. Stages measured first in a
   series pay for code the later ones inherit already compiled.
+- **One document is not a corpus.** The digests over eight generated variants of the reference
+  document say nothing about the shapes that document lacks — and it lacks tracked revisions,
+  tables and drawings, which between them gate the revision-transform path, the table differ
+  and every media import. `--corpus TestFiles` is the answer: 678 documents, 8,136 digests,
+  ~4 minutes. Run it before believing a perf change to this engine is free.
 - **`--check` is the point.** A perf change to a diff engine is only interesting if the diff
   is unchanged, and "the tests still pass" is a weaker claim than "all 36 output digests are
   byte-identical across eight edit shapes and a four-way consolidate".

--- a/benchmarks/docxdiff-stress/FINDINGS.md
+++ b/benchmarks/docxdiff-stress/FINDINGS.md
@@ -88,6 +88,14 @@ Two floors, for calibration: parsing every part the reader consumes costs ~13 ms
 opening a package and re-serializing it unchanged costs ~17 ms. So roughly 45 ms of a
 330 ms comparison is package I/O that no design avoids.
 
+## Filed follow-ups
+
+| | |
+|---|---|
+| [#617](https://github.com/JSv4/Docxodus/issues/617) | Reusable snapshot so bulk pipelines read a document once — the lever that decides 10/s |
+| [#618](https://github.com/JSv4/Docxodus/issues/618) | `UnidHelper` hashes twice per element for elements the IR never reads back |
+| [#619](https://github.com/JSv4/Docxodus/issues/619) | `MarkupCompatibilityNormalizer` full-parses `document.xml` on every call to find nothing |
+
 ## On the 10 comparisons/second target
 
 Not reached for a cold pairwise redline of a document this size, and worth being precise
@@ -100,9 +108,11 @@ read, about 60 ms of that is the diff itself. **If the question is "10 analyses 
 that is reachable now with snapshot reuse; if it is "10 redlined .docx packages per second",
 the zip round-trip is a hard floor and the answer on this hardware is no.**
 
-Three levers remain, in descending value, none of them taken here:
+Four things remain, in descending value, none of them taken here. The first three are filed
+so they are trackable rather than buried in this file:
 
-1. **Reuse reads across comparisons.** Nothing in the pipeline lets a caller say "I already
+1. **Reuse reads across comparisons — [#617](https://github.com/JSv4/Docxodus/issues/617).**
+   Nothing in the pipeline lets a caller say "I already
    read this document." Every realistic bulk workload — one baseline against many
    counterparties' markups, a version chain, an N-way consolidate — reads the same document
    over and over. A snapshot type carrying the pre-accepted document plus its IR, accepted
@@ -112,7 +122,8 @@ Three levers remain, in descending value, none of them taken here:
    es across every transport (see the ripple checklist in `CLAUDE.md`), which is why it was
    left out of a change set whose remit was to not alter the surface.
 
-2. **Assign Unids only where they are read.** ~51 ms of every read hashes twice per element
+2. **Assign Unids only where they are read — [#618](https://github.com/JSv4/Docxodus/issues/618).**
+   ~51 ms of every read hashes twice per element
    for all 15,360 elements, but the IR reads a Unid back only on blocks, content controls
    and `w:drawing`. A block's Unid derives from its ancestors, never its descendants, so
    pruning the assignment would leave every anchor byte-identical. It was not taken because
@@ -120,11 +131,21 @@ Three levers remain, in descending value, none of them taken here:
    saved packages, and "which elements carry an identity" is exactly the kind of contract
    a green test suite can fail to protect.
 
-3. **Spend the other two cores.** Pre-accept and the two IR reads are concurrent now, which
+3. **Stop full-parsing `document.xml` to prove there is nothing to normalize —
+   [#619](https://github.com/JSv4/Docxodus/issues/619).** `MarkupCompatibilityNormalizer`
+   gates its parse on the part containing the literal `pPr`, which every real
+   `word/document.xml` does, so the gate never closes: ~18 ms per side, ~10% of a
+   comparison, spent building a DOM that finds nothing. The reference document has zero
+   paragraphs carrying the duplicate-`w:pPr` shape the repair targets.
+
+4. **Spend the other two cores.** Pre-accept and the two IR reads are concurrent now, which
    uses about two of four cores; the build and the render are single-threaded. Per-block
    token diffs are independent and the per-scope reads within one document are nearly so.
-   Worth perhaps 15-20% and a real risk of introducing order-dependence into a pipeline
-   whose determinism is a documented guarantee.
+   Deliberately NOT filed: it is worth perhaps 15-20% against a real risk of introducing
+   order-dependence into a pipeline whose determinism is a documented guarantee, it is
+   unavailable in the browser at all (see below), and an issue saying "consider more
+   threads" is not a unit of work anyone can pick up. It belongs here as a note, not in the
+   tracker.
 
 ## The concurrency is not available everywhere
 

--- a/benchmarks/docxdiff-stress/Probe.cs
+++ b/benchmarks/docxdiff-stress/Probe.cs
@@ -1,0 +1,371 @@
+// Sub-stage probe for IrReader: replicates the package-open / Unid / registry steps so the
+// cost inside a single Read can be attributed without a native profiler.
+
+using System.Diagnostics;
+using System.Text;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using Docxodus;
+using Docxodus.Ir;
+using Docxodus.Ir.Diff;
+
+namespace Docxodus.Stress;
+
+internal static class Probe
+{
+    private static readonly XNamespace W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+
+    public static void Run(byte[] bytes, int n)
+    {
+        var doc = new WmlDocument("probe.docx", bytes);
+
+        Console.WriteLine();
+        Console.WriteLine("=== IrReader sub-stage probe (median ms of {0}) ===", n);
+
+        Time("WmlDocument copy", n, () => { var w = new WmlDocument(doc); return w.DocumentByteArray.Length; });
+
+        Time("package open (unzip + WordprocessingDocument)", n, () =>
+        {
+            using var s = new OpenXmlMemoryStreamDocument(new WmlDocument(doc));
+            using var w = s.GetWordprocessingDocument();
+            return w.MainDocumentPart!.Uri.ToString().Length;
+        });
+
+        Time("package open + main GetXDocument", n, () =>
+        {
+            using var s = new OpenXmlMemoryStreamDocument(new WmlDocument(doc));
+            using var w = s.GetWordprocessingDocument();
+            return w.MainDocumentPart!.GetXDocument().Root!.Name.LocalName.Length;
+        });
+
+        Time("package open + ALL reader parts GetXDocument (~HasRevisionMarkup)", n, () =>
+        {
+            using var s = new OpenXmlMemoryStreamDocument(new WmlDocument(doc));
+            using var w = s.GetWordprocessingDocument();
+            var main = w.MainDocumentPart!;
+            var total = 0;
+            foreach (var part in ScannableParts(main))
+            {
+                var root = part.GetXDocument().Root;
+                if (root is null) continue;
+                foreach (var e in root.DescendantsAndSelf()) total++;
+            }
+
+            return total;
+        });
+
+        // Unid assignment on a freshly parsed main part (the cold case Read always hits).
+        Time("UnidHelper.AssignToAllElementsDeterministic (main)", n, () =>
+        {
+            using var s = new OpenXmlMemoryStreamDocument(new WmlDocument(doc));
+            using var w = s.GetWordprocessingDocument();
+            var root = w.MainDocumentPart!.GetXDocument().Root!;
+            var t = Stopwatch.GetTimestamp();
+            UnidHelper.AssignToAllElementsDeterministic(root);
+            return (int)(Stopwatch.GetTimestamp() - t);
+        }, subtractOpen: true);
+
+        Time("IrReader.Read (RetainSources=false)", n,
+            () => IrReader.Read(doc, new IrReaderOptions { RetainSources = false, RevisionView = RevisionView.Accept }).Body.Blocks.Count);
+
+        Time("IrReader.Read (RetainSources=true)", n,
+            () => IrReader.Read(doc, new IrReaderOptions { RetainSources = true, RevisionView = RevisionView.Accept }).Body.Blocks.Count);
+
+        Time("IrReader.Read (RevisionView=FailIfPresent)", n,
+            () => IrReader.Read(doc, new IrReaderOptions { RetainSources = false, RevisionView = RevisionView.FailIfPresent }).Body.Blocks.Count);
+
+        Time("IrReader.Read (body scope only)", n,
+            () => IrReader.Read(doc, new IrReaderOptions { RetainSources = false, RevisionView = RevisionView.Accept, Scopes = IrScopes.Body }).Body.Blocks.Count);
+
+        // Element counts, for context on what the walks are traversing.
+        using var s2 = new OpenXmlMemoryStreamDocument(new WmlDocument(doc));
+        using var w2 = s2.GetWordprocessingDocument();
+        var m = w2.MainDocumentPart!;
+        Console.WriteLine();
+        foreach (var part in ScannableParts(m))
+        {
+            var root = part.GetXDocument().Root;
+            if (root is null) continue;
+            Console.WriteLine($"  part {part.Uri,-32} {root.DescendantsAndSelf().Count(),8:N0} elements");
+        }
+    }
+
+    private static IEnumerable<OpenXmlPart> ScannableParts(MainDocumentPart main)
+    {
+        yield return main;
+        foreach (var p in main.HeaderParts) yield return p;
+        foreach (var p in main.FooterParts) yield return p;
+        if (main.FootnotesPart != null) yield return main.FootnotesPart;
+        if (main.EndnotesPart != null) yield return main.EndnotesPart;
+        if (main.WordprocessingCommentsPart != null) yield return main.WordprocessingCommentsPart;
+    }
+
+    private static void Time<T>(string label, int n, Func<T> act, bool subtractOpen = false)
+    {
+        for (var i = 0; i < 2; i++) _ = act();
+        var samples = new double[n];
+        for (var i = 0; i < n; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            _ = act();
+            sw.Stop();
+            samples[i] = sw.Elapsed.TotalMilliseconds;
+        }
+
+        Array.Sort(samples);
+        Console.WriteLine($"  {label,-58} {samples[n / 2],8:F1} ms");
+    }
+}
+
+internal static class UnidProbe
+{
+    private static readonly XNamespace W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+    private static readonly XName Unid = "{http://powertools.codeplex.com/2011}Unid";
+
+    public static void Run(byte[] bytes, int n)
+    {
+        var doc = new WmlDocument("probe.docx", bytes);
+
+        XElement FreshRoot()
+        {
+            var s = new OpenXmlMemoryStreamDocument(new WmlDocument(doc));
+            var w = s.GetWordprocessingDocument();
+            return w.MainDocumentPart!.GetXDocument().Root!;
+        }
+
+        var root = FreshRoot();
+        var all = root.DescendantsAndSelf().ToList();
+        Console.WriteLine();
+        Console.WriteLine($"=== Unid walk attribution ({all.Count:N0} elements, median of {n}) ===");
+
+        Median("DescendantsAndSelf() enumeration only", n, () =>
+        {
+            var c = 0;
+            foreach (var e in root.DescendantsAndSelf()) c++;
+            return c;
+        });
+
+        Median("live-set construction (cold: every element missing)", n, () =>
+        {
+            var fresh = FreshRoot();
+            var live = new HashSet<XElement>();
+            foreach (var el in fresh.DescendantsAndSelf())
+            {
+                if (el.Attribute(Unid) is not null || el == fresh) continue;
+                for (XElement? a = el.Parent; a is not null; a = a.Parent)
+                    if (!live.Add(a)) break;
+            }
+
+            return live.Count;
+        });
+
+        Median("hasBlockDescendants scan for every element", n, () =>
+        {
+            var hits = 0;
+            foreach (var e in all)
+                if (e.Descendants().Any(d => d.Name == W + "p" || d.Name == W + "tbl")) hits++;
+            return hits;
+        });
+
+        Median("w:t text concat for every element", n, () =>
+        {
+            var len = 0;
+            foreach (var e in all)
+                len += string.Concat(e.Descendants(W + "t").Select(t => (string)t)).Length;
+            return len;
+        });
+
+        Median("descendant-name StringBuilder for every element", n, () =>
+        {
+            var len = 0;
+            foreach (var e in all)
+            {
+                var sb = new StringBuilder(64);
+                foreach (var d in e.Descendants())
+                {
+                    if (d.Name == W + "t") continue;
+                    sb.Append(d.Name.LocalName).Append(',');
+                }
+
+                len += sb.Length;
+            }
+
+            return len;
+        });
+
+        Median($"{all.Count * 2:N0} ShortHash calls (sig + derive per element)", n, () =>
+        {
+            var len = 0;
+            foreach (var e in all)
+            {
+                len += UnidHelper.ShortHash(e.Name.LocalName + "|abc|def|", 16).Length;
+                len += UnidHelper.ShortHash("seed:tag:0123456789abcdef:0", 32).Length;
+            }
+
+            return len;
+        });
+
+        Median("AssignToAllElementsDeterministic (cold, full)", n, () =>
+        {
+            var fresh = FreshRoot();
+            UnidHelper.AssignToAllElementsDeterministic(fresh);
+            return 1;
+        });
+    }
+
+    private static void Median<T>(string label, int n, Func<T> act)
+    {
+        for (var i = 0; i < 2; i++) _ = act();
+        var s = new double[n];
+        for (var i = 0; i < n; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            _ = act();
+            sw.Stop();
+            s[i] = sw.Elapsed.TotalMilliseconds;
+        }
+
+        Array.Sort(s);
+        Console.WriteLine($"  {label,-58} {s[n / 2],8:F1} ms");
+    }
+}
+
+// End-to-end decomposition of DocxDiff.Compare, replicating DocxDiffComparison's own steps.
+internal static class PipelineProbe
+{
+    public static void Run(byte[] leftBytes, byte[] rightBytes, int n)
+    {
+        var left = new WmlDocument("l.docx", leftBytes);
+        var right = new WmlDocument("r.docx", rightBytes);
+        var settings = new DocxDiffSettings();
+        var diff = settings.ToIrDiffSettings();
+        var dataDiff = diff with { CrossParagraphTokenDiff = false };
+        var readOpts = DocxDiff.ReadOpts;
+        var srcOpts = new IrReaderOptions { RetainSources = true, RevisionView = RevisionView.Accept };
+
+        Console.WriteLine();
+        Console.WriteLine($"=== DocxDiff.Compare decomposition (median of {n}) ===");
+
+        Median("StrictOoxmlNormalizer.NormalizeToTransitional x2", n, () =>
+        {
+            _ = StrictOoxmlNormalizer.NormalizeToTransitional(left);
+            return StrictOoxmlNormalizer.NormalizeToTransitional(right);
+        });
+
+        Median("MarkupCompatibilityNormalizer.Normalize x2", n, () =>
+        {
+            _ = MarkupCompatibilityNormalizer.Normalize(left);
+            return MarkupCompatibilityNormalizer.Normalize(right);
+        });
+
+        Median("DocxDiff.PreAccept x2 (both normalizers)", n, () =>
+        {
+            _ = DocxDiff.PreAccept(settings, left);
+            return DocxDiff.PreAccept(settings, right);
+        });
+
+        var preLeft = DocxDiff.PreAccept(settings, left);
+        var preRight = DocxDiff.PreAccept(settings, right);
+
+        Median("IrReader.Read x2 (script opts, sequential)", n, () =>
+        {
+            _ = IrReader.Read(preLeft, readOpts);
+            return IrReader.Read(preRight, readOpts);
+        });
+
+        Median("IrReader.Read x2 (script opts, PARALLEL)", n, () =>
+        {
+            IrDocument? a = null, b = null;
+            var t = Task.Run(() => a = IrReader.Read(preLeft, readOpts));
+            b = IrReader.Read(preRight, readOpts);
+            t.Wait();
+            return (a, b);
+        });
+
+        Median("IrReader.Read x2 (RetainSources, sequential)", n, () =>
+        {
+            _ = IrReader.Read(preLeft, srcOpts);
+            return IrReader.Read(preRight, srcOpts);
+        });
+
+        var irLeft = IrReader.Read(preLeft, readOpts);
+        var irRight = IrReader.Read(preRight, readOpts);
+
+        Median("IrEditScriptBuilder.Build", n, () => IrEditScriptBuilder.Build(irLeft, irRight, dataDiff));
+
+        var script = IrEditScriptBuilder.Build(irLeft, irRight, dataDiff);
+
+        Median("IrMarkupRenderer.Render (incl. its 2 internal reads)", n,
+            () => IrMarkupRenderer.Render(script, preLeft, preRight, diff));
+
+        Median("DocxDiff.Compare (whole thing)", n, () => DocxDiff.Compare(left, right));
+    }
+
+    private static void Median<T>(string label, int n, Func<T> act)
+    {
+        for (var i = 0; i < 2; i++) _ = act();
+        var s = new double[n];
+        for (var i = 0; i < n; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            _ = act();
+            sw.Stop();
+            s[i] = sw.Elapsed.TotalMilliseconds;
+        }
+
+        Array.Sort(s);
+        Console.WriteLine($"  {label,-58} {s[n / 2],8:F1} ms");
+    }
+}
+
+// How repetitive are the strings UnidHelper hashes? Decides whether memoizing ShortHash pays.
+internal static class SigProbe
+{
+    private static readonly XNamespace W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+
+    public static void Run(byte[] bytes)
+    {
+        var doc = new WmlDocument("probe.docx", bytes);
+        using var s = new OpenXmlMemoryStreamDocument(new WmlDocument(doc));
+        using var w = s.GetWordprocessingDocument();
+
+        Console.WriteLine();
+        Console.WriteLine("=== ContentSignature input repetition ===");
+        foreach (var (name, part) in Parts(w))
+        {
+            var root = part?.GetXDocument().Root;
+            if (root is null) continue;
+            var sigs = new List<string>();
+            foreach (var e in root.DescendantsAndSelf()) sigs.Add(SigInput(e));
+            var distinct = sigs.Distinct(StringComparer.Ordinal).Count();
+            Console.WriteLine($"  {name,-14} {sigs.Count,7:N0} elements   {distinct,7:N0} distinct signature inputs   {100.0 * (sigs.Count - distinct) / Math.Max(1, sigs.Count),5:F1}% repeats");
+        }
+    }
+
+    private static IEnumerable<(string, OpenXmlPart?)> Parts(WordprocessingDocument w)
+    {
+        yield return ("document", w.MainDocumentPart);
+        yield return ("footnotes", w.MainDocumentPart?.FootnotesPart);
+    }
+
+    // Mirrors UnidHelper.ContentSignature's hashed input (not its output).
+    private static string SigInput(XElement element)
+    {
+        if (element.Descendants().Any(d => d.Name == W + "p" || d.Name == W + "tbl"))
+            return element.Name.LocalName;
+
+        var text = string.Concat(element.Descendants(W + "t").Select(t => (string)t));
+        var pPr = element.Element(W + "pPr");
+        var styleId = pPr?.Element(W + "pStyle")?.Attribute(W + "val")?.Value ?? string.Empty;
+        var numId = pPr?.Element(W + "numPr")?.Element(W + "numId")?.Attribute(W + "val")?.Value ?? string.Empty;
+        var sb = new StringBuilder(text.Length + 64);
+        sb.Append(text).Append('|').Append(styleId).Append('|').Append(numId).Append('|');
+        foreach (var d in element.Descendants())
+        {
+            if (d.Name == W + "t") continue;
+            sb.Append(d.Name.LocalName).Append(',');
+        }
+
+        return sb.ToString();
+    }
+}

--- a/benchmarks/docxdiff-stress/Probe.cs
+++ b/benchmarks/docxdiff-stress/Probe.cs
@@ -63,7 +63,7 @@ internal static class Probe
             var t = Stopwatch.GetTimestamp();
             UnidHelper.AssignToAllElementsDeterministic(root);
             return (int)(Stopwatch.GetTimestamp() - t);
-        }, subtractOpen: true);
+        });
 
         Time("IrReader.Read (RetainSources=false)", n,
             () => IrReader.Read(doc, new IrReaderOptions { RetainSources = false, RevisionView = RevisionView.Accept }).Body.Blocks.Count);
@@ -76,6 +76,28 @@ internal static class Probe
 
         Time("IrReader.Read (body scope only)", n,
             () => IrReader.Read(doc, new IrReaderOptions { RetainSources = false, RevisionView = RevisionView.Accept, Scopes = IrScopes.Body }).Body.Blocks.Count);
+
+        // The floor: what any pipeline pays just to get the bytes in and a package back out.
+        Time("open + reserialize package unchanged (redline floor)", n, () =>
+        {
+            using var sd = new OpenXmlMemoryStreamDocument(new WmlDocument(doc));
+            using (var wd = sd.GetWordprocessingDocument())
+            {
+                _ = wd.MainDocumentPart!.GetXDocument();
+            }
+
+            return sd.GetModifiedWmlDocument().DocumentByteArray.Length;
+        });
+
+        Time("parse every reader part, no IR built (read floor)", n, () =>
+        {
+            using var sd = new OpenXmlMemoryStreamDocument(new WmlDocument(doc));
+            using var wd = sd.GetWordprocessingDocument();
+            var n2 = 0;
+            foreach (var part in ScannableParts(wd.MainDocumentPart!))
+                n2 += part.GetXDocument().Root?.DescendantsAndSelf().Count() ?? 0;
+            return n2;
+        });
 
         // Element counts, for context on what the walks are traversing.
         using var s2 = new OpenXmlMemoryStreamDocument(new WmlDocument(doc));
@@ -100,9 +122,15 @@ internal static class Probe
         if (main.WordprocessingCommentsPart != null) yield return main.WordprocessingCommentsPart;
     }
 
-    private static void Time<T>(string label, int n, Func<T> act, bool subtractOpen = false)
+    // Tiered JIT promotes a method only after it has been called many times, so two warm-up passes
+    // leave the first cases in a series paying for JIT that the later ones inherit warm — enough to
+    // report a stage as several times its steady-state cost. Every case gets the same promotion
+    // budget before any of them is timed.
+    private const int JitWarmup = 30;
+
+    private static void Time<T>(string label, int n, Func<T> act)
     {
-        for (var i = 0; i < 2; i++) _ = act();
+        for (var i = 0; i < JitWarmup; i++) _ = act();
         var samples = new double[n];
         for (var i = 0; i < n; i++)
         {
@@ -119,6 +147,8 @@ internal static class Probe
 
 internal static class UnidProbe
 {
+    private const int JitWarmup = 30;
+
     private static readonly XNamespace W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
     private static readonly XName Unid = "{http://powertools.codeplex.com/2011}Unid";
 
@@ -215,7 +245,7 @@ internal static class UnidProbe
 
     private static void Median<T>(string label, int n, Func<T> act)
     {
-        for (var i = 0; i < 2; i++) _ = act();
+        for (var i = 0; i < JitWarmup; i++) _ = act();
         var s = new double[n];
         for (var i = 0; i < n; i++)
         {
@@ -233,6 +263,8 @@ internal static class UnidProbe
 // End-to-end decomposition of DocxDiff.Compare, replicating DocxDiffComparison's own steps.
 internal static class PipelineProbe
 {
+    private const int JitWarmup = 30;
+
     public static void Run(byte[] leftBytes, byte[] rightBytes, int n)
     {
         var left = new WmlDocument("l.docx", leftBytes);
@@ -303,7 +335,7 @@ internal static class PipelineProbe
 
     private static void Median<T>(string label, int n, Func<T> act)
     {
-        for (var i = 0; i < 2; i++) _ = act();
+        for (var i = 0; i < JitWarmup; i++) _ = act();
         var s = new double[n];
         for (var i = 0; i < n; i++)
         {

--- a/benchmarks/docxdiff-stress/Program.cs
+++ b/benchmarks/docxdiff-stress/Program.cs
@@ -39,15 +39,21 @@ usage: DocxDiffStress <document.docx> [options]
   --baseline FILE    write output digests to FILE
   --check FILE       compare output digests against FILE and fail on any mismatch
   --out DIR          write the generated variants here (default: skip)
+  --corpus DIR       instead of the generated variants, run EVERY .docx under DIR through the
+                     products and digest the results (use with --baseline / --check)
+  --limit N          corpus mode: stop after N documents
+  --threads N        corpus mode: documents in flight (default: processor count)
 """;
 
-if (args.Length < 1 || args[0].StartsWith("--"))
+// Corpus mode takes its input from --corpus, so it is the one shape with no positional document.
+var corpusMode = args.Contains("--corpus");
+if (args.Length < 1 || (!corpusMode && args[0].StartsWith("--")))
 {
     Console.Error.WriteLine(Usage);
     return 1;
 }
 
-var docPath = args[0];
+var docPath = corpusMode ? string.Empty : args[0];
 var iterations = IntArg("--iterations", 5);
 var warmup = IntArg("--warmup", 2);
 var wantStages = args.Contains("--stages");
@@ -58,6 +64,16 @@ var outDir = StrArg("--out");
 var caseFilter = StrArg("--cases")?.Split(',', StringSplitOptions.RemoveEmptyEntries).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
 if (outDir != null) Directory.CreateDirectory(outDir);
+
+if (StrArg("--corpus") is { } corpusRoot)
+{
+    return Docxodus.Stress.Corpus.Run(
+        corpusRoot,
+        baselineOut ?? Path.Combine(Path.GetTempPath(), "corpus-digests.json"),
+        checkAgainst,
+        IntArg("--limit", 0) is var lim && lim > 0 ? lim : null,
+        IntArg("--threads", Environment.ProcessorCount));
+}
 
 var baseBytes = File.ReadAllBytes(docPath);
 Console.WriteLine($"document : {docPath} ({baseBytes.Length:N0} bytes)");

--- a/benchmarks/docxdiff-stress/Program.cs
+++ b/benchmarks/docxdiff-stress/Program.cs
@@ -95,6 +95,7 @@ foreach (var v in variants)
     var right = new WmlDocument($"{v.Name}.docx", v.Bytes);
 
     for (var i = 0; i < warmup; i++) _ = DocxDiff.Compare(left, right);
+    Settle();
 
     var row = new Row(v.Name, Measure(iterations, () => DocxDiff.Compare(left, right)));
 
@@ -121,6 +122,38 @@ foreach (var v in variants)
     digests[$"{v.Name}/revisions"] = Sha(Encoding.UTF8.GetBytes(RevisionsFingerprint(revs)));
     digests[$"{v.Name}/editscript"] = Sha(Encoding.UTF8.GetBytes(DocxDiff.GetEditScriptJson(left, right)));
     digests[$"{v.Name}/revcount"] = revs.Count.ToString(CultureInfo.InvariantCulture);
+}
+
+// ---- N-way consolidate: one base, several reviewers, the path whose read count scales with N ----
+{
+    var baseDoc = new WmlDocument("baseline.docx", baseBytes);
+    var reviewerNames = new[] { "light", "heavy", "reorder", "structural" };
+    // Built from the full variant set, not the (possibly filtered) compare list, so --cases still
+    // selects which pairwise comparisons run without silently dropping the N-way case.
+    var reviewers = Docxodus.Stress.Variants.Build(baseBytes)
+        .Where(v => reviewerNames.Contains(v.Name))
+        .Select((v, i) => new DocxDiffReviewer { Author = $"Reviewer {i + 1}", Document = new WmlDocument($"{v.Name}.docx", v.Bytes) })
+        .ToList();
+
+    if (reviewers.Count > 1)
+    {
+        for (var i = 0; i < warmup; i++) _ = DocxDiff.Consolidate(baseDoc, reviewers);
+        Settle();
+        var stat = Measure(iterations, () => DocxDiff.Consolidate(baseDoc, reviewers));
+        Console.WriteLine();
+        Console.WriteLine($"=== DocxDiff.Consolidate ({reviewers.Count} reviewers) ===");
+        Console.WriteLine($"{"case",-12} {"min ms",9} {"median",9} {"max ms",9} {"runs/s",9} {"alloc MB",10}");
+        Console.WriteLine($"{"consolidate",-12} {stat.Min,9:F1} {stat.Median,9:F1} {stat.Max,9:F1} {1000 / stat.Median,9:F2} {stat.AllocBytes / 1048576.0,10:F1}");
+
+        digests["consolidate/document"] = Sha(DocxDiff.Consolidate(baseDoc, reviewers).DocumentByteArray);
+        digests["consolidate/conflicts"] = Sha(Encoding.UTF8.GetBytes(
+            string.Join("\n", DocxDiff.GetConflicts(baseDoc, reviewers)
+                .Select(c => $"{c.Id}|{c.BaseAnchor}|{c.TokenStart}-{c.TokenEnd}|{string.Join(";", c.Competitors.Select(x => $"{x.Author}={x.ResultText}"))}"))));
+        digests["consolidate/script"] = Sha(Encoding.UTF8.GetBytes(DocxDiff.GetConsolidatedEditScriptJson(baseDoc, reviewers)));
+        digests["consolidate/revisions"] = Sha(Encoding.UTF8.GetBytes(
+            string.Join("\n", DocxDiff.GetConsolidatedRevisions(baseDoc, reviewers)
+                .Select(r => $"{r.Type}|{r.Author}|{r.Text}|{r.MoveGroupId}|{r.IsMoveSource}"))));
+    }
 }
 
 Report(rows, wantProducts, wantStages);
@@ -152,6 +185,16 @@ if (checkAgainst != null)
 return exit;
 
 // ---------------- measurement ----------------
+
+// A comparison of this document allocates hundreds of megabytes, so whichever case runs first after a
+// quiet stretch otherwise absorbs the Gen2 collection for everything before it. Collecting to a known
+// state between cases keeps them comparable with each other.
+static void Settle()
+{
+    GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+    GC.WaitForPendingFinalizers();
+    GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+}
 
 static Stat Measure<T>(int n, Func<T> act)
 {

--- a/benchmarks/docxdiff-stress/Program.cs
+++ b/benchmarks/docxdiff-stress/Program.cs
@@ -1,0 +1,287 @@
+// DocxDiff performance stress harness.
+//
+// Generates a family of deterministic edited variants of one heavyweight .docx and times
+// the DocxDiff pipeline against each — end to end and stage by stage (pre-accept, IR read,
+// edit-script build, markup render). The variants span the shapes that dominate real
+// redline work and the shapes that stress the aligner hardest:
+//
+//   identical   no change at all (fast-path floor)
+//   light       a handful of scattered word edits (a typical counsel pass)
+//   heavy       an edit in every fifth paragraph
+//   churn       an edit in roughly half of all text nodes
+//   reorder     blocks relocated across the document (move detection)
+//   structural  paragraphs deleted and new ones inserted
+//   footnotes   edits inside the footnote part only
+//   rewrite     every paragraph's text replaced (worst case)
+//
+// Each case also records SHA-256 digests of the redline bytes, the revision list, and the
+// edit-script JSON, so an optimization pass can be proven output-identical: run with
+// --baseline before the change, --check after.
+//
+// The document is not committed — pass any comparable .docx on the command line.
+
+using System.Diagnostics;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Docxodus;
+using Docxodus.Ir;
+using Docxodus.Ir.Diff;
+
+const string Usage = """
+usage: DocxDiffStress <document.docx> [options]
+  --iterations N     timed iterations per case (default 5)
+  --warmup N         untimed warm-up iterations per case (default 2)
+  --cases a,b,c      restrict to named cases (default: all)
+  --stages           also report per-stage timings for each case
+  --products         time GetRevisions / GetEditScriptJson / the fused pass too
+  --baseline FILE    write output digests to FILE
+  --check FILE       compare output digests against FILE and fail on any mismatch
+  --out DIR          write the generated variants here (default: skip)
+""";
+
+if (args.Length < 1 || args[0].StartsWith("--"))
+{
+    Console.Error.WriteLine(Usage);
+    return 1;
+}
+
+var docPath = args[0];
+var iterations = IntArg("--iterations", 5);
+var warmup = IntArg("--warmup", 2);
+var wantStages = args.Contains("--stages");
+var wantProducts = args.Contains("--products");
+var baselineOut = StrArg("--baseline");
+var checkAgainst = StrArg("--check");
+var outDir = StrArg("--out");
+var caseFilter = StrArg("--cases")?.Split(',', StringSplitOptions.RemoveEmptyEntries).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+if (outDir != null) Directory.CreateDirectory(outDir);
+
+var baseBytes = File.ReadAllBytes(docPath);
+Console.WriteLine($"document : {docPath} ({baseBytes.Length:N0} bytes)");
+Console.WriteLine($"runtime  : .NET {Environment.Version}, {Environment.ProcessorCount} cores, server GC={System.Runtime.GCSettings.IsServerGC}");
+Console.WriteLine($"schedule : {warmup} warm-up + {iterations} timed iterations per case");
+Console.WriteLine();
+
+if (args.Contains("--probe"))
+{
+    Docxodus.Stress.Probe.Run(baseBytes, iterations);
+    Docxodus.Stress.UnidProbe.Run(baseBytes, iterations);
+    Docxodus.Stress.SigProbe.Run(baseBytes);
+    var probeRight = Docxodus.Stress.Variants.Build(baseBytes).First(v => v.Name == "light").Bytes;
+    Docxodus.Stress.PipelineProbe.Run(baseBytes, probeRight, iterations);
+    return 0;
+}
+
+var variants = Docxodus.Stress.Variants.Build(baseBytes);
+if (caseFilter != null) variants = variants.Where(v => caseFilter.Contains(v.Name)).ToList();
+if (variants.Count == 0) { Console.Error.WriteLine("no cases selected"); return 1; }
+
+foreach (var v in variants)
+{
+    Console.WriteLine($"case {v.Name,-11} {v.Description} ({v.Bytes.Length:N0} bytes)");
+    if (outDir != null) File.WriteAllBytes(Path.Combine(outDir, $"{v.Name}.docx"), v.Bytes);
+}
+Console.WriteLine();
+
+var digests = new SortedDictionary<string, string>(StringComparer.Ordinal);
+var rows = new List<Row>();
+
+foreach (var v in variants)
+{
+    var left = new WmlDocument("baseline.docx", baseBytes);
+    var right = new WmlDocument($"{v.Name}.docx", v.Bytes);
+
+    for (var i = 0; i < warmup; i++) _ = DocxDiff.Compare(left, right);
+
+    var row = new Row(v.Name, Measure(iterations, () => DocxDiff.Compare(left, right)));
+
+    if (wantProducts)
+    {
+        for (var i = 0; i < warmup; i++) { _ = DocxDiff.GetRevisions(left, right); _ = DocxDiff.GetEditScriptJson(left, right); }
+        row.Revisions = Measure(iterations, () => DocxDiff.GetRevisions(left, right));
+        row.EditScript = Measure(iterations, () => DocxDiff.GetEditScriptJson(left, right));
+        row.AllProducts = Measure(iterations, () =>
+        {
+            var c = DocxDiff.CreateComparison(left, right);
+            _ = c.ToRedline(); _ = c.GetRevisions(); _ = c.GetEditScriptJson();
+            return c;
+        });
+    }
+
+    if (wantStages) row.Stages = MeasureStages(left, right, iterations, warmup);
+
+    rows.Add(row);
+
+    var redline = DocxDiff.Compare(left, right);
+    var revs = DocxDiff.GetRevisions(left, right);
+    digests[$"{v.Name}/redline"] = Sha(redline.DocumentByteArray);
+    digests[$"{v.Name}/revisions"] = Sha(Encoding.UTF8.GetBytes(RevisionsFingerprint(revs)));
+    digests[$"{v.Name}/editscript"] = Sha(Encoding.UTF8.GetBytes(DocxDiff.GetEditScriptJson(left, right)));
+    digests[$"{v.Name}/revcount"] = revs.Count.ToString(CultureInfo.InvariantCulture);
+}
+
+Report(rows, wantProducts, wantStages);
+
+if (baselineOut != null)
+{
+    File.WriteAllText(baselineOut, JsonSerializer.Serialize(digests, new JsonSerializerOptions { WriteIndented = true }));
+    Console.WriteLine($"{Environment.NewLine}baseline digests written to {baselineOut} ({digests.Count} entries)");
+}
+
+var exit = 0;
+if (checkAgainst != null)
+{
+    var expected = JsonSerializer.Deserialize<SortedDictionary<string, string>>(File.ReadAllText(checkAgainst))!;
+    var mismatches = 0;
+    foreach (var (k, want) in expected)
+    {
+        if (!digests.TryGetValue(k, out var got)) { Console.WriteLine($"[parity] MISSING  {k}"); mismatches++; }
+        else if (got != want) { Console.WriteLine($"[parity] MISMATCH {k}"); Console.WriteLine($"           expected {want}"); Console.WriteLine($"           actual   {got}"); mismatches++; }
+    }
+    foreach (var k in digests.Keys.Where(k => !expected.ContainsKey(k))) Console.WriteLine($"[parity] EXTRA    {k}");
+    Console.WriteLine();
+    Console.WriteLine(mismatches == 0
+        ? $"[parity] OK - all {expected.Count} digests identical to baseline"
+        : $"[parity] {mismatches} MISMATCH(ES) - output changed");
+    exit = mismatches == 0 ? 0 : 2;
+}
+
+return exit;
+
+// ---------------- measurement ----------------
+
+static Stat Measure<T>(int n, Func<T> act)
+{
+    var samples = new double[n];
+    var alloc0 = GC.GetTotalAllocatedBytes(precise: false);
+    for (var i = 0; i < n; i++)
+    {
+        var sw = Stopwatch.StartNew();
+        _ = act();
+        sw.Stop();
+        samples[i] = sw.Elapsed.TotalMilliseconds;
+    }
+    var alloc = (GC.GetTotalAllocatedBytes(precise: false) - alloc0) / (double)n;
+    Array.Sort(samples);
+    return new Stat(samples[0], samples[n / 2], samples[^1], samples.Average(), alloc);
+}
+
+static StageTimes MeasureStages(WmlDocument left, WmlDocument right, int n, int warmup)
+{
+    var settings = new DocxDiffSettings();
+    var diff = settings.ToIrDiffSettings();
+    var dataDiff = diff with { CrossParagraphTokenDiff = false };
+    var readOpts = DocxDiff.ReadOpts;
+    var srcOpts = new IrReaderOptions { RetainSources = true, RevisionView = RevisionView.Accept };
+
+    // Warm every stage before timing any of it.
+    for (var i = 0; i < warmup; i++)
+    {
+        var wl = IrReader.Read(left, readOpts);
+        var wr = IrReader.Read(right, readOpts);
+        var ws = IrEditScriptBuilder.Build(wl, wr, dataDiff);
+        _ = IrMarkupRenderer.Render(ws, left, right, diff);
+    }
+
+    var readLeft = Measure(n, () => IrReader.Read(left, readOpts));
+    var readRight = Measure(n, () => IrReader.Read(right, readOpts));
+    var readSrcLeft = Measure(n, () => IrReader.Read(left, srcOpts));
+    var readSrcRight = Measure(n, () => IrReader.Read(right, srcOpts));
+
+    var irLeft = IrReader.Read(left, readOpts);
+    var irRight = IrReader.Read(right, readOpts);
+    var build = Measure(n, () => IrEditScriptBuilder.Build(irLeft, irRight, dataDiff));
+
+    var script = IrEditScriptBuilder.Build(irLeft, irRight, dataDiff);
+    var render = Measure(n, () => IrMarkupRenderer.Render(script, left, right, diff));
+    var revRender = Measure(n, () => IrRevisionRenderer.Render(script, irLeft, irRight, dataDiff));
+
+    return new StageTimes(readLeft, readRight, readSrcLeft, readSrcRight, build, render, revRender);
+}
+
+static void Report(List<Row> rows, bool products, bool stages)
+{
+    Console.WriteLine();
+    Console.WriteLine("=== DocxDiff.Compare (end to end) ===");
+    Console.WriteLine($"{"case",-12} {"min ms",9} {"median",9} {"max ms",9} {"diffs/s",9} {"alloc MB",10}");
+    foreach (var r in rows)
+        Console.WriteLine($"{r.Name,-12} {r.Compare.Min,9:F1} {r.Compare.Median,9:F1} {r.Compare.Max,9:F1} {1000 / r.Compare.Median,9:F2} {r.Compare.AllocBytes / 1048576.0,10:F1}");
+
+    if (products)
+    {
+        Console.WriteLine();
+        Console.WriteLine("=== products (median ms) ===");
+        Console.WriteLine($"{"case",-12} {"compare",9} {"revisions",10} {"editscript",11} {"fused x3",11}");
+        foreach (var r in rows)
+            Console.WriteLine($"{r.Name,-12} {r.Compare.Median,9:F1} {r.Revisions!.Median,10:F1} {r.EditScript!.Median,11:F1} {r.AllProducts!.Median,11:F1}");
+    }
+
+    if (stages)
+    {
+        Console.WriteLine();
+        Console.WriteLine("=== pipeline stages (median ms) ===");
+        Console.WriteLine($"{"case",-12} {"read L",8} {"read R",8} {"src L",8} {"src R",8} {"build",9} {"markup",9} {"revrender",10} {"sum",9}");
+        foreach (var r in rows)
+        {
+            var s = r.Stages!;
+            var sum = s.ReadLeft.Median + s.ReadRight.Median + s.ReadSrcLeft.Median + s.ReadSrcRight.Median + s.Build.Median + s.Render.Median;
+            Console.WriteLine($"{r.Name,-12} {s.ReadLeft.Median,8:F1} {s.ReadRight.Median,8:F1} {s.ReadSrcLeft.Median,8:F1} {s.ReadSrcRight.Median,8:F1} {s.Build.Median,9:F1} {s.Render.Median,9:F1} {s.RevRender.Median,10:F1} {sum,9:F1}");
+        }
+        Console.WriteLine();
+        Console.WriteLine("note: 'markup' performs its own two RetainSources reads internally, so 'sum' double-counts");
+        Console.WriteLine("      'src L'/'src R' and is an upper bound rather than the end-to-end figure.");
+    }
+}
+
+static string Sha(byte[] b) => Convert.ToHexString(SHA256.HashData(b));
+
+static string RevisionsFingerprint(IReadOnlyList<DocxDiffRevision> revs)
+{
+    var sb = new StringBuilder();
+    foreach (var r in revs)
+    {
+        sb.Append(r.Type).Append('|').Append(r.Author).Append('|')
+          .Append(r.Text).Append('|').Append(r.LeftAnchor).Append('|')
+          .Append(r.RightAnchor).Append('|').Append(r.MoveGroupId).Append('|')
+          .Append(r.IsMoveSource).Append('|');
+        if (r.FormatChange is { } fc)
+        {
+            sb.Append(fc.Scope).Append('~').Append(string.Join(',', fc.ChangedPropertyNames)).Append('~')
+              .Append(string.Join(',', fc.OldProperties.OrderBy(kv => kv.Key, StringComparer.Ordinal).Select(kv => $"{kv.Key}={kv.Value}"))).Append('~')
+              .Append(string.Join(',', fc.NewProperties.OrderBy(kv => kv.Key, StringComparer.Ordinal).Select(kv => $"{kv.Key}={kv.Value}")));
+        }
+
+        sb.Append('\n');
+    }
+
+    return sb.ToString();
+}
+
+int IntArg(string name, int fallback)
+{
+    var i = Array.IndexOf(args, name);
+    return i >= 0 && i + 1 < args.Length && int.TryParse(args[i + 1], out var v) ? v : fallback;
+}
+
+string? StrArg(string name)
+{
+    var i = Array.IndexOf(args, name);
+    return i >= 0 && i + 1 < args.Length ? args[i + 1] : null;
+}
+
+sealed record Stat(double Min, double Median, double Max, double Mean, double AllocBytes);
+
+sealed record StageTimes(Stat ReadLeft, Stat ReadRight, Stat ReadSrcLeft, Stat ReadSrcRight, Stat Build, Stat Render, Stat RevRender);
+
+sealed class Row(string name, Stat compare)
+{
+    public string Name { get; } = name;
+    public Stat Compare { get; } = compare;
+    public Stat? Revisions { get; set; }
+    public Stat? EditScript { get; set; }
+    public Stat? AllProducts { get; set; }
+    public StageTimes? Stages { get; set; }
+}

--- a/benchmarks/docxdiff-stress/README.md
+++ b/benchmarks/docxdiff-stress/README.md
@@ -1,0 +1,85 @@
+# DocxDiff performance stress harness
+
+A standalone harness that times the `DocxDiff` pipeline against one heavyweight legal
+`.docx` and its own generated edit variants, and proves that an optimization changed
+nothing about the output. It is deliberately **not** part of `Docxodus.sln`, so it never
+affects CI, packaging, or the warning baselines.
+
+Its sibling `benchmarks/complex-form-doc` answers "does the toolchain get this document
+right?". This one answers "how fast, and where does the time go?".
+
+## Variants
+
+The generator edits the source package's XML directly rather than driving `DocxSession`,
+so the generator's own cost never lands in the measured numbers and the same input always
+produces byte-identical variants.
+
+| Case | What it is | What it stresses |
+|---|---|---|
+| `identical` | no change at all | the byte-identical fast paths |
+| `light` | 8 scattered word-level edits | a typical counsel pass |
+| `heavy` | an edit in every fifth paragraph | many small in-place modifications |
+| `churn` | an edit in every second text node | the token differ |
+| `reorder` | 24 blocks relocated across the body | move detection and the LIS spine |
+| `structural` | 20 paragraphs deleted, 20 inserted | gap filling and in-gap pairing |
+| `footnotes` | an edit in every second footnote paragraph | the note-scope diff |
+| `rewrite` | every paragraph's text replaced | the worst case: nothing aligns cheaply |
+
+Plus an N-way `DocxDiff.Consolidate` over four of those variants as reviewers, which is
+where read cost scales with reviewer count.
+
+## Output parity
+
+Timing a change is only half the job; the other half is proving the change was free. Each
+run records SHA-256 digests of the redline package, the rendered revision list, the
+edit-script JSON, and the four consolidate products, for every variant:
+
+```bash
+# before the change
+dotnet run -c Release --project benchmarks/docxdiff-stress -- doc.docx --baseline before.json
+# after
+dotnet run -c Release --project benchmarks/docxdiff-stress -- doc.docx --check before.json
+```
+
+`--check` exits 2 on any mismatch and prints which product diverged. A perf change that
+prints `[parity] OK` produced byte-identical output on every case.
+
+## Running
+
+```bash
+dotnet run -c Release --project benchmarks/docxdiff-stress -- path/to/document.docx [options]
+```
+
+| Option | Effect |
+|---|---|
+| `--iterations N` | timed iterations per case (default 5) |
+| `--warmup N` | untimed warm-up iterations per case (default 2) |
+| `--cases a,b,c` | restrict to named pairwise cases (the N-way case always runs) |
+| `--stages` | per-stage timings: IR reads, edit-script build, markup render, revision render |
+| `--products` | also time `GetRevisions`, `GetEditScriptJson`, and the fused multi-product pass |
+| `--probe` | sub-stage attribution inside `IrReader` and `UnidHelper`, plus the pipeline decomposition |
+| `--baseline FILE` / `--check FILE` | write / verify output digests |
+| `--out DIR` | write the generated variants as `.docx` for inspection |
+
+Build in `Release`. A `Debug` build's numbers are not meaningful.
+
+### Reading the numbers
+
+`Compare` on this document allocates hundreds of megabytes, so whichever case runs first
+after a quiet stretch would otherwise absorb the Gen2 collection for everything before it;
+the harness forces a collection between cases to keep them comparable. Medians are the
+figure to quote — the max column regularly catches a collection and is not the steady
+state.
+
+The `--probe` timings warm each stage past the tiered-JIT promotion threshold before
+timing any of them. Without that, the first stages in the series report several times
+their steady-state cost, because the later ones inherit code they paid to compile.
+
+## Reference document
+
+Written against the NVCA Model Certificate of Incorporation (October 2025): ~51 pages, 234
+body paragraphs, 15,360 elements in `word/document.xml`, 97 footnotes (5,461 elements),
+16 abstract numbering definitions, 4 sections, 8 headers and 10 footers. Publicly
+available from the NVCA; not committed here. Any comparable form document works.
+
+See `FINDINGS.md` for what the harness measured and what it cost.

--- a/benchmarks/docxdiff-stress/README.md
+++ b/benchmarks/docxdiff-stress/README.md
@@ -59,11 +59,28 @@ dotnet run -c Release --project benchmarks/docxdiff-stress -- --corpus TestFiles
 dotnet run -c Release --project benchmarks/docxdiff-stress -- --corpus TestFiles --check before.json
 ```
 
-Against `TestFiles/` that is **678 documents → 8,136 digests**, about 4 minutes on four threads.
-Each document contributes four comparisons — an edited variant under default settings, the
-document against itself (the byte-identical shortcuts), and the edited variant again under
-`PreAcceptInputRevisions` and `PreserveInputRevisions`, which are the only way to reach the
-revision-transform path — times three products (redline, revision list, edit script).
+> **Building the baseline branch.** The harness reaches internal types, so the branch you take the
+> baseline on needs `<InternalsVisibleTo Include="DocxDiffStress" />` in `Docxodus/Docxodus.csproj`.
+> Any branch predating that line fails to compile the harness with a wall of `CS0122`, which looks
+> like a harness bug and is not one — add the line to the checkout you are baselining, or the
+> "before" half of the differential cannot be produced at all.
+
+Against `TestFiles/` each document contributes:
+
+- **four pairwise comparisons** — an edited variant under default settings, the document against
+  itself (the byte-identical shortcuts), and the edited variant again under
+  `PreAcceptInputRevisions` and `PreserveInputRevisions`, the only settings that reach the
+  revision-transform path — times three products (redline, revision list, edit script);
+- **one N-way consolidate** of two reviewers off that document as base, times four products
+  (redline, consolidated revision list, conflicts, consolidated edit script). The consolidate path
+  has its own reader fan-out, merger and markup renderer; not one of the pairwise products touches
+  any of them, so without this the whole N-way half of the engine sits outside the differential;
+- **two pre-flight digests per pairwise product** (edited and identical), recording the
+  compatibility warnings each product reports. Output digests cannot see this: a product that stops
+  running the pre-flight and a product that runs it and finds nothing produce identical output. The
+  identical-bytes shortcuts are where that gap is most tempting, so they are digested too.
+
+That is **678 documents → 22,374 digests**, roughly 15 minutes on four threads.
 
 A thrown exception is digested too, as `FAIL <Type>: <message>`. Malformed and unsupported
 fixtures are expected to throw; a change in **which** exception they throw is still a regression.
@@ -87,17 +104,20 @@ An always-green check is worthless, so verify it detects a change before trustin
 perturbation is not enough**, because the three products are sensitive to different halves of the
 pipeline — a control that moves two of them can leave the third completely unexercised:
 
-| Perturbation | redline | revisions | editscript |
-|---|---|---|---|
-| drop the `w:t` skip in `UnidHelper.ContentSignature` | **0%** | 82% | 84% |
-| swap the snapshots handed to `IrMarkupRenderer.Render` | **64%** | 0% | 0% |
+| Perturbation | redline | revisions | editscript | preflight |
+|---|---|---|---|---|
+| drop the `w:t` skip in `UnidHelper.ContentSignature` | **0%** | 82% | 84% | 0% |
+| swap the snapshots handed to `IrMarkupRenderer.Render` | **64%** | 0% | 0% | 0% |
+| skip the pre-flight on the identical-bytes shortcut | **0%** | **0%** | **0%** | fires |
 
-The split is not an accident, and it is worth understanding before trusting either column.
+The split is not an accident, and it is worth understanding before trusting any column.
 Unids feed block anchors, so corrupting a content signature shows up all over the edit script and
 the revision list — but the markup renderer strips `PtOpenXml.Unid` on the way out, so the
 rendered package is byte-identical and the redline digest never moves. Conversely the hand-off
 only affects rendering: the script and revisions were already computed, so they are untouched
-while the redline scrambles. Run both, or you are validating half the harness.
+while the redline scrambles. And the third row is why the pre-flight column exists at all: a
+product that stops warning still returns the right answer, so **every output digest stays green**
+while a documented behaviour is gone. Run all of them, or you are validating part of the harness.
 
 **It is not omniscient.** Reintroducing the `wp:docPr/@id` stripping-order bug that
 `IrHasherTests.Canonicalize_LoneDocPrId_StillStripped` guards produces **zero** corpus

--- a/benchmarks/docxdiff-stress/README.md
+++ b/benchmarks/docxdiff-stress/README.md
@@ -79,7 +79,7 @@ reports 161 differences on every run and would drown a real regression in noise.
 
 So the redline is digested with those generated names folded to a placeholder, in entry names and
 inside XML content, with entries hashed in canonical-name order. Content still has to match
-exactly: this hides the naming churn and nothing else. See #620.
+exactly: this hides the naming churn and nothing else. See #621.
 
 ### Confirm the harness can actually fail
 

--- a/benchmarks/docxdiff-stress/README.md
+++ b/benchmarks/docxdiff-stress/README.md
@@ -83,9 +83,21 @@ exactly: this hides the naming churn and nothing else. See #621.
 
 ### Confirm the harness can actually fail
 
-An always-green check is worthless, so verify it detects a change before trusting a pass.
-Reintroducing a real defect — dropping the `w:t` skip in `UnidHelper.ContentSignature`'s
-descendant-name walk — moves **3,905 of the 8,136 digests**.
+An always-green check is worthless, so verify it detects a change before trusting a pass. **One
+perturbation is not enough**, because the three products are sensitive to different halves of the
+pipeline — a control that moves two of them can leave the third completely unexercised:
+
+| Perturbation | redline | revisions | editscript |
+|---|---|---|---|
+| drop the `w:t` skip in `UnidHelper.ContentSignature` | **0%** | 82% | 84% |
+| swap the snapshots handed to `IrMarkupRenderer.Render` | **64%** | 0% | 0% |
+
+The split is not an accident, and it is worth understanding before trusting either column.
+Unids feed block anchors, so corrupting a content signature shows up all over the edit script and
+the revision list — but the markup renderer strips `PtOpenXml.Unid` on the way out, so the
+rendered package is byte-identical and the redline digest never moves. Conversely the hand-off
+only affects rendering: the script and revisions were already computed, so they are untouched
+while the redline scrambles. Run both, or you are validating half the harness.
 
 **It is not omniscient.** Reintroducing the `wp:docPr/@id` stripping-order bug that
 `IrHasherTests.Canonicalize_LoneDocPrId_StillStripped` guards produces **zero** corpus

--- a/benchmarks/docxdiff-stress/README.md
+++ b/benchmarks/docxdiff-stress/README.md
@@ -44,6 +44,55 @@ dotnet run -c Release --project benchmarks/docxdiff-stress -- doc.docx --check b
 `--check` exits 2 on any mismatch and prints which product diverged. A perf change that
 prints `[parity] OK` produced byte-identical output on every case.
 
+## Corpus differential — the regression evidence
+
+The eight generated variants answer "did this change the diff of one heavyweight legal form".
+They do not answer "did this change the diff of anything else", and the reference document
+happens to carry **no tracked revisions, no tables and no drawings** — three shapes the
+engine's riskiest paths are keyed on. `--corpus` closes that: it runs every document in a
+directory through the products and digests the results, so two builds can be compared.
+
+```bash
+# baseline on one build
+dotnet run -c Release --project benchmarks/docxdiff-stress -- --corpus TestFiles --baseline before.json
+# ...switch builds, then
+dotnet run -c Release --project benchmarks/docxdiff-stress -- --corpus TestFiles --check before.json
+```
+
+Against `TestFiles/` that is **678 documents → 8,136 digests**, about 4 minutes on four threads.
+Each document contributes four comparisons — an edited variant under default settings, the
+document against itself (the byte-identical shortcuts), and the edited variant again under
+`PreAcceptInputRevisions` and `PreserveInputRevisions`, which are the only way to reach the
+revision-transform path — times three products (redline, revision list, edit script).
+
+A thrown exception is digested too, as `FAIL <Type>: <message>`. Malformed and unsupported
+fixtures are expected to throw; a change in **which** exception they throw is still a regression.
+
+### The redline digest is rename-invariant, and why
+
+Media and diagram parts imported into a redline are named `P` + a fresh GUID, and the
+relationships pointing at them get ids of `R` + a fresh GUID. **`DocxDiff.Compare` is therefore
+not byte-deterministic on any document whose redline imports media**, contradicting
+`DocxDiffSettings.Deterministic`. This is pre-existing — `origin/main` disagrees with itself on
+exactly those documents — and it affects 54 of the 678 fixtures here. Digesting raw package bytes
+reports 161 differences on every run and would drown a real regression in noise.
+
+So the redline is digested with those generated names folded to a placeholder, in entry names and
+inside XML content, with entries hashed in canonical-name order. Content still has to match
+exactly: this hides the naming churn and nothing else. See #620.
+
+### Confirm the harness can actually fail
+
+An always-green check is worthless, so verify it detects a change before trusting a pass.
+Reintroducing a real defect — dropping the `w:t` skip in `UnidHelper.ContentSignature`'s
+descendant-name walk — moves **3,905 of the 8,136 digests**.
+
+**It is not omniscient.** Reintroducing the `wp:docPr/@id` stripping-order bug that
+`IrHasherTests.Canonicalize_LoneDocPrId_StillStripped` guards produces **zero** corpus
+mismatches: real Word documents emit `<wp:docPr id=".." name=".."/>`, so the lone-attribute
+shape that bug needs does not occur in this corpus at all. Corpus parity and unit tests cover
+different things; neither replaces the other.
+
 ## Running
 
 ```bash

--- a/benchmarks/docxdiff-stress/Variants.cs
+++ b/benchmarks/docxdiff-stress/Variants.cs
@@ -1,0 +1,195 @@
+// Deterministic edited variants of a source .docx.
+//
+// Every variant is produced by editing the source package's XML directly rather than by
+// driving DocxSession, so the generator's own cost never lands in the measured numbers and
+// the same input always yields byte-identical variants (the seeded RNG makes the "random"
+// selections reproducible run to run).
+
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using Docxodus;
+
+namespace Docxodus.Stress;
+
+internal sealed record Variant(string Name, string Description, byte[] Bytes);
+
+internal static class Variants
+{
+    private static readonly XNamespace W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+
+    public static List<Variant> Build(byte[] source) =>
+    [
+        new("identical", "no change at all (fast-path floor)", source),
+        new("light", "8 scattered word-level edits", EditEveryNthTextNode(source, nth: 0, count: 8)),
+        new("heavy", "an edit in every fifth paragraph", EditParagraphs(source, nth: 5)),
+        new("churn", "an edit in every second text node", EditEveryNthTextNode(source, nth: 2, count: int.MaxValue)),
+        new("reorder", "24 blocks relocated across the body", Reorder(source, blocks: 24)),
+        new("structural", "20 paragraphs deleted, 20 inserted", Structural(source, count: 20)),
+        new("footnotes", "an edit in every second footnote paragraph", EditFootnotes(source)),
+        new("rewrite", "every paragraph's text replaced", Rewrite(source)),
+    ];
+
+    // ---- variant builders ----
+
+    private static byte[] EditEveryNthTextNode(byte[] source, int nth, int count) =>
+        Transform(source, body =>
+        {
+            var texts = body.Descendants(W + "t").Where(t => t.Value.Trim().Length > 3).ToList();
+            var done = 0;
+            if (nth == 0)
+            {
+                // Spread `count` edits evenly over the document instead of clustering them.
+                var stride = Math.Max(1, texts.Count / Math.Max(1, count));
+                for (var i = 0; i < texts.Count && done < count; i += stride)
+                {
+                    texts[i].Value = MutateWord(texts[i].Value, i);
+                    done++;
+                }
+                return;
+            }
+
+            for (var i = 0; i < texts.Count && done < count; i++)
+            {
+                if (i % nth != 0) continue;
+                texts[i].Value = MutateWord(texts[i].Value, i);
+                done++;
+            }
+        });
+
+    private static byte[] EditParagraphs(byte[] source, int nth) =>
+        Transform(source, body =>
+        {
+            var paras = body.Elements(W + "p").ToList();
+            for (var i = 0; i < paras.Count; i++)
+            {
+                if (i % nth != 0) continue;
+                var t = paras[i].Descendants(W + "t").FirstOrDefault(x => x.Value.Trim().Length > 3);
+                if (t != null) t.Value = MutateWord(t.Value, i);
+            }
+        });
+
+    private static byte[] Rewrite(byte[] source) =>
+        Transform(source, body =>
+        {
+            var i = 0;
+            foreach (var t in body.Descendants(W + "t").ToList())
+            {
+                if (t.Value.Trim().Length > 0) t.Value = MutateWord(t.Value, i);
+                i++;
+            }
+        });
+
+    // Relocation stress: take blocks from the second quarter of the body and re-insert them
+    // in the last quarter, unchanged, so the aligner has to recover them as moves.
+    private static byte[] Reorder(byte[] source, int blocks) =>
+        Transform(source, body =>
+        {
+            var all = body.Elements().Where(e => e.Name == W + "p" || e.Name == W + "tbl").ToList();
+            if (all.Count < blocks * 4) blocks = Math.Max(1, all.Count / 4);
+            var take = all.Skip(all.Count / 4).Take(blocks).ToList();
+            var anchor = all[Math.Min(all.Count - 1, all.Count * 3 / 4)];
+            foreach (var b in take) b.Remove();
+            anchor.AddAfterSelf(take);
+        });
+
+    private static byte[] Structural(byte[] source, int count) =>
+        Transform(source, body =>
+        {
+            var paras = body.Elements(W + "p")
+                .Where(p => p.Descendants(W + "t").Any(t => t.Value.Trim().Length > 20))
+                .ToList();
+            if (paras.Count == 0) return;
+
+            var stride = Math.Max(1, paras.Count / Math.Max(1, count * 2));
+            var deleted = 0;
+            var inserted = 0;
+            for (var i = 0; i < paras.Count && (deleted < count || inserted < count); i += stride)
+            {
+                if (deleted < count && i % 2 == 0)
+                {
+                    paras[i].Remove();
+                    deleted++;
+                }
+                else if (inserted < count)
+                {
+                    var clone = new XElement(paras[i]);
+                    foreach (var t in clone.Descendants(W + "t").ToList())
+                        t.Value = $"Negotiated addition {inserted}: {t.Value}";
+                    // Drop bookmark/comment anchors so the insertion is genuinely new content.
+                    foreach (var e in clone.Descendants().Where(IsAnchorish).ToList()) e.Remove();
+                    paras[i].AddAfterSelf(clone);
+                    inserted++;
+                }
+            }
+        });
+
+    private static bool IsAnchorish(XElement e) =>
+        e.Name == W + "bookmarkStart" || e.Name == W + "bookmarkEnd" ||
+        e.Name == W + "commentRangeStart" || e.Name == W + "commentRangeEnd" ||
+        e.Name == W + "commentReference";
+
+    private static byte[] EditFootnotes(byte[] source) =>
+        TransformPart(source, doc => doc.MainDocumentPart?.FootnotesPart, root =>
+        {
+            var texts = root.Descendants(W + "t").Where(t => t.Value.Trim().Length > 3).ToList();
+            for (var i = 0; i < texts.Count; i += 2)
+                texts[i].Value = MutateWord(texts[i].Value, i);
+        });
+
+    // ---- plumbing ----
+
+    private static byte[] Transform(byte[] source, Action<XElement> editBody) =>
+        TransformPart(source, doc => doc.MainDocumentPart, root =>
+        {
+            var body = root.Element(W + "body");
+            if (body != null) editBody(body);
+        });
+
+    private static byte[] TransformPart(
+        byte[] source, Func<WordprocessingDocument, OpenXmlPart?> pick, Action<XElement> edit)
+    {
+        var wml = new WmlDocument("in.docx", source);
+        using var streamDoc = new OpenXmlMemoryStreamDocument(wml);
+        using (var doc = streamDoc.GetWordprocessingDocument())
+        {
+            var part = pick(doc);
+            if (part != null)
+            {
+                var xdoc = part.GetXDocument();
+                if (xdoc.Root != null)
+                {
+                    edit(xdoc.Root);
+                    part.PutXDocument();
+                }
+            }
+        }
+
+        return streamDoc.GetModifiedWmlDocument().DocumentByteArray;
+    }
+
+    // A word-level substitution, not a whole-string replacement: this is what a counsel edit
+    // looks like to the tokenizer, and it keeps the surrounding tokens Equal so the token
+    // differ has real work to do rather than a trivially total replacement.
+    private static string MutateWord(string value, int seed)
+    {
+        var words = value.Split(' ');
+        var target = -1;
+        for (var i = 0; i < words.Length; i++)
+        {
+            if (words[i].Trim().Length <= 2) continue;
+            target = i;
+            if (i >= seed % Math.Max(1, words.Length)) break;
+        }
+
+        if (target < 0) return value + " (amended)";
+        words[target] = Replacements[seed % Replacements.Length];
+        return string.Join(' ', words);
+    }
+
+    private static readonly string[] Replacements =
+    [
+        "amended", "restated", "supplemental", "conditional", "irrevocable",
+        "notwithstanding", "pari-passu", "as-converted", "post-money", "pre-money",
+        "liquidation", "redemption", "conversion", "protective", "cumulative",
+    ];
+}

--- a/docs/architecture/ir_diff_engine.md
+++ b/docs/architecture/ir_diff_engine.md
@@ -121,8 +121,11 @@ order.
 `Environment.ProcessorCount > 1`. `wasm/DocxodusWasm/DocxodusWasm.csproj` does not set
 `WasmEnableThreads`, so the browser runtime is single-threaded, and there `Task.Run` does not start a
 second thread — it queues the delegate for
-the ONE thread, which is the thread about to block on the result. An unguarded blocking join there
-would hang the page rather than merely fail to be faster. The browser therefore keeps the sequential
+the ONE thread, which is the thread that would then block on the result. The runtime refuses rather
+than deadlocking: the join throws `PlatformNotSupportedException: Cannot wait on monitors on this
+runtime`, so an unguarded fan-out fails every browser comparison outright. (Measured — with the guard
+forced open, all ten `npm/tests/docx-diff.spec.ts` cases fail with exactly that exception; those specs
+are this guard's regression test.) The browser therefore keeps the sequential
 schedule and still gets the read-sharing win, which is the larger half: on the reference document a
 two-way `Compare` runs roughly 1.4-1.6x faster than before with no parallelism at all, against
 ~2.3x with it.

--- a/docs/architecture/ir_diff_engine.md
+++ b/docs/architecture/ir_diff_engine.md
@@ -84,7 +84,7 @@ right ─ IrReader.Read ──▶ IrDocument ─┘                             
 
 Internal stages (all `internal`, under `Docxodus/Ir/Diff/`):
 
-- **`IrReader`** — reads a `WmlDocument` to an `IrDocument` (anchor-indexed blocks; accepted-revision view; provenance off for the diff path). Shared with the markdown projection.
+- **`IrReader`** — reads a `WmlDocument` to an `IrDocument` (anchor-indexed blocks; accepted-revision view). Shared with the markdown projection.
 - **`IrDiffTokenizer`** — splits IR runs into word/separator/atomic tokens with match keys (case folding, NBSP conflation, hyperlink-target-in-key, field transparency). The diff's tokenization, NOT an IR fact.
 - **`IrBlockAligner`** — unique-hash `(ContentHash, FormatFingerprint)` anchoring → LIS spine → in-order gap fill; relocations fall off the spine as moves; similarity-based in-gap pairing + cross-gap fuzzy moves. When a reorder admits several equal-length spines, a **structural-anchor tie-break** keeps heavy blocks (tables / section breaks / opaque) anchored and relocates the lighter paragraph instead (a max-WEIGHT LIS, cardinality-primary so the move count is unchanged; fires only when the plain LIS relocated a structural block, so the paragraph-only path is byte-identical). Beyond cleaner two-way markup, this stops an ambiguous paragraph move across a table boundary from spuriously moving the table — which in `Consolidate` would contest the whole table block and block per-cell composition of a second reviewer's disjoint table edit (issue #229).
   - **The in-place ORDER invariant (`EnforceInPlaceOrderMonotonicity`, issue #288).** `EmitEntries` walks the RIGHT document and emits each left-owning unit at its right position, so `reject ≡ left` is exact in ORDER — not merely as a word multiset — only when the left → right map is strictly increasing across **every** in-place unit: 1:1 pairs *and* split/merge groups. Each forming pass enforces order-preservation against the pairings that existed when it ran (`InOrderRefine`'s crossing bounds, `SameSlotPair`/`JunctionPair`'s `maxBelow`/`minAbove` sweeps, `ReleaseCrossingModifiedPairs`' post-normalization), but nothing re-checked what a LATER pass added — and the split/merge containment scan runs after the refinement passes. A **verbatim-duplicate** block never anchors (`BuildUniqueIndex` keys on content unique to each side), so which occurrence pairs with which is settled in-gap, and the losing occurrence can end up on the wrong side of a group formed afterwards. A single global pass therefore enforces the invariant once: keep a maximum-**weight** strictly-increasing subsequence of (left → right position) and release the rest to plain Deleted/Inserted (always reversible), weight = blocks kept paired, so an ambiguous cut sacrifices the pairing holding the least content. It runs BEFORE cross-gap move detection, so a released pair that IS a relocation comes straight back as a `Moved` — usually a better reading than the in-place pairing it replaced. Fast path: an already-monotone alignment returns after one linear scan, untouched. Pinned by `IrAlignmentAsserts.AssertLeftOrderReconstructible` (asserted on **every** aligner test) and by `DocxDiffFuzzRoundTripTests`' block-sequence comparison.
@@ -92,6 +92,35 @@ Internal stages (all `internal`, under `Docxodus/Ir/Diff/`):
 - **`IrTableDiffer`** — nested table row/cell diffs (a cell-text edit surfaces as a token diff inside that cell, not a whole-table blob).
 - **`IrEditScriptBuilder`** — assembles the `IrEditScript` from the alignment + token/table diffs, including footnote/endnote scope ops.
 - **`IrMarkupRenderer` / `IrRevisionRenderer` / `IrEditScriptJson`** — the three renderers above.
+
+### One read per document per comparison
+
+The pipeline reads each input **once**, with `RetainSources` ON, and every stage works off that
+snapshot. This is worth stating because the obvious reading of the stage list suggests otherwise:
+`IrMarkupRenderer` clones source `w:p`/`w:tbl` elements, so it needs provenance the script builder
+does not — and it used to obtain that by re-reading both documents itself. It cannot tell the
+difference: `RetainSources` decides only whether `IrProvenance` pins the source `XElement`, and
+`IrProvenance` is equality-neutral by construction (it equals any other instance and hashes to
+zero), so a retention-on snapshot is node-for-node value-equal to a retention-off one. `Render`
+therefore takes an optional pre-read pair and `DocxDiffComparison` supplies it; the same hand-off
+exists on `IrCompositeMarkupRenderer` for the N-way path, where re-reading meant `2*(N+1)` package
+reads to compare `N+1` documents.
+
+`IrReader.Read` likewise opens each package once. Deciding the accepted-revision view needs every
+story parsed, and so does the body walk, so the scan runs against the package the walk is about to
+use (`GetXDocument` caches per part). Only a document that genuinely carries revision markup pays
+for the `RevisionProcessor` round-trip and the reopen that follows it.
+
+The left and right sides are independent pure reads, so pre-accept and the IR reads run
+concurrently; `Consolidate` reads the base and all reviewers the same way. Nothing about the output
+depends on this — the reads share no state — but it is why `DocxDiffComparison` takes a dependency
+on `System.Threading.Tasks`.
+
+On a 574 KB `document.xml` with 15,360 elements, collapsing four reads to two concurrent ones took
+a two-way `Compare` from ~820 ms to ~350 ms and a four-reviewer `Consolidate` from ~1870 ms to
+~675 ms. `benchmarks/docxdiff-stress` measures this and digests every product to prove the output
+did not move; see its `FINDINGS.md` for the full stage attribution and for what still stands
+between the engine and 10 comparisons per second.
 
 ## Edit script
 

--- a/docs/architecture/ir_diff_engine.md
+++ b/docs/architecture/ir_diff_engine.md
@@ -106,6 +106,16 @@ therefore takes an optional pre-read pair and `DocxDiffComparison` supplies it; 
 exists on `IrCompositeMarkupRenderer` for the N-way path, where re-reading meant `2*(N+1)` package
 reads to compare `N+1` documents.
 
+`GetRevisions` gained the byte-identical shortcut `Compare` already had: two packages with the
+same bytes have nothing to report, and running the pipeline to establish that costs as much as a
+real comparison. Both shortcuts skip the **work** and not the compatibility pre-flight — that
+pre-flight is a property of the inputs, so a caller who asked to be warned about an under-tested
+construct gets the same answer whether or not the two sides happen to match. This distinction has
+no output-digest signature (a product that stops warning still returns the right answer), so it is
+covered by unit tests and by the pre-flight digests in `benchmarks/docxdiff-stress`' corpus mode
+rather than by output parity. The edit script deliberately keeps no such shortcut: its all-Equal
+operations are the answer the caller asked for.
+
 `IrReader.Read` likewise opens each package once. Deciding the accepted-revision view needs every
 story parsed, and so does the body walk, so the scan runs against the package the walk is about to
 use (`GetXDocument` caches per part). Only a document that genuinely carries revision markup pays
@@ -132,9 +142,10 @@ two-way `Compare` runs roughly 1.4-1.6x faster than before with no parallelism a
 
 On a 574 KB `document.xml` with 15,360 elements, collapsing four reads to two concurrent ones took
 a two-way `Compare` from ~820 ms to ~350 ms and a four-reviewer `Consolidate` from ~1870 ms to
-~675 ms. `benchmarks/docxdiff-stress` measures this and digests every product to prove the output
-did not move; see its `FINDINGS.md` for the full stage attribution and for what still stands
-between the engine and 10 comparisons per second.
+~675 ms. `benchmarks/docxdiff-stress` measures this and digests every product — pairwise and N-way, plus
+the compatibility report — across all of `TestFiles/` to prove the output did not move; see its
+`FINDINGS.md` for the full stage attribution and for what still stands between the engine and 10
+comparisons per second.
 
 ## Edit script
 

--- a/docs/architecture/ir_diff_engine.md
+++ b/docs/architecture/ir_diff_engine.md
@@ -113,8 +113,19 @@ for the `RevisionProcessor` round-trip and the reopen that follows it.
 
 The left and right sides are independent pure reads, so pre-accept and the IR reads run
 concurrently; `Consolidate` reads the base and all reviewers the same way. Nothing about the output
-depends on this — the reads share no state — but it is why `DocxDiffComparison` takes a dependency
-on `System.Threading.Tasks`.
+depends on this — the reads share no state — and both schedules produce the same values in the same
+order.
+
+**The fan-out is gated, and the gate is not an optimization.** It runs through
+`Docxodus.Internal.ParallelWork`, which is compiled out under `WASM_BUILD` and additionally checks
+`Environment.ProcessorCount > 1`. `wasm/DocxodusWasm/DocxodusWasm.csproj` does not set
+`WasmEnableThreads`, so the browser runtime is single-threaded, and there `Task.Run` does not start a
+second thread — it queues the delegate for
+the ONE thread, which is the thread about to block on the result. An unguarded blocking join there
+would hang the page rather than merely fail to be faster. The browser therefore keeps the sequential
+schedule and still gets the read-sharing win, which is the larger half: on the reference document a
+two-way `Compare` runs roughly 1.4-1.6x faster than before with no parallelism at all, against
+~2.3x with it.
 
 On a 574 KB `document.xml` with 15,360 elements, collapsing four reads to two concurrent ones took
 a two-way `Compare` from ~820 ms to ~350 ms and a four-reviewer `Consolidate` from ~1870 ms to


### PR DESCRIPTION
## Why

We had no way to answer "how fast is `DocxDiff` on a real legal document, and where does the time go?" — and no way to prove a performance change left the diff itself untouched. This adds both, then acts on what they showed.

The reference document is the NVCA Model Certificate of Incorporation (October 2025): 574 KB of `word/document.xml` holding 15,360 elements across 234 body paragraphs, plus 97 footnotes in a 227 KB part, 16 abstract numbering definitions, 4 sections, 8 headers and 10 footers. A `DocxDiff.Compare` of it against an edited copy took about 820 ms.

## What the measurement showed

**About 72% of a comparison was spent inside `IrReader`, reading the same two documents four times.**

1. `DocxDiffComparison` read both sides with `RetainSources` off to build the edit script.
2. `IrMarkupRenderer` then re-read the *same two documents* with `RetainSources` on, to get the source `w:p`/`w:tbl` elements it clones from.
3. And inside every one of those reads, settling the accepted-revision view opened a whole second package and parsed every story to scan it for revision markup — then threw that parse away and reopened the document for the walk.

None of it was necessary. `RetainSources` decides only whether `IrProvenance` pins the source `XElement`, and `IrProvenance` is equality-neutral by construction (it equals any other instance and hashes to zero, precisely so provenance never leaks into IR value equality). The two snapshots are therefore node-for-node value-equal, and the renderer can simply be handed the one the script was built over. And because `GetXDocument` caches per part, running the revision scan against the package the walk is about to use costs nothing.

The N-way path carried the same duplication multiplied by reviewer count: an N-reviewer `Consolidate` read `2*(N+1)` packages to compare `N+1` documents.

## How it works now

- **One read per document per comparison.** `IrMarkupRenderer.Render` and `IrCompositeMarkupRenderer.Render` take an optional pre-read snapshot; `DocxDiffComparison` and `Consolidate` read once with provenance on and hand it over.
- **One package open per read.** `IrReader.Read` opens the package, decides the revision view against it, and walks it. Only a document that genuinely needs a `RevisionProcessor` round-trip reopens.
- **Both sides concurrently, where there are threads to do it on** — see the guard section below.
- **`GetRevisions` on byte-identical packages returns empty immediately**, the same shortcut `ToRedline` already had. The edit script keeps no such shortcut: its all-Equal operations are the answer the caller asked for.
- **Cheaper hashing walks.** `UnidHelper.ContentSignature` walked every element's subtree three times building a string per walk; one fused walk now appends the same characters in the same order, and a per-call cache serves its repeated hash inputs (about seven in eight are duplicates). Canonical-XML hashing no longer materializes a byte array per call, and attribute canonicalization skips the sort for elements carrying none or one.

## Results

Medians of nine timed iterations after four warm-ups, before and after in one run:

| Case | Before | After | |
|---|---|---|---|
| 8 scattered word edits | 821 ms | **351 ms** | 2.3× |
| an edit in every fifth paragraph | 868 ms | **395 ms** | 2.2× |
| 24 blocks relocated | 792 ms | **338 ms** | 2.3× |
| 20 paragraphs deleted, 20 inserted | 803 ms | **334 ms** | 2.4× |
| half the footnote paragraphs edited | 959 ms | **510 ms** | 1.9× |
| every second text node edited | 1062 ms | **611 ms** | 1.7× |
| every paragraph rewritten | 1279 ms | **868 ms** | 1.5× |
| `GetRevisions` | 395 ms | **216 ms** | 1.8× |
| `GetEditScriptJson` | 389 ms | **216 ms** | 1.8× |
| all three products fused | 852 ms | **387 ms** | 2.2× |
| `GetRevisions`, identical packages | 371 ms | **0 ms** | — |
| `Consolidate`, 4 reviewers | 1870 ms | **675 ms** | 2.8× |

Allocation per comparison drops 528 → 276 MB; per four-reviewer consolidate 1337 → 710 MB.

## How it was validated

**4,161 of 4,161 .NET tests pass**, warning count byte-for-byte identical to `main` (262, same distribution), WASM builds at 3689 KB wire size (budget 4096), browser diff specs green.

The evidence that matters for a change like this is that **the diff itself did not move**, and it is checkable:

```bash
dotnet run -c Release --project benchmarks/docxdiff-stress -- --corpus TestFiles --baseline main.json   # on main
dotnet run -c Release --project benchmarks/docxdiff-stress -- --corpus TestFiles --check main.json      # on this branch
```

**678 documents → 8,136 digests → all identical.** Each document contributes an edited variant under default settings, the document against itself (the byte-identical shortcuts), and the edited variant again under `PreAcceptInputRevisions` and `PreserveInputRevisions` — the only settings that reach the revision-transform path — times three products.

That corpus matters because the reference document has **no tracked revisions, no tables and no drawings**, which is to say it never exercised the path `IrReader.Read` was restructured around. `TestFiles` has 89 revision-bearing, 218 table-bearing, 95 drawing-bearing and 124 content-control-bearing documents.

Validated in both directions, because a check that cannot fail proves nothing:

| | |
|---|---|
| `main` vs this branch | all 8,136 identical |
| `main` vs itself | all 8,136 identical |
| this branch vs itself | all 8,136 identical |
| drop the `w:t` skip in `UnidHelper.ContentSignature` | **3,905 mismatches** |

And its limit, stated rather than glossed: reintroducing the `wp:docPr/@id` stripping-order bug that `IrHasherTests.Canonicalize_LoneDocPrId_StillStripped` guards produces **zero** corpus mismatches — real Word documents emit `docPr` with both `id` and `name`, so the lone-attribute shape never occurs in these 678 files. Corpus parity and unit tests cover different things.

### Found on the way: `Compare` is not byte-deterministic with media (#621)

The first corpus run reported 161 mismatches. They were **not** this branch's: `main` disagrees with itself on exactly the same 161. Media and diagram parts imported into a redline are named `P` + a fresh GUID, with relationship ids of `R` + a fresh GUID, so any document whose redline imports media produces different bytes every run — contradicting `DocxDiffSettings.Deterministic`. Filed as #621; the harness folds those names before digesting so real changes are not buried under naming churn.

### One bug this PR's own review caught

Skipping the attribute sort for single-attribute elements was briefly wrong: canonicalization strips `wp:docPr/@id` by consulting `attribute.Parent`, so deciding an attribute's fate *after* detaching it changes the verdict. The LINQ chain it replaced got this right by accident (`ToList()` forces evaluation before `RemoveAttributes()`). Three tests now pin that path; the first fails against the wrong ordering.

## The concurrency needed a guard, and it is not an optimization

`wasm/DocxodusWasm/DocxodusWasm.csproj` does not set `WasmEnableThreads`, so the browser runtime is single-threaded: `Task.Run` queues the delegate for the **one** thread that would then block on the result, and the runtime refuses rather than deadlocking —

```
PlatformNotSupportedException: Cannot wait on monitors on this runtime
```

Measured, not inferred: with the guard forced open, **all ten `npm/tests/docx-diff.spec.ts` cases fail with exactly that exception**; with it in place they pass (10 passed, 14.0s). Both call sites go through `Docxodus.Internal.ParallelWork`, compiled out under `WASM_BUILD` and additionally requiring `Environment.ProcessorCount > 1`. It preserves the sequential failure ordering, and a concurrent failure is always observed rather than left as an unobserved task exception.

The browser keeps most of the win regardless, because the larger half does not depend on threads: roughly 1.4–1.6× sequential against ~2.3× concurrent.

## On the 10 comparisons/second question that prompted this

Not reached for a cold pairwise redline of a document this size. At ~350 ms this is just under 3/s; 10/s means 100 ms, and ~45 ms of that is package I/O no design avoids (13 ms to parse every story, 17 ms to re-serialize a package unchanged). The **data** products are much closer: with both documents already read, the diff itself is about 60 ms.

Three levers remain, filed rather than buried: **#617** (reusable snapshot so bulk pipelines read a document once — the one that decides 10/s), **#618** (`UnidHelper` hashes twice per element for elements the IR never reads back), **#619** (`MarkupCompatibilityNormalizer` full-parses `document.xml` on every call to find nothing). A fourth — spend the remaining two cores — is deliberately *not* filed; `FINDINGS.md` says why.

## Files

`benchmarks/docxdiff-stress/` is a new standalone harness, outside `Docxodus.sln` so it never touches CI, packaging or the warning baselines. Its README covers the variants, the corpus differential, the rename-invariant digest and the measurement traps (force a collection between cases; warm past tiered JIT before timing — an early draft reported `UnidHelper` at 108 ms where the steady state is 51 ms). `FINDINGS.md` carries the full stage attribution.

`docs/architecture/ir_diff_engine.md` previously described the renderer's re-read as unconditional; it now documents the single-read design and why the fan-out is gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQ7aHQV9e11SSt4idtyWaK