### PR TITLE
Keep the compatibility pre-flight on GetRevisions' identical-bytes shortcut, and cover the paths that hid it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@ All notable changes to this project will be documented in this file.
   task there throws `PlatformNotSupportedException: Cannot wait on monitors on this runtime`
   and fails the comparison outright; it still gets the read-sharing win, which is the larger
   half (roughly 1.4-1.6x with no parallelism at all). `GetRevisions` on byte-identical packages takes the same shortcut `Compare` already had
-  instead of running the whole pipeline to prove there is nothing to report. The N-way
+  instead of running the whole pipeline to prove there is nothing to report — the shortcut
+  skips the work, not the compatibility pre-flight, so
+  `OnCompatibilityWarning`/`ThrowOnCompatibilityWarning` still report on the inputs whether
+  or not the two sides happen to match. The N-way
   `Consolidate` carried the same duplication multiplied by reviewer count (`2*(N+1)` reads
   to compare `N+1` documents) and is fixed the same way. Supporting cuts: `ContentSignature`
   walks each subtree once instead of three times, its repeated hash inputs (about seven in
@@ -30,8 +33,9 @@ All notable changes to this project will be documented in this file.
   216 ms and 371 → 0 ms on identical inputs; a four-reviewer `Consolidate` 1870 → 675 ms;
   allocation per comparison 528 → 276 MB. **Output is unchanged** — the new
   `benchmarks/docxdiff-stress` harness digests the redline package, revision list, edit
-  script and all four consolidate products across eight generated edit shapes, and all 36
-  digests are byte-identical before and after.
+  script, all four consolidate products and the compatibility report across eight generated
+  edit shapes and every one of the 678 documents in `TestFiles/`, and every digest is
+  byte-identical before and after.
 - **The ribbon's strips signal their overflow instead of hard-clipping.** On a narrow
   surface the compact chrome keeps every command by scrolling its strips (title bar, tab
   strip, ribbon panels, anchor rail) — but the clipped edge read as a squashed, broken

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ nullable-checked by default, so a new file needs no directive. The exception is 
 inherited OpenXmlPowerTools core — 21 legacy files (`WmlComparer`, `WmlToHtmlConverter`,
 the `HtmlToWml*` family, `FormattingAssembler`, `DocumentBuilder`, `RevisionProcessor`,
 `PtOpenXmlUtil`, …) carry an explicit `#nullable disable` header. They hold back a lot:
-stripping all 21 takes the library from 131 warnings to **3,659**.
+stripping all 21 takes the library from its baseline to **3,659**.
 `grep -l "^#nullable disable" Docxodus/*.cs` lists the remaining debt; when
 substantially refactoring one of those files, consider removing its header and fixing
 that file's warnings. CS8632 stays in `NoWarn` deliberately: with the project context
@@ -40,9 +40,15 @@ are kept for the day each file migrates.
 **`Docxodus.csproj` and `Docxodus.Tests.csproj` both override it to `false`**, so the core
 library and the test project do *not* fail on warnings. The CLI tools, MCP server,
 python-host and WASM project do inherit it. Current baseline: the library builds with
-**131 warnings**, the test project with **774** (mostly StyleCop `SA1633`/`SA1636` file
+**132 warnings**, the test project with **775** (mostly StyleCop `SA1633`/`SA1636` file
 headers and `SA1206` using-order). Don't add to either baseline. Measure with
 `--no-incremental` — a warm incremental build reports zero because nothing recompiles.
+
+The one movement that is not a regression: no file in the library carries a StyleCop file
+header, so `SA1633` fires once per file and **every new `.cs` file under `Docxodus/` moves
+both counts by exactly one** (the test build compiles the library through its project
+reference). A change that adds one file and one warning is at baseline; anything more is not.
+Update the two numbers here in the same commit rather than leaving them stale.
 
 ## Repository Layout
 

--- a/Docxodus.Tests/DocxDiffCompatibilityTests.cs
+++ b/Docxodus.Tests/DocxDiffCompatibilityTests.cs
@@ -74,6 +74,79 @@ public class DocxDiffCompatibilityTests
         Assert.Contains(captured!.Warnings, w => w.Feature.Id == "contentControls");
     }
 
+    // ---- the identical-bytes shortcuts must not swallow the pre-flight ------------------------
+    //
+    // Compare and GetRevisions both short-circuit byte-identical packages. The shortcut skips the
+    // WORK; the pre-flight is a property of the INPUTS, so a caller who asked to be warned about an
+    // under-tested construct still has to be. These pin every product on the shortcut path, because
+    // a shortcut added to one product and not wired to the pre-flight is invisible to output-parity
+    // evidence: the answer (nothing changed) is right, and the warning simply never arrives.
+
+    [Fact]
+    public void GetRevisions_IdenticalPackages_StillThrowsOnCompatibilityWarning()
+    {
+        var doc = Math();
+        var ex = Assert.Throws<DocxDiffCompatibilityException>(() =>
+            DocxDiff.GetRevisions(doc, new WmlDocument(doc),
+                new DocxDiffSettings { ThrowOnCompatibilityWarning = true }));
+        Assert.Contains(ex.Report.Warnings, w => w.Feature.Id == "math");
+    }
+
+    [Fact]
+    public void GetRevisions_IdenticalPackages_StillFiresCompatibilityCallback()
+    {
+        var doc = Math();
+        DocxDiffCompatibilityReport? captured = null;
+        var revisions = DocxDiff.GetRevisions(doc, new WmlDocument(doc),
+            new DocxDiffSettings { OnCompatibilityWarning = r => captured = r });
+        Assert.Empty(revisions);
+        Assert.NotNull(captured);
+        Assert.Contains(captured!.Warnings, w => w.Feature.Id == "math");
+    }
+
+    [Fact]
+    public void Compare_IdenticalPackages_StillThrowsOnCompatibilityWarning()
+    {
+        var doc = Math();
+        var ex = Assert.Throws<DocxDiffCompatibilityException>(() =>
+            DocxDiff.Compare(doc, new WmlDocument(doc),
+                new DocxDiffSettings { ThrowOnCompatibilityWarning = true }));
+        Assert.Contains(ex.Report.Warnings, w => w.Feature.Id == "math");
+    }
+
+    /// <summary>One comparison, every product: the pre-flight fires on whichever product is asked for
+    /// first, so a shortcut on any one of them cannot be the reason a warning goes missing.</summary>
+    [Theory]
+    [InlineData("revisions")]
+    [InlineData("redline")]
+    [InlineData("editscript")]
+    public void Comparison_IdenticalPackages_EveryProductPreflights(string product)
+    {
+        var doc = Math();
+        DocxDiffCompatibilityReport? captured = null;
+        var comparison = DocxDiff.CreateComparison(doc, new WmlDocument(doc),
+            new DocxDiffSettings { OnCompatibilityWarning = r => captured = r });
+
+        switch (product)
+        {
+            case "revisions": Assert.Empty(comparison.GetRevisions()); break;
+            case "redline": Assert.NotNull(comparison.ToRedline()); break;
+            default: Assert.NotNull(comparison.GetEditScriptJson()); break;
+        }
+
+        Assert.NotNull(captured);
+        Assert.Contains(captured!.Warnings, w => w.Feature.Id == "math");
+    }
+
+    /// <summary>The shortcut is still a shortcut: with the pre-flight not engaged, an identical pair
+    /// reports nothing and never opens either package.</summary>
+    [Fact]
+    public void GetRevisions_IdenticalPackages_DefaultSettings_ReportNothing()
+    {
+        var doc = Math();
+        Assert.Empty(DocxDiff.GetRevisions(doc, new WmlDocument(doc)));
+    }
+
     /// <summary>A minimal valid DOCX whose body is <paramref name="bodyInner"/>. The document element declares the
     /// w/m/v/o namespaces so any construct in bodyInner parses under the right namespace. extraParts can add a
     /// footnotes/header/etc. part for multi-part tests.</summary>

--- a/Docxodus/DocxDiffComparison.cs
+++ b/Docxodus/DocxDiffComparison.cs
@@ -34,10 +34,16 @@ namespace Docxodus;
 /// <see cref="DocxDiffSettings"/> flow into the semantic pass (as
 /// <see cref="SemanticDiffOptions.DiffSettings"/>) and the result is memoized. Passing explicit
 /// <see cref="SemanticDiffOptions"/> bypasses the memo and runs the semantic pipeline with those
-/// options verbatim. The semantic pipeline keeps its own package-preflighted read (its reader
-/// retains sources, the diff read does not), so it shares the snapshot but not the IR pass.</para>
+/// options verbatim. The semantic pipeline keeps its own package-preflighted read, so it shares the
+/// snapshot but not the IR pass.</para>
 /// <para><b>Memory.</b> The instance retains the input packages and every materialized product
-/// for its lifetime; scope it to the pipeline run that needs the products.</para>
+/// for its lifetime; scope it to the pipeline run that needs the products. What it retains includes
+/// the two IR snapshots, once a product has forced them. Those are read with provenance retained, so
+/// that the markup renderer can clone source elements out of them rather than re-reading both
+/// documents — which means they pin the parsed <c>XDocument</c> of every story on both sides, not
+/// only the IR values. That is the price of reading each input once instead of four times: bounded
+/// by the inputs, but not small, and one more reason not to hold a comparison beyond the run that
+/// uses it.</para>
 /// <para><b>Thread-safety.</b> All memoization is <see cref="LazyThreadSafetyMode.ExecutionAndPublication"/>;
 /// concurrent product calls are safe.</para>
 /// </remarks>
@@ -107,9 +113,20 @@ public sealed class DocxDiffComparison
             // the same reason and with the same exception: an explicit accept-all request rewrites the
             // input even when the two sides match, so it is not a no-op. Note the edit script has no
             // equivalent shortcut — its all-Equal operations are the answer callers asked for.
+            //
+            // The shortcut skips the WORK, never the compatibility preflight. That preflight is a
+            // property of the inputs, not of whether they differ: a caller who asked to be told about
+            // an under-tested construct is asking about THIS document, and gets the same answer
+            // whether or not the other side happens to be byte-identical. ToRedline's identical-bytes
+            // path runs it for exactly that reason, and this class documents the preflight as firing
+            // on the first product call; dropping it here would silently make GetRevisions the one
+            // product that never warns.
             if (DocxCompare.HasIdenticalPackageBytes(_originalLeft, _originalRight) &&
                 !(_settings.PreAcceptInputRevisions && !_settings.PreserveInputRevisions))
+            {
+                RunGatedPreflight();
                 return Array.Empty<DocxDiffRevision>();
+            }
 
             var diff = _settings.ToIrDiffSettings() with { CrossParagraphTokenDiff = false };
             var (irLeft, irRight) = _ir.Value;
@@ -180,13 +197,7 @@ public sealed class DocxDiffComparison
         if (DocxCompare.HasIdenticalPackageBytes(_originalLeft, _originalRight) &&
             !(s.PreAcceptInputRevisions && !s.PreserveInputRevisions))
         {
-            if (s.OnCompatibilityWarning != null || s.ThrowOnCompatibilityWarning)
-            {
-                var preflightLeft = DocxDiff.PreAccept(s, _originalLeft);
-                var preflightRight = DocxDiff.PreAccept(s, _originalRight);
-                DocxDiff.PreflightCompatibility(s, preflightLeft, preflightRight);
-            }
-
+            RunGatedPreflight();
             return new WmlDocument(_originalLeft);
         }
 
@@ -200,6 +211,23 @@ public sealed class DocxDiffComparison
             : _dataScript.Value;
         var (irLeft, irRight) = _ir.Value;
         return IrMarkupRenderer.Render(script, left, right, diff, irLeft, irRight);
+    }
+
+    /// <summary>
+    /// The compatibility preflight a product's identical-bytes shortcut still owes its caller, run
+    /// only when the caller actually asked for it. Both shortcuts (<see cref="BuildRedline"/> and the
+    /// revision list) route through here so they cannot drift apart again: the pre-accept pair is
+    /// built the same way <c>_preflighted</c> builds it, but nothing else on the shortcut path needs
+    /// those documents, so they are not memoized.
+    /// </summary>
+    private void RunGatedPreflight()
+    {
+        var s = _settings;
+        if (s.OnCompatibilityWarning == null && !s.ThrowOnCompatibilityWarning)
+            return;
+        var preflightLeft = DocxDiff.PreAccept(s, _originalLeft);
+        var preflightRight = DocxDiff.PreAccept(s, _originalRight);
+        DocxDiff.PreflightCompatibility(s, preflightLeft, preflightRight);
     }
 
     private IrEditScript BuildFusedScript(IrDiffSettings diff)

