### PR TITLE
Make the corpus differential observe the call, not just what it returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- **The corpus differential observes a product call, not just what it returned.** The #616
+  regression — a fast path that skipped the compatibility pre-flight — passed all 8,136 digests
+  correctly, because for two byte-identical documents "no revisions" is the right answer before and
+  after and the return value never moved. The recorded unit is now an `Observation` with one field
+  per channel (result, compatibility warnings, input mutation, product-order variance), so adding a
+  channel is one field on one type applied to every product and every document rather than a new
+  digest family per mode. Two channels are new: whether a call left its inputs byte-for-byte
+  unchanged, which `IrReader.Read` and `PreAccept` both promise in prose and nothing verified; and
+  whether the memoized `DocxDiffComparison` agrees with the statics when the products are requested
+  in the opposite order, which is a risk `DocxDiff.CreateComparison` created and nothing tested. The
+  pre-flight report is now captured from the same call that produced the result instead of from a
+  second run of every product — cheaper and stricter. Each run prints how many observations record a
+  non-default value per channel, because a channel that never fires is coverage nobody should count.
+  A fifth comparison per document varies exactly one `DocxDiffSettings` property, rotated by document
+  index, so all twenty get exercised across the corpus for one extra comparison rather than a
+  cross-product. And the redline digest's generated-part-name folding is gone: it existed because
+  `Compare` was not byte-reproducible, which #623 fixed, so it was only making the harness less
+  sensitive — confirmed by running the corpus twice on one build and getting all 12,882 observations
+  identical.
 - **The compatibility normalizer stops full-parsing every part to prove it has nothing to do.**
   Deciding whether a part needed either of its two repairs meant building the whole `XDocument`,
   gated on a literal substring test for `AlternateContent` or `pPr` — and every real

--- a/Docxodus.Tests/Ir/IrReaderTests.cs
+++ b/Docxodus.Tests/Ir/IrReaderTests.cs
@@ -1,6 +1,8 @@
 #nullable enable
 
 using System;
+using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using Docxodus;
 using Docxodus.Ir;
@@ -521,5 +523,65 @@ public class IrReaderTests
             .Body.Blocks.OfType<IrParagraph>().Single();
 
         Assert.NotEqual(textbox.ContentHash.ToHex(), plain.ContentHash.ToHex());
+    }
+
+    // ─── Throw paths (issue #624, item 5) ────────────────────────────────
+    //
+    // A leaked resource is invisible to every differential and to tooling: the harness digests
+    // return values, and CA2000 was measured against this exact leak shape and does not fire at any
+    // AnalysisMode. What IS assertable is the contract the throw path owes its caller, and that a
+    // failed read leaves the reader usable — which the structural fix (construct the package inside
+    // the try, null-tolerant finally) is what actually delivers.
+
+    /// <summary>
+    /// Handing the reader a spreadsheet package is a real caller mistake and a real throw path.
+    /// The byte-array constructors of <see cref="WmlDocument"/> reject one up front, but the
+    /// <c>MemoryStream</c> constructors do not validate at all — so that is the door this arrives
+    /// through, and it lands on the exact path where the reader used to leak an open package
+    /// (the <c>OpenXmlMemoryStreamDocument</c> was built before the <c>try</c>, so the failure
+    /// escaped the <c>using</c> that disposed it). The call must refuse it, leave the caller's bytes
+    /// alone, and leave nothing behind that stops the next read from working.
+    /// </summary>
+    [Fact]
+    public void Read_SpreadsheetPackage_RefusesWithoutTouchingTheInputOrTheNextRead()
+    {
+        var spreadsheet = EmbeddedWorkbookBytes();
+        Assert.Throws<PowerToolsDocumentException>(() => new WmlDocument("workbook.xlsx", spreadsheet));
+
+        var stream = new MemoryStream();
+        stream.Write(spreadsheet, 0, spreadsheet.Length);
+        var doc = new WmlDocument("workbook.xlsx", stream);
+        var before = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(spreadsheet));
+
+        // Repeated so a per-call leak would have to accumulate, and so "the second one still works"
+        // is asserted rather than assumed.
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            var thrown = Assert.ThrowsAny<Exception>(() => IrReader.Read(doc));
+            Assert.Contains("Wordprocessing", thrown.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        // The reader promises the caller's DocumentByteArray is left byte-for-byte unchanged, on the
+        // failure path as much as the success path.
+        Assert.Equal(before,
+            Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(doc.DocumentByteArray)));
+
+        // …and a good document still reads afterwards, so the failed reads left nothing behind.
+        var good = IrReader.Read(new WmlDocument("../../../../TestFiles/CU011-Chart-Embedded-Xlsx-03.docx"));
+        Assert.NotEmpty(good.Body.Blocks);
+    }
+
+    /// <summary>The embedded workbook inside a chart-bearing fixture — a real spreadsheet package,
+    /// so the test does not depend on a hand-built one being convincing.</summary>
+    private static byte[] EmbeddedWorkbookBytes()
+    {
+        using var file = File.OpenRead("../../../../TestFiles/CU011-Chart-Embedded-Xlsx-03.docx");
+        using var zip = new ZipArchive(file, ZipArchiveMode.Read);
+        var entry = zip.Entries.Single(e =>
+            e.FullName.EndsWith(".xlsx", StringComparison.OrdinalIgnoreCase));
+        using var stream = entry.Open();
+        using var buffer = new MemoryStream();
+        stream.CopyTo(buffer);
+        return buffer.ToArray();
     }
 }

--- a/benchmarks/docxdiff-stress/Corpus.cs
+++ b/benchmarks/docxdiff-stress/Corpus.cs
@@ -9,6 +9,11 @@
 //
 // Failures are digested too. An exception is a result like any other, and a change in WHICH
 // exception a malformed document produces is exactly the kind of regression worth catching.
+//
+// The unit of comparison is an Observation, not a digest string: a product call has more
+// observable effects than its return value, and the #616 regression lived on one of the others
+// (see Observation.cs). Adding a channel is one field on that record rather than a new sink[...]
+// family per mode.
 
 using System.Collections.Concurrent;
 using System.IO.Compression;
@@ -36,28 +41,30 @@ internal static class Corpus
         Console.WriteLine($"threads : {threads}");
         Console.WriteLine();
 
