### PR TITLE
Record note and rule insertion as tracked changes so the redline can be rejected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,32 @@ All notable changes to this project will be documented in this file.
   `action` gets an error that spells out the nested shape.
 
 ### Fixed
+- **Authoring a footnote or endnote while recording tracked changes now produces a redline that
+  can actually be rejected (#614).** `InsertFootnote`/`InsertEndnote` ignored
+  `TrackedChangeMode.RenderInline` entirely: the citation and the note definition were both
+  written as ordinary content, so a reviewer had nothing to accept or reject, and reject-all left
+  the note in the document. The redline looked complete and only failed when somebody actually
+  rejected it — potentially long after the document had left the building. The citation is now
+  wrapped in `w:ins`, and the definition follows it: rejecting removes the reference, which leaves
+  the note uncited, and the note-lifecycle rule deletes it in the same resolve. Accepting keeps
+  both. The definition carries no revision markup of its own on purpose — a `w:ins` inside it
+  would be a revision with no independently meaningful resolution.
+
+  That rule — *a note definition exists exactly as long as something still cites it* — now has one
+  owner, `Internal/NoteReferenceOps.cs`, shared by the session's resolve paths (#516, #591) and by
+  the stateless `RevisionProcessor` **reject** path, which is what every non-.NET transport reaches
+  through `DocxDiffOps.RejectRevisions`; without that the same redline was reversible in-session
+  and not reversible through npm/python/MCP. The stateless **accept** path deliberately does not
+  apply it, because `Accept(Compare(l, r)) ≡ r` is the comparison engine's contract and a
+  counterpart document that carries a reference-less note definition is entitled to keep it.
+  Consolidating the rule also fixed its scope: it asks the whole package who cites a note rather
+  than only the body, so a note cited from a running header as well no longer disappears when its
+  body citation goes away.
+- **`InsertHorizontalRule` records under tracked-change recording too (#614).** Same defect,
+  smaller blast radius: the rule paragraph was written untracked, so rejecting the redline left it
+  behind. It now takes the same paragraph marking `InsertParagraph` applies. `docx_mutation_api.md`
+  gains the full table of which mutations record, which refuse with `TrackedOperationUnsupported`,
+  and which apply untracked by design.
 - **`DocxDiff.Compare` is byte-reproducible again once a redline creates or imports a part
   (#621).** `Deterministic` promises that two comparisons of the same inputs are byte-identical,
   and that only held for text-only documents. Two generators were reseeded on every run: parts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ are kept for the day each file migrates.
 **`Docxodus.csproj` and `Docxodus.Tests.csproj` both override it to `false`**, so the core
 library and the test project do *not* fail on warnings. The CLI tools, MCP server,
 python-host and WASM project do inherit it. Current baseline: the library builds with
-**132 warnings**, the test project with **775** (mostly StyleCop `SA1633`/`SA1636` file
+**133 warnings**, the test project with **776** (mostly StyleCop `SA1633`/`SA1636` file
 headers and `SA1206` using-order). Don't add to either baseline. Measure with
 `--no-incremental` — a warm incremental build reports zero because nothing recompiles.
 

--- a/Docxodus.Tests/DocxSessionNoteAuthoringTests.cs
+++ b/Docxodus.Tests/DocxSessionNoteAuthoringTests.cs
@@ -696,6 +696,119 @@ public class DocxSessionNoteAuthoringTests
         return ms.ToArray();
     }
 
+    // ─── Recording as a tracked change (issue #614) ──────────────────────
+    //
+    // Under TrackedChangeMode.RenderInline the CITATION is the reversible unit and the definition
+    // follows it: rejecting the w:ins takes the reference away, which leaves the definition
+    // unreferenced, and the note-lifecycle rule in Internal.NoteReferenceOps removes it in the same
+    // resolve. Before #614 the op ignored the recording mode entirely — it wrote an untracked
+    // citation and an untracked definition, so reject-all had nothing to reject and the "rejected"
+    // document still shipped the note text.
+
+    /// <summary>Insert one note under recording and return (baseline, redline).</summary>
+    private static (byte[] Baseline, byte[] Redline) AuthorNoteUnderRecording(bool footnote)
+    {
+        var baseline = DocxSessionTests.BuildDS001_SimpleTwoParagraphs();
+        using var session = new DocxSession(baseline, new DocxSessionSettings
+        {
+            PersistAnchorIds = false,
+            TrackedChanges = TrackedChangeMode.RenderInline,
+            RevisionAuthor = "Note Author",
+        });
+        var anchor = FirstBodyParagraph(session);
+        var result = footnote
+            ? session.InsertFootnote(anchor, 5, "Negotiated on March 11.")
+            : session.InsertEndnote(anchor, 5, "Negotiated on March 11.");
+        Assert.True(result.Success, result.Error?.Message);
+        return (baseline, session.Save(persistAnchorIds: false));
+    }
+
+    private static System.Collections.Generic.List<XElement> UserNotes(byte[] bytes, bool footnote) =>
+        PartXml(bytes, m => footnote ? m.FootnotesPart : (OpenXmlPart?)m.EndnotesPart)
+            .Elements(W + (footnote ? "footnote" : "endnote"))
+            .Where(n => n.Attribute(W + "type") is null)
+            .ToList();
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DS366_NoteAuthoredUnderRecording_ResolvesBothWays(bool footnote)
+    {
+        var (baseline, redline) = AuthorNoteUnderRecording(footnote);
+        var referenceName = W + (footnote ? "footnoteReference" : "endnoteReference");
+
+        using (var review = new DocxSession(redline, new DocxSessionSettings { PersistAnchorIds = false }))
+        {
+            // The citation is a revision at all, which is what was missing.
+            Assert.NotEmpty(review.ListRevisions());
+            Assert.True(review.RejectAllRevisions().Success);
+            var rejected = review.Save(persistAnchorIds: false);
+
+            // The definition went with the citation: only Word's two reserved notes remain…
+            Assert.Empty(UserNotes(rejected, footnote));
+            Assert.Empty(BodyXml(rejected).Descendants(referenceName));
+
+            // …and the document as a whole is the baseline again, which is the property that matters.
+            Assert.Empty(DocxDiff.GetRevisions(
+                new WmlDocument("baseline.docx", baseline), new WmlDocument("rejected.docx", rejected)));
+        }
+
+        using (var review = new DocxSession(redline, new DocxSessionSettings { PersistAnchorIds = false }))
+        {
+            Assert.True(review.AcceptAllRevisions().Success);
+            var accepted = review.Save(persistAnchorIds: false);
+
+            var note = Assert.Single(UserNotes(accepted, footnote));
+            Assert.Contains("Negotiated on March 11.", note.Descendants(W + "t").Select(t => (string)t));
+            Assert.Single(BodyXml(accepted).Descendants(referenceName));
+            Assert.Empty(BodyXml(accepted).Descendants(W + "ins"));
+        }
+    }
+
+    /// <summary>The citation is a note reference nested inside <c>w:ins</c> — a shape this op had
+    /// never produced before — so pin that the diff engine still reports it.</summary>
+    [Fact]
+    public void DS367_RecordedNoteInsertion_IsReportedByTheDiffEngine()
+    {
+        var (baseline, redline) = AuthorNoteUnderRecording(footnote: true);
+
+        var revisions = DocxDiff.GetRevisions(
+            new WmlDocument("baseline.docx", baseline), new WmlDocument("redline.docx", redline));
+
+        Assert.Contains(revisions, r => r.Text.Contains("Negotiated on March 11."));
+    }
+
+    /// <summary>
+    /// What the reversibility proof reports, which is how #614 was found. The reject path keeps
+    /// divergences a generated redline legitimately explains — the run the citation split, the
+    /// <c>w:trackRevisions</c>/<c>w:footnotePr</c> declarations, the note styles — but the note
+    /// STORY must not be among them any more. Before the fix the residue included
+    /// <c>/word/footnotes.xml</c> carrying the whole note body.
+    /// </summary>
+    [Fact]
+    public void DS368_RecordedNoteInsertion_LeavesNoNoteResidueOnTheRejectPath()
+    {
+        var (baseline, redline) = AuthorNoteUnderRecording(footnote: true);
+        byte[] intendedFinal;
+        using (var accepting = new DocxSession(redline, new DocxSessionSettings { PersistAnchorIds = false }))
+        {
+            Assert.True(accepting.AcceptAllRevisions().Success);
+            intendedFinal = accepting.Save(persistAnchorIds: false);
+        }
+
+        var run = Docxodus.Verification.RedlineReversibilityVerifier.Prove(baseline, intendedFinal, redline);
+        var reject = run.Proof.RejectToBaseline;
+
+        Assert.True(reject?.Completed, run.Proof.ToJson());
+        // Non-vacuous: the redline-authoring residue IS still reported, so the filter below is
+        // reading a populated list rather than an empty one.
+        Assert.NotEmpty(reject!.Divergences);
+        Assert.DoesNotContain(reject.Divergences,
+            divergence => divergence.PartUri.Contains("notes.xml", StringComparison.Ordinal));
+        Assert.Contains(reject.Divergences,
+            divergence => divergence.PartUri == "/word/document.xml");
+    }
+
     /// <summary>
     /// Footnotes part whose user notes are ids 1, 5 and 9 (non-contiguous), so a "count + 1"
     /// id allocator would collide. Body cites all three.

--- a/Docxodus.Tests/DocxSessionRevisionTests.cs
+++ b/Docxodus.Tests/DocxSessionRevisionTests.cs
@@ -1294,6 +1294,141 @@ public class DocxSessionRevisionTests
         Assert.Contains("Orphan note body.", string.Concat(texts));
     }
 
+    /// <summary>
+    /// The same rule through the STATELESS resolver — the path every non-.NET transport reaches
+    /// through <c>DocxDiffOps</c>. Rejecting a redline reproduces the baseline, so a note the
+    /// redline introduced has to go with the citation it introduced; before #614 the citation
+    /// vanished and the definition stayed, and the "rejected" package still shipped the note.
+    /// </summary>
+    [Fact]
+    public void DS429_StatelessReject_TakesAnIntroducedNoteWithItsCitation()
+    {
+        var left = File.ReadAllBytes(Path.Combine("../../../../TestFiles/WC", "WC035-Footnote-Before.docx"));
+        var right = File.ReadAllBytes(Path.Combine("../../../../TestFiles/WC", "WC035-Footnote-After.docx"));
+
+        // Compare in the direction that INSERTS the note, so rejecting must take it back out.
+        var inserting = UserNoteCount(left, "footnote") < UserNoteCount(right, "footnote")
+            ? (Baseline: left, Counterpart: right)
+            : (Baseline: right, Counterpart: left);
+        Assert.True(UserNoteCount(inserting.Counterpart, "footnote")
+            > UserNoteCount(inserting.Baseline, "footnote"), "fixture no longer inserts a note");
+
+        var redline = DocxDiff.Compare(
+            new WmlDocument("baseline.docx", inserting.Baseline),
+            new WmlDocument("counterpart.docx", inserting.Counterpart)).DocumentByteArray;
+
+        var rejected = Docxodus.Internal.DocxDiffOps.RejectRevisions(redline);
+
+        Assert.True(HasNotesPart(rejected, "footnote"), "the notes part itself must survive");
+        Assert.Equal(UserNoteCount(inserting.Baseline, "footnote"), UserNoteCount(rejected, "footnote"));
+    }
+
+    /// <summary>
+    /// …and the accept side deliberately does NOT apply it. Accept reproduces the counterpart
+    /// document as the comparison saw it — <c>Accept(Compare(l, r)) == r</c> — so a counterpart that
+    /// carries a reference-less note definition keeps it. <see cref="DocxSession"/>'s own resolve
+    /// paths (DS418) apply the rule in both directions because an editor is authoring a document
+    /// rather than inverting a comparison; this test pins that the two contracts stay distinct.
+    /// </summary>
+    [Fact]
+    public void DS430_StatelessAccept_PreservesACounterpartsOwnOrphanedNote()
+    {
+        var baseline = BuildWithBody(
+            new XElement(W.p,
+                new XElement(W.r,
+                    new XElement(W.t, "Cited here."),
+                    new XElement(W.footnoteReference, new XAttribute(W.id, "7")))),
+            new XElement(W.p, new XElement(W.r, new XElement(W.t, "Sentinel."))));
+        baseline = AddDanglingFootnote(baseline, noteId: 7, text: "Kept as a husk.");
+
+        // The counterpart drops the citing paragraph but keeps the definition — the husk shape a
+        // naive edit leaves behind, and exactly what accept has to reproduce.
+        var counterpart = BuildWithBody(
+            new XElement(W.p, new XElement(W.r, new XElement(W.t, "Sentinel."))));
+        counterpart = AddDanglingFootnote(counterpart, noteId: 7, text: "Kept as a husk.");
+
+        var redline = DocxDiff.Compare(
+            new WmlDocument("baseline.docx", baseline),
+            new WmlDocument("counterpart.docx", counterpart)).DocumentByteArray;
+
+        var accepted = Docxodus.Internal.DocxDiffOps.AcceptRevisions(redline);
+
+        Assert.Equal(1, UserNoteCount(counterpart, "footnote"));
+        Assert.Equal(1, UserNoteCount(accepted, "footnote"));
+    }
+
+    /// <summary>
+    /// The prune asks the whole package who still cites a note, not just the body. A note cited
+    /// from the body AND a running header outlives the body citation; a body-only scan would read
+    /// "referenced before, unreferenced after" and delete a note the header still points at.
+    /// </summary>
+    [Fact]
+    public void DS431_NoteStillCitedFromAHeader_SurvivesLosingItsBodyCitation()
+    {
+        var bytes = BuildWithBody(
+            new XElement(W.p,
+                new XElement(W.r,
+                    new XElement(W.t, "Cited here."),
+                    new XElement(W.footnoteReference, new XAttribute(W.id, "7")))),
+            new XElement(W.p, new XElement(W.r, new XElement(W.t, "Sentinel."))));
+        bytes = AddDanglingFootnote(bytes, noteId: 7, text: "Cited twice.");
+        bytes = AddHeaderCiting(bytes, noteId: 7);
+
+        using var session = new DocxSession(bytes);
+        var citing = session.Project().AnchorIndex.Values
+            .First(t => t.Anchor.Scope == "body" && (t.TextPreview ?? string.Empty).StartsWith("Cited"))
+            .Anchor.Id;
+        Assert.True(session.DeleteBlock(citing).Success);
+
+        var saved = session.Save();
+        Assert.Equal(1, UserNoteCount(saved, "footnote"));
+    }
+
+    private static int UserNoteCount(byte[] bytes, string kind)
+    {
+        using var stream = new MemoryStream(bytes, writable: false);
+        using var document = WordprocessingDocument.Open(stream, false);
+        var main = document.MainDocumentPart!;
+        return kind == "footnote"
+            ? main.FootnotesPart?.Footnotes?.Elements<Footnote>().Count(n => n.Type is null) ?? 0
+            : main.EndnotesPart?.Endnotes?.Elements<Endnote>().Count(n => n.Type is null) ?? 0;
+    }
+
+    /// <summary>Add a default running header that cites <paramref name="noteId"/>, so the note has a
+    /// second citation outside the body.</summary>
+    private static byte[] AddHeaderCiting(byte[] source, int noteId)
+    {
+        using var ms = new MemoryStream();
+        ms.Write(source);
+        ms.Position = 0;
+        using (var wDoc = WordprocessingDocument.Open(ms, true))
+        {
+            var main = wDoc.MainDocumentPart!;
+            var header = main.AddNewPart<HeaderPart>();
+            header.Header = new Header(
+                new Paragraph(new Run(
+                    new Text("Running head."),
+                    new FootnoteReference { Id = noteId })));
+            header.Header.Save();
+
+            var body = main.Document!.Body!;
+            var sectPr = body.Elements<SectionProperties>().FirstOrDefault();
+            if (sectPr is null)
+            {
+                sectPr = new SectionProperties();
+                body.Append(sectPr);
+            }
+
+            sectPr.PrependChild(new HeaderReference
+            {
+                Type = HeaderFooterValues.Default,
+                Id = main.GetIdOfPart(header),
+            });
+            main.Document.Save();
+        }
+        return ms.ToArray();
+    }
+
     private static bool HasNotesPart(byte[] bytes, string kind)
     {
         using var stream = new MemoryStream(bytes, writable: false);

--- a/Docxodus.Tests/DocxSessionS1FeaturesTests.cs
+++ b/Docxodus.Tests/DocxSessionS1FeaturesTests.cs
@@ -221,6 +221,41 @@ public class DocxSessionS1FeaturesTests
         Assert.Equal(string.Empty, rule.Value);
     }
 
+    /// <summary>
+    /// A rule is a paragraph, so under recording it records as one (issue #614). It used to be
+    /// written untracked, which made it the same silent defect note authoring had: the redline
+    /// looked complete, and rejecting it left the rule behind.
+    /// </summary>
+    [Fact]
+    public void DS224_InsertHorizontalRule_UnderRecording_IsRejectedBackOut()
+    {
+        var baseline = DocxSessionTests.BuildDS001_SimpleTwoParagraphs();
+        byte[] redline;
+        using (var session = new DocxSession(baseline, new DocxSessionSettings
+        {
+            PersistAnchorIds = false,
+            TrackedChanges = TrackedChangeMode.RenderInline,
+            RevisionAuthor = "Rule Author",
+        }))
+        {
+            var anchor = FirstBodyParagraph(session);
+            Assert.True(session.InsertHorizontalRule(anchor, Position.After).Success);
+            redline = session.Save(persistAnchorIds: false);
+        }
+
+        // The rule is visible as a revision rather than as plain new content.
+        using var review = new DocxSession(redline, new DocxSessionSettings { PersistAnchorIds = false });
+        Assert.NotEmpty(review.ListRevisions());
+        Assert.True(review.RejectAllRevisions().Success);
+        var rejected = review.Save(persistAnchorIds: false);
+
+        var root = DocumentXml(rejected);
+        Assert.Empty(root.Descendants(W + "pBdr"));
+        Assert.Equal(
+            DocumentXml(baseline).Descendants(W + "p").Count(),
+            root.Descendants(W + "p").Count());
+    }
+
     // ─── F3: table insertion ────────────────────────────────────────────
 
     [Fact]

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -3010,75 +3010,24 @@ public sealed partial class DocxSession : IDisposable
         else part.PutXDocument();
     }
 
-    /// <summary>Footnote/endnote ids currently referenced from the main document story —
-    /// the only story OOXML lets a note reference live in.</summary>
-    private (HashSet<int> Footnotes, HashSet<int> Endnotes) ReferencedNoteIds()
-    {
-        var footnotes = new HashSet<int>();
-        var endnotes = new HashSet<int>();
-        var root = _doc?.MainDocumentPart?.GetXDocument().Root;
-        if (root is null) return (footnotes, endnotes);
-        foreach (var reference in root.Descendants(W.footnoteReference))
-            if (int.TryParse((string?)reference.Attribute(W.id), out var id)) footnotes.Add(id);
-        foreach (var reference in root.Descendants(W.endnoteReference))
-            if (int.TryParse((string?)reference.Attribute(W.id), out var id)) endnotes.Add(id);
-        return (footnotes, endnotes);
-    }
+    /// <summary>Footnote/endnote ids cited anywhere in the package, captured before an op that
+    /// can carry a citation away. See <see cref="Internal.NoteReferenceOps"/> for the rule.</summary>
+    private (HashSet<int> Footnotes, HashSet<int> Endnotes) ReferencedNoteIds() =>
+        Internal.NoteReferenceOps.ReferencedNoteIds(_doc?.MainDocumentPart);
 
     /// <summary>
-    /// Word-faithful note cleanup after an op that removes body content (issues #516, #591).
-    /// A note whose LAST reference was removed — by revision resolution carrying the reference
-    /// away, or by a structural delete removing the block that held it — is deleted from its
-    /// part; without this the note survived as a reference-less husk still shipping its full
-    /// text inside the package. The PART itself always stays: Word never prunes a notes part
-    /// (the RP050-Deleted-Footnote oracle keeps its separator-only footnotes.xml after
-    /// accepting the only note's deletion), and a separator-only part is exactly what Word
-    /// ships in every fresh document. Scoped strictly to ids referenced before and
-    /// unreferenced after THIS op: a note that was already dangling is pre-existing
-    /// document state and stays untouched.
+    /// Word-faithful note cleanup after an op that removes body content (issues #516, #591): a note
+    /// whose LAST citation this op carried away is deleted from its part. The rule and the reasons
+    /// live in <see cref="Internal.NoteReferenceOps"/>, which the stateless
+    /// <see cref="RevisionProcessor"/> path shares so a redline is reversible on every transport.
     /// </summary>
     /// <returns>The removed note elements with their part uri, for removed-anchor reporting.</returns>
     private List<(XElement Note, string PartUri)> PruneOrphanedNotes(
-        (HashSet<int> Footnotes, HashSet<int> Endnotes) before)
-    {
-        var removed = new List<(XElement, string)>();
-        var main = _doc?.MainDocumentPart;
-        if (main is null) return removed;
-        var after = ReferencedNoteIds();
-        PruneNoteStory(main.FootnotesPart, W.footnote, before.Footnotes, after.Footnotes, removed);
-        PruneNoteStory(main.EndnotesPart, W.endnote, before.Endnotes, after.Endnotes, removed);
-        return removed;
-    }
-
-    private static void PruneNoteStory(
-        OpenXmlPart? part,
-        XName noteName,
-        HashSet<int> referencedBefore,
-        HashSet<int> referencedAfter,
-        List<(XElement, string)> removed)
-    {
-        var root = part?.GetXDocument().Root;
-        if (part is null || root is null) return;
-        var orphaned = referencedBefore.Except(referencedAfter).ToHashSet();
-        if (orphaned.Count == 0) return;
-
-        var partUri = part.Uri.ToString();
-        bool changed = false;
-        foreach (var note in root.Elements(noteName).ToList())
-        {
-            if (!int.TryParse((string?)note.Attribute(W.id), out var id)
-                || !orphaned.Contains(id) || IsSeparatorNote(note))
-                continue;
-            note.Remove();
-            removed.Add((note, partUri));
-            changed = true;
-        }
-
-        if (changed) part.PutXDocument();
-    }
+        (HashSet<int> Footnotes, HashSet<int> Endnotes) before) =>
+        Internal.NoteReferenceOps.PruneOrphanedNotes(_doc?.MainDocumentPart, before);
 
     private static bool IsSeparatorNote(XElement note) =>