--- a/Docxodus/Internal/ParallelWork.cs
+++ b/Docxodus/Internal/ParallelWork.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 
 namespace Docxodus.Internal;
@@ -115,9 +116,27 @@ internal static class ParallelWork
             throw;
         }
 
+        // Collect in argument order so the FIRST failure in sequential order is the one that
+        // propagates — but drain every task before throwing. Rethrowing straight out of the loop
+        // would leave a later task's exception unobserved, which is the very thing the head-failure
+        // path above takes care to avoid.
         var results = new T[rest.Length];
+        Exception? failure = null;
         for (var i = 0; i < rest.Length; i++)
-            results[i] = tasks[i].GetAwaiter().GetResult();
+        {
+            try
+            {
+                results[i] = tasks[i].GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                failure ??= ex;
+            }
+        }
+
+        if (failure is not null)
+            ExceptionDispatchInfo.Capture(failure).Throw();
+
         return (headResult, results);
     }
 }

--- a/Docxodus/Ir/IrHash.cs
+++ b/Docxodus/Ir/IrHash.cs
@@ -40,6 +40,11 @@ internal readonly struct IrHash : IEquatable<IrHash>
             BinaryPrimitives.ReadUInt64BigEndian(digest.Slice(24, 8)));
     }
 
+    /// <summary>The largest buffer <see cref="ArrayPool{T}.Shared"/> actually pools (1 MiB). A rent
+    /// above it allocates a fresh array and a return discards it, so the pooled-buffer trade stops
+    /// paying and an exact size becomes the cheaper one.</summary>
+    private const int PooledCeiling = 1024 * 1024;
+
     /// <summary>Compute the SHA-256 digest of the UTF-8 encoding of <paramref name="text"/>.</summary>
     public static IrHash Compute(string text)
     {
@@ -57,7 +62,16 @@ internal readonly struct IrHash : IEquatable<IrHash>
         ArgumentNullException.ThrowIfNull(text);
 
         Span<byte> inline = stackalloc byte[1024];
+
+        // GetMaxByteCount is 3n+3, and ArrayPool.Shared stops pooling above 1 MB: renting the
+        // worst case for a large canonical subtree (a block content control, an opaque table) would
+        // allocate three times the string's actual UTF-8 length and then drop it, which is WORSE than
+        // the single exact-sized array this method exists to avoid. Past that threshold, pay one
+        // counting pass and rent the exact size instead.
         int maxBytes = Encoding.UTF8.GetMaxByteCount(text.Length);
+        if (maxBytes > PooledCeiling)
+            maxBytes = Encoding.UTF8.GetByteCount(text);
+
         byte[]? rented = maxBytes <= inline.Length ? null : ArrayPool<byte>.Shared.Rent(maxBytes);
         Span<byte> buffer = rented is null ? inline : rented;
 

--- a/Docxodus/Ir/IrReader.cs
+++ b/Docxodus/Ir/IrReader.cs
@@ -84,15 +84,24 @@ internal static class IrReader
         // XML parsing cost of every read. GetXDocument caches per part, so keeping this package alive means
         // the walk reuses the very trees the scan already parsed. Only a document that genuinely needs a
         // revision transform pays for a second open, and it pays it inside RevisionProcessor regardless.
-        var stream = new OpenXmlMemoryStreamDocument(working);
-        var wdoc = stream.GetWordprocessingDocument();
+        // The pair is opened inside the try and the finally is null-tolerant, because
+        // GetWordprocessingDocument throws on a package that is not Wordprocessing (an .xlsx handed to
+        // the reader) or is structurally damaged. `using` used to cover that; a bare assignment before
+        // the try would leak the open package on exactly those inputs.
+        OpenXmlMemoryStreamDocument? stream = null;
+        WordprocessingDocument? wdoc = null;
         try
         {
+            stream = new OpenXmlMemoryStreamDocument(working);
+            wdoc = stream.GetWordprocessingDocument();
+
             var transformed = ApplyRevisionView(working, wdoc, options.RevisionView);
             if (transformed is not null)
             {
                 wdoc.Dispose();
+                wdoc = null;
                 stream.Dispose();
+                stream = null;
                 working = transformed;
                 stream = new OpenXmlMemoryStreamDocument(working);
                 wdoc = stream.GetWordprocessingDocument();
@@ -102,8 +111,8 @@ internal static class IrReader
         }
         finally
         {
-            wdoc.Dispose();
-            stream.Dispose();
+            wdoc?.Dispose();
+            stream?.Dispose();
         }
     }
 

--- a/benchmarks/docxdiff-stress/Corpus.cs
+++ b/benchmarks/docxdiff-stress/Corpus.cs
@@ -53,9 +53,16 @@ internal static class Corpus
             try { edited = CorpusVariant.Edit(bytes); }
             catch (Exception ex) { digests[$"{name}#variant"] = $"VARIANT-FAIL {ex.GetType().Name}"; edited = bytes; }
 
+            // A second, differently-offset edit of the same document: the N-way case needs two
+            // reviewers who actually disagree, or the merger never has a competitor to order.
+            byte[] editedAlt;
+            try { editedAlt = CorpusVariant.Edit(bytes, offset: 2); }
+            catch (Exception ex) { digests[$"{name}#variant-alt"] = $"VARIANT-FAIL {ex.GetType().Name}"; editedAlt = bytes; }
+
             var left = new WmlDocument("left.docx", bytes);
             var right = new WmlDocument("right.docx", edited);
             var same = new WmlDocument("same.docx", bytes);
+            var alt = new WmlDocument("alt.docx", editedAlt);
 
             // Default settings over the edited pair: the ordinary comparison path.
             Record(digests, name, "edited", left, right, new DocxDiffSettings());
@@ -71,6 +78,20 @@ internal static class Corpus
                 new DocxDiffSettings { PreAcceptInputRevisions = true });
             Record(digests, name, "preserve", left, right,
                 new DocxDiffSettings { PreserveInputRevisions = true });