-        var digests = new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
+        var digests = new ConcurrentDictionary<string, Observation>(StringComparer.Ordinal);
         var done = 0;
         var errors = 0;
 
-        Parallel.ForEach(files, new ParallelOptions { MaxDegreeOfParallelism = threads }, path =>
+        Parallel.ForEach(files.Select((f, i) => (Path: f, Index: i)),
+            new ParallelOptions { MaxDegreeOfParallelism = threads }, item =>
         {
+            var (path, index) = item;
             var name = Path.GetRelativePath(root, path).Replace('\\', '/');
             byte[] bytes;
             try { bytes = File.ReadAllBytes(path); }
-            catch (Exception ex) { digests[$"{name}#read"] = $"READ-FAIL {ex.GetType().Name}"; return; }
+            catch (Exception ex) { digests[$"{name}#read"] = Observation.NotRun($"READ-FAIL {ex.GetType().Name}"); return; }
 
             // Every document is compared against a deterministically edited copy of itself, and
             // against itself unchanged (the identical-bytes fast paths).
             byte[] edited;
             try { edited = CorpusVariant.Edit(bytes); }
-            catch (Exception ex) { digests[$"{name}#variant"] = $"VARIANT-FAIL {ex.GetType().Name}"; edited = bytes; }
+            catch (Exception ex) { digests[$"{name}#variant"] = Observation.NotRun($"VARIANT-FAIL {ex.GetType().Name}"); edited = bytes; }
 
             // A second, differently-offset edit of the same document: the N-way case needs two
             // reviewers who actually disagree, or the merger never has a competitor to order.
             byte[] editedAlt;
             try { editedAlt = CorpusVariant.Edit(bytes, offset: 2); }
-            catch (Exception ex) { digests[$"{name}#variant-alt"] = $"VARIANT-FAIL {ex.GetType().Name}"; editedAlt = bytes; }
+            catch (Exception ex) { digests[$"{name}#variant-alt"] = Observation.NotRun($"VARIANT-FAIL {ex.GetType().Name}"); editedAlt = bytes; }
 
             var left = new WmlDocument("left.docx", bytes);
             var right = new WmlDocument("right.docx", edited);
@@ -79,13 +86,11 @@ internal static class Corpus
             Record(digests, name, "preserve", left, right,
                 new DocxDiffSettings { PreserveInputRevisions = true });
 
-            // The compatibility pre-flight is a SECOND observable output, and it is invisible to
-            // everything above: with it disengaged, a product that never runs it and a product that
-            // runs it and finds nothing produce the same digest. Digest the report itself, so a
-            // shortcut that skips the pre-flight rather than the work shows up as a mismatch — on the
-            // identical pair as well, where a shortcut is most tempting and least observable.
-            RecordPreflight(digests, name, "edited", left, right);
-            RecordPreflight(digests, name, "identical", left, same);
+            // A fifth comparison with ONE non-default setting, rotated per document so the whole
+            // DocxDiffSettings surface gets exercised across the corpus for one extra comparison per
+            // document rather than a combinatorial explosion (issue #624, item 3).
+            var rotated = SettingsRotation.For(index);
+            Record(digests, name, $"rot-{rotated.Name}", left, right, rotated.Settings);
 
             // N-way. The consolidate path has its own reader fan-out, its own merger and its own
             // markup renderer, and NONE of the three products above touches any of them. Two
@@ -98,27 +103,27 @@ internal static class Corpus
         });
 
         foreach (var kv in digests)
-            if (kv.Value.Contains("FAIL", StringComparison.Ordinal)) errors++;
+            if (kv.Value.Result.Contains("FAIL", StringComparison.Ordinal)) errors++;
 
-        var sorted = new SortedDictionary<string, string>(digests, StringComparer.Ordinal);
+        var sorted = new SortedDictionary<string, Observation>(digests, StringComparer.Ordinal);
         File.WriteAllText(outPath, JsonSerializer.Serialize(sorted, new JsonSerializerOptions { WriteIndented = true }));
         Console.WriteLine();
         Console.WriteLine($"{sorted.Count:N0} digests over {files.Count:N0} documents written to {outPath}");
         Console.WriteLine($"({errors:N0} of them record a thrown exception rather than a result — that is expected for");
         Console.WriteLine(" malformed or unsupported fixtures, and a CHANGE in them is still a regression.)");
+        ReportChannelCoverage(sorted);
 
         if (checkPath is null) return 0;
 
-        var expected = JsonSerializer.Deserialize<SortedDictionary<string, string>>(File.ReadAllText(checkPath))!;
+        var expected = JsonSerializer.Deserialize<SortedDictionary<string, Observation>>(File.ReadAllText(checkPath))!;
         var mismatches = 0;
         foreach (var (k, want) in expected)
         {
             if (!sorted.TryGetValue(k, out var got)) { Console.WriteLine($"[parity] MISSING  {k}"); mismatches++; }
-            else if (got != want)
+            else if (got.DifferencesFrom(want) is { Count: > 0 } diffs)
             {
                 Console.WriteLine($"[parity] MISMATCH {k}");
-                Console.WriteLine($"           expected {want}");
-                Console.WriteLine($"           actual   {got}");
+                foreach (var d in diffs) Console.WriteLine($"           {d}");
                 mismatches++;
             }
         }
@@ -136,28 +141,92 @@ internal static class Corpus
         return mismatches == 0 ? 0 : 2;
     }
 
