### PR TITLE
Gate the compatibility normalizer on a streaming scan instead of a full parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- **The compatibility normalizer stops full-parsing every part to prove it has nothing to do.**
+  Deciding whether a part needed either of its two repairs meant building the whole `XDocument`,
+  gated on a literal substring test for `AlternateContent` or `pPr` — and every real
+  `word/document.xml` contains `pPr`, so the gate never closed. `PreAccept` runs the normalizer
+  once per side of every comparison, so that was a DOM build plus two descendant sweeps per side,
+  spent almost entirely on documents where neither repair fires (the NVCA model certificate of
+  incorporation has zero paragraphs with two direct `w:pPr`). A streaming `XmlReader` pass now
+  answers the same two questions — any `mc:AlternateContent`, any paragraph with two or more
+  direct `pPr` children — without building a tree, and the archive is opened read-only for it, so
+  a package that needs no repair never pays `ZipArchiveMode.Update`'s entry buffering either. Only
+  a package with a candidate part reaches the rewrite pass, and only its candidate parts are
+  parsed. The gate stays a superset of what the repairs act on: it matches on local names, where
+  the repairs are namespace-exact, so a false positive costs one parse of one part and a false
+  negative — which would be a correctness bug — cannot happen. Measured on the same document:
+  `Normalize` for both sides of a comparison 31.6 → 10.2 ms.
 - **`DocxDiff` no longer reads each document four times per comparison.** On a heavyweight
   legal document (the NVCA model certificate of incorporation: 574 KB of `document.xml`,
   15,360 elements, 97 footnotes) about 72% of a `Compare` was spent inside `IrReader`,

--- a/Docxodus.Tests/MarkupCompatibilityNormalizerTests.cs
+++ b/Docxodus.Tests/MarkupCompatibilityNormalizerTests.cs
@@ -34,15 +34,24 @@ public class MarkupCompatibilityNormalizerTests
             "<w:r><w:t>" + anchorText + "</w:t></w:r>");
     }
 
-    private static byte[] DocWithParagraphXml(string paragraphInnerXml)
+    private static byte[] DocWithParagraphXml(string paragraphInnerXml) =>
+        DocWithBodyChildrenXml("<w:p>" + paragraphInnerXml + "</w:p>");
+
+    private static byte[] DocWithBodyChildrenXml(
+        string bodyChildrenXml, params (string Name, string Xml)[] extraParts)
     {
         var documentXml =
             "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
             "<w:document xmlns:w=\"" + WNs + "\"" +
             " xmlns:mc=\"" + McNs + "\"" +
             " xmlns:v=\"" + VNs + "\">" +
-            "<w:body><w:p>" + paragraphInnerXml + "</w:p>" +
+            "<w:body>" + bodyChildrenXml +
             "<w:sectPr/></w:body></w:document>";
+        return Package(documentXml, extraParts);
+    }
+
+    private static byte[] Package(string documentXml, params (string Name, string Xml)[] extraParts)
+    {
         var relsXml =
             "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
             "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">" +
@@ -67,8 +76,18 @@ public class MarkupCompatibilityNormalizerTests
             Add("[Content_Types].xml", contentTypes);
             Add("_rels/.rels", relsXml);
             Add("word/document.xml", documentXml);
+            foreach (var (name, xml) in extraParts)
+                Add(name, xml);
         }
         return ms.ToArray();
+    }
+
+    private static XDocument PartOf(WmlDocument doc, string entryName)
+    {
+        using var ms = new MemoryStream(doc.DocumentByteArray);
+        using var zip = new ZipArchive(ms, ZipArchiveMode.Read);
+        using var reader = new StreamReader(zip.GetEntry(entryName)!.Open());
+        return XDocument.Parse(reader.ReadToEnd());
     }
 
     private static XDocument MainPart(WmlDocument doc)
@@ -202,6 +221,126 @@ public class MarkupCompatibilityNormalizerTests
         var normalized = MarkupCompatibilityNormalizer.Normalize(doc);
 
         Assert.Same(doc, normalized);
