### PR TITLE
test: wire the corpus differential's consolidate rows into every observation channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,24 @@ All notable changes to this project will be documented in this file.
   All four now run the same gate.
 
 ### Changed
+- **The corpus differential's consolidate rows now observe their calls (#632).** The N-way half of
+  the differential recorded its warnings and order-variance channels as `n/a` on two premises that
+  were both false when they were written down: that the consolidate settings type carries no
+  compatibility callback (it composes `DocxDiffSettings`, so `settings.Diff` carries the
+  subscription like any other), and that the four consolidate statics share no memoized state (since
+  `DocxDiff.CreateConsolidation` they each delegate to a single-use consolidation whose caller-held
+  form shares one read/merge across every product). The first false premise is what let the #629 gap
+  — three of the four N-way entry points never running the compatibility pre-flight — hide behind
+  thousands of rows that looked as though the question had been asked and answered.
+  `RecordConsolidate` is now a structural mirror of the pairwise recorder: warnings captured from
+  the same call that produced each result, and every product re-asked of one caller-held
+  consolidation in reverse order — which also pins `CreateConsolidation` against the statics, a
+  class corpus mode otherwise never reached. The settings rotation extends to the N-way path: each
+  document also consolidates with one non-default setting, the pairwise variations wrapped in a
+  consolidate settings object plus the two conflict-resolution policies that exist only there. The
+  audit the issue asked for found no third silent gap: every in-process entry point taking a
+  `DocxDiffSettings` (directly or composed) runs the pre-flight, and the wire transports uniformly
+  do not expose the gate at all rather than dropping it silently.
 - **The corpus differential observes a product call, not just what it returned.** The #616
   regression — a fast path that skipped the compatibility pre-flight — passed all 8,136 digests
   correctly, because for two byte-identical documents "no revisions" is the right answer before and

--- a/benchmarks/docxdiff-stress/Corpus.cs
+++ b/benchmarks/docxdiff-stress/Corpus.cs
@@ -96,7 +96,16 @@ internal static class Corpus
             // markup renderer, and NONE of the three products above touches any of them. Two
             // reviewers off the same base is the smallest shape that exercises reviewer ordering and
             // conflict competitor order.
-            RecordConsolidate(digests, name, left, right, alt);
+            RecordConsolidate(digests, name, "consolidate", left, right, alt,
+                new DocxDiffConsolidateSettings());
+
+            // And the N-way rotation (issue #632): the same one-non-default-setting argument as the
+            // fifth pairwise comparison, applied to the composed settings surface — the pairwise
+            // variations wrapped in a consolidate settings object, plus the conflict-resolution
+            // policies that exist only there.
+            var consolidateRotation = SettingsRotation.ForConsolidate(index);
+            RecordConsolidate(digests, name, $"consolidate-rot-{consolidateRotation.Name}",
+                left, right, alt, consolidateRotation.Settings);
 
             var n = Interlocked.Increment(ref done);
             if (n % 50 == 0) Console.WriteLine($"  {n,5}/{files.Count} ...");
@@ -225,47 +234,52 @@ internal static class Corpus
 
     // Every consolidate product, over two reviewers off one base. Reviewer order is significant to
     // conflict reporting, so the digest carries the authors and the per-revision order as emitted.