-        (string?)note.Attribute(W.type) is "separator" or "continuationSeparator";
+        Internal.NoteReferenceOps.IsSeparatorNote(note);
 
     /// <summary>Appends the anchors of pruned note definitions (with their descendants) to
     /// <paramref name="removed"/>, deduplicated through <paramref name="seenRemoved"/> — the
@@ -8770,6 +8719,12 @@ public sealed partial class DocxSession : IDisposable
             if (pos == Position.Before) element.AddBeforeSelf(p);
             else element.AddAfterSelf(p);
 
+            // A rule is a paragraph, so it records as one — same marking InsertParagraph applies,
+            // so rejecting the revision takes the rule back out instead of leaving it behind.
+            if (_trackedChanges == TrackedChangeMode.RenderInline)
+                MarkParagraphContentAndMark(p, W.ins, _revisionAuthor ?? "docxodus",
+                    NextTrackedFormatRevisionDate());
+
             var unid = (string)p.Attribute(PtOpenXml.Unid)!;
             InvalidateProjectionCache();
             var created = AnchorForUnid(unid, target.PartUri)
@@ -9388,7 +9343,19 @@ public sealed partial class DocxSession : IDisposable
             SplitInlineContainersAtOffset(element, characterOffset);
             var refRun = BuildNoteReferenceRun(isFootnote, NoteIdPlaceholder);
             UnidHelper.AssignToSelfAndDescendants(refRun);