+    }
+
+    // ─── The detection gate (issue #619) ────────────────────────────────
+    //
+    // Deciding whether a part needs either repair used to mean building its whole XDocument, and
+    // the literal that gated it ("pPr") is in every real word/document.xml, so the gate never
+    // closed. A streaming pass answers the same two questions without a DOM. The tests below are
+    // about that gate specifically: it must stay a SUPERSET of what the repairs act on, because a
+    // part that needs repair and is skipped is a correctness bug where an over-broad gate is only
+    // a performance one.
+
+    /// <summary>
+    /// The two duplicates are separated by a whole nested subtree — the shape a comparer produces
+    /// when it inserts revision runs between the original malformed property elements. A detector
+    /// tracking the open-element stack has to still pair them across that depth excursion.
+    /// </summary>
+    [Fact]
+    public void Gate_FindsDuplicateParagraphPropertiesSeparatedByNestedContent()
+    {
+        var doc = new WmlDocument("d.docx", DocWithParagraphXml(
+            "<w:pPr><w:spacing w:after=\"0\"/></w:pPr>" +
+            "<w:ins w:id=\"9\" w:author=\"a\" w:date=\"2026-01-01T00:00:00Z\">" +
+            "<w:r><w:rPr><w:b/></w:rPr><w:t>inserted</w:t></w:r></w:ins>" +
+            "<w:pPr><w:numPr><w:numId w:val=\"42\"/></w:numPr></w:pPr>"));
+
+        var normalized = MarkupCompatibilityNormalizer.Normalize(doc);
+
+        XNamespace w = WNs;
+        Assert.NotSame(doc, normalized);
+        Assert.Single(MainPart(normalized).Descendants(w + "p").First().Elements(w + "pPr"));
+    }
+
+    /// <summary>
+    /// The duplicate is inside a text-box paragraph nested in another paragraph, while the OUTER
+    /// paragraph is well formed. Counting per paragraph rather than per part is what makes this
+    /// visible; the repair walks every descendant paragraph, so the gate has to as well.
+    /// </summary>
+    [Fact]
+    public void Gate_FindsDuplicateParagraphPropertiesInsideANestedParagraph()
+    {
+        var doc = new WmlDocument("d.docx", DocWithParagraphXml(
+            "<w:pPr><w:spacing w:after=\"0\"/></w:pPr>" +
+            "<w:r><w:pict><v:shape><v:textbox><w:txbxContent><w:p>" +
+            "<w:pPr><w:spacing w:before=\"120\"/></w:pPr>" +
+            "<w:r><w:t>boxed</w:t></w:r>" +
+            "<w:pPr><w:numPr><w:numId w:val=\"7\"/></w:numPr></w:pPr>" +
+            "</w:p></w:txbxContent></v:textbox></v:shape></w:pict></w:r>"));
+
+        var normalized = MarkupCompatibilityNormalizer.Normalize(doc);
+
+        XNamespace w = WNs;
+        Assert.NotSame(doc, normalized);
+        var nested = MainPart(normalized).Descendants(w + "p")
+            .Single(p => !p.Descendants(w + "p").Any());
+        Assert.Single(nested.Elements(w + "pPr"));
+        Assert.Contains("boxed", nested.Descendants(w + "t").Select(t => (string)t));
+    }
+
+    /// <summary>The counterpart: three well-formed sibling paragraphs carry three
+    /// <c>w:pPr</c> between them, and none of them is a duplicate. Counting per part rather than
+    /// per paragraph would read that as a repair candidate.</summary>
+    [Fact]
+    public void Gate_DoesNotMistakeOnePPrPerSiblingParagraphForADuplicate()
+    {
+        var doc = new WmlDocument("d.docx", DocWithBodyChildrenXml(
+            "<w:p><w:pPr><w:spacing w:after=\"0\"/></w:pPr><w:r><w:t>one</w:t></w:r></w:p>" +
+            "<w:p><w:pPr><w:spacing w:after=\"1\"/></w:pPr><w:r><w:t>two</w:t></w:r></w:p>" +
+            "<w:p><w:pPr><w:spacing w:after=\"2\"/></w:pPr><w:r><w:t>three</w:t></w:r></w:p>"));
+
+        Assert.Same(doc, MarkupCompatibilityNormalizer.Normalize(doc));
+    }
+
+    /// <summary>Every <c>.xml</c> part is a candidate, not just <c>word/document.xml</c>.</summary>
+    [Fact]
+    public void Gate_ResolvesAlternateContentInAPartOtherThanTheMainDocument()
+    {
+        var headerXml =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+            "<w:hdr xmlns:w=\"" + WNs + "\" xmlns:mc=\"" + McNs + "\" xmlns:v=\"" + VNs + "\">" +
+            "<w:p><w:r>" +
+            "<mc:AlternateContent><mc:Choice Requires=\"v\">" +
+            "<w:pict><v:shape id=\"wm\"/></w:pict>" +
+            "</mc:Choice></mc:AlternateContent>" +
+            "</w:r></w:p></w:hdr>";
+        var doc = new WmlDocument("d.docx", DocWithBodyChildrenXml(
+            "<w:p><w:r><w:t>body</w:t></w:r></w:p>", ("word/header1.xml", headerXml)));
+
+        var normalized = MarkupCompatibilityNormalizer.Normalize(doc);
+
+        XNamespace mc = McNs;
+        XNamespace w = WNs;
+        Assert.NotSame(doc, normalized);
+        var header = PartOf(normalized, "word/header1.xml");
+        Assert.Empty(header.Descendants(mc + "AlternateContent"));
+        Assert.Single(header.Descendants(w + "pict"));
+    }
+
+    /// <summary>
+    /// The repairs are namespace-exact and prefix-agnostic, so the gate matches on local names.
+    /// A part that binds the WordprocessingML namespace to some prefix other than <c>w</c> is
+    /// still repaired — which the literal substring gate this replaced also managed, and which is
+    /// the property that must not regress.
+    /// </summary>
+    [Fact]
+    public void Gate_FindsDuplicatesUnderANonstandardNamespacePrefix()
+    {
+        var documentXml =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+            "<x:document xmlns:x=\"" + WNs + "\"><x:body><x:p>" +
+            "<x:pPr><x:spacing x:after=\"0\"/></x:pPr>" +
+            "<x:r><x:t>anchor text</x:t></x:r>" +
+            "<x:pPr><x:numPr><x:numId x:val=\"42\"/></x:numPr></x:pPr>" +
+            "</x:p><x:sectPr/></x:body></x:document>";
+        var doc = new WmlDocument("d.docx", Package(documentXml));
+
+        var normalized = MarkupCompatibilityNormalizer.Normalize(doc);
+
+        XNamespace w = WNs;
+        Assert.NotSame(doc, normalized);
+        Assert.Single(MainPart(normalized).Descendants(w + "p").Single().Elements(w + "pPr"));
     }
 
     [Fact]