+    // ─── One product call, every channel ─────────────────────────────────
+    //
+    // Each product is run ONCE with a warning-collecting settings clone, with both inputs hashed
+    // around the call. The pre-flight report used to need its own second run of every product;
+    // capturing it from the call under observation is both cheaper and stricter, because it is the
+    // same call that produced the result.
+
     private static void Record(
-        ConcurrentDictionary<string, string> sink, string name, string mode,
+        ConcurrentDictionary<string, Observation> sink, string name, string mode,
         WmlDocument left, WmlDocument right, DocxDiffSettings settings)
     {
-        sink[$"{name}#{mode}/redline"] = Try(() => StableRedlineDigest(DocxDiff.Compare(left, right, settings).DocumentByteArray));
-        sink[$"{name}#{mode}/revisions"] = Try(() =>
+        var products = new (string Key, Func<string> Run)[]
         {
-            var revs = DocxDiff.GetRevisions(left, right, settings);
-            var sb = new StringBuilder().Append(revs.Count).Append('\n');
-            foreach (var r in revs)
-                sb.Append(r.Type).Append('|').Append(r.Author).Append('|').Append(r.Text).Append('|')
-                  .Append(r.LeftAnchor).Append('|').Append(r.RightAnchor).Append('|')
-                  .Append(r.MoveGroupId).Append('|').Append(r.IsMoveSource).Append('\n');
-            return Sha(Encoding.UTF8.GetBytes(sb.ToString()));
-        });
-        sink[$"{name}#{mode}/editscript"] = Try(() => Sha(Encoding.UTF8.GetBytes(DocxDiff.GetEditScriptJson(left, right, settings))));
+            ("redline", () => StableRedlineDigest(DocxDiff.Compare(left, right, settings).DocumentByteArray)),
+            ("revisions", () => RevisionsDigest(DocxDiff.GetRevisions(left, right, settings))),
+            ("editscript", () => Sha(Encoding.UTF8.GetBytes(DocxDiff.GetEditScriptJson(left, right, settings)))),
+        };
+
+        // The pre-flight report is captured from the SAME call that produces the result, rather than
+        // from a second run of every product: cheaper, and stricter, because a product that stops
+        // running the pre-flight records "none" against the very call whose result it produced.
+        var reported = new List<string>();
+        var callerCallback = settings.OnCompatibilityWarning;
+        settings.OnCompatibilityWarning = report =>
+        {
+            foreach (var w in report.Warnings.OrderBy(w => w.Feature.Id, StringComparer.Ordinal))
+                reported.Add(w.Feature.Id);
+            callerCallback?.Invoke(report);
+        };
+
+        var observed = new Dictionary<string, (string Result, string Warnings, string Mutation)>(
+            StringComparer.Ordinal);
+        foreach (var (key, run) in products)
+        {
+            reported.Clear();
+            var beforeLeft = Sha(left.DocumentByteArray);
+            var beforeRight = Sha(right.DocumentByteArray);
+            var result = Try(run);
+            var mutation = MutationOf(beforeLeft, beforeRight, left, right);
+            observed[key] = (result, reported.Count == 0 ? "none" : string.Join(",", reported), mutation);
+        }
+
+        // Order independence. Since #616 the statics delegate to a memoized DocxDiffComparison that
+        // shares ONE provenance-bearing IR snapshot across every product, so asking for the products
+        // in a different order traverses different shared state. Ask a single comparison for all
+        // three in REVERSE order and require each to match what the static produced — which also
+        // pins CreateComparison(l, r, s) against DocxDiff.Compare(l, r, s), a class the corpus
+        // otherwise never reaches because it only ever calls the statics.
+        //
+        // Each product is wrapped separately rather than the block as a whole, so a settings mode
+        // that makes every product throw (ThrowOnCompatibilityWarning) compares one recorded failure
+        // against the other and reads as stable, which it is.
+        DocxDiffComparison? comparison = null;
+        string? createFailure = null;
+        try { comparison = DocxDiff.CreateComparison(left, right, settings); }
+        catch (Exception ex) { createFailure = $"FAIL {ex.GetType().Name}: {Truncate(ex.Message)}"; }
+
+        string ViaComparison(Func<string> run) => createFailure ?? Try(run);
+        var reorderedScript = ViaComparison(() => Sha(Encoding.UTF8.GetBytes(comparison!.GetEditScriptJson())));
+        var reorderedRevisions = ViaComparison(() => RevisionsDigest(comparison!.GetRevisions()));
+        var reorderedRedline = ViaComparison(() =>
+            StableRedlineDigest(comparison!.ToRedline().DocumentByteArray));
+
+        string Variance(string key, string reordered) =>
+            observed[key].Result == reordered ? "stable" : $"reordered {reordered}";
+
+        Store(sink, name, mode, "redline", observed["redline"], Variance("redline", reorderedRedline));
+        Store(sink, name, mode, "revisions", observed["revisions"], Variance("revisions", reorderedRevisions));
+        Store(sink, name, mode, "editscript", observed["editscript"], Variance("editscript", reorderedScript));
     }
+
+    private static void Store(
+        ConcurrentDictionary<string, Observation> sink, string name, string mode, string product,
+        (string Result, string Warnings, string Mutation) observed, string variance) =>
+        sink[$"{name}#{mode}/{product}"] = new Observation
+        {
+            Result = observed.Result,
+            Warnings = observed.Warnings,
+            InputMutation = observed.Mutation,
+            OrderVariance = variance,
+        };
 
     // Every consolidate product, over two reviewers off one base. Reviewer order is significant to
     // conflict reporting, so the digest carries the authors and the per-revision order as emitted.
     private static void RecordConsolidate(
-        ConcurrentDictionary<string, string> sink, string name,
+        ConcurrentDictionary<string, Observation> sink, string name,
         WmlDocument baseDoc, WmlDocument reviewerA, WmlDocument reviewerB)
     {
         var reviewers = new List<DocxDiffReviewer>
@@ -167,65 +236,100 @@ internal static class Corpus
         };
         var settings = new DocxDiffConsolidateSettings();
 