-            InsertInlineAtOffset(element, characterOffset, refRun);
+
+            // Under recording, the CITATION is the reversible unit and the definition follows it.
+            // Rejecting the w:ins carries the reference away, which leaves the definition
+            // unreferenced, and PruneOrphanedNotes — the single owner of "a note exists iff it is
+            // cited" (#516/#591) — removes it in the same resolve. A second w:ins inside the
+            // definition would be a revision with no independently meaningful resolution: rejecting
+            // it while keeping the citation yields an empty note, and keeping it while rejecting the
+            // citation yields a note that is pruned anyway.
+            InsertInlineAtOffset(element, characterOffset,
+                _trackedChanges == TrackedChangeMode.RenderInline
+                    ? CreateRevisionEnvelope(W.ins, _revisionAuthor ?? "docxodus",
+                        NextTrackedFormatRevisionDate(), refRun)
+                    : refRun);
 
             var id = NextNoteIdInReferenceOrder(main, root, noteName);
             refRun.Descendants(isFootnote ? W.footnoteReference : W.endnoteReference).First()
@@ -9595,14 +9562,8 @@ public sealed partial class DocxSession : IDisposable
     }
 
     /// <summary>Every part whose XML can carry a note reference, for id-collision scanning.</summary>
-    private static IEnumerable<OpenXmlPart> NoteReferenceHostParts(MainDocumentPart main)
-    {
-        yield return main;
-        foreach (var h in main.HeaderParts) yield return h;
-        foreach (var f in main.FooterParts) yield return f;
-        if (main.FootnotesPart is not null) yield return main.FootnotesPart;
-        if (main.EndnotesPart is not null) yield return main.EndnotesPart;
-    }
+    private static IEnumerable<OpenXmlPart> NoteReferenceHostParts(MainDocumentPart main) =>
+        Internal.NoteReferenceOps.ReferenceHostParts(main);
 
     /// <summary>
     /// Shape the note body the way Word does: every paragraph gets the note-text style (unless the

