### PR TITLE
Stop giving the diff engine's reads an identity nothing asks for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- **The diff engine stops giving 13,000 elements an identity nothing asks for.** The
+  deterministic Unid pass assigns to every element in a part at two SHA-256 hashes each — 30,720
+  hashes on a 15,360-element legal document, about 40% of an `IrReader.Read`. The IR reads one back
+  from a small fraction of them: block elements, table structure, section breaks, content controls,
+  notes, comments and `w:drawing`. The rest — `w:rPr`, `w:sz`, `w:color`, `w:t` and their kin — get
+  an identity no consumer can address, and the markup renderer strips the attribute on the way out
+  anyway. `IrReaderOptions.UnidAssignment` now lets a reader ask for only the identity-bearing
+  elements and their ancestors, and the diff engine's four read paths do. The default is unchanged
+  (`All`), because a Unid persists into a saved package and "which elements carry an identity" is a
+  contract `DocxSession`, the markdown projection and the package change detector own. The assigned
+  **values are identical** either way: a Unid derives from its ancestors, never its descendants, and
+  the skip predicate is keyed on element names, so it removes whole tag-groups at once and no
+  surviving element's duplicate index can shift. Both reads of a comparison: 294 → 201 ms. Proven
+  by reading every one of the 678 fixtures in `TestFiles/` both ways and comparing the IR's
+  diagnostic JSON — identical on all of them — and by the corpus differential's 14,916 output
+  digests.
 - **`DocxDiff` no longer reads each document four times per comparison.** On a heavyweight
   legal document (the NVCA model certificate of incorporation: 574 KB of `document.xml`,
   15,360 elements, 97 footnotes) about 72% of a `Compare` was spent inside `IrReader`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ are kept for the day each file migrates.
 **`Docxodus.csproj` and `Docxodus.Tests.csproj` both override it to `false`**, so the core
 library and the test project do *not* fail on warnings. The CLI tools, MCP server,
 python-host and WASM project do inherit it. Current baseline: the library builds with