-        sink[$"{name}#consolidate/redline"] = Try(() =>
-            StableRedlineDigest(DocxDiff.Consolidate(baseDoc, reviewers, settings).DocumentByteArray));
-
-        sink[$"{name}#consolidate/revisions"] = Try(() =>
+        var products = new (string Key, Func<string> Run)[]
         {
-            var revs = DocxDiff.GetConsolidatedRevisions(baseDoc, reviewers, settings);
-            var sb = new StringBuilder().Append(revs.Count).Append('\n');
-            foreach (var r in revs)
-                sb.Append(r.Type).Append('|').Append(r.Author).Append('|').Append(r.Text).Append('|')
-                  .Append(r.LeftAnchor).Append('|').Append(r.RightAnchor).Append('|')
-                  .Append(r.ConflictId).Append('\n');
-            return Sha(Encoding.UTF8.GetBytes(sb.ToString()));
-        });
-
-        sink[$"{name}#consolidate/conflicts"] = Try(() =>
-        {
-            var conflicts = DocxDiff.GetConflicts(baseDoc, reviewers, settings);
-            var sb = new StringBuilder().Append(conflicts.Count).Append('\n');
-            foreach (var c in conflicts)
-                sb.Append(c.Id).Append('|').Append(c.BaseAnchor).Append('|')
-                  .Append(c.TokenStart).Append('-').Append(c.TokenEnd).Append('|')
-                  .Append(string.Join(",", c.Competitors.Select(x => x.Author + "=" + x.ResultText))).Append('\n');
-            return Sha(Encoding.UTF8.GetBytes(sb.ToString()));
-        });
-
-        sink[$"{name}#consolidate/editscript"] = Try(() =>
-            Sha(Encoding.UTF8.GetBytes(DocxDiff.GetConsolidatedEditScriptJson(baseDoc, reviewers, settings))));
-    }
-
-    // The compatibility report each product hands back through the OnCompatibilityWarning callback,
-    // digested per product. A product that stops running the pre-flight records "none" where it used
-    // to record a report — which no output digest can tell you, because the output was already right.
-    private static void RecordPreflight(
-        ConcurrentDictionary<string, string> sink, string name, string mode,
-        WmlDocument left, WmlDocument right)
-    {
-        foreach (var (product, run) in PreflightProducts(left, right))
-            sink[$"{name}#{mode}/preflight-{product}"] = Try(() =>
+            ("redline", () =>
+                StableRedlineDigest(DocxDiff.Consolidate(baseDoc, reviewers, settings).DocumentByteArray)),
+            ("revisions", () =>
             {
-                var seen = new List<string>();
-                var settings = new DocxDiffSettings
-                {
-                    OnCompatibilityWarning = report =>
-                    {
-                        foreach (var w in report.Warnings.OrderBy(w => w.Feature.Id, StringComparer.Ordinal))
-                            seen.Add(w.Feature.Id);
-                    },
-                };
-                run(settings);
-                return seen.Count == 0 ? "none" : string.Join(",", seen);
-            });
+                var revs = DocxDiff.GetConsolidatedRevisions(baseDoc, reviewers, settings);
+                var sb = new StringBuilder().Append(revs.Count).Append('\n');
+                foreach (var r in revs)
+                    sb.Append(r.Type).Append('|').Append(r.Author).Append('|').Append(r.Text).Append('|')
+                      .Append(r.LeftAnchor).Append('|').Append(r.RightAnchor).Append('|')
+                      .Append(r.ConflictId).Append('\n');
+                return Sha(Encoding.UTF8.GetBytes(sb.ToString()));
+            }),
+            ("conflicts", () =>
+            {
+                var conflicts = DocxDiff.GetConflicts(baseDoc, reviewers, settings);
+                var sb = new StringBuilder().Append(conflicts.Count).Append('\n');
+                foreach (var c in conflicts)
+                    sb.Append(c.Id).Append('|').Append(c.BaseAnchor).Append('|')
+                      .Append(c.TokenStart).Append('-').Append(c.TokenEnd).Append('|')
+                      .Append(string.Join(",", c.Competitors.Select(x => x.Author + "=" + x.ResultText))).Append('\n');
+                return Sha(Encoding.UTF8.GetBytes(sb.ToString()));
+            }),
+            ("editscript", () =>
+                Sha(Encoding.UTF8.GetBytes(DocxDiff.GetConsolidatedEditScriptJson(baseDoc, reviewers, settings)))),
+        };
+
+        foreach (var (key, run) in products)
+        {
+            var beforeBase = Sha(baseDoc.DocumentByteArray);
+            var beforeA = Sha(reviewerA.DocumentByteArray);
+            var beforeB = Sha(reviewerB.DocumentByteArray);
+            var result = Try(run);
+            var moved = new List<string>();
+            if (Sha(baseDoc.DocumentByteArray) != beforeBase) moved.Add("base");
+            if (Sha(reviewerA.DocumentByteArray) != beforeA) moved.Add("reviewerA");
+            if (Sha(reviewerB.DocumentByteArray) != beforeB) moved.Add("reviewerB");
+
+            sink[$"{name}#consolidate/{key}"] = new Observation
+            {
+                Result = result,
+                // The consolidate settings type carries no compatibility callback, so this channel
+                // is not observable here. Recorded honestly rather than as a misleading "none".
+                Warnings = "n/a",
+                InputMutation = moved.Count == 0 ? "clean" : "MUTATED " + string.Join("+", moved),
+                // GetConflicts / GetConsolidatedRevisions / Consolidate are independent statics with
+                // no shared memoized snapshot between them, so there is no request order to vary.
+                OrderVariance = "n/a",
+            };
+        }
     }
 