--- a/Docxodus/Internal/NoteReferenceOps.cs
+++ b/Docxodus/Internal/NoteReferenceOps.cs
@@ -1,0 +1,119 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace Docxodus.Internal;
+
+/// <summary>
+/// The single owner of Word's note-lifecycle rule: <b>a footnote/endnote definition exists exactly
+/// as long as something still cites it.</b> Word deletes a note when its last reference goes, and
+/// every path in this library that can carry a reference away has to do the same or the note
+/// survives as a reference-less husk that still ships its full text inside the package.
+/// </summary>
+/// <remarks>
+/// Two callers, one rule. <see cref="DocxSession"/> applies it after a structural delete or a
+/// revision resolution (issues #516, #591); <see cref="RevisionProcessor"/> applies it after a
+/// stateless accept/reject, which is the path every non-.NET transport reaches through
+/// <c>DocxDiffOps</c> (issue #614). Both capture <see cref="ReferencedNoteIds"/> before the
+/// mutation and call <see cref="PruneOrphanedNotes"/> after it.
+///
+/// The PART itself always stays. Word never prunes a notes part — the RP050-Deleted-Footnote
+/// oracle keeps its separator-only <c>footnotes.xml</c> after accepting the only note's deletion,
+/// and a separator-only part is exactly what Word ships in every fresh document.
+///
+/// The rule is scoped strictly to ids referenced <em>before</em> and unreferenced <em>after</em>
+/// one operation: a note that was already dangling on the way in is pre-existing document state
+/// and is left alone.
+/// </remarks>
+internal static class NoteReferenceOps
+{
+    private static readonly XNamespace W =
+        "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+
+    /// <summary>The parts a <c>w:footnoteReference</c>/<c>w:endnoteReference</c> can legally live
+    /// in: the body, the running header/footer stories, and the note stories themselves (a note may
+    /// cite another note).</summary>
+    internal static IEnumerable<OpenXmlPart> ReferenceHostParts(MainDocumentPart main)
+    {
+        yield return main;
+        foreach (var header in main.HeaderParts) yield return header;
+        foreach (var footer in main.FooterParts) yield return footer;
+        if (main.FootnotesPart is not null) yield return main.FootnotesPart;
+        if (main.EndnotesPart is not null) yield return main.EndnotesPart;
+    }
+
+    /// <summary>Footnote/endnote ids cited from anywhere in the package. Every host story counts,
+    /// not just the body — a note cited from a header as well as the body must survive the body
+    /// citation going away.</summary>
+    internal static (HashSet<int> Footnotes, HashSet<int> Endnotes) ReferencedNoteIds(
+        MainDocumentPart? main)
+    {
+        var footnotes = new HashSet<int>();
+        var endnotes = new HashSet<int>();
+        if (main is null) return (footnotes, endnotes);
+        foreach (var part in ReferenceHostParts(main))
+        {
+            var root = part.GetXDocument().Root;
+            if (root is null) continue;
+            Collect(root, W + "footnoteReference", footnotes);
+            Collect(root, W + "endnoteReference", endnotes);
+        }
+
+        return (footnotes, endnotes);
+
+        static void Collect(XElement root, XName referenceName, HashSet<int> into)
+        {
+            foreach (var reference in root.Descendants(referenceName))
+                if (int.TryParse((string?)reference.Attribute(W + "id"), out var id)) into.Add(id);
+        }
+    }
+
+    /// <summary>Remove every note definition whose last citation disappeared between
+    /// <paramref name="before"/> and now.</summary>
+    /// <returns>The removed note elements with their part uri, for removed-anchor reporting.</returns>
+    internal static List<(XElement Note, string PartUri)> PruneOrphanedNotes(
+        MainDocumentPart? main, (HashSet<int> Footnotes, HashSet<int> Endnotes) before)
+    {
+        var removed = new List<(XElement, string)>();
+        if (main is null) return removed;
+        var after = ReferencedNoteIds(main);
+        PruneStory(main.FootnotesPart, W + "footnote", before.Footnotes, after.Footnotes, removed);
+        PruneStory(main.EndnotesPart, W + "endnote", before.Endnotes, after.Endnotes, removed);
+        return removed;
+    }
+
+    /// <summary>Word's reserved scaffolding notes, which are never citation targets and are never
+    /// pruned.</summary>
+    internal static bool IsSeparatorNote(XElement note) =>
+        (string?)note.Attribute(W + "type") is "separator" or "continuationSeparator";
+
+    private static void PruneStory(
+        OpenXmlPart? part,
+        XName noteName,
+        HashSet<int> referencedBefore,
+        HashSet<int> referencedAfter,
+        List<(XElement, string)> removed)
+    {
+        var root = part?.GetXDocument().Root;
+        if (part is null || root is null) return;
+        var orphaned = referencedBefore.Except(referencedAfter).ToHashSet();
+        if (orphaned.Count == 0) return;
+
+        var partUri = part.Uri.ToString();
+        bool changed = false;
+        foreach (var note in root.Elements(noteName).ToList())
+        {
+            if (!int.TryParse((string?)note.Attribute(W + "id"), out var id)
+                || !orphaned.Contains(id) || IsSeparatorNote(note))
+                continue;
+            note.Remove();
+            removed.Add((note, partUri));
+            changed = true;
+        }
+
+        if (changed) part.PutXDocument();
+    }
+}