-**133 warnings**, the test project with **776** (mostly StyleCop `SA1633`/`SA1636` file
+**132 warnings**, the test project with **775** (mostly StyleCop `SA1633`/`SA1636` file
 headers and `SA1206` using-order). Don't add to either baseline. Measure with
 `--no-incremental` — a warm incremental build reports zero because nothing recompiles.
 

--- a/Docxodus.Tests/Ir/IrCorpusTests.cs
+++ b/Docxodus.Tests/Ir/IrCorpusTests.cs
@@ -37,6 +37,73 @@ public class IrCorpusTests
     public IrCorpusTests(ITestOutputHelper output) => _output = output;
 
     /// <summary>
+    /// Issue #618: reading with <see cref="UnidAssignment.IdentityBearing"/> must produce a
+    /// byte-identical IR to reading with <see cref="UnidAssignment.All"/>, over the whole corpus.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The pruned pass skips assigning a Unid to elements no consumer can address — run/table/row/cell
+    /// property containers, page setup, paragraph properties other than an inline section break, and
+    /// text leaves. That is safe only if the assigned VALUES do not move, and the reason they cannot
+    /// is structural: a Unid derives from <c>parentUnid : tag : signature : dupIndex</c> — ancestors
+    /// only, never descendants — and the skip predicate is keyed on element names, so it removes whole
+    /// tag-groups at once and no surviving element's <c>dupIndex</c> can shift.
+    /// </para>
+    /// <para>
+    /// This asserts that reasoning against real documents rather than trusting it. The diagnostic JSON
+    /// is the right comparison surface because it carries EVERY identity the reader hands out — block,
+    /// row, cell, section-break, note, comment and content-control anchors, the inline section-break
+    /// anchor, and the <c>w:drawing</c> Unid on an inline image, which is deliberately equality-neutral
+    /// on <c>IrInlineImage</c> and so would slip through a structural record comparison.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    [Trait("Category", "Corpus")]
+    public void Read_PrunedUnidAssignment_ProducesAnIdenticalIr()
+    {
+        var all = new IrReaderOptions { UnidAssignment = UnidAssignment.All };
+        var pruned = new IrReaderOptions { UnidAssignment = UnidAssignment.IdentityBearing };
+
+        var files = TestFilesDir.GetFiles("*.docx", SearchOption.AllDirectories)
+            .OrderBy(f => f.FullName, StringComparer.Ordinal)
+            .ToList();
+
+        var divergent = new List<string>();
+        int compared = 0;
+        int withAnchors = 0;
+        foreach (var file in files)
+        {
+            if (!CanOpen(file)) continue;
+
+            string expected;
+            string actual;
+            try
+            {
+                expected = IrDiagnosticJson.Write(IrReader.Read(new WmlDocument(file.FullName), all));
+                actual = IrDiagnosticJson.Write(IrReader.Read(new WmlDocument(file.FullName), pruned));
+            }
+            catch (Exception)
+            {
+                // Totality is Read_EntireTestFilesCorpus_DoesNotThrow's job, not this test's.
+                continue;
+            }
+
+            compared++;
+            if (expected.Contains("\"anchor\"", StringComparison.Ordinal)) withAnchors++;
+            if (!string.Equals(expected, actual, StringComparison.Ordinal))
+                divergent.Add(file.Name);
+        }
+
+        // Non-vacuous: the corpus really was read, and the JSON really does carry anchors.
+        Assert.True(compared > 500, $"only {compared} documents compared");
+        Assert.True(withAnchors > 500, $"only {withAnchors} documents produced anchors");
+        Assert.True(divergent.Count == 0,
+            $"{divergent.Count} document(s) read differently under the pruned Unid pass: "
+            + string.Join(", ", divergent.Take(10)));
+        _output.WriteLine($"identical IR on {compared} documents ({withAnchors} carrying anchors)");
+    }
+
+    /// <summary>
     /// Totality proof: the reader must consume every readable fixture in <c>TestFiles/</c> without
     /// throwing (opaque fallback is the contract; a crash on weird-but-valid OOXML is a reader bug).
     /// Files that even <see cref="WordprocessingDocument.Open(Stream, bool)"/> rejects are

--- a/Docxodus/DocxDiff.cs
+++ b/Docxodus/DocxDiff.cs
@@ -49,8 +49,17 @@ public static class DocxDiff
     // The diff engine reads with provenance OFF (it never needs element-level provenance and the lower
     // footprint matters for bulk pipelines) and revisions ACCEPTED (the IR the script is built over is
     // the accepted view of each side). The markup renderer re-reads internally with its own options.
+    // …and with the Unid pass pruned to the elements an identity is read back FROM (issue #618).
+    // The engine addresses block elements, table structure, content controls, notes, comments and
+    // w:drawing; the renderer strips the attribute on the way out. The assigned values are identical
+    // either way — see UnidAssignment — so this is purely the work of not hashing 13k elements twice.
     internal static readonly IrReaderOptions ReadOpts =
-        new() { RetainSources = false, RevisionView = RevisionView.Accept };
+        new()
+        {
+            RetainSources = false,
+            RevisionView = RevisionView.Accept,
+            UnidAssignment = UnidAssignment.IdentityBearing,
+        };
 
     // The same read WITH provenance. DocxDiffComparison uses this one so a single pass per side feeds both
     // the edit-script build and the markup renderer's clone-from-provenance pass; provenance is
@@ -58,7 +67,12 @@ public static class DocxDiff
     // ReadOpts. ReadOpts stays for the paths that genuinely never clone source XML and want the lower
     // footprint (the consolidate scoreboard, compatibility probes).
     internal static readonly IrReaderOptions RenderReadOpts =
-        new() { RetainSources = true, RevisionView = RevisionView.Accept };
+        new()
+        {
+            RetainSources = true,
+            RevisionView = RevisionView.Accept,
+            UnidAssignment = UnidAssignment.IdentityBearing,
+        };
 
     /// <summary>
     /// Compare <paramref name="left"/> and <paramref name="right"/> and produce a tracked-changes

--- a/Docxodus/Ir/Diff/IrCompositeMarkupRenderer.cs
+++ b/Docxodus/Ir/Diff/IrCompositeMarkupRenderer.cs
@@ -76,7 +76,12 @@ internal static class IrCompositeMarkupRenderer
         }
         else
         {
-            var readOpts = new IrReaderOptions { RetainSources = true, RevisionView = RevisionView.Accept };
+            var readOpts = new IrReaderOptions
+            {
+                RetainSources = true,
+                RevisionView = RevisionView.Accept,
+                UnidAssignment = UnidAssignment.IdentityBearing,
+            };
             baseIr = IrReader.Read(baseDoc, readOpts);
             reviewerIrs = reviewers.Select(r => IrReader.Read(r.Doc, readOpts)).ToList();
         }