+    //
+    // This is a structural mirror of Record. It used to record Warnings and OrderVariance as "n/a"
+    // on two premises that were both false by the time they were written down (issue #632): the
+    // consolidate settings type COMPOSES DocxDiffSettings rather than inheriting it, so
+    // settings.Diff carries the compatibility subscription like any other; and since #617 the four
+    // statics each delegate to a single-use DocxDiffConsolidation, whose caller-held form shares
+    // one memoized read/merge across every product in whatever order the caller asks. The first
+    // false premise is what let the #629 gap — three of the four N-way entry points never ran the
+    // pre-flight — hide behind thousands of rows that looked as though the question had been asked
+    // and answered.
     private static void RecordConsolidate(
-        ConcurrentDictionary<string, Observation> sink, string name,
-        WmlDocument baseDoc, WmlDocument reviewerA, WmlDocument reviewerB)
+        ConcurrentDictionary<string, Observation> sink, string name, string mode,
+        WmlDocument baseDoc, WmlDocument reviewerA, WmlDocument reviewerB,
+        DocxDiffConsolidateSettings settings)
     {
         var reviewers = new List<DocxDiffReviewer>
         {
             new() { Author = "Reviewer A", Document = reviewerA },
             new() { Author = "Reviewer B", Document = reviewerB },
         };
-        var settings = new DocxDiffConsolidateSettings();
 
         var products = new (string Key, Func<string> Run)[]
         {
             ("redline", () =>
                 StableRedlineDigest(DocxDiff.Consolidate(baseDoc, reviewers, settings).DocumentByteArray)),
             ("revisions", () =>
-            {
-                var revs = DocxDiff.GetConsolidatedRevisions(baseDoc, reviewers, settings);
-                var sb = new StringBuilder().Append(revs.Count).Append('\n');
-                foreach (var r in revs)
-                    sb.Append(r.Type).Append('|').Append(r.Author).Append('|').Append(r.Text).Append('|')
-                      .Append(r.LeftAnchor).Append('|').Append(r.RightAnchor).Append('|')
-                      .Append(r.ConflictId).Append('\n');
-                return Sha(Encoding.UTF8.GetBytes(sb.ToString()));
-            }),
-            ("conflicts", () =>
-            {
-                var conflicts = DocxDiff.GetConflicts(baseDoc, reviewers, settings);
-                var sb = new StringBuilder().Append(conflicts.Count).Append('\n');
-                foreach (var c in conflicts)
-                    sb.Append(c.Id).Append('|').Append(c.BaseAnchor).Append('|')
-                      .Append(c.TokenStart).Append('-').Append(c.TokenEnd).Append('|')
-                      .Append(string.Join(",", c.Competitors.Select(x => x.Author + "=" + x.ResultText))).Append('\n');
-                return Sha(Encoding.UTF8.GetBytes(sb.ToString()));
-            }),
+                ConsolidatedRevisionsDigest(DocxDiff.GetConsolidatedRevisions(baseDoc, reviewers, settings))),
+            ("conflicts", () => ConflictsDigest(DocxDiff.GetConflicts(baseDoc, reviewers, settings))),
             ("editscript", () =>
                 Sha(Encoding.UTF8.GetBytes(DocxDiff.GetConsolidatedEditScriptJson(baseDoc, reviewers, settings)))),
         };
 
+        var reported = new List<string>();
+        var callerCallback = settings.Diff.OnCompatibilityWarning;
+        settings.Diff.OnCompatibilityWarning = report =>
+        {
+            foreach (var w in report.Warnings.OrderBy(w => w.Feature.Id, StringComparer.Ordinal))
+                reported.Add(w.Feature.Id);
+            callerCallback?.Invoke(report);
+        };
+
+        var observed = new Dictionary<string, (string Result, string Warnings, string Mutation)>(
+            StringComparer.Ordinal);
         foreach (var (key, run) in products)
         {
+            reported.Clear();
             var beforeBase = Sha(baseDoc.DocumentByteArray);
             var beforeA = Sha(reviewerA.DocumentByteArray);
             var beforeB = Sha(reviewerB.DocumentByteArray);
@@ -274,19 +288,54 @@ internal static class Corpus
             if (Sha(baseDoc.DocumentByteArray) != beforeBase) moved.Add("base");
             if (Sha(reviewerA.DocumentByteArray) != beforeA) moved.Add("reviewerA");
             if (Sha(reviewerB.DocumentByteArray) != beforeB) moved.Add("reviewerB");
-
-            sink[$"{name}#consolidate/{key}"] = new Observation
-            {
-                Result = result,
-                // The consolidate settings type carries no compatibility callback, so this channel
-                // is not observable here. Recorded honestly rather than as a misleading "none".
-                Warnings = "n/a",
-                InputMutation = moved.Count == 0 ? "clean" : "MUTATED " + string.Join("+", moved),
-                // GetConflicts / GetConsolidatedRevisions / Consolidate are independent statics with
-                // no shared memoized snapshot between them, so there is no request order to vary.
-                OrderVariance = "n/a",
-            };
+            observed[key] = (result, reported.Count == 0 ? "none" : string.Join(",", reported),
+                moved.Count == 0 ? "clean" : "MUTATED " + string.Join("+", moved));
         }