--- a/Docxodus/RevisionProcessor.cs
+++ b/Docxodus/RevisionProcessor.cs
@@ -33,6 +33,20 @@ namespace Docxodus
 
         public static void RejectRevisions(WordprocessingDocument doc)
         {
+            // Word's note-lifecycle rule, on the reject side only (issue #614). Rejecting a redline
+            // reproduces the BASELINE, and a note the redline itself introduced has no place there:
+            // its citation came in a w:ins and its definition came with the redline, so dropping the
+            // citation has to drop the definition or the "rejected" package still ships the note.
+            //
+            // Accepting deliberately does NOT do this. Accept reproduces the COUNTERPART document as
+            // the comparison saw it, husks included — Accept(Compare(l, r)) == r is the comparison
+            // engine's contract, and a counterpart that carries a reference-less note definition is
+            // entitled to keep it. DocxSession's own resolve paths apply the rule in both directions
+            // because an editor is authoring a document, not inverting a comparison.
+            //
+            // The rule and its scoping (only citations THIS operation removed) live in
+            // Internal.NoteReferenceOps, shared with those session paths.
+            var citedBefore = Internal.NoteReferenceOps.ReferencedNoteIds(doc.MainDocumentPart);
             RejectRevisionsForPart(doc.MainDocumentPart);
             foreach (var part in doc.MainDocumentPart.HeaderParts)
                 RejectRevisionsForPart(part);
@@ -57,6 +71,8 @@ namespace Docxodus
                 AcceptRevisionsForPart(doc.MainDocumentPart.FootnotesPart);
             if (doc.MainDocumentPart.StyleDefinitionsPart != null)
                 AcceptRevisionsForStylesDefinitionPart(doc.MainDocumentPart.StyleDefinitionsPart);
+
+            Internal.NoteReferenceOps.PruneOrphanedNotes(doc.MainDocumentPart, citedBefore);
         }
 
         // Reject revisions for those revisions that can't be rejected by inverting the sense of the revision, and then accepting.