--- a/Docxodus/Ir/Diff/IrMarkupRenderer.cs
+++ b/Docxodus/Ir/Diff/IrMarkupRenderer.cs
@@ -232,7 +232,12 @@ internal static class IrMarkupRenderer
         }
         else
         {
-            var readOpts = new IrReaderOptions { RetainSources = true, RevisionView = RevisionView.Accept };
+            var readOpts = new IrReaderOptions
+            {
+                RetainSources = true,
+                RevisionView = RevisionView.Accept,
+                UnidAssignment = UnidAssignment.IdentityBearing,
+            };
             irLeft = IrReader.Read(left, readOpts);
             irRight = IrReader.Read(right, readOpts);
         }

--- a/Docxodus/Ir/IrReader.cs
+++ b/Docxodus/Ir/IrReader.cs
@@ -135,7 +135,7 @@ internal static class IrReader
         var mainXDoc = main.GetXDocument();
         var root = mainXDoc.Root
             ?? throw new DocxodusException("MainDocumentPart has no root element.");
-        UnidHelper.AssignToAllElementsDeterministic(root);
+        UnidHelper.AssignToAllElementsDeterministic(root, options.UnidAssignment);
 
         // Stash the owning part on the root so WmlToMarkdownConverter.KindFor → IsListItem can
         // reach the StyleDefinitionsPart and walk the pStyle → basedOn chain. Without it, a
@@ -197,10 +197,10 @@ internal static class IrReader
         {
             headers = ReadHeaderFooterScopes(main, body, styles, numbering, sources, anchorIndex,
                 main.HeaderParts.Cast<OpenXmlPart>(), "hdr", W + "headerReference", retain,
-                drawingGraphFallbackDocumentHash);
+                options.UnidAssignment, drawingGraphFallbackDocumentHash);
             footers = ReadHeaderFooterScopes(main, body, styles, numbering, sources, anchorIndex,
                 main.FooterParts.Cast<OpenXmlPart>(), "ftr", W + "footerReference", retain,
-                drawingGraphFallbackDocumentHash);
+                options.UnidAssignment, drawingGraphFallbackDocumentHash);
         }
 
         // --- footnote / endnote scopes (rule M1.3) ----------------------------------------------
@@ -209,16 +209,18 @@ internal static class IrReader
         if (options.Scopes.HasFlag(IrScopes.Notes))
         {
             footnotes = ReadNoteStore(main, main.FootnotesPart, styles, numbering, sources,
-                anchorIndex, "fn", W + "footnote", retain, drawingGraphFallbackDocumentHash);
+                anchorIndex, "fn", W + "footnote", retain, options.UnidAssignment,
+                drawingGraphFallbackDocumentHash);
             endnotes = ReadNoteStore(main, main.EndnotesPart, styles, numbering, sources,
-                anchorIndex, "en", W + "endnote", retain, drawingGraphFallbackDocumentHash);
+                anchorIndex, "en", W + "endnote", retain, options.UnidAssignment,
+                drawingGraphFallbackDocumentHash);
         }
 
         // --- comment scope (rule M1.3 + N15 record-half) ----------------------------------------
         var comments = IrCommentStore.Empty;
         if (options.Scopes.HasFlag(IrScopes.Comments))
             comments = ReadCommentStore(main, styles, numbering, sources, anchorIndex, commentTracker!,
-                retain, drawingGraphFallbackDocumentHash);
+                retain, options.UnidAssignment, drawingGraphFallbackDocumentHash);
 
         var projectionAnchors = CaptureProjectionAnchors(wdoc, options.Scopes);
 
@@ -2978,12 +2980,12 @@ internal static class IrReader
     /// main part's <c>StyleDefinitionsPart</c> through the part's package). Idempotent on the
     /// annotation. Returns the part's root, or null when the part has no readable root (tolerated).
     /// </summary>