+
+        // Order independence, N-way: ask a single caller-held consolidation for all four products in
+        // REVERSE order and require each to match what its static produced — which also pins
+        // CreateConsolidation against the statics, a class corpus mode otherwise never reaches.
+        DocxDiffConsolidation? consolidation = null;
+        string? createFailure = null;
+        try { consolidation = DocxDiff.CreateConsolidation(baseDoc, reviewers, settings); }
+        catch (Exception ex) { createFailure = $"FAIL {ex.GetType().Name}: {Truncate(ex.Message)}"; }
+
+        string ViaConsolidation(Func<string> run) => createFailure ?? Try(run);
+        var reorderedScript = ViaConsolidation(() =>
+            Sha(Encoding.UTF8.GetBytes(consolidation!.GetConsolidatedEditScriptJson())));
+        var reorderedConflicts = ViaConsolidation(() => ConflictsDigest(consolidation!.GetConflicts()));
+        var reorderedRevisions = ViaConsolidation(() =>
+            ConsolidatedRevisionsDigest(consolidation!.GetConsolidatedRevisions()));
+        var reorderedRedline = ViaConsolidation(() =>
+            StableRedlineDigest(consolidation!.Consolidate().DocumentByteArray));
+
+        string Variance(string key, string reordered) =>
+            observed[key].Result == reordered ? "stable" : $"reordered {reordered}";
+
+        Store(sink, name, mode, "redline", observed["redline"], Variance("redline", reorderedRedline));
+        Store(sink, name, mode, "revisions", observed["revisions"], Variance("revisions", reorderedRevisions));
+        Store(sink, name, mode, "conflicts", observed["conflicts"], Variance("conflicts", reorderedConflicts));
+        Store(sink, name, mode, "editscript", observed["editscript"], Variance("editscript", reorderedScript));
+    }
+
+    private static string ConsolidatedRevisionsDigest(IReadOnlyList<DocxDiffConsolidatedRevision> revs)
+    {
+        var sb = new StringBuilder().Append(revs.Count).Append('\n');
+        foreach (var r in revs)
+            sb.Append(r.Type).Append('|').Append(r.Author).Append('|').Append(r.Text).Append('|')
+              .Append(r.LeftAnchor).Append('|').Append(r.RightAnchor).Append('|')
+              .Append(r.ConflictId).Append('\n');
+        return Sha(Encoding.UTF8.GetBytes(sb.ToString()));
+    }
+
+    private static string ConflictsDigest(IReadOnlyList<DocxDiffConflict> conflicts)
+    {
+        var sb = new StringBuilder().Append(conflicts.Count).Append('\n');
+        foreach (var c in conflicts)
+            sb.Append(c.Id).Append('|').Append(c.BaseAnchor).Append('|')
+              .Append(c.TokenStart).Append('-').Append(c.TokenEnd).Append('|')
+              .Append(string.Join(",", c.Competitors.Select(x => x.Author + "=" + x.ResultText))).Append('\n');
+        return Sha(Encoding.UTF8.GetBytes(sb.ToString()));
     }
 
     /// <summary><c>clean</c>, or which side's bytes the call moved. <c>IrReader.Read</c> promises

--- a/benchmarks/docxdiff-stress/README.md
+++ b/benchmarks/docxdiff-stress/README.md
@@ -78,7 +78,11 @@ Against `TestFiles/` each document contributes:
 - **one rotated comparison** — the edited variant again with exactly ONE `DocxDiffSettings`
   property moved off its default, chosen by `document index mod N`. The surface is twenty
   properties and a cross-product of them explodes, so each is exercised on roughly `678/N`