--- a/Docxodus/MarkupCompatibilityNormalizer.cs
+++ b/Docxodus/MarkupCompatibilityNormalizer.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text;
+using System.Xml;
 using System.Xml.Linq;
 
 namespace Docxodus;
@@ -61,6 +62,15 @@ internal static class MarkupCompatibilityNormalizer
 
     internal static WmlDocument Normalize(WmlDocument doc)
     {
+        // Two passes, because almost every document needs no repair at all and the expensive work
+        // is proving that. The first pass streams each part looking for the two shapes the repairs
+        // react to; it builds no DOM and reads the archive read-only, so it never pays for
+        // ZipArchiveMode.Update's entry buffering either. Only a document that has a candidate part
+        // reaches the second pass, and only its candidate parts are parsed and rewritten.
+        var candidates = FindCandidateParts(doc.DocumentByteArray);
+        if (candidates is null)
+            return doc;
+
         using var ms = new MemoryStream();
         ms.Write(doc.DocumentByteArray, 0, doc.DocumentByteArray.Length);
         var anyChanged = false;
@@ -68,18 +78,12 @@ internal static class MarkupCompatibilityNormalizer
         {
             foreach (var entry in zip.Entries.ToList())
             {
-                if (!entry.FullName.EndsWith(".xml", StringComparison.OrdinalIgnoreCase))
+                if (!candidates.Contains(entry.FullName))
                     continue;
 
                 string text;
                 using (var reader = new StreamReader(entry.Open(), Encoding.UTF8))
                     text = reader.ReadToEnd();
-                // Most parts need no XML parse. A literal pPr check is deliberately broad enough
-                // to cover nonstandard Word prefixes too; a harmless false positive only parses
-                // the part and still returns it unchanged.
-                if (!text.Contains("AlternateContent", StringComparison.Ordinal) &&
-                    !text.Contains("pPr", StringComparison.Ordinal))
-                    continue;
 
                 var rewritten = NormalizePart(text);
                 if (rewritten is null)
@@ -93,6 +97,86 @@ internal static class MarkupCompatibilityNormalizer
         }
         return anyChanged ? new WmlDocument(doc.FileName, ms.ToArray()) : doc;
     }
+
+    /// <summary>The <c>.xml</c> entries that carry a shape one of the repairs reacts to, or
+    /// <c>null</c> when the package carries none.</summary>
+    private static HashSet<string>? FindCandidateParts(byte[] package)
+    {
+        HashSet<string>? candidates = null;
+        using var probe = new MemoryStream(package, writable: false);
+        using var zip = new ZipArchive(probe, ZipArchiveMode.Read);
+        foreach (var entry in zip.Entries)
+        {
+            if (!entry.FullName.EndsWith(".xml", StringComparison.OrdinalIgnoreCase))
+                continue;
+            using var stream = entry.Open();
+            if (!CarriesRepairableShape(stream))
+                continue;
+            (candidates ??= new HashSet<string>(StringComparer.Ordinal)).Add(entry.FullName);
+        }
+
+        return candidates;
+    }
+
+    /// <summary>
+    /// Stream one part and answer the only two questions the repairs ask: is there an
+    /// <c>mc:AlternateContent</c> anywhere, and is there a paragraph carrying two or more DIRECT
+    /// <c>pPr</c> children. Matching is by local name, which keeps the gate a superset of what the
+    /// repairs actually act on (they are namespace-exact) — a false positive costs one parse of one
+    /// part and still returns it unchanged, whereas a false negative would be a correctness bug.
+    /// Malformed XML answers "no", which is what <see cref="NormalizePart"/> concludes anyway.
+    /// </summary>
+    private static bool CarriesRepairableShape(Stream part)
+    {
+        // Per-depth view of the open element stack: what opened at each depth, and — for a depth
+        // holding a paragraph — how many direct pPr children it has seen so far. Opening a new
+        // element at a depth resets that depth's count, so sibling paragraphs never pool.
+        var nameAtDepth = new List<string>();
+        var pPrAtDepth = new List<int>();
+
+        try
+        {
+            using var reader = XmlReader.Create(part, StreamingProbeSettings);
+            while (reader.Read())
+            {
+                if (reader.NodeType != XmlNodeType.Element)
+                    continue;
+
+                var name = reader.LocalName;
+                if (name == "AlternateContent")
+                    return true;
+
+                var depth = reader.Depth;
+                while (nameAtDepth.Count <= depth)
+                {
+                    nameAtDepth.Add(string.Empty);
+                    pPrAtDepth.Add(0);
+                }
+
+                nameAtDepth[depth] = name;
+                pPrAtDepth[depth] = 0;
+
+                if (name == "pPr" && depth > 0 && nameAtDepth[depth - 1] == "p"
+                    && ++pPrAtDepth[depth - 1] > 1)
+                    return true;
+            }
+        }
+        catch (System.Xml.XmlException)
+        {
+            return false;
+        }
+
+        return false;
+    }
+
+    private static readonly XmlReaderSettings StreamingProbeSettings = new()
+    {
+        DtdProcessing = DtdProcessing.Prohibit,
+        IgnoreComments = true,
+        IgnoreProcessingInstructions = true,
+        IgnoreWhitespace = true,
+        CloseInput = false,
+    };
 
     /// <summary>Returns rewritten part XML, or null when no conservative repair was applicable.</summary>
     private static string? NormalizePart(string xml)


### PR DESCRIPTION
Closes #619.

## The gate that never closed

`MarkupCompatibilityNormalizer.Normalize` decided whether a part needed either of its two repairs by building the part's whole `XDocument` and sweeping it twice. What was supposed to keep that rare was a literal substring test:

```csharp
if (!text.Contains("AlternateContent", StringComparison.Ordinal) &&
    !text.Contains("pPr", StringComparison.Ordinal))
    continue;
```

Every real `word/document.xml` contains `pPr`, so the gate never closed. `PreAccept` runs the normalizer once per side of every comparison, so that was a DOM build plus two descendant sweeps per side — and the `pPr` half exists for a repair that fires on paragraphs carrying **two or more** direct `w:pPr`, a malformed shape the reference document has **zero** of. The cost was almost entirely the cost of proving there was nothing to do.

## What replaces it

A streaming `XmlReader` pass that answers the same two questions without building a tree: is there an `mc:AlternateContent` anywhere, and is there a paragraph with two or more **direct** `pPr` children. It tracks the open-element stack per depth, so a duplicate separated by a nested subtree (the shape a comparer produces when it inserts revision runs *between* the two malformed property elements) still pairs, and one `pPr` per sibling paragraph is never mistaken for a duplicate.

Two smaller things fall out of restructuring it as detect-then-rewrite:

- The detection pass opens the archive **read-only**, so a package needing no repair never pays `ZipArchiveMode.Update`'s entry buffering. That was option 3 in the issue; it comes free here rather than as a separate change.
- The detection pass reads each entry as a stream rather than materialising it as a string, so a 574 KB `document.xml` is no longer decoded to a `string` just to be substring-searched.

Only a package with a candidate part reaches the rewrite pass, and only its candidate parts are parsed.

## The gate is still a superset

The issue's constraint is the one that matters: a part that needs repair and is skipped is a **correctness** bug, where an over-broad gate is only a performance one. The scan matches on **local names**, while both repairs are namespace-exact (`doc.Descendants(W.p)`, `paragraph.Elements(W.pPr)`). So the gate admits strictly more than the repairs act on — a false positive costs one parse of one part and still returns it unchanged, and a false negative cannot happen. That also preserves the property the old literal had and its comment cared about: a part binding the WordprocessingML namespace to a prefix other than `w` is still found.

Malformed XML answers "no", which is what `NormalizePart` already concluded by returning `null` on `XmlException`.

## Measured

`benchmarks/docxdiff-stress --probe` against `TestFiles/NVCA-Model-COI.docx` (574 KB of `document.xml`, 15,360 elements), median of five:

| | before | after |
|---|---|---|
| `MarkupCompatibilityNormalizer.Normalize` ×2 | 31.6 ms | **10.2 ms** |
| `StrictOoxmlNormalizer.NormalizeToTransitional` ×2 | 7.8 ms | 7.9 ms |

About 21 ms off every comparison, or roughly 6% of a ~350 ms `Compare`.

## Output parity

The full corpus differential, which is the check this change actually needs — `--probe` alone would not catch a gate that wrongly closed:

```
$ dotnet run -c Release --project benchmarks/docxdiff-stress -- --corpus TestFiles --check main.json
[parity] OK - all 14,916 digests identical across 678 documents
```

That covers the redline package, revision list, edit script, all four consolidate products and the compatibility report, across eight generated edit shapes, for every `.docx`/`.docm`/`.dotx` in `TestFiles/` — including the ones that do carry `mc:AlternateContent`.

## Tests

Five new tests, all specifically about the gate rather than the repairs, and the issue is explicit that this is what was missing (the reference document exercises only the skip path):

- `Gate_FindsDuplicateParagraphPropertiesSeparatedByNestedContent` — a whole `w:ins` subtree between the two duplicates.
- `Gate_FindsDuplicateParagraphPropertiesInsideANestedParagraph` — the duplicate is in a text-box paragraph nested inside a well-formed outer paragraph.
- `Gate_DoesNotMistakeOnePPrPerSiblingParagraphForADuplicate` — three sibling paragraphs, three `pPr`, no duplicate; counting per part rather than per paragraph would read that as a candidate.
- `Gate_ResolvesAlternateContentInAPartOtherThanTheMainDocument` — every `.xml` entry is a candidate, not just `word/document.xml`.
- `Gate_FindsDuplicatesUnderANonstandardNamespacePrefix` — the superset property the old literal had.

Verified non-vacuous: disabling the `pPr` half of the detector fails three of the five plus the pre-existing `DisjointDuplicateParagraphProperties_AreCoalescedAndOrdered`.

Full suite: **4180 passed, 0 failed, 3 skipped**. No new files, so both warning baselines are unmoved.