-    private static XElement? PreparePartRoot(OpenXmlPart part)
+    private static XElement? PreparePartRoot(OpenXmlPart part, UnidAssignment unids)
     {
         var root = part.GetXDocument().Root;
         if (root is null)
             return null;
-        UnidHelper.AssignToAllElementsDeterministic(root);
+        UnidHelper.AssignToAllElementsDeterministic(root, unids);
         if (root.Annotation<OpenXmlPart>() == null)
             root.AddAnnotation(part);
         return root;
@@ -3006,7 +3008,7 @@ internal static class IrReader
         MainDocumentPart main, XElement body, IrStyleRegistry styles, IrNumberingRegistry numbering,
         Dictionary<Uri, XDocument> sources, Dictionary<string, IrBlock> anchorIndex,
         IEnumerable<OpenXmlPart> parts, string scopePrefix, XName referenceName, bool retain,
-        Lazy<IrHash> drawingGraphFallbackDocumentHash)
+        UnidAssignment unids, Lazy<IrHash> drawingGraphFallbackDocumentHash)
     {
         var result = new List<IrHeaderFooter>();
         int i = 1;
@@ -3015,7 +3017,7 @@ internal static class IrReader
             var scopeName = $"{scopePrefix}{i++}";
             try
             {
-                var root = PreparePartRoot(part);
+                var root = PreparePartRoot(part, unids);
                 if (root is null)
                     continue;
 
@@ -3089,14 +3091,15 @@ internal static class IrReader
     private static IrNoteStore ReadNoteStore(
         MainDocumentPart main, OpenXmlPart? part, IrStyleRegistry styles, IrNumberingRegistry numbering,
         Dictionary<Uri, XDocument> sources, Dictionary<string, IrBlock> anchorIndex,
-        string scopeName, XName noteName, bool retain, Lazy<IrHash> drawingGraphFallbackDocumentHash)
+        string scopeName, XName noteName, bool retain, UnidAssignment unids,
+        Lazy<IrHash> drawingGraphFallbackDocumentHash)
     {
         if (part is null)
             return IrNoteStore.Empty;
 
         try
         {
-            var root = PreparePartRoot(part);
+            var root = PreparePartRoot(part, unids);
             if (root is null)
                 return IrNoteStore.Empty;
 
@@ -3147,7 +3150,8 @@ internal static class IrReader
     private static IrCommentStore ReadCommentStore(
         MainDocumentPart main, IrStyleRegistry styles, IrNumberingRegistry numbering,
         Dictionary<Uri, XDocument> sources, Dictionary<string, IrBlock> anchorIndex,
-        CommentTracker tracker, bool retain, Lazy<IrHash> drawingGraphFallbackDocumentHash)
+        CommentTracker tracker, bool retain, UnidAssignment unids,
+        Lazy<IrHash> drawingGraphFallbackDocumentHash)
     {
         var part = main.WordprocessingCommentsPart;
         if (part is null)
@@ -3155,7 +3159,7 @@ internal static class IrReader
 
         try
         {
-            var root = PreparePartRoot(part);
+            var root = PreparePartRoot(part, unids);
             if (root is null)
                 return IrCommentStore.Empty;
 

--- a/Docxodus/Ir/IrReaderOptions.cs
+++ b/Docxodus/Ir/IrReaderOptions.cs
@@ -70,4 +70,16 @@ internal sealed class IrReaderOptions
     /// </para>
     /// </summary>
     public bool RetainSources { get; init; } = true;
+
+    /// <summary>
+    /// Which elements the deterministic Unid pass assigns to (default <see cref="UnidAssignment.All"/>
+    /// — today's behavior). The diff engine reads an identity back from block elements, table
+    /// structure, content controls, notes, comments and <c>w:drawing</c> and from nothing else, and
+    /// the markup renderer strips the attribute on the way out, so it reads with
+    /// <see cref="UnidAssignment.IdentityBearing"/>. The default stays <see cref="UnidAssignment.All"/>
+    /// because a Unid assigned on the <see cref="DocxSession"/> / markdown-projection paths persists
+    /// into a saved package, which makes "which elements carry an identity" a contract those paths own.
+    /// The assigned values are identical either way.
+    /// </summary>
+    public UnidAssignment UnidAssignment { get; init; } = UnidAssignment.All;
 }

--- a/Docxodus/UnidHelper.cs
+++ b/Docxodus/UnidHelper.cs
@@ -48,6 +48,24 @@ namespace Docxodus;
 /// <c>dup_index</c> of later duplicates of the same content (the only rough edge in the scheme).</item>
 /// </list>
 /// </remarks>
+/// <summary>Which elements a deterministic Unid pass assigns to.</summary>
+internal enum UnidAssignment
+{
+    /// <summary>Every element, which is what <see cref="DocxSession"/>, the markdown projection and
+    /// the package change detector expect — a Unid assigned here persists into a saved package, so
+    /// "which elements carry an identity" is a cross-cutting contract those paths keep unchanged.</summary>
+    All,
+
+    /// <summary>
+    /// Only elements an identity can be read back from, plus their ancestors. The diff engine reads
+    /// a Unid from block elements, table structure, content controls, notes, comments and
+    /// <c>w:drawing</c>; the markup renderer strips the attribute on the way out. Assigning to the
+    /// rest costs two SHA-256 hashes each for an identity nothing queries. The assigned VALUES are
+    /// unchanged — see <c>CarriesNoIdentity</c> for why.
+    /// </summary>
+    IdentityBearing,
+}
+
 internal static class UnidHelper
 {
     /// <summary>Random 32-char hex Unid. Used by the legacy bulk-assign path and by
@@ -91,8 +109,10 @@ internal static class UnidHelper
     /// <returns><c>true</c> when at least one Unid was assigned — callers use this to
     /// skip persistence work (part flushes) on the no-op passes that dominate per-op
     /// index rebuilds.</returns>
-    internal static bool AssignToAllElementsDeterministic(XElement contentParent)
+    internal static bool AssignToAllElementsDeterministic(
+        XElement contentParent, UnidAssignment assignment = UnidAssignment.All)
     {
+        bool prune = assignment == UnidAssignment.IdentityBearing;
         // Run the legacy deterministic walk first. Descendant block/run identities below an
         // SDT must keep using the same structural seed they used before SDTs became public
         // anchors; otherwise merely exposing the wrapper would rename every child anchor.
@@ -119,17 +139,9 @@ internal static class UnidHelper
         // wholesale. Assigned values are IDENTICAL to the unpruned walk: dup-index
         // bookkeeping only ever influences an assignment within a parent that has a
         // missing child, and such parents are always in `live`.
-        HashSet<XElement>? live = null;
-        foreach (var el in contentParent.DescendantsAndSelf())
-        {
-            if (el.Attribute(PtOpenXml.Unid) is not null || el == contentParent) continue;
-            live ??= new HashSet<XElement>();
-            for (XElement? a = el.Parent; a is not null; a = a.Parent)
-            {
-                if (!live.Add(a)) break; // ancestors above are already marked
-            }
-        }
-        if (live is null)
+        var live = new HashSet<XElement>();
+        CollectLiveAncestors(contentParent, prune, live);
+        if (live.Count == 0)
         {
             ContentControlIdentity.AssignStableUnids(contentParent, out bool changedControls);
             return assignedRoot || changedControls;
@@ -143,7 +155,7 @@ internal static class UnidHelper
         // lives for one call only: it is keyed on the exact string that is hashed, so a hit returns
         // precisely what a fresh hash would have, and nothing survives to leak between documents.
         var sigCache = new Dictionary<string, string>(StringComparer.Ordinal);
-        AssignDescendantsDeterministic(contentParent, parentUnid, live, sigCache);
+        AssignDescendantsDeterministic(contentParent, parentUnid, live, sigCache, prune);
         ContentControlIdentity.AssignStableUnids(contentParent);
         return true;
     }
@@ -264,7 +276,8 @@ internal static class UnidHelper
     // ─── Deterministic derivation internals ──────────────────────────────
 
     private static void AssignDescendantsDeterministic(
-        XElement parent, string parentUnid, HashSet<XElement> live, Dictionary<string, string> sigCache)
+        XElement parent, string parentUnid, HashSet<XElement> live, Dictionary<string, string> sigCache,
+        bool prune)
     {
         // Signature/dup-index bookkeeping is only needed when THIS parent has a child
         // to assign — for fully-assigned parents (the overwhelming majority after the
@@ -272,12 +285,14 @@ internal static class UnidHelper
         bool anyMissing = false;
         foreach (var c in parent.Elements())
         {
+            if (prune && CarriesNoIdentity(c)) continue;
             if (c.Attribute(PtOpenXml.Unid) == null) { anyMissing = true; break; }
         }
 
         var dup = anyMissing ? new Dictionary<(string Tag, string Sig), int>() : null;
         foreach (var child in parent.Elements())
         {
+            if (prune && CarriesNoIdentity(child)) continue;
             if (child.Attribute(PtOpenXml.Unid) == null)
             {
                 var sig = ContentSignature(child, sigCache);
@@ -305,10 +320,63 @@ internal static class UnidHelper
             // still missing — is a member; anything else has a fully-assigned subtree.
             if (live.Contains(child))
             {
-                var childUnid = (string?)child.Attribute(PtOpenXml.Unid)!;
-                AssignDescendantsDeterministic(child, childUnid, live, sigCache);
+                var childUnid = (string)child.Attribute(PtOpenXml.Unid)!;
+                AssignDescendantsDeterministic(child, childUnid, live, sigCache, prune);
             }
         }
+    }
+
+    /// <summary>
+    /// Mark every element whose subtree still holds an element needing a Unid, so the assignment
+    /// walk can skip fully-assigned subtrees wholesale. Under <paramref name="prune"/> the walk
+    /// does not descend into identityless subtrees either, so they never mark their ancestors live.
+    /// </summary>
+    /// <returns>Whether <paramref name="parent"/>'s subtree holds anything to assign.</returns>
+    private static bool CollectLiveAncestors(XElement parent, bool prune, HashSet<XElement> live)
+    {
+        bool anythingBelow = false;
+        foreach (var child in parent.Elements())
+        {
+            if (prune && CarriesNoIdentity(child)) continue;
+            var below = CollectLiveAncestors(child, prune, live);
+            if (below || child.Attribute(PtOpenXml.Unid) is null) anythingBelow = true;
+        }
+
+        if (anythingBelow) live.Add(parent);
+        return anythingBelow;
+    }
+
+    /// <summary>
+    /// Elements — with their whole subtree — that no consumer can address: run/table/row/cell
+    /// property containers, the page-setup children of a section break, everything under a
+    /// <c>w:pPr</c> other than an inline <c>w:sectPr</c>, and the text leaves. Under
+    /// <see cref="UnidAssignment.IdentityBearing"/> these are neither assigned a Unid nor descended
+    /// into, which is most of a document: an identity is read back from block elements, table
+    /// structure, content controls, notes, comments and <c>w:drawing</c>, and from nothing else.
+    /// <para>
+    /// The predicate is a pure function of the element's name and its parent's name, and that is
+    /// what makes the pruned Unids <b>identical</b> to the unpruned ones rather than merely similar.
+    /// A Unid derives from <c>parentUnid : tag : signature : dupIndex</c> — ancestors only, never
+    /// descendants — and <c>dupIndex</c> counts same-<c>(tag, signature)</c> preceding siblings. A
+    /// name-keyed skip therefore removes whole tag-groups at once, so no surviving element ever
+    /// shares a dup key with a skipped one and no surviving element's index can shift. A predicate
+    /// that looked at content instead could split a tag-group and move an index.
+    /// </para>
+    /// </summary>
+    private static bool CarriesNoIdentity(XElement el)
+    {
+        var name = el.Name;
+        if (name == W.rPr || name == W.tblPr || name == W.tblPrEx || name == W.trPr || name == W.tcPr)
+            return true;
+        if (name == W.t || name == W.delText || name == W.instrText || name == W.delInstrText)
+            return true;
+
+        var parent = el.Parent?.Name;
+        // The one addressable thing under paragraph properties is an inline section break.
+        if (parent == W.pPr) return name != W.sectPr;
+        // The section break itself is addressable; its page setup is not.
+        if (parent == W.sectPr) return true;
+        return false;
     }
 
     /// <summary>

--- a/benchmarks/docxdiff-stress/Probe.cs
+++ b/benchmarks/docxdiff-stress/Probe.cs
@@ -235,12 +235,22 @@ internal static class UnidProbe
             return len;
         });
 
-        Median("AssignToAllElementsDeterministic (cold, full)", n, () =>
+        // The two assignment modes, alternated inside ONE process so machine load cannot
+        // masquerade as the difference (issue #618). IdentityBearing skips the elements no
+        // consumer can address; the values it assigns are identical.
+        for (var round = 0; round < 2; round++)
         {
-            var fresh = FreshRoot();
-            UnidHelper.AssignToAllElementsDeterministic(fresh);
-            return 1;
-        });
+            Median("AssignToAllElementsDeterministic (cold, All)", n, () =>
+            {
+                UnidHelper.AssignToAllElementsDeterministic(FreshRoot(), UnidAssignment.All);
+                return 1;
+            });
+            Median("AssignToAllElementsDeterministic (cold, IdentityBearing)", n, () =>
+            {
+                UnidHelper.AssignToAllElementsDeterministic(FreshRoot(), UnidAssignment.IdentityBearing);
+                return 1;
+            });
+        }
     }
 
     private static void Median<T>(string label, int n, Func<T> act)

--- a/docs/architecture/document_ir.md
+++ b/docs/architecture/document_ir.md
@@ -120,6 +120,30 @@ populated in BOTH modes; the markdown emitter prefers those over per-node proven
 Retention is a pure memory knob — anchors, `ContentHash`, and `FormatFingerprint` are
 byte-identical across modes.
 
+**Optional pruning — `IrReaderOptions.UnidAssignment` (default `All`).** The deterministic
+Unid pass assigns an identity to every element in a part, at two SHA-256 hashes each. The IR
+reads one back from a small fraction of them: block elements, table structure (`w:tbl`/`w:tr`/
+`w:tc`/`w:gridCol`), section breaks, content controls, notes, comments and `w:drawing`.
+Everything else — `w:rPr`, `w:sz`, `w:color`, `w:t` and their kin — gets an identity nothing
+queries during a diff, and the markup renderer strips the attribute on the way out. With
+`UnidAssignment.IdentityBearing` the pass neither assigns to nor descends into those subtrees.
+
+The default stays `All` because a Unid **persists into a saved package**: which elements carry
+an identity is a cross-cutting contract that `DocxSession`, the markdown projection and the
+package change detector own, so only the diff engine opts in.
+
+The assigned **values are identical** either way, and the reason is structural rather than
+empirical. A Unid derives from `parentUnid : tag : signature : dupIndex` — its *ancestors*,
+never its descendants — and `dupIndex` counts preceding siblings sharing `(tag, signature)`.
+The skip predicate is a pure function of an element's name and its parent's name, so it removes
+whole tag-groups at once: no surviving element ever shares a dup key with a skipped one, and no
+surviving element's index can shift. A predicate that looked at *content* could split a
+tag-group and move an index, which is why it does not. `IrCorpusTests.
+Read_PrunedUnidAssignment_ProducesAnIdenticalIr` asserts that against every fixture in
+`TestFiles/`, comparing the diagnostic JSON — the surface that carries every anchor the reader
+hands out plus the `w:drawing` Unid, which is deliberately equality-neutral on `IrInlineImage`
+and would otherwise slip through a structural comparison.
+
 ## Normalization
 
 The reader applies normalization rules **N1–N15** before any node is


### PR DESCRIPTION
Closes #618.

## The waste

`UnidHelper.AssignToAllElementsDeterministic` gives every element in a part a content-addressable identity, at **two SHA-256 hashes each** — one for the content signature, one for the derivation. On the NVCA model certificate of incorporation that is 15,360 elements and 30,720 hashes, per part, per read, and a `Compare` reads two documents.

The IR reads one back from block elements, table structure (`w:tbl`/`w:tr`/`w:tc`/`w:gridCol`), section breaks, content controls, notes, comments and `w:drawing`. Nothing else. The markup renderer then strips the attribute on the way out. An element census of that document:

| population | count | addressable? |
|---|---|---|
| `w:r` | 3,464 | no, but it is the parent of `w:drawing` |
| `w:rPr` + its children (`w:szCs`, `w:u`, `w:color`, `w:lang`, `w:rStyle`, `w:b`, …) | ~6,600 | no |
| `w:t` | 2,624 | no |
| `w:pPr` children (`w:pStyle`, `w:widowControl`, …) | ~400 | no, except an inline `w:sectPr` |
| `w:instrText` | 201 | no |
| `w:p` | 234 | **yes** |

The skip predicate covers **64% of the elements**.

## What the option is, and why the default does not move

`IrReaderOptions.UnidAssignment` — `All` (unchanged default) or `IdentityBearing`. The diff engine's four read paths (`DocxDiff.ReadOpts`, `DocxDiff.RenderReadOpts`, and the two markup renderers' internal re-reads) opt in; nothing else does.