-  documents for one extra comparison per document rather than twenty.
+  documents for one extra comparison per document rather than twenty;
+- **one rotated consolidate** (issue #632) — the same argument applied to the N-way surface:
+  the pairwise variations wrapped in a `DocxDiffConsolidateSettings` (which COMPOSES
+  `DocxDiffSettings`, so every wrapped variation is reachable on this path too), extended with
+  the two conflict-resolution policies that exist only there.
 
 A thrown exception is recorded too, as `FAIL <Type>: <message>`. Malformed and unsupported
 fixtures are expected to throw; a change in **which** exception they throw is still a regression.
@@ -154,6 +158,20 @@ The same applies to the two newer channels, and both were verified the same way:
 inside a product call moves `InputMutation` on 200 of 760 observations, and making one comparison
 product disagree with its static moves `OrderVariance` on 400 of 600. A channel that has never been
 seen to fire is a channel nobody should trust.
+
+The consolidate rows are the cautionary tale (issue #632). They recorded `Warnings` and
+`OrderVariance` as `n/a` on two premises that were both false when written down — the consolidate
+settings type COMPOSES `DocxDiffSettings`, so `settings.Diff` carries the compatibility
+subscription like any other, and since #617 the four statics each delegate to a single-use
+`DocxDiffConsolidation` whose caller-held form shares one memoized read/merge across products.
+That inert channel is what let the #629 gap — three of the four N-way entry points never running
+the pre-flight — hide behind thousands of rows that looked as though the question had been asked
+and answered. Both channels are wired now, and the fire drill was repeated for the N-way half:
+disabling the consolidate pre-flight moves 1,832 of 15,594 observations — every consolidate row
+that records a real warning (916 default-mode + 916 rotated) — where the pre-change harness
+recorded zero. 56 of those also move on the RESULT channel: the rotated `throw-on-compat`
+consolidate stops throwing, so the rotation catches the same defect a second, independent way,
+exactly as it would have caught #629.
 
 The split is not an accident, and it is worth understanding before trusting any column.
 Unids feed block anchors, so corrupting a content signature shows up all over the edit script and

--- a/benchmarks/docxdiff-stress/SettingsRotation.cs
+++ b/benchmarks/docxdiff-stress/SettingsRotation.cs
@@ -55,11 +55,44 @@ internal static class SettingsRotation
         ("invariant-culture", () => new DocxDiffSettings { Culture = CultureInfo.InvariantCulture }),
     };
 
+    /// <summary>
+    /// The consolidate-only deviations: <see cref="DocxDiffConsolidateSettings.ConflictResolution"/>
+    /// is the one setting that exists on the composed type and not on the pairwise surface.
+    /// </summary>
+    private static readonly (string Name, ConflictResolution Policy)[] ConflictPolicies =
+    {
+        ("first-reviewer-wins", ConflictResolution.FirstReviewerWins),
+        ("stack-all", ConflictResolution.StackAll),
+    };
+
     public static int Count => Variations.Length;
 
     public static (string Name, DocxDiffSettings Settings) For(int documentIndex)
     {
         var (name, build) = Variations[((documentIndex % Count) + Count) % Count];
         return (name, build());
+    }
+
+    /// <summary>
+    /// The N-way rotation (issue #632). <see cref="DocxDiffConsolidateSettings"/> COMPOSES
+    /// <see cref="DocxDiffSettings"/> rather than inheriting it, so every pairwise variation is
+    /// reachable on the consolidate path by wrapping — the rotation that knows how to wrap is
+    /// shared rather than duplicated — and the wheel is extended with the conflict-resolution
+    /// policies that only exist there. The two lists have different lengths, so a document's
+    /// consolidate variation drifts against its pairwise one across the corpus instead of always
+    /// pairing the same two.
+    /// </summary>
+    public static (string Name, DocxDiffConsolidateSettings Settings) ForConsolidate(int documentIndex)
+    {
+        var total = Variations.Length + ConflictPolicies.Length;
+        var i = ((documentIndex % total) + total) % total;
+        if (i < Variations.Length)
+        {
+            var (name, build) = Variations[i];
+            return (name, new DocxDiffConsolidateSettings { Diff = build() });
+        }
+
+        var (policyName, policy) = ConflictPolicies[i - Variations.Length];
+        return (policyName, new DocxDiffConsolidateSettings { ConflictResolution = policy });
     }
 }


### PR DESCRIPTION
Closes #632

## What this fixes

The corpus differential records an `Observation` per product call — result, compatibility
warnings, input mutation, product-order variance — so that a defect on a channel other than the
return value still shows up. The N-way consolidate rows, however, recorded `Warnings: "n/a"` with
a comment claiming "the consolidate settings type carries no compatibility callback". That comment
was factually wrong: `DocxDiffConsolidateSettings` composes `DocxDiffSettings` via its `Diff`
property, which carries `OnCompatibilityWarning` like any other. The channel was observable all
along; it was switched off on a false premise — and that inert channel is exactly what let the
#629 defect (three of the four N-way entry points silently skipping the compatibility pre-flight)
go undetected by a harness that had just grown a `Warnings` channel expressly to catch that class
of defect.