+
+            // The compatibility pre-flight is a SECOND observable output, and it is invisible to
+            // everything above: with it disengaged, a product that never runs it and a product that
+            // runs it and finds nothing produce the same digest. Digest the report itself, so a
+            // shortcut that skips the pre-flight rather than the work shows up as a mismatch — on the
+            // identical pair as well, where a shortcut is most tempting and least observable.
+            RecordPreflight(digests, name, "edited", left, right);
+            RecordPreflight(digests, name, "identical", left, same);
+
+            // N-way. The consolidate path has its own reader fan-out, its own merger and its own
+            // markup renderer, and NONE of the three products above touches any of them. Two
+            // reviewers off the same base is the smallest shape that exercises reviewer ordering and
+            // conflict competitor order.
+            RecordConsolidate(digests, name, left, right, alt);
 
             var n = Interlocked.Increment(ref done);
             if (n % 50 == 0) Console.WriteLine($"  {n,5}/{files.Count} ...");
@@ -131,6 +152,80 @@ internal static class Corpus
             return Sha(Encoding.UTF8.GetBytes(sb.ToString()));
         });
         sink[$"{name}#{mode}/editscript"] = Try(() => Sha(Encoding.UTF8.GetBytes(DocxDiff.GetEditScriptJson(left, right, settings))));