The default stays `All` deliberately, and this is the reason the issue asked for the option rather than a change to `UnidHelper`'s behaviour: **a Unid persists into a saved package.** Which elements carry an identity is a cross-cutting contract that `DocxSession`, the markdown projection and `OpcSemanticPackageChangeDetector` own, and none of them should discover a change to it as a side effect of a diff-engine optimisation.

## Why the values cannot move

This is the part worth reviewing carefully, because it is a structural argument, not an empirical one.

A Unid derives from `parentUnid : tag : signature : dupIndex` — its **ancestors, never its descendants**. `ContentSignature` reads element names, `w:t` text and `pPr` values; it does not read descendant Unids. And `dupIndex` counts preceding siblings sharing `(tag, signature)`.

So the only way pruning could move a value is by changing some surviving element's `dupIndex` — which needs a skipped sibling that shares a dup key with a kept one. **The skip predicate is a pure function of the element's name and its parent's name**, so it removes whole tag-groups at once: same-tag siblings are always skipped together, and a surviving element never shares a dup key with a skipped one. A predicate that consulted *content* could split a tag-group and shift an index, which is exactly why this one does not.

Nothing kept can have a skipped ancestor either, by construction: every skipped subtree is a property container, a page-setup child or a text leaf, none of which can contain an addressable element. The one exception is spelled out — the inline `w:sectPr` under a `w:pPr`, which *is* addressable, so `w:pPr` is descended into for it.