-    private static IEnumerable<(string Product, Action<DocxDiffSettings> Run)> PreflightProducts(
-        WmlDocument left, WmlDocument right)
+    /// <summary><c>clean</c>, or which side's bytes the call moved. <c>IrReader.Read</c> promises
+    /// "the caller's DocumentByteArray is left byte-for-byte unchanged" and <c>PreAccept</c> promises
+    /// "the input is untouched"; nothing verified either, and sharing one parsed snapshot across
+    /// stages is exactly the direction that ends in mutating a caller's bytes.</summary>
+    private static string MutationOf(string beforeLeft, string beforeRight, WmlDocument left, WmlDocument right)
     {
-        yield return ("redline", s => DocxDiff.Compare(left, right, s));
-        yield return ("revisions", s => DocxDiff.GetRevisions(left, right, s));
-        yield return ("editscript", s => DocxDiff.GetEditScriptJson(left, right, s));
+        var moved = new List<string>();
+        if (Sha(left.DocumentByteArray) != beforeLeft) moved.Add("left");
+        if (Sha(right.DocumentByteArray) != beforeRight) moved.Add("right");
+        return moved.Count == 0 ? "clean" : "MUTATED " + string.Join("+", moved);
+    }
+
+    private static string RevisionsDigest(IReadOnlyList<DocxDiffRevision> revs)
+    {
+        var sb = new StringBuilder().Append(revs.Count).Append('\n');
+        foreach (var r in revs)
+            sb.Append(r.Type).Append('|').Append(r.Author).Append('|').Append(r.Text).Append('|')
+              .Append(r.LeftAnchor).Append('|').Append(r.RightAnchor).Append('|')
+              .Append(r.MoveGroupId).Append('|').Append(r.IsMoveSource).Append('\n');
+        return Sha(Encoding.UTF8.GetBytes(sb.ToString()));
+    }
+
+    /// <summary>How many observations record a non-default value on each channel. A channel that is
+    /// never anything but its default across the whole corpus is coverage nobody should count.</summary>
+    private static void ReportChannelCoverage(SortedDictionary<string, Observation> observations)
+    {
+        int warnings = 0, mutations = 0, variances = 0, warningsObservable = 0, varianceObservable = 0;
+        foreach (var o in observations.Values)
+        {
+            if (o.Warnings is not ("n/a" or "none")) warnings++;
+            if (o.Warnings != "n/a") warningsObservable++;
+            if (o.InputMutation.StartsWith("MUTATED", StringComparison.Ordinal)) mutations++;
+            if (o.OrderVariance != "n/a") varianceObservable++;
+            if (o.OrderVariance is not ("n/a" or "stable")) variances++;
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("channel coverage (non-default of observable):");
+        Console.WriteLine($"  warnings       {warnings,6:N0} / {warningsObservable,6:N0}");
+        Console.WriteLine($"  inputMutation  {mutations,6:N0} / {observations.Count,6:N0}");
+        Console.WriteLine($"  orderVariance  {variances,6:N0} / {varianceObservable,6:N0}");
     }
 
     // A thrown exception is a recorded outcome, not a crash: the type and message are digested so a
@@ -244,24 +348,11 @@ internal static class Corpus
 
     private static string Sha(byte[] b) => Convert.ToHexString(SHA256.HashData(b));
 
-    // Media and diagram parts imported into a redline are named "P" + a fresh GUID, and the
-    // relationships pointing at them get ids of "R" + a fresh GUID. Two runs of the SAME comparison
-    // on the SAME build therefore emit packages that differ in those part names, in the relationship
-    // ids and targets, and in the r:embed/r:id references in the story parts — while the bytes they
-    // hold are identical. That is a real defect, but a PRE-EXISTING one:
-    // origin/main disagrees with itself on exactly the documents this affects. Digesting raw package
-    // bytes would therefore report 161 differences per run and drown any genuine regression on the
-    // 54 media-bearing documents in the corpus.
-    //
-    // So the redline is digested rename-invariantly: every generated part name is folded to a
-    // placeholder, in entry names AND inside XML content, and entries are hashed in canonical-name
-    // order. Content still has to match exactly — this hides only the naming churn, so a genuine
-    // change to any part's bytes, to the set of parts, or to which content sits under which
-    // canonical name still shows up as a mismatch.
-    // "P<32 hex>" for a generated part name, "R<32 hex>" for a generated relationship id.
-    private static readonly System.Text.RegularExpressions.Regex GeneratedPartName =
-        new("[PR][0-9a-f]{32}", System.Text.RegularExpressions.RegexOptions.Compiled);
-
+    // The redline package is digested entry by entry, exactly as produced. Generated part names used
+    // to be folded to a placeholder first, because #621 meant a redline that imported or created a
+    // part emitted a fresh GUID per run and origin/main disagreed with itself. #623 fixed that, so
+    // the fold now only makes the harness less sensitive -- and its "[PR][0-9a-f]{32}" pattern would
+    // also fold a legitimate token of that shape out of XML content.
     private static string StableRedlineDigest(byte[] package)
     {
         var entries = new SortedDictionary<string, string>(StringComparer.Ordinal);
@@ -273,20 +364,7 @@ internal static class Corpus
                 using var stream = entry.Open();
                 using var buffer = new MemoryStream();
                 stream.CopyTo(buffer);
-                var content = buffer.ToArray();
-
-                var canonicalName = GeneratedPartName.Replace(entry.FullName, "@");
-                var isXml = entry.FullName.EndsWith(".xml", StringComparison.OrdinalIgnoreCase)
-                         || entry.FullName.EndsWith(".rels", StringComparison.OrdinalIgnoreCase);
-                var digest = isXml
-                    ? Sha(Encoding.UTF8.GetBytes(GeneratedPartName.Replace(Encoding.UTF8.GetString(content), "@")))
-                    : Sha(content);
-
-                // Two parts can fold to one canonical name (P<guid1>.jpeg and P<guid2>.jpeg). Their
-                // content digests are combined in sorted order so the fold stays order-independent.
-                entries[canonicalName] = entries.TryGetValue(canonicalName, out var existing)
-                    ? string.Join(",", new[] { existing, digest }.OrderBy(x => x, StringComparer.Ordinal))
-                    : digest;
+                entries[entry.FullName] = Sha(buffer.ToArray());
             }
         }
 

--- a/benchmarks/docxdiff-stress/Observation.cs
+++ b/benchmarks/docxdiff-stress/Observation.cs
@@ -1,0 +1,64 @@
+// One observation of one product on one document: everything the harness can see about that call,
+// not just what the call returned.
+//
+// The differential used to digest the return value and nothing else, which is why the #616
+// regression -- a fast path that skipped the compatibility pre-flight -- passed all 8,136 digests
+// while genuinely changing behaviour. For two byte-identical documents "no revisions" is the right
+// answer before and after; the return value never moved. The defect was on a channel nothing
+// watched.
+//
+// Making the unit a record with one field per channel is the structural fix. Adding a channel is
+// one field on one type, applied to every product and every document at once, rather than a new
+// sink[...] family that someone has to remember to wire into each mode.
+
+namespace Docxodus.Stress;
+
+/// <summary>Everything observed about one product call. Every field is a digest or a short literal,
+/// so a mismatch names the channel that moved rather than just saying "the digest changed".</summary>
+internal readonly record struct Observation
+{
+    /// <summary>The return value's digest, or <c>FAIL &lt;Type&gt;: &lt;message&gt;</c>. A thrown
+    /// exception is an outcome like any other: a build that throws something different, or stops
+    /// throwing, is a regression.</summary>
+    public required string Result { get; init; }
+
+    /// <summary>The compatibility pre-flight's feature ids for this call, or <c>none</c>. Captured
+    /// from the same call that produced <see cref="Result"/>, so a product that stops running the
+    /// pre-flight records <c>none</c> where it used to record a report.</summary>
+    public required string Warnings { get; init; }
+
+    /// <summary>Whether the call left its inputs byte-for-byte unchanged: <c>clean</c>, or which
+    /// side's bytes moved. <c>IrReader.Read</c> and <c>PreAccept</c> both promise this in prose and
+    /// nothing verified it.</summary>
+    public required string InputMutation { get; init; }
+
+    /// <summary>Whether the product agrees with itself when the engine is reached a different way:
+    /// <c>stable</c>, or a description of the disagreement. Guards the shared memoized snapshot
+    /// <c>DocxDiffComparison</c> introduced.</summary>
+    public required string OrderVariance { get; init; }
+
+    public static Observation NotRun(string reason) => new()
+    {
+        Result = reason,
+        Warnings = "n/a",
+        InputMutation = "n/a",
+        OrderVariance = "n/a",
+    };
+
+    /// <summary>Field-by-field difference against a recorded observation, or an empty list.</summary>
+    public IReadOnlyList<string> DifferencesFrom(Observation expected)
+    {
+        var diffs = new List<string>();
+        void Check(string channel, string want, string got)
+        {
+            if (!string.Equals(want, got, StringComparison.Ordinal))
+                diffs.Add($"{channel}: expected {want} / actual {got}");
+        }
+
+        Check("result", expected.Result, Result);
+        Check("warnings", expected.Warnings, Warnings);
+        Check("inputMutation", expected.InputMutation, InputMutation);
+        Check("orderVariance", expected.OrderVariance, OrderVariance);
+        return diffs;
+    }
+}

--- a/benchmarks/docxdiff-stress/README.md
+++ b/benchmarks/docxdiff-stress/README.md
@@ -75,28 +75,68 @@ Against `TestFiles/` each document contributes:
   (redline, consolidated revision list, conflicts, consolidated edit script). The consolidate path
   has its own reader fan-out, merger and markup renderer; not one of the pairwise products touches
   any of them, so without this the whole N-way half of the engine sits outside the differential;
-- **two pre-flight digests per pairwise product** (edited and identical), recording the
-  compatibility warnings each product reports. Output digests cannot see this: a product that stops
-  running the pre-flight and a product that runs it and finds nothing produce identical output. The
-  identical-bytes shortcuts are where that gap is most tempting, so they are digested too.
+- **one rotated comparison** — the edited variant again with exactly ONE `DocxDiffSettings`
+  property moved off its default, chosen by `document index mod N`. The surface is twenty
+  properties and a cross-product of them explodes, so each is exercised on roughly `678/N`
+  documents for one extra comparison per document rather than twenty.
 
-That is **678 documents → 22,374 digests**, roughly 15 minutes on four threads.
-
-A thrown exception is digested too, as `FAIL <Type>: <message>`. Malformed and unsupported
+A thrown exception is recorded too, as `FAIL <Type>: <message>`. Malformed and unsupported
 fixtures are expected to throw; a change in **which** exception they throw is still a regression.
 
-### The redline digest is rename-invariant, and why
+### The unit is an observation, not a digest
 
-Media and diagram parts imported into a redline are named `P` + a fresh GUID, and the
-relationships pointing at them get ids of `R` + a fresh GUID. **`DocxDiff.Compare` is therefore
-not byte-deterministic on any document whose redline imports media**, contradicting
-`DocxDiffSettings.Deterministic`. This is pre-existing — `origin/main` disagrees with itself on
-exactly those documents — and it affects 54 of the 678 fixtures here. Digesting raw package bytes
-reports 161 differences on every run and would drown a real regression in noise.
+A product call has more observable effects than its return value, and that is not a detail — it is
+where the #616 regression lived. That change added a fast path returning an empty revision list for
+byte-identical documents, and skipped the compatibility pre-flight on the way. For two identical
+documents "no revisions" is the correct answer before and after, so **the return value never moved
+and all 8,136 digests agreed, correctly**. The harness was not broken and it was not unlucky: it
+answered the question it was built to answer, and the defect was somewhere else.
 
-So the redline is digested with those generated names folded to a placeholder, in entry names and
-inside XML content, with entries hashed in canonical-name order. Content still has to match
-exactly: this hides the naming churn and nothing else. See #621.
+So the recorded unit is a record with one field per channel, and adding a channel is one field on
+one type applied to every product and every document at once:
+
+| Channel | Records | Default |
+|---|---|---|
+| `Result` | the return value's digest, or `FAIL <Type>: <message>` | — |
+| `Warnings` | the compatibility pre-flight's feature ids **for that same call** | `none` |
+| `InputMutation` | which side's bytes the call moved | `clean` |
+| `OrderVariance` | whether the memoized `DocxDiffComparison` agrees with the static | `stable` |
+
+`Warnings` closes the #616 hole directly: a product that stops running the pre-flight records
+`none` where it used to record a report, which no output digest can tell you because the output was
+already right. It is captured from the call under observation rather than from a second run of every
+product, which is both cheaper and stricter.
+
+`InputMutation` exists because `IrReader.Read` documents *"the caller's `DocumentByteArray` is left
+byte-for-byte unchanged"* and `PreAccept` promises *"the input is untouched"*, and nothing verified
+either — while the engine moves toward sharing one parsed snapshot across stages, which is exactly
+the direction that ends in mutating a caller's bytes.
+
+`OrderVariance` guards a risk #616 created. Each static used to recompute from scratch; now they
+delegate to a `DocxDiffComparison` that memoizes one provenance-bearing IR snapshot and shares it
+across every product, so `GetRevisions()` then `ToRedline()` traverses different shared state than
+the reverse order. Each observation asks a single comparison for all three products in **reverse**
+order and requires each to match what the static produced — which also pins
+`CreateComparison(l, r, s)` against `DocxDiff.Compare(l, r, s)`, a class corpus mode otherwise never
+reaches, since it only ever calls the statics.
+
+Every run prints how many observations record a **non-default** value per channel. A channel that
+is never anything but its default across the whole corpus is coverage nobody should count.
+
+### What a differential cannot do
+
+**It validates change, not correctness.** The baseline comes from `main`. A behaviour that was
+already wrong on `main` agrees with itself and prints `[parity] OK`. Digests catch drift; only
+assertions catch violation — which is why the unit tests matter more than any digest column.
+
+And one class is invisible to every harness: a **leaked resource**. `IrReader.Read` once
+constructed its `OpenXmlMemoryStreamDocument` before the `try`, so handing it an `.xlsx` leaked the
+open package that the previous `using` disposed. No digest, in any harness, can see that. Nor can
+tooling: `CA2000` was measured against the exact leak shape and **does not fire** at default
+`AnalysisMode`, at `Recommended`, at `All`, or with `dotnet_diagnostic.CA2000.severity = warning`
+set explicitly. Turning on broad CA analysis is separately a non-starter — `AllEnabledByDefault` on
+`Docxodus.csproj` produces thousands of warnings, almost entirely legacy noise. That class needs a
+targeted test per known throw path, and someone to notice the path exists.
 
 ### Confirm the harness can actually fail
 