+    }
+
+    // Every consolidate product, over two reviewers off one base. Reviewer order is significant to
+    // conflict reporting, so the digest carries the authors and the per-revision order as emitted.
+    private static void RecordConsolidate(
+        ConcurrentDictionary<string, string> sink, string name,
+        WmlDocument baseDoc, WmlDocument reviewerA, WmlDocument reviewerB)
+    {
+        var reviewers = new List<DocxDiffReviewer>
+        {
+            new() { Author = "Reviewer A", Document = reviewerA },
+            new() { Author = "Reviewer B", Document = reviewerB },
+        };
+        var settings = new DocxDiffConsolidateSettings();
+
+        sink[$"{name}#consolidate/redline"] = Try(() =>
+            StableRedlineDigest(DocxDiff.Consolidate(baseDoc, reviewers, settings).DocumentByteArray));
+
+        sink[$"{name}#consolidate/revisions"] = Try(() =>
+        {
+            var revs = DocxDiff.GetConsolidatedRevisions(baseDoc, reviewers, settings);
+            var sb = new StringBuilder().Append(revs.Count).Append('\n');
+            foreach (var r in revs)
+                sb.Append(r.Type).Append('|').Append(r.Author).Append('|').Append(r.Text).Append('|')
+                  .Append(r.LeftAnchor).Append('|').Append(r.RightAnchor).Append('|')
+                  .Append(r.ConflictId).Append('\n');
+            return Sha(Encoding.UTF8.GetBytes(sb.ToString()));
+        });
+
+        sink[$"{name}#consolidate/conflicts"] = Try(() =>
+        {
+            var conflicts = DocxDiff.GetConflicts(baseDoc, reviewers, settings);
+            var sb = new StringBuilder().Append(conflicts.Count).Append('\n');
+            foreach (var c in conflicts)
+                sb.Append(c.Id).Append('|').Append(c.BaseAnchor).Append('|')
+                  .Append(c.TokenStart).Append('-').Append(c.TokenEnd).Append('|')
+                  .Append(string.Join(",", c.Competitors.Select(x => x.Author + "=" + x.ResultText))).Append('\n');
+            return Sha(Encoding.UTF8.GetBytes(sb.ToString()));
+        });
+
+        sink[$"{name}#consolidate/editscript"] = Try(() =>
+            Sha(Encoding.UTF8.GetBytes(DocxDiff.GetConsolidatedEditScriptJson(baseDoc, reviewers, settings))));
+    }
+
+    // The compatibility report each product hands back through the OnCompatibilityWarning callback,
+    // digested per product. A product that stops running the pre-flight records "none" where it used
+    // to record a report — which no output digest can tell you, because the output was already right.
+    private static void RecordPreflight(
+        ConcurrentDictionary<string, string> sink, string name, string mode,
+        WmlDocument left, WmlDocument right)
+    {
+        foreach (var (product, run) in PreflightProducts(left, right))
+            sink[$"{name}#{mode}/preflight-{product}"] = Try(() =>
+            {
+                var seen = new List<string>();
+                var settings = new DocxDiffSettings
+                {
+                    OnCompatibilityWarning = report =>
+                    {
+                        foreach (var w in report.Warnings.OrderBy(w => w.Feature.Id, StringComparer.Ordinal))
+                            seen.Add(w.Feature.Id);
+                    },
+                };
+                run(settings);
+                return seen.Count == 0 ? "none" : string.Join(",", seen);
+            });
+    }
+
+    private static IEnumerable<(string Product, Action<DocxDiffSettings> Run)> PreflightProducts(
+        WmlDocument left, WmlDocument right)
+    {
+        yield return ("redline", s => DocxDiff.Compare(left, right, s));
+        yield return ("revisions", s => DocxDiff.GetRevisions(left, right, s));
+        yield return ("editscript", s => DocxDiff.GetEditScriptJson(left, right, s));
     }
 
     // A thrown exception is a recorded outcome, not a crash: the type and message are digested so a