## Evidence

The issue is explicit that a green suite does not protect this area, since #616's `wp:docPr/@id` bug passed 4,161 tests and 36 digests. So, three independent checks:

**1. Every fixture, both ways, identical IR.** `IrCorpusTests.Read_PrunedUnidAssignment_ProducesAnIdenticalIr` reads all 678 `TestFiles/` documents under both modes and compares the reader's diagnostic JSON:

```
identical IR on 678 documents (678 carrying anchors)
```

The diagnostic JSON is the right surface because it carries every identity the reader hands out — block, row, cell, section-break, note, comment and content-control anchors, the inline section-break anchor, and the `w:drawing` Unid on an inline image. That last one is **deliberately equality-neutral on `IrInlineImage`** and would slip straight through a structural record comparison. The test asserts non-vacuity itself (`compared > 500`, `withAnchors > 500`), and it does fail when the predicate is wrong: adding `w:drawing` to the skip list turns it red immediately.

**2. The corpus differential.** 14,916 digests over the same 678 documents — redline package, revision list, edit script, four consolidate products and the compatibility report, across eight generated edit shapes:

```
[parity] OK - all 14,916 digests identical across 678 documents
```

**3. The unit suite.** 4183 passed, 0 failed, 3 skipped.

## Measured

Cross-process timings drifted badly on this machine (the same stage measured 242 ms and 294 ms an hour apart on identical code), so the two modes are alternated **inside one process** — a probe line added to `benchmarks/docxdiff-stress` so the comparison stays repeatable:

```
AssignToAllElementsDeterministic (cold, All)                33.4 ms
AssignToAllElementsDeterministic (cold, IdentityBearing)    21.7 ms
AssignToAllElementsDeterministic (cold, All)                42.2 ms
AssignToAllElementsDeterministic (cold, IdentityBearing)    23.6 ms
```

Roughly a third off the stage, twice per comparison, plus the renderer's own reads. Smaller than the issue's estimate, and worth saying why: that estimate predates #616, which already fused `ContentSignature`'s three subtree walks into one and added a per-call cache for its repeated hash inputs.

Both warning baselines drop by one — a pre-existing `CS8604` at the recursion site was fixed while adding the parameter — and `CLAUDE.md` is updated in the same commit.