@@ -104,18 +144,23 @@ An always-green check is worthless, so verify it detects a change before trustin
 perturbation is not enough**, because the three products are sensitive to different halves of the
 pipeline — a control that moves two of them can leave the third completely unexercised:
 
-| Perturbation | redline | revisions | editscript | preflight |
+| Perturbation | redline | revisions | editscript | `Warnings` |
 |---|---|---|---|---|
 | drop the `w:t` skip in `UnidHelper.ContentSignature` | **0%** | 82% | 84% | 0% |
 | swap the snapshots handed to `IrMarkupRenderer.Render` | **64%** | 0% | 0% | 0% |
 | skip the pre-flight on the identical-bytes shortcut | **0%** | **0%** | **0%** | fires |
+
+The same applies to the two newer channels, and both were verified the same way: mutating an input
+inside a product call moves `InputMutation` on 200 of 760 observations, and making one comparison
+product disagree with its static moves `OrderVariance` on 400 of 600. A channel that has never been
+seen to fire is a channel nobody should trust.
 
 The split is not an accident, and it is worth understanding before trusting any column.
 Unids feed block anchors, so corrupting a content signature shows up all over the edit script and
 the revision list — but the markup renderer strips `PtOpenXml.Unid` on the way out, so the
 rendered package is byte-identical and the redline digest never moves. Conversely the hand-off
 only affects rendering: the script and revisions were already computed, so they are untouched
-while the redline scrambles. And the third row is why the pre-flight column exists at all: a
+while the redline scrambles. And the third row is why the `Warnings` channel exists at all: a
 product that stops warning still returns the right answer, so **every output digest stays green**
 while a documented behaviour is gone. Run all of them, or you are validating part of the harness.
 

--- a/benchmarks/docxdiff-stress/SettingsRotation.cs
+++ b/benchmarks/docxdiff-stress/SettingsRotation.cs
@@ -1,0 +1,65 @@
+// Round-robin over the DocxDiffSettings surface (issue #624, item 3).
+//
+// The matrix used to sample four settings combinations out of a surface of twenty properties, and
+// the #616 regression sat behind one of the sixteen that were never set: the harness DOES digest a
+// thrown exception, so had ThrowOnCompatibilityWarning=true appeared anywhere in the matrix, the
+// existing code would have caught it. That is the more dangerous of the two failure modes -- the
+// channel IS observed, but no input ever puts the code in a state where it differs, so the harness
+// looks like it has you covered.
+//
+// A cross-product of twenty properties explodes. A rotation does not: document i also runs with
+// setting (i mod N) varied from its default, so every setting is exercised on roughly
+// documents/N of the corpus for ONE extra comparison per document rather than twenty.
+
+using System.Globalization;
+using Docxodus;
+
+namespace Docxodus.Stress;
+
+internal static class SettingsRotation
+{
+    /// <summary>
+    /// Each entry names one non-default setting and builds a settings object carrying only that
+    /// deviation, so a mismatch on a rotated observation names the setting responsible.
+    /// <para>
+    /// <c>Deterministic = false</c> is deliberately NOT here. It is a real setting and it is not
+    /// covered, but by construction it makes two comparisons of the same inputs emit different
+    /// bytes — which is what the differential exists to detect, so including it would make the
+    /// harness disagree with itself on every run and drown genuine regressions. A setting whose
+    /// whole purpose is to defeat reproducibility cannot be covered by a reproducibility check.
+    /// </para>
+    /// </summary>
+    private static readonly (string Name, Func<DocxDiffSettings> Build)[] Variations =
+    {
+        // The one that would have caught #616: it turns a compatibility report into a thrown
+        // exception, which the harness records as an outcome like any other.
+        ("throw-on-compat", () => new DocxDiffSettings { ThrowOnCompatibilityWarning = true }),
+        ("case-insensitive", () => new DocxDiffSettings { CaseInsensitive = true }),
+        ("no-space-conflation", () => new DocxDiffSettings { ConflateBreakingAndNonbreakingSpaces = false }),
+        ("no-moves", () => new DocxDiffSettings { DetectMoves = false }),
+        ("loose-moves", () => new DocxDiffSettings { MoveSimilarityThreshold = 0.5, MoveMinimumWordCount = 1 }),
+        ("coarse-revisions", () => new DocxDiffSettings
+        {
+            RevisionGranularity = DocxDiffRevisionGranularity.WmlComparerCompatible,
+        }),
+        ("full-format", () => new DocxDiffSettings { FormatComparison = DocxDiffFormatComparison.Full }),
+        ("normalize-authors", () => new DocxDiffSettings { NormalizeRevisionAuthors = true }),
+        ("no-header-footer", () => new DocxDiffSettings { CompareHeadersFooters = false }),
+        ("no-block-format", () => new DocxDiffSettings { TrackBlockFormatChanges = false }),
+        ("no-cross-paragraph", () => new DocxDiffSettings { CrossParagraphTokenDiff = false }),
+        ("author-and-date", () => new DocxDiffSettings
+        {
+            AuthorForRevisions = "Rotation",
+            DateTimeForRevisions = "2020-01-01T00:00:00Z",
+        }),
+        ("invariant-culture", () => new DocxDiffSettings { Culture = CultureInfo.InvariantCulture }),
+    };
+
+    public static int Count => Variations.Length;
+
+    public static (string Name, DocxDiffSettings Settings) For(int documentIndex)
+    {
+        var (name, build) = Variations[((documentIndex % Count) + Count) % Count];
+        return (name, build());
+    }
+}


### PR DESCRIPTION
Closes #624. Items 1, 2, 3, 4 and 5 from the issue.

## The problem, restated

The #616 regression passed **all 8,136 digests, correctly**. That is the fact worth sitting with. A fast path returned an empty revision list for byte-identical documents and skipped the compatibility pre-flight on the way; for two identical documents "no revisions" is the right answer before and after, so the return value never moved. The harness was not broken and it was not unlucky — it answered the question it was built to answer, and the defect was on a channel nothing watched.

## 1. The observation record

The digest unit is now `Observation`, one field per channel:

| Channel | Records | Default |
|---|---|---|
| `Result` | the return value's digest, or `FAIL <Type>: <message>` | — |
| `Warnings` | the compatibility pre-flight's feature ids **for that same call** | `none` |
| `InputMutation` | which side's bytes the call moved | `clean` |
| `OrderVariance` | whether the memoized `DocxDiffComparison` agrees with the static | `stable` |

Adding a channel is now one field on one type, applied to every product and every document at once. It also makes a failure legible — the parity output names the channel instead of saying the digest changed:

```
[parity] MISMATCH CA/CA001-Plain-COMPARE-CA001-Plain-Mod.docx#edited/redline
           result: expected 584774F6… / actual DBA08ABC…
```

The pre-flight moved from six extra product runs per document into a field captured from the call under observation — cheaper, and stricter, because it is now the same call that produced the result. **Verified result-neutral**, since attaching a callback where there was none is a change to the call under test: running 40 documents with and without it, `Result` differs on **0 of 760** observations.

## 2. The two channels current work most threatens

**Input immutability.** `IrReader.Read` documents *"the caller's `DocumentByteArray` is left byte-for-byte unchanged"* and `PreAccept` promises *"the input is untouched"*. Nothing verified either, while #616 moved the engine toward sharing one parsed snapshot across stages and #617 proposes going further — exactly the direction that ends in mutating a caller's bytes. Both inputs are hashed around every call.

**Product-order independence.** Each static used to recompute from scratch; since #616 they delegate to a `DocxDiffComparison` that memoizes one provenance-bearing IR snapshot and shares it across products, so `GetRevisions()` then `ToRedline()` traverses different shared state than the reverse. Each observation asks one comparison for all three products in **reverse** order and requires each to match the static — which also pins `CreateComparison(l, r, s)` against `DocxDiff.Compare(l, r, s)`, a class corpus mode never reached because it only calls the statics.

Both are `0` across all 678 documents, which is the right answer and is *not* evidence the channels work. So each was broken deliberately: mutating an input inside a product call moves `InputMutation` on **200 of 760** observations, and making one comparison product disagree with its static moves `OrderVariance` on **400 of 600**. Every run now prints the non-default count per channel, because a channel that has never been seen to fire is coverage nobody should count.

## 3. The settings rotation

Twenty properties, four sampled. Not a cross-product — document *i* also runs with setting *i mod N* moved off its default, so each is exercised on ~48 documents for **one extra comparison per document**. First in the rotation is `ThrowOnCompatibilityWarning`, which is the one that would have caught #616 outright: the harness already digests exceptions, so the mechanism existed and only the input was missing.

The issue flagged this as the item with a real wall-clock bill (~15 → ~19 min). At this corpus's measured runtime that does not hold: a full run is about **5 minutes on 8 threads**, and the rotation adds one comparison to a document that already does thirteen. The digest count actually **falls**, 14,916 → 12,882, because folding the pre-flight into the observation removes 4,068 separate entries while the rotation adds 2,034.

`Deterministic = false` is deliberately **not** in the rotation, and the omission is documented rather than silent: it is a real setting and it is not covered, but by construction it makes two comparisons of the same inputs emit different bytes. Including it made the harness disagree with itself on every run — found by trying it, not by reasoning about it.

## 4. The rename fold is gone

`StableRedlineDigest` folded generated part names (`P` + GUID) and relationship ids (`R` + GUID) to a placeholder before hashing, because #621 meant `Compare` emitted fresh names every run and `main` disagreed with itself on 54 documents. **#623 fixed that**, so the fold was only making the harness less sensitive — and its `[PR][0-9a-f]{32}` pattern would fold a legitimate token of that shape out of XML content too.

Removed, and validated the way it needs to be validated — the same build, run twice, before trusting any re-baseline:

```
[parity] OK - all 12,882 digests identical across 678 documents
```

The README section "The redline digest is rename-invariant, and why" and its `See #621` go with it.

## 5. The class no harness can see

The issue's own conclusion is that leaked resources need tests, not tooling, and records the measured negative: `CA2000` does not fire on the shape `IrReader.Read` used to leak, at any `AnalysisMode`. I did not add instrumentation to chase it — a mutable static counter in `PtOpenXmlDocument.cs` would be a new global in shared legacy code that CI cannot validate. **Disposal is not observable from outside, and this PR does not pretend otherwise.** What is assertable is the contract the throw path owes its caller, and that is what `Read_SpreadsheetPackage_RefusesWithoutTouchingTheInputOrTheNextRead` asserts: the documented refusal, the caller's bytes unchanged, and a good document still readable afterwards, repeated so a per-call leak would have to accumulate.

Getting there turned up something worth recording: `WmlDocument`'s byte-array constructors reject a spreadsheet up front, but its `MemoryStream` constructors **do not validate at all**. That is the door this reaches the reader through, and it is the real route to the path #622 fixed.

## Also recorded

The README gains "What a differential cannot do", which states the limit plainly: **a differential validates change, not correctness.** The baseline comes from `main`, so a behaviour already wrong on `main` agrees with itself and prints `[parity] OK`. Digests catch drift; only assertions catch violation.

Full suite: 4189 passed, 0 failed, 3 skipped. The harness is out of solution, so no warning baseline moves.