--- a/benchmarks/docxdiff-stress/CorpusVariant.cs
+++ b/benchmarks/docxdiff-stress/CorpusVariant.cs
@@ -22,7 +22,12 @@ internal static class CorpusVariant
     /// zip entry directly rather than through the SDK, so a package the SDK rejects still produces a
     /// usable right-hand side instead of aborting the document's whole row.
     /// </summary>
-    public static byte[] Edit(byte[] source)
+    /// <param name="source">The document to edit.</param>
+    /// <param name="offset">Which of the four residues to edit. The default (0) is the ordinary
+    /// variant; a second reviewer built with a different offset edits DIFFERENT text nodes in the
+    /// same paragraphs, which is what gives an N-way consolidate real competitors to order and real
+    /// conflicts to report instead of one reviewer's edits applied unopposed.</param>
+    public static byte[] Edit(byte[] source, int offset = 0)
     {
         using var ms = new MemoryStream();
         ms.Write(source, 0, source.Length);
@@ -46,9 +51,9 @@ internal static class CorpusVariant
                 if (texts.Count == 0) return source;
 
                 var edits = 0;
-                for (var i = 0; i < texts.Count; i += 4)
+                for (var i = offset % 4; i < texts.Count; i += 4)
                 {
-                    texts[i].Value = MutateWord(texts[i].Value, i);
+                    texts[i].Value = MutateWord(texts[i].Value, i + offset);
                     edits++;
                 }
 

--- a/benchmarks/docxdiff-stress/README.md
+++ b/benchmarks/docxdiff-stress/README.md
@@ -59,11 +59,28 @@ dotnet run -c Release --project benchmarks/docxdiff-stress -- --corpus TestFiles
 dotnet run -c Release --project benchmarks/docxdiff-stress -- --corpus TestFiles --check before.json
 ```
 
-Against `TestFiles/` that is **678 documents → 8,136 digests**, about 4 minutes on four threads.
-Each document contributes four comparisons — an edited variant under default settings, the
-document against itself (the byte-identical shortcuts), and the edited variant again under
-`PreAcceptInputRevisions` and `PreserveInputRevisions`, which are the only way to reach the
-revision-transform path — times three products (redline, revision list, edit script).
+> **Building the baseline branch.** The harness reaches internal types, so the branch you take the
+> baseline on needs `<InternalsVisibleTo Include="DocxDiffStress" />` in `Docxodus/Docxodus.csproj`.
+> Any branch predating that line fails to compile the harness with a wall of `CS0122`, which looks
+> like a harness bug and is not one — add the line to the checkout you are baselining, or the
+> "before" half of the differential cannot be produced at all.
+
+Against `TestFiles/` each document contributes:
+
+- **four pairwise comparisons** — an edited variant under default settings, the document against
+  itself (the byte-identical shortcuts), and the edited variant again under
+  `PreAcceptInputRevisions` and `PreserveInputRevisions`, the only settings that reach the
+  revision-transform path — times three products (redline, revision list, edit script);
+- **one N-way consolidate** of two reviewers off that document as base, times four products
+  (redline, consolidated revision list, conflicts, consolidated edit script). The consolidate path
+  has its own reader fan-out, merger and markup renderer; not one of the pairwise products touches
+  any of them, so without this the whole N-way half of the engine sits outside the differential;
+- **two pre-flight digests per pairwise product** (edited and identical), recording the
+  compatibility warnings each product reports. Output digests cannot see this: a product that stops
+  running the pre-flight and a product that runs it and finds nothing produce identical output. The
+  identical-bytes shortcuts are where that gap is most tempting, so they are digested too.
+
+That is **678 documents → 22,374 digests**, roughly 15 minutes on four threads.
 
 A thrown exception is digested too, as `FAIL <Type>: <message>`. Malformed and unsupported
 fixtures are expected to throw; a change in **which** exception they throw is still a regression.
@@ -87,17 +104,20 @@ An always-green check is worthless, so verify it detects a change before trustin
 perturbation is not enough**, because the three products are sensitive to different halves of the
 pipeline — a control that moves two of them can leave the third completely unexercised:
 
-| Perturbation | redline | revisions | editscript |
-|---|---|---|---|
-| drop the `w:t` skip in `UnidHelper.ContentSignature` | **0%** | 82% | 84% |
-| swap the snapshots handed to `IrMarkupRenderer.Render` | **64%** | 0% | 0% |
+| Perturbation | redline | revisions | editscript | preflight |
+|---|---|---|---|---|
+| drop the `w:t` skip in `UnidHelper.ContentSignature` | **0%** | 82% | 84% | 0% |
+| swap the snapshots handed to `IrMarkupRenderer.Render` | **64%** | 0% | 0% | 0% |
+| skip the pre-flight on the identical-bytes shortcut | **0%** | **0%** | **0%** | fires |
 
-The split is not an accident, and it is worth understanding before trusting either column.
+The split is not an accident, and it is worth understanding before trusting any column.
 Unids feed block anchors, so corrupting a content signature shows up all over the edit script and
 the revision list — but the markup renderer strips `PtOpenXml.Unid` on the way out, so the
 rendered package is byte-identical and the redline digest never moves. Conversely the hand-off
 only affects rendering: the script and revisions were already computed, so they are untouched
-while the redline scrambles. Run both, or you are validating half the harness.
+while the redline scrambles. And the third row is why the pre-flight column exists at all: a
+product that stops warning still returns the right answer, so **every output digest stays green**
+while a documented behaviour is gone. Run all of them, or you are validating part of the harness.
 
 **It is not omniscient.** Reintroducing the `wp:docPr/@id` stripping-order bug that
 `IrHasherTests.Canonicalize_LoneDocPrId_StillStripped` guards produces **zero** corpus

--- a/docs/architecture/ir_diff_engine.md
+++ b/docs/architecture/ir_diff_engine.md
@@ -106,6 +106,16 @@ therefore takes an optional pre-read pair and `DocxDiffComparison` supplies it; 
 exists on `IrCompositeMarkupRenderer` for the N-way path, where re-reading meant `2*(N+1)` package
 reads to compare `N+1` documents.
 
+`GetRevisions` gained the byte-identical shortcut `Compare` already had: two packages with the
+same bytes have nothing to report, and running the pipeline to establish that costs as much as a
+real comparison. Both shortcuts skip the **work** and not the compatibility pre-flight — that
+pre-flight is a property of the inputs, so a caller who asked to be warned about an under-tested
+construct gets the same answer whether or not the two sides happen to match. This distinction has
+no output-digest signature (a product that stops warning still returns the right answer), so it is
+covered by unit tests and by the pre-flight digests in `benchmarks/docxdiff-stress`' corpus mode
+rather than by output parity. The edit script deliberately keeps no such shortcut: its all-Equal
+operations are the answer the caller asked for.
+
 `IrReader.Read` likewise opens each package once. Deciding the accepted-revision view needs every
 story parsed, and so does the body walk, so the scan runs against the package the walk is about to
 use (`GetXDocument` caches per part). Only a document that genuinely carries revision markup pays
@@ -132,9 +142,10 @@ two-way `Compare` runs roughly 1.4-1.6x faster than before with no parallelism a
 
 On a 574 KB `document.xml` with 15,360 elements, collapsing four reads to two concurrent ones took
 a two-way `Compare` from ~820 ms to ~350 ms and a four-reviewer `Consolidate` from ~1870 ms to
-~675 ms. `benchmarks/docxdiff-stress` measures this and digests every product to prove the output
-did not move; see its `FINDINGS.md` for the full stage attribution and for what still stands
-between the engine and 10 comparisons per second.
+~675 ms. `benchmarks/docxdiff-stress` measures this and digests every product — pairwise and N-way, plus
+the compatibility report — across all of `TestFiles/` to prove the output did not move; see its
+`FINDINGS.md` for the full stage attribution and for what still stands between the engine and 10
+comparisons per second.
 
 ## Edit script
 


### PR DESCRIPTION
Adversarial review of #616, with the gaps it turned up resolved. Targets #616's branch so that PR can land complete; it does not merge #616 itself.

The performance work in #616 holds up. I reproduced its headline evidence independently — 678 documents, 8,136 digests, all identical between `main` and its branch — and the reasoning behind the single-read change checks out: `IrProvenance.Equals` returns true for any other instance and `GetHashCode` returns 0, `RetainSources` feeds nothing but `Provenance()` and `IrDocument.Sources`, and every static reachable from `IrReader.Read` is an initialize-once read-only collection, so the concurrent reads really are independent. The WASM guard's premise is real too: `DocxodusWasm.csproj` references the library with `AdditionalProperties="WASM_BUILD=true"`, and `WasmEnableThreads` appears nowhere in the repository.

What follows is what did not hold up.

## The behaviour regression

`GetRevisions` gained a byte-identical shortcut, described in the PR and in the code as "the same guard `ToRedline` uses, for the same reason and with the same exception". It is not the same guard. `ToRedline`'s identical-bytes path deliberately still runs the compatibility pre-flight; the new one returned an empty list without it.

So a caller who set `OnCompatibilityWarning` or `ThrowOnCompatibilityWarning` and compared a document against an identical copy stopped being told about under-tested constructs in it. On `main` that call throws `DocxDiffCompatibilityException`; on #616's branch it returns an empty list and says nothing. `DocxDiffComparison`'s own remarks promise the opposite — "Compatibility preflight … therefore fires on the first product call, exactly as it fires inside each stateless static."

The pre-flight is a property of the inputs, not of whether they differ. A caller asking to be warned about this document gets the same answer whether or not the other side happens to be byte-identical. Both shortcuts now route through one `RunGatedPreflight`, so they cannot drift apart again, and the shortcut still costs nothing under default settings — the 371 ms → 0 ms figure is unaffected.

Three of the tests added here fail against the unfixed shortcut and pass with it fixed.

## Why nothing caught it, and what now would

This defect has no output-digest signature. A product that stops warning still returns the right answer, so 4,161 unit tests and a 678-document output-parity differential were both structurally incapable of seeing it. Two coverage gaps follow from that, and both are closed:

- **Corpus mode now digests the compatibility report** each pairwise product produces, on the edited pair and on the identical pair. It is the only digest in the harness that can see a pre-flight disappear. The README's "confirm the harness can actually fail" table gains a third row for it, showing all three output columns staying green while the behaviour is gone.
- **Corpus mode now runs an N-way consolidate per document** — two reviewers editing different text nodes of the same base, so the merger has real competitors to order — and digests all four consolidate products. #616 restructured the N-way path substantially (`ReadReviewerSet`, the `IrCompositeMarkupRenderer` hand-off, `ParallelWork.Fan`), yet not one of the three pairwise products touches any of it. Consolidate parity rested entirely on a reference document that is not committed to the repository.

The corpus differential is now 678 documents → **14,916 digests**, and it is green between `main` and this branch.

## Also fixed

- **`IrReader.Read` leaked an open package on the error path.** The `OpenXmlMemoryStreamDocument` was constructed and `GetWordprocessingDocument()` called *before* the `try`, so a package that is not Wordprocessing (an `.xlsx` handed to the reader — `GetDocumentType` detects exactly that and throws) or is structurally damaged leaked what the previous `using` disposed. The pair is now opened inside the `try` with a null-tolerant `finally`.
- **`ParallelWork.Fan` left task exceptions unobserved on its success path.** The collect loop rethrew at the first faulted task, so a later faulted task was never observed — the exact thing its head-failure path documents itself as taking care to avoid. It now drains every task and still propagates the failure the sequential order would have surfaced.
- **`IrHash.ComputeUtf8` allocated 3× on large subtrees.** It rented `GetMaxByteCount` (3n+3) unconditionally, and `ArrayPool<byte>.Shared` stops pooling above 1 MB. For a large canonical subtree — a block content control, an opaque table — that allocated three times the string's actual UTF-8 length and then dropped it, which is worse than the single exact-sized array the method exists to avoid. Past that threshold it now pays one counting pass and rents the exact size.

## Stale documentation

- `DocxDiffComparison`'s remarks still said the diff read "does not" retain sources. It does now, and that has a consequence worth stating: the two IR snapshots pin the parsed `XDocument` of every story in both inputs for the instance's lifetime, not just the IR values. The **Memory** paragraph now says so — it is the price of reading each input once instead of four times.
- **The harness README's reproduction could not be followed.** Taking the "before" baseline needs `<InternalsVisibleTo Include="DocxDiffStress" />` in `Docxodus/Docxodus.csproj`, which no branch predating #616 has; without it the harness fails to compile against `main` with a wall of `CS0122` that reads like a harness bug. I hit this reproducing the evidence. Documented as a prerequisite, with what the failure looks like.
- **`CLAUDE.md`'s warning baselines were stale.** #616 reports the count as unchanged; measured with `--no-incremental` here, the library goes 131 → 132 and the test project 774 → 775. Both come from the one new file, `Docxodus/Internal/ParallelWork.cs`: no file in the library carries a StyleCop header, so `SA1633` fires once per file and every new `.cs` under `Docxodus/` moves both counts by exactly one. Recorded, so the next reader knows what "at baseline" means rather than chasing a phantom regression.
- The CHANGELOG entry said "all 36 digests", which was true of the eight-variant run but not of the corpus evidence #616 ended up resting on, and it did not mention the pre-flight semantics of the new shortcut. Both corrected.

## Two observations, deliberately not changed

- **The renderers' re-read fallback is exercised only by tests.** Both `IrMarkupRenderer.Render` and `IrCompositeMarkupRenderer.Render` have exactly one production call site each, and both supply the snapshots — so in the shipped library the optional parameters are never null. The unit tests call the 4-argument form throughout, which means the test suite validates the fallback and production validates the hand-off. That is fine, but it is the opposite of what one would assume, and worth knowing before deleting either path.
- **`UnidHelper.ContentSignature`'s new walks are recursive where the old ones were not.** `AppendDescendantText`/`AppendDescendantNames` recurse over subtree depth, while `element.Descendants()` did not. `AssignDescendantsDeterministic` already recursed over depth, so this is not a new class of failure — it roughly doubles the frame count at a given depth. Converting to an explicit stack is a larger change than the risk warrants, but a document deep enough to overflow was already a problem and is now a slightly nearer one.

## Validation

- **4,168 of 4,168 .NET tests pass** (3 skipped, 4,171 total). Three of the new compatibility tests fail against the unfixed shortcut — a check that cannot fail proves nothing.
- **Corpus differential green:** `main` vs this branch, 678 documents → 14,916 digests, all identical. Baselines were produced by building this harness against `main` with the `InternalsVisibleTo` line added, which is the prerequisite documented above.
- Library builds clean in both default and `WASM_BUILD` modes; the WASM build is what makes `ParallelWork.CanFanOut` a compile-time `false`.
- Warning counts measured with `--no-incremental` on both branches, and the delta accounted for file by file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXd14dyGpHFMhitKQh5FDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXd14dyGpHFMhitKQh5FDW)_