--- a/docs/architecture/docx_mutation_api.md
+++ b/docs/architecture/docx_mutation_api.md
@@ -1131,13 +1131,50 @@ rendering notes, appeared as a stray empty footnote with no citation.
   Word's default (`1, 2, 3…`, continuous).
 - **Citing an existing note twice.** Each call creates a new definition; there is no
   "reference note N again" op.
-- **Tracked-changes mode.** `Settings.TrackedChanges = RenderInline` does not wrap the citation
-  in `w:ins` — consistent with every other insert op (`InsertParagraph`, `InsertTable`,
-  `InsertHorizontalRule`, `SetHeaderText`); only `ReplaceText`/`DeleteBlock`/`DeleteRange`/`DeleteSection` track.
+- **Note numbering under recording.** The citation records (see below), but Word renumbers notes
+  by position and does not track that renumbering; a redline that inserts a note ahead of existing
+  ones shifts their displayed numbers on both the accept and the reject side.
 - **Narrowed projection scopes.** A session opened with `ProjectionSettings.Scopes` excluding
   `Footnotes`/`Endnotes` still writes the note correctly, but `Created` comes back without the
   note anchors — they resolve against a projection that omits the part. Family behavior, identical
   to `SetHeaderText` with `Headers` excluded.
+
+### Recording a note as a tracked change (issue #614)
+
+Under `Settings.TrackedChanges = RenderInline` the **citation is the reversible unit and the
+definition follows it**: the body-side reference run is wrapped in `w:ins`, and rejecting that
+revision removes the reference, which leaves the definition uncited — at which point the
+note-lifecycle rule deletes it. Accepting unwraps the `w:ins` and both survive.
+
+The definition itself carries no revision markup of its own, deliberately. A second `w:ins`
+inside it would be a revision with no independently meaningful resolution: rejecting it while
+keeping the citation yields an empty note, and keeping it while rejecting the citation yields a
+note that is pruned anyway.
+
+`Internal/NoteReferenceOps.cs` is the single owner of that rule — *a note definition exists
+exactly as long as something still cites it* — and it asks the whole package who cites a note,
+not just the body, so a note cited from a running header as well outlives losing its body
+citation. `DocxSession` applies it after a structural delete or a revision resolution
+(issues #516, #591); `RevisionProcessor` applies it on the stateless **reject** path, which is
+what every non-.NET transport reaches through `DocxDiffOps.RejectRevisions`.
+
+The stateless **accept** path deliberately does not apply it. `Accept(Compare(l, r)) ≡ r` is the
+comparison engine's contract, and a counterpart document that carries a reference-less note
+definition is entitled to keep it. `DocxSession`'s own resolve paths apply the rule in both
+directions because an editor is authoring a document rather than inverting a comparison.
+
+### Which mutations record, and which refuse
+
+| Under `RenderInline` | Operations |
+|---|---|
+| Record as native revisions | `ReplaceText` (and `ReplaceMatch`/`ReplaceInner`/`ReplaceTextAtSpan`), `DeleteBlock`, `DeleteRange`, `DeleteSection`, `InsertParagraph`, `SplitParagraph`, `MergeParagraphs`, `MoveBlock`, `InsertHorizontalRule`, `InsertFootnote`, `InsertEndnote`, the formatting ops (`*PrChange`), and the table row/column ops |
+| Refuse with `TrackedOperationUnsupported` | `InsertTable`, `ApplyListFormatRange`, and every image mutation — no reversible native encoding exists, so nothing is written rather than something that cannot be taken back |
+| Apply untracked | The running-story and document-setup ops: `SetHeaderText`, `SetFooterText`, `EnsureHeaderFooterVisible`, `InsertPageNumberField`, `SetPageNumbering`, `ClearPageNumbering`. Word does not redline header/footer authoring either; a document opened for review shows the new running story, not a revision. Comments and annotations are likewise not revisions, by design |
+
+Anything that writes package state under recording belongs in exactly one of those three rows.
+The failure #614 fixed was a fourth, unwritten one — writing content that reject-all could not
+take back — which is the worst of the three, because the redline looks complete and only fails
+when somebody actually rejects it.
 
 ## Comments (issues #300, #317, and #341)
 


### PR DESCRIPTION
Closes #614.

## What was actually wrong

The issue describes the citation as being wrapped in `w:ins` and the definition as staying behind. It is worth correcting the mechanism, because the next reader will otherwise go looking for a `w:ins` that was never there: **`InsertFootnote`/`InsertEndnote` never consulted the recording mode at all.** Both the body citation and the note definition were written as ordinary content, so `rejectAllRevisions` had nothing to reject — which is why the reproduction reports *two* residual revisions rather than one. Dumped from the real op before any change:

```xml
<w:p>
  <w:r><w:t>First</w:t></w:r>
  <w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr>
    <w:footnoteReference w:id="1"/></w:r>   <!-- no w:ins anywhere -->
  <w:r><w:t xml:space="preserve"> paragraph.</w:t></w:r>
</w:p>
```

The consequence the issue names is exactly right, and it is the bad one: the redline looks complete and only fails when somebody actually rejects it.

## The encoding

The citation is the reversible unit and the definition follows it. Rejecting the `w:ins` carries the reference away, which leaves the definition uncited, and the note-lifecycle rule deletes it in the same resolve. Accepting unwraps the `w:ins` and both survive.

The definition deliberately carries no revision markup of its own. A second `w:ins` inside it would be a revision with no independently meaningful resolution: rejecting it while keeping the citation yields an empty note, and keeping it while rejecting the citation yields a note that is pruned anyway.

This is option 1 from the issue rather than the fail-closed fallback, because the mechanism it needs was already in the codebase — `PruneOrphanedNotes`, added for #516 and extended for #591 — and pointing the op at it costs less than refusing does.

## One rule, one owner, and one place it was wrong

`Internal/NoteReferenceOps.cs` is now the single owner of *a note definition exists exactly as long as something still cites it*. Two callers:

- **`DocxSession`**, after a structural delete or a revision resolution, in both directions. Its previous private copy moved here unchanged in behaviour except for one thing — it scanned only `word/document.xml` for citations. A note cited from the body **and** a running header was therefore "referenced before, unreferenced after" when the body citation went away, and got deleted out from under the header. It now asks every story a note reference can legally live in. `DS431` covers it.
- **`RevisionProcessor`, on the reject path only.** This is the gap that made the fix incomplete without it: `DocxDiffOps.AcceptRevisions`/`RejectRevisions` route to `RevisionProcessor`, and that is what npm, python, the MCP server and WASM call. Before this change the same redline was reversible through a `DocxSession` and *not* reversible through any of those transports.

**Why reject only, and not accept.** I tried it symmetrically first and it broke three `DocxDiffScenarioTests` cases, which turned out to be the right answer arriving as a test failure. `Accept(Compare(l, r)) ≡ r` is the comparison engine's documented contract, and the fixtures' counterpart documents legitimately carry a reference-less note definition — a naive paragraph deletion leaves one. Accept must reproduce the counterpart as the comparison saw it, husks included. Reject cannot hit that conflict: a note loses its citation on reject only when the redline *introduced* that citation, in which case the definition came in with the redline too. `DocxSession` applies the rule in both directions because an editor is authoring a document rather than inverting a comparison. `DS429`/`DS430` pin the two contracts as distinct so a future symmetry cleanup fails loudly.

## The audit the issue asked for

Every session op that writes package state under recording now falls in one of three rows, and `docx_mutation_api.md` carries the table:

| | |
|---|---|
| Record as revisions | `ReplaceText` family, the delete family, `InsertParagraph`, `SplitParagraph`, `MergeParagraphs`, `MoveBlock`, the formatting ops, the table row/column ops, **`InsertHorizontalRule`** (fixed here), **`InsertFootnote`/`InsertEndnote`** (fixed here) |
| Refuse with `tracked_operation_unsupported` | `InsertTable`, `ApplyListFormatRange`, every image mutation |
| Apply untracked, by design | The running-story and document-setup ops (`SetHeaderText`, `SetFooterText`, `InsertPageNumberField`, `SetPageNumbering`, …). Word does not redline header/footer authoring either. Comments and annotations are likewise not revisions |

Images were already fail-closed, so the issue's other named suspect was clean. `InsertHorizontalRule` was not: it wrote its paragraph untracked, so rejecting left the rule behind. It now takes the same `MarkParagraphContentAndMark` call `InsertParagraph` already makes. The documentation that claimed `InsertParagraph` does not track was simply stale and has been corrected.

Making header/footer authoring trackable is feature-sized and is not attempted here; the table says so plainly rather than leaving the reader to infer that the gap is closed.

## Validation

Eight new test cases, all of which fail on `main`:

- `DS366` (footnote and endnote) — author under recording, then resolve **both** ways. Reject leaves only Word's two reserved separator notes, no citation, and `DocxDiff.GetRevisions(baseline, rejected)` is **empty**, which is the property that actually matters. Accept keeps citation and definition with no `w:ins` left.
- `DS367` — the diff engine still reports the insertion. The citation is a `w:footnoteReference` nested inside `w:ins`, a shape this op had never produced.
- `DS368` — what `proveRedlineReversibility` reports, which is how the issue was found. The reject path still diverges in `document.xml` (the run the citation split), `settings.xml` and `styles.xml` — residue a generated redline legitimately explains — but **`/word/footnotes.xml` is no longer among them**. The assertion reads a populated divergence list, so it is not vacuously true.
- `DS429`/`DS430` — the stateless transport path in both directions, pinning the asymmetry above.
- `DS431` — a note cited from a header survives losing its body citation.
- `DS224` — the horizontal rule is a revision, and rejecting it takes the paragraph back out.

Full suite: **4183 passed, 0 failed, 3 skipped**. Warning baselines move by exactly one each (132 → 133 library, 775 → 776 tests) for the one new file, per the rule in `CLAUDE.md`; both numbers are updated in the same commit.

## Note for whoever lands #615

That branch carries a guard asserting `insert_footnote` is not reversible under recording:

```js
assert.notEqual(step.args?.action, 'insert_footnote', ...)
```

It is now stale. The demo can footnote the negotiated liability cap again if that reads better than the paragraph it was changed to.