The neighbouring `OrderVariance: "n/a"` sat on a second false premise from the same commit: that
the consolidate statics are "independent statics with no shared memoized snapshot". Since #617
they each delegate to a single-use `DocxDiffConsolidation`, and a caller-held
`DocxDiff.CreateConsolidation` shares one memoized read/merge across every product in whatever
order the caller asks — the same risk shape the pairwise `OrderVariance` channel exists to guard.
Fixing the quoted comment while leaving its twin would repeat the mistake this issue is about.

## The change

`RecordConsolidate` is now a structural mirror of the pairwise `Record`:

- **Warnings** are captured from the same call that produced each result, through
  `settings.Diff.OnCompatibilityWarning`, exactly as `Record` does.
- **OrderVariance** asks a single caller-held `DocxDiff.CreateConsolidation` for all four products
  in reverse order and requires each to match what its static produced — which also pins
  `CreateConsolidation` against the statics, a class corpus mode otherwise never reached.
- **The settings rotation extends to the N-way path** (`SettingsRotation.ForConsolidate`): each
  document also consolidates with exactly one non-default setting — the pairwise variations
  wrapped in a `DocxDiffConsolidateSettings`, plus the two `ConflictResolution` policies that
  exist only on the composed type. `throw-on-compat` is included via the wrapped pairwise list,
  the rotation entry that would have caught #629 the same way it would have caught #616.

## Verification

All measured on `TestFiles/` (678 documents, 15,594 observations after the change):

- **The channel reports plausible values**: consolidate rows record real compatibility warnings on
  916 of 2,712 default-mode observations (33.8%) — the same neighbourhood as the pairwise rows
  (3,429 of 10,170, 33.7%), which is the sanity check the issue proposed. All consolidate rows
  report `OrderVariance: stable` and `InputMutation: clean`.
- **Determinism**: two runs of the same build produce all 15,594 observations identical
  (`[parity] OK`).
- **Observing is result-neutral**: the pre-flight only runs when something subscribes, so
  attaching the capture callback makes it run where it previously no-opped. Probed directly on a
  warning-bearing fixture (`WC067-Textbox-Image.docx`): the callback fires on all four consolidate
  products and every product's output is byte-identical to the unobserved call.
- **The channel can actually fire** (the fire drill the other channels got in #628): disabling the
  consolidate pre-flight in `DocxDiffConsolidation` and re-running against the baseline moves
  1,832 of 15,594 observations — every consolidate row that records a real warning (916
  default-mode + 916 rotated), and nothing else. 56 of those also move on the **result** channel:
  the rotated `throw-on-compat` consolidate stops throwing, so the new rotation catches the same
  defect a second, independent way. The pre-change harness records zero movement for this
  perturbation. The perturbation was then reverted.

## The audit the issue asked for

"Which other public entry points take a settings object with an opt-in channel and quietly do not
honour it?" — answer: none found.

- The only gate-style opt-in channels on any public settings type are
  `DocxDiffSettings.OnCompatibilityWarning`/`ThrowOnCompatibilityWarning`
  (`WmlComparerSettings.LogCallback` is a debug log hook on the frozen engine, not a gate).
- Every in-process entry point that receives a `DocxDiffSettings` runs the pre-flight: the three
  pairwise statics and both `CreateComparison` overloads route through `DocxDiffComparison`, whose
  snapshot constructor is the single funnel (#622 covered the identical-bytes shortcuts via
  `RunGatedPreflight`); the four consolidate statics and `CreateConsolidation` route through
  `DocxDiffConsolidation` (#629); `DocxCompare` takes the legacy `WmlComparerSettings`, which has
  no compatibility channel to drop.
- The wire transports (npm, python, MCP, WASM via `DocxDiffOps.ParseSettings`) uniformly do not
  expose the gate at all — no transport declares it and the parser does not read it, so nothing is
  silently dropped. `ThrowOnCompatibilityWarning` would be wire-representable if a transport ever
  wants it; that is a capability question, not a silent defect, and is deliberately out of scope
  here.
