### PR TITLE
fix: accepting a redline takes a wholly-deleted note's definition with it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,20 @@ All notable changes to this project will be documented in this file.
   candidate that fails carries its error instead of products rather than failing the batch.
 
 ### Fixed
+- **Accepting a redline through the stateless path now takes a wholly-deleted note's definition
+  with it (#631).** The redline itself distinguishes the two reference-less-husk cases: a note
+  definition the counterpart *kept* passes through the comparison unmarked, while one the
+  counterpart *deleted* arrives with every block deletion-marked, so accepting strips it bare.
+  `RevisionProcessor.AcceptRevisions` — the path npm, python, MCP and WASM all reach through
+  `docxDiffAcceptRevisions` — kept such a stripped-bare definition anyway, shipping a note the
+  counterpart had deleted and disagreeing with `DocxSession.AcceptAllRevisions` about the same
+  redline. The note-lifecycle rule now runs on the accept side with a blockless guard: a
+  definition this accept both orphaned and emptied goes (Word's own tracked deletions carry the
+  same fully-deletion-marked shape — `RP050-Deleted-Footnote` is authored exactly like this),
+  while a counterpart's own husk keeps its unmarked content and stays — so `Accept(Compare(l, r)) ≡ r` holds for both note stores and no policy setting is
+  needed. The same rule now also applies wherever an accepted view of a document is computed (the
+  comparison engines' input flattens), where a husk emptied of its content was riding into
+  redlines as debris.
 - **Authoring a footnote or endnote while recording tracked changes now produces a redline that
   can actually be rejected (#614).** `InsertFootnote`/`InsertEndnote` ignored
   `TrackedChangeMode.RenderInline` entirely: the citation and the note definition were both

--- a/Docxodus.Tests/DocxSessionRevisionTests.cs
+++ b/Docxodus.Tests/DocxSessionRevisionTests.cs
@@ -1324,11 +1324,14 @@ public class DocxSessionRevisionTests
     }
 
     /// <summary>
-    /// …and the accept side deliberately does NOT apply it. Accept reproduces the counterpart
-    /// document as the comparison saw it — <c>Accept(Compare(l, r)) == r</c> — so a counterpart that
-    /// carries a reference-less note definition keeps it. <see cref="DocxSession"/>'s own resolve
-    /// paths (DS418) apply the rule in both directions because an editor is authoring a document
-    /// rather than inverting a comparison; this test pins that the two contracts stay distinct.
+    /// …and the accept side's blockless guard is what protects a counterpart's own husk. Accept
+    /// reproduces the counterpart document as the comparison saw it — <c>Accept(Compare(l, r)) == r</c>
+    /// — and a counterpart that carries a reference-less note definition keeps it: the comparison
+    /// reconciles the two equal definitions, so the redline's definition is unmarked, survives the
+    /// accept with its content, and is never pruned (issue #631 prunes only a definition the accept
+    /// itself emptied — see DS432). <see cref="DocxSession"/>'s own resolve paths (DS418) apply the
+    /// rule unguarded in both directions because an editor is authoring a document rather than
+    /// inverting a comparison; this test pins that the two contracts stay distinct.
     /// </summary>
     [Fact]
     public void DS430_StatelessAccept_PreservesACounterpartsOwnOrphanedNote()
@@ -1355,6 +1358,49 @@ public class DocxSessionRevisionTests
 
         Assert.Equal(1, UserNoteCount(counterpart, "footnote"));
         Assert.Equal(1, UserNoteCount(accepted, "footnote"));
+    }
+
+    /// <summary>
+    /// The accept-side completion of the rule (issue #631). The redline itself distinguishes the
+    /// two husk cases: a note the COUNTERPART kept (DS430) passes through with its content
+    /// unmarked, while a note the counterpart deleted arrives with every block deletion-marked —
+    /// so accepting empties it. A definition this accept both orphaned and emptied is the redline
+    /// saying "this whole note is deleted", and accepting must take the definition with it, or the
+    /// stateless path ships a note the counterpart deleted and disagrees with
+    /// <see cref="DocxSession.AcceptAllRevisions"/> on the same redline.
+    /// </summary>
+    [Fact]
+    public void DS432_StatelessAccept_TakesAWhollyDeletedNoteWithItsCitation()
+    {
+        var left = File.ReadAllBytes(Path.Combine("../../../../TestFiles/WC", "WC035-Footnote-Before.docx"));
+        var right = File.ReadAllBytes(Path.Combine("../../../../TestFiles/WC", "WC035-Footnote-After.docx"));
+
+        // Compare in the direction that DELETES the note, so accepting must take it out.
+        var deleting = UserNoteCount(left, "footnote") > UserNoteCount(right, "footnote")
+            ? (Baseline: left, Counterpart: right)
+            : (Baseline: right, Counterpart: left);
+        Assert.True(UserNoteCount(deleting.Counterpart, "footnote")
+            < UserNoteCount(deleting.Baseline, "footnote"), "fixture no longer deletes a note");
+
+        var redline = DocxDiff.Compare(
+            new WmlDocument("baseline.docx", deleting.Baseline),
+            new WmlDocument("counterpart.docx", deleting.Counterpart)).DocumentByteArray;
+
+        var accepted = Docxodus.Internal.DocxDiffOps.AcceptRevisions(redline);
+
+        Assert.True(HasNotesPart(accepted, "footnote"), "the notes part itself must survive");
+        Assert.Equal(UserNoteCount(deleting.Counterpart, "footnote"), UserNoteCount(accepted, "footnote"));
+
+        // The two transports must agree about the same redline: the session resolves it to the
+        // same note store the stateless path now produces.
+        using var session = new DocxSession(redline);
+        session.AcceptAllRevisions();
+        Assert.Equal(UserNoteCount(accepted, "footnote"), UserNoteCount(session.Save(), "footnote"));
+
+        // And the inverse still reproduces the baseline: rejecting restores the citation, so the
+        // definition was never orphaned and stays.
+        var rejected = Docxodus.Internal.DocxDiffOps.RejectRevisions(redline);
+        Assert.Equal(UserNoteCount(deleting.Baseline, "footnote"), UserNoteCount(rejected, "footnote"));
     }
 
     /// <summary>

--- a/Docxodus.Tests/DocxSessionRevisionTests.cs
+++ b/Docxodus.Tests/DocxSessionRevisionTests.cs
@@ -1391,8 +1391,10 @@ public class DocxSessionRevisionTests
         Assert.True(HasNotesPart(accepted, "footnote"), "the notes part itself must survive");
         Assert.Equal(UserNoteCount(deleting.Counterpart, "footnote"), UserNoteCount(accepted, "footnote"));
 
-        // The two transports must agree about the same redline: the session resolves it to the
-        // same note store the stateless path now produces.
+        // The two transports must agree about a wholly-deleted note: the session resolves this
+        // redline to the same note store the stateless path now produces. (On the OTHER husk
+        // shape they stay deliberately distinct — DS430's counterpart-kept husk survives the
+        // stateless accept but not the session's unguarded editorial rule, DS418.)
         using var session = new DocxSession(redline);
         session.AcceptAllRevisions();
         Assert.Equal(UserNoteCount(accepted, "footnote"), UserNoteCount(session.Save(), "footnote"));
@@ -1401,6 +1403,35 @@ public class DocxSessionRevisionTests
         // definition was never orphaned and stays.
         var rejected = Docxodus.Internal.DocxDiffOps.RejectRevisions(redline);
         Assert.Equal(UserNoteCount(deleting.Baseline, "footnote"), UserNoteCount(rejected, "footnote"));
+    }
+
+    /// <summary>
+    /// The same rule through the shared accept funnel every other caller reaches too —
+    /// <see cref="RevisionProcessor.AcceptRevisions(WmlDocument)"/> is the single core behind the
+    /// stateless facade, the <c>PreAcceptInputRevisions</c> flatten, <c>IrReader</c>'s revision
+    /// view, <c>WmlComparer</c>'s input flatten and <c>WmlToHtmlConverter</c>'s accept — pinned on
+    /// the Word-authored RP050 fixture. Word marks a tracked note deletion exactly as the engine
+    /// does (every run in <c>w:del</c>, paragraph mark deleted), so accepting strips the
+    /// definition bare and the prune takes it. Word's own accepted oracle keeps a childless
+    /// <c>&lt;w:footnote/&gt;</c> shell instead (see <c>docs/ooxml_corner_cases.md</c>); the shell
+    /// and its absence are the same note store, and removal is the schema-valid form.
+    /// </summary>
+    [Fact]
+    public void DS433_AcceptFunnel_TakesAWordAuthoredNoteDeletionsDefinition()
+    {
+        var source = new WmlDocument(
+            Path.Combine("../../../../TestFiles/RP", "RP050-Deleted-Footnote.docx"));
+        Assert.Equal(1, UserNoteCount(source.DocumentByteArray, "footnote"));
+
+        var accepted = RevisionProcessor.AcceptRevisions(source);
+
+        Assert.True(HasNotesPart(accepted.DocumentByteArray, "footnote"),
+            "the notes part itself must survive");
+        Assert.Equal(0, UserNoteCount(accepted.DocumentByteArray, "footnote"));
+
+        // Rejecting the same document restores the baseline: citation back, definition kept.
+        var rejected = RevisionProcessor.RejectRevisions(source);
+        Assert.Equal(1, UserNoteCount(rejected.DocumentByteArray, "footnote"));
     }
 
     /// <summary>

--- a/Docxodus/Internal/NoteReferenceOps.cs
+++ b/Docxodus/Internal/NoteReferenceOps.cs
@@ -55,7 +55,12 @@ internal static class NoteReferenceOps
     {
         var footnotes = new HashSet<int>();
         var endnotes = new HashSet<int>();
-        if (main is null) return (footnotes, endnotes);
+
+        // No notes parts means nothing a prune could ever remove, and every caller captures these
+        // ids only to prune against them afterwards — skip the package-wide scans instead of
+        // walking the body and every header/footer twice per resolution on note-free documents.
+        if (main is null || (main.FootnotesPart is null && main.EndnotesPart is null))
+            return (footnotes, endnotes);
         foreach (var part in ReferenceHostParts(main))
         {
             var root = part.GetXDocument().Root;
@@ -108,7 +113,14 @@ internal static class NoteReferenceOps
     }
 
     /// <summary>Whether a note definition has no block-level content left (no <c>w:p</c>,
-    /// <c>w:tbl</c> or <c>w:sdt</c> children).</summary>
+    /// <c>w:tbl</c> or <c>w:sdt</c> children). A direct-children check is sufficient HERE — and
+    /// only here — because this runs after <see cref="RevisionProcessor"/>'s accept, whose
+    /// block-content coalescing pass (<c>AcceptDeletedAndMoveFromParagraphMarksTransform</c>,
+    /// applied to every note via <c>BlockLevelContentContainers</c>) promotes block content out of
+    /// wrappers like <c>mc:AlternateContent</c> to direct children. It is deliberately narrower
+    /// than <c>RevisionProcessor.BlockLevelElements</c> and <c>IsBlockContentElement</c>, which
+    /// classify pre-accept trees that still carry revision wrappers; if the accept pipeline ever
+    /// starts leaving a new wrapper shape inside notes, this predicate must learn it too.</summary>
     private static bool IsBlockless(XElement note) =>
         !note.Elements().Any(e =>
             e.Name == W + "p" || e.Name == W + "tbl" || e.Name == W + "sdt");

--- a/Docxodus/Internal/NoteReferenceOps.cs
+++ b/Docxodus/Internal/NoteReferenceOps.cs
@@ -17,8 +17,10 @@ namespace Docxodus.Internal;
 /// Two callers, one rule. <see cref="DocxSession"/> applies it after a structural delete or a
 /// revision resolution (issues #516, #591); <see cref="RevisionProcessor"/> applies it after a
 /// stateless accept/reject, which is the path every non-.NET transport reaches through
-/// <c>DocxDiffOps</c> (issue #614). Both capture <see cref="ReferencedNoteIds"/> before the
-/// mutation and call <see cref="PruneOrphanedNotes"/> after it.
+/// <c>DocxDiffOps</c> (issues #614, #631). Every caller captures <see cref="ReferencedNoteIds"/>
+/// before the mutation and prunes after it — via <see cref="PruneOrphanedNotes"/>, except the
+/// stateless accept, whose <see cref="PruneNotesEmptiedByAccept"/> adds a guard the comparison
+/// contract needs.
 ///
 /// The PART itself always stays. Word never prunes a notes part — the RP050-Deleted-Footnote
 /// oracle keeps its separator-only <c>footnotes.xml</c> after accepting the only note's deletion,
@@ -75,15 +77,41 @@ internal static class NoteReferenceOps
     /// <paramref name="before"/> and now.</summary>
     /// <returns>The removed note elements with their part uri, for removed-anchor reporting.</returns>
     internal static List<(XElement Note, string PartUri)> PruneOrphanedNotes(
-        MainDocumentPart? main, (HashSet<int> Footnotes, HashSet<int> Endnotes) before)
+        MainDocumentPart? main, (HashSet<int> Footnotes, HashSet<int> Endnotes) before) =>
+        Prune(main, before, onlyBlockless: false);
+
+    /// <summary>
+    /// The accept-side variant of the rule (issue #631): remove a note definition whose last
+    /// citation disappeared between <paramref name="before"/> and now AND which is left without
+    /// block content. Accepting can only strip a note bare when every block was deletion-marked —
+    /// an unmarked paragraph survives its runs — so a bare, newly-uncited definition is the
+    /// redline saying "this whole note is deleted", and accepting must take the definition with
+    /// it or the accepted package ships a note the counterpart deleted. The blockless guard is
+    /// what distinguishes that from a counterpart's own reference-less husk: a definition the
+    /// counterpart kept arrives with its content unmarked, keeps that content through the accept,
+    /// and stays — so <c>Accept(Compare(l, r)) ≡ r</c> holds for both note stores.
+    /// </summary>
+    internal static List<(XElement Note, string PartUri)> PruneNotesEmptiedByAccept(
+        MainDocumentPart? main, (HashSet<int> Footnotes, HashSet<int> Endnotes) before) =>
+        Prune(main, before, onlyBlockless: true);
+
+    private static List<(XElement Note, string PartUri)> Prune(
+        MainDocumentPart? main, (HashSet<int> Footnotes, HashSet<int> Endnotes) before,
+        bool onlyBlockless)
     {
         var removed = new List<(XElement, string)>();
         if (main is null) return removed;
         var after = ReferencedNoteIds(main);
-        PruneStory(main.FootnotesPart, W + "footnote", before.Footnotes, after.Footnotes, removed);
-        PruneStory(main.EndnotesPart, W + "endnote", before.Endnotes, after.Endnotes, removed);
+        PruneStory(main.FootnotesPart, W + "footnote", before.Footnotes, after.Footnotes, removed, onlyBlockless);
+        PruneStory(main.EndnotesPart, W + "endnote", before.Endnotes, after.Endnotes, removed, onlyBlockless);
         return removed;
     }
+
+    /// <summary>Whether a note definition has no block-level content left (no <c>w:p</c>,
+    /// <c>w:tbl</c> or <c>w:sdt</c> children).</summary>
+    private static bool IsBlockless(XElement note) =>
+        !note.Elements().Any(e =>
+            e.Name == W + "p" || e.Name == W + "tbl" || e.Name == W + "sdt");
 
     /// <summary>Word's reserved scaffolding notes, which are never citation targets and are never
     /// pruned.</summary>
@@ -95,7 +123,8 @@ internal static class NoteReferenceOps
         XName noteName,
         HashSet<int> referencedBefore,
         HashSet<int> referencedAfter,
-        List<(XElement, string)> removed)
+        List<(XElement, string)> removed,
+        bool onlyBlockless)
     {
         var root = part?.GetXDocument().Root;
         if (part is null || root is null) return;
@@ -108,6 +137,8 @@ internal static class NoteReferenceOps
         {
             if (!int.TryParse((string?)note.Attribute(W + "id"), out var id)
                 || !orphaned.Contains(id) || IsSeparatorNote(note))
+                continue;
+            if (onlyBlockless && !IsBlockless(note))
                 continue;
             note.Remove();
             removed.Add((note, partUri));

--- a/Docxodus/RevisionProcessor.cs
+++ b/Docxodus/RevisionProcessor.cs
@@ -33,19 +33,19 @@ namespace Docxodus
 
         public static void RejectRevisions(WordprocessingDocument doc)
         {
-            // Word's note-lifecycle rule, on the reject side only (issue #614). Rejecting a redline
-            // reproduces the BASELINE, and a note the redline itself introduced has no place there:
-            // its citation came in a w:ins and its definition came with the redline, so dropping the
+            // Word's note-lifecycle rule, reject side (issue #614). Rejecting a redline reproduces
+            // the BASELINE, and a note the redline itself introduced has no place there: its
+            // citation came in a w:ins and its definition came with the redline, so dropping the
             // citation has to drop the definition or the "rejected" package still ships the note.
             //
-            // Accepting deliberately does NOT do this. Accept reproduces the COUNTERPART document as
-            // the comparison saw it, husks included — Accept(Compare(l, r)) == r is the comparison
-            // engine's contract, and a counterpart that carries a reference-less note definition is
-            // entitled to keep it. DocxSession's own resolve paths apply the rule in both directions
-            // because an editor is authoring a document, not inverting a comparison.
+            // The accept side applies the rule with an extra guard — only a definition the accept
+            // also left without block content goes (issue #631, see AcceptRevisions). That guard is
+            // why Accept(Compare(l, r)) == r holds for BOTH husk shapes: a counterpart's own
+            // reference-less definition arrives unmarked, keeps its content, and stays; one the
+            // counterpart deleted arrives deletion-marked, is stripped bare, and goes.
             //
             // The rule and its scoping (only citations THIS operation removed) live in
-            // Internal.NoteReferenceOps, shared with those session paths.
+            // Internal.NoteReferenceOps, shared with DocxSession's resolve paths.
             var citedBefore = Internal.NoteReferenceOps.ReferencedNoteIds(doc.MainDocumentPart);
             RejectRevisionsForPart(doc.MainDocumentPart);
             foreach (var part in doc.MainDocumentPart.HeaderParts)
@@ -1480,6 +1480,20 @@ namespace Docxodus
 
         private static void AcceptRevisions(WordprocessingDocument doc, bool preservePreexistingCleanTableRuns)
         {
+            // Word's note-lifecycle rule, accept side (issue #631). The redline itself tells the two
+            // husk cases apart: a definition the counterpart kept passes through with its content
+            // unmarked and survives the accept intact, while a definition the counterpart deleted
+            // arrives with every block deletion-marked, so accepting strips it bare. A definition
+            // this accept both orphaned and emptied is the redline saying "this whole note is
+            // deleted", and the definition has to go with it or the accepted package ships a note
+            // the counterpart deleted and disagrees with DocxSession.AcceptAllRevisions about the
+            // same redline. (Word's own accepted oracle for RP050 leaves a childless <w:footnote/>
+            // shell behind instead; a childless definition is not a note, and the session's resolve
+            // paths have removed the definition outright since #516 — the stateless path now agrees
+            // with them, which is also the schema-valid form.) The blockless guard is what
+            // keeps Accept(Compare(l, r)) == r true for a counterpart's own reference-less husk
+            // (see NoteReferenceOps.PruneNotesEmptiedByAccept).
+            var citedBefore = Internal.NoteReferenceOps.ReferencedNoteIds(doc.MainDocumentPart);
             AcceptRevisionsForPart(doc.MainDocumentPart, preservePreexistingCleanTableRuns);
             foreach (var part in doc.MainDocumentPart.HeaderParts)
                 AcceptRevisionsForPart(part, preservePreexistingCleanTableRuns);
@@ -1491,6 +1505,8 @@ namespace Docxodus
                 AcceptRevisionsForPart(doc.MainDocumentPart.FootnotesPart, preservePreexistingCleanTableRuns);
             if (doc.MainDocumentPart.StyleDefinitionsPart != null)
                 AcceptRevisionsForStylesDefinitionPart(doc.MainDocumentPart.StyleDefinitionsPart);
+
+            Internal.NoteReferenceOps.PruneNotesEmptiedByAccept(doc.MainDocumentPart, citedBefore);
         }
 
         private static void AcceptRevisionsForStylesDefinitionPart(StyleDefinitionsPart stylesDefinitionsPart)

--- a/Docxodus/RevisionProcessor.cs
+++ b/Docxodus/RevisionProcessor.cs
@@ -33,19 +33,10 @@ namespace Docxodus
 
         public static void RejectRevisions(WordprocessingDocument doc)
         {
-            // Word's note-lifecycle rule, reject side (issue #614). Rejecting a redline reproduces
-            // the BASELINE, and a note the redline itself introduced has no place there: its
-            // citation came in a w:ins and its definition came with the redline, so dropping the
-            // citation has to drop the definition or the "rejected" package still ships the note.
-            //
-            // The accept side applies the rule with an extra guard — only a definition the accept
-            // also left without block content goes (issue #631, see AcceptRevisions). That guard is
-            // why Accept(Compare(l, r)) == r holds for BOTH husk shapes: a counterpart's own
-            // reference-less definition arrives unmarked, keeps its content, and stays; one the
-            // counterpart deleted arrives deletion-marked, is stripped bare, and goes.
-            //
-            // The rule and its scoping (only citations THIS operation removed) live in
-            // Internal.NoteReferenceOps, shared with DocxSession's resolve paths.
+            // Word's note-lifecycle rule, reject side (issue #614): a note the redline introduced
+            // (w:ins citation) has no place in the rejected baseline, so its definition goes with
+            // the citation. Rationale and scoping live with the rule's owner,
+            // Internal.NoteReferenceOps; the accept side applies the guarded variant (issue #631).
             var citedBefore = Internal.NoteReferenceOps.ReferencedNoteIds(doc.MainDocumentPart);
             RejectRevisionsForPart(doc.MainDocumentPart);
             foreach (var part in doc.MainDocumentPart.HeaderParts)
@@ -1480,19 +1471,11 @@ namespace Docxodus
 
         private static void AcceptRevisions(WordprocessingDocument doc, bool preservePreexistingCleanTableRuns)
         {
-            // Word's note-lifecycle rule, accept side (issue #631). The redline itself tells the two
-            // husk cases apart: a definition the counterpart kept passes through with its content
-            // unmarked and survives the accept intact, while a definition the counterpart deleted
-            // arrives with every block deletion-marked, so accepting strips it bare. A definition
-            // this accept both orphaned and emptied is the redline saying "this whole note is
-            // deleted", and the definition has to go with it or the accepted package ships a note
-            // the counterpart deleted and disagrees with DocxSession.AcceptAllRevisions about the
-            // same redline. (Word's own accepted oracle for RP050 leaves a childless <w:footnote/>
-            // shell behind instead; a childless definition is not a note, and the session's resolve
-            // paths have removed the definition outright since #516 — the stateless path now agrees
-            // with them, which is also the schema-valid form.) The blockless guard is what
-            // keeps Accept(Compare(l, r)) == r true for a counterpart's own reference-less husk
-            // (see NoteReferenceOps.PruneNotesEmptiedByAccept).
+            // Word's note-lifecycle rule, accept side (issue #631): a definition this accept both
+            // orphaned and stripped of its blocks is a note the redline wholly deleted, and it goes
+            // with its citation. Why the blockless guard makes this safe for the other husk shape
+            // is documented once, on the rule's owner: Internal.NoteReferenceOps
+            // .PruneNotesEmptiedByAccept.
             var citedBefore = Internal.NoteReferenceOps.ReferencedNoteIds(doc.MainDocumentPart);
             AcceptRevisionsForPart(doc.MainDocumentPart, preservePreexistingCleanTableRuns);
             foreach (var part in doc.MainDocumentPart.HeaderParts)

--- a/docs/architecture/docx_mutation_api.md
+++ b/docs/architecture/docx_mutation_api.md
@@ -1158,10 +1158,19 @@ citation. `DocxSession` applies it after a structural delete or a revision resol
 (issues #516, #591); `RevisionProcessor` applies it on the stateless **reject** path, which is
 what every non-.NET transport reaches through `DocxDiffOps.RejectRevisions`.
 
-The stateless **accept** path deliberately does not apply it. `Accept(Compare(l, r)) ≡ r` is the
-comparison engine's contract, and a counterpart document that carries a reference-less note
-definition is entitled to keep it. `DocxSession`'s own resolve paths apply the rule in both
-directions because an editor is authoring a document rather than inverting a comparison.
+The stateless **accept** path applies it with an extra guard (issue #631): only a definition the
+accept also left without block content goes. The guard exists because `Accept(Compare(l, r)) ≡ r`
+is the comparison engine's contract and the redline itself distinguishes the two husk shapes — a
+reference-less definition the counterpart *kept* passes through the comparison with its content
+unmarked, survives the accept intact, and stays, while a definition the counterpart *deleted*
+arrives with every block deletion-marked, so accepting strips it bare and the prune takes it.
+Word's tracked deletions carry the same fully-marked shape (`RP050-Deleted-Footnote` is authored
+exactly like this), though Word's own accept leaves a childless `<w:footnote/>` shell where we
+remove the definition — the schema-valid form, and what the session has done since #516. Without
+the accept-side
+prune the two transports disagreed about the same redline: `DocxSession.AcceptAllRevisions`
+removed the note (its resolve paths apply the rule in both directions, because an editor is
+authoring a document) while the stateless path shipped a definition the counterpart had deleted.
 
 ### Which mutations record, and which refuse
 

--- a/docs/architecture/docx_mutation_api.md
+++ b/docs/architecture/docx_mutation_api.md
@@ -1168,9 +1168,12 @@ Word's tracked deletions carry the same fully-marked shape (`RP050-Deleted-Footn
 exactly like this), though Word's own accept leaves a childless `<w:footnote/>` shell where we
 remove the definition — the schema-valid form, and what the session has done since #516. Without
 the accept-side
-prune the two transports disagreed about the same redline: `DocxSession.AcceptAllRevisions`
-removed the note (its resolve paths apply the rule in both directions, because an editor is
+prune the two paths disagreed about a wholly-deleted note: `DocxSession.AcceptAllRevisions`
+removed it (its resolve paths apply the rule unguarded in both directions, because an editor is
 authoring a document) while the stateless path shipped a definition the counterpart had deleted.
+On the counterpart-kept husk shape the two contracts remain deliberately distinct — the stateless
+accept preserves the husk to reproduce the counterpart, the session's editorial rule still strips
+it (DS430 vs DS418).
 
 ### Which mutations record, and which refuse
 

--- a/docs/ooxml_corner_cases.md
+++ b/docs/ooxml_corner_cases.md
@@ -378,6 +378,39 @@ This means a body that references footnote id `2` ("See Section 1.2…") with an
 - `tools/diffharness/lo/lo_footnote_check.py` — headless-LibreOffice load + footnote-count/text report (the independent validity backstop).
 - `DocxDiffScenarioTests.Scenario_PreservesFootnoteStructure` — the in-process id↔reference↔text round-trip oracle (asserts at the OOXML id level, immune to LibreOffice's positional quirk).
 
+### Word's Accept of a Tracked Note Deletion Leaves a CHILDLESS `<w:footnote/>` Shell
+
+**Status:** Documented behavior; Docxodus deliberately differs (issue #631)
+**Discovered:** 2026-08-31 (while making the stateless accept reproduce the counterpart's note store)
+**Test File:** `TestFiles/RP/RP050-Deleted-Footnote.docx` + its `-Accepted.docx` oracle
+
+#### The corner case
+
+Word represents a tracked footnote deletion by marking the citation **and the whole definition**:
+every run in the definition sits inside `w:del`, and the paragraph mark carries `w:pPr/w:rPr/w:del`
+(see `RP050-Deleted-Footnote.docx`). But Word's own *accept* of that deletion does not remove the
+definition element — the Word-produced `RP050-Deleted-Footnote-Accepted.docx` oracle keeps a
+childless `<w:footnote w:id="1"/>` next to the separator notes. `CT_FtnEdn` requires at least one
+block-level child, so the shape Word writes is schema-questionable, invisible in Word (nothing
+references it), and — per the positional-re-association entry above — actively dangerous in
+LibreOffice, where a leftover definition shifts every subsequent reference→definition pairing.
+
+#### What Docxodus does
+
+`RevisionProcessor.AcceptRevisions` removes a definition that the accept left both **orphaned**
+(cited before, uncited after) and **blockless** (which can only happen when every block was
+deletion-marked — an unmarked paragraph always survives). That is what `DocxSession`'s resolve
+paths have done since #516, it is the schema-valid form, and it makes `Accept(Compare(l, r)) ≡ r`
+hold for the counterpart's note store. The redline-reversibility sweep (`RRS001`) compares the
+result to Word's oracle semantically, where a childless definition and an absent one are the same
+note store.
+
+#### Relevant code
+
+- `Docxodus/Internal/NoteReferenceOps.cs` (`PruneNotesEmptiedByAccept`, the blockless guard)
+- `Docxodus/RevisionProcessor.cs` (accept-side capture/prune)
+- `DS430`/`DS432` in `DocxSessionRevisionTests.cs` — the two husk shapes and their opposite fates
+
 ### `OpenXmlValidator` Does NOT Resolve Note-Body (note-in-note) References — a validation blind spot
 
 **Status:** Documented gotcha

--- a/docs/ooxml_corner_cases.md
+++ b/docs/ooxml_corner_cases.md
@@ -386,14 +386,37 @@ This means a body that references footnote id `2` ("See Section 1.2…") with an
 
 #### The corner case
 
-Word represents a tracked footnote deletion by marking the citation **and the whole definition**:
-every run in the definition sits inside `w:del`, and the paragraph mark carries `w:pPr/w:rPr/w:del`
-(see `RP050-Deleted-Footnote.docx`). But Word's own *accept* of that deletion does not remove the
-definition element — the Word-produced `RP050-Deleted-Footnote-Accepted.docx` oracle keeps a
-childless `<w:footnote w:id="1"/>` next to the separator notes. `CT_FtnEdn` requires at least one
-block-level child, so the shape Word writes is schema-questionable, invisible in Word (nothing
-references it), and — per the positional-re-association entry above — actively dangerous in
-LibreOffice, where a leftover definition shifts every subsequent reference→definition pairing.
+Word represents a tracked footnote deletion by marking the citation **and the whole definition**.
+Minimal reproducer (the shape `RP050-Deleted-Footnote.docx` carries, trimmed):
+
+```xml
+<!-- word/document.xml: the citation is deleted -->
+<w:del w:author="Eric White"><w:r><w:footnoteReference w:id="1"/></w:r></w:del>
+
+<!-- word/footnotes.xml: every run is deleted AND the paragraph mark is deleted -->
+<w:footnote w:id="1">
+  <w:p>
+    <w:pPr><w:rPr><w:del w:author="Eric White"/></w:rPr></w:pPr>
+    <w:del w:author="Eric White">
+      <w:r><w:footnoteRef/></w:r>
+      <w:r><w:delText>This is a test.</w:delText></w:r>
+    </w:del>
+  </w:p>
+</w:footnote>
+```
+
+Accepting that deletion, per renderer:
+
+| | Accepted `word/footnotes.xml` |
+|---|---|
+| Word (the `RP050-…-Accepted.docx` oracle) | separators + a **childless `<w:footnote w:id="1"/>` shell** |
+| LibreOffice | removes the definition; a leftover shell would shift its positional reference→definition pairing (entry above) |
+| Docxodus (since #631) | separators only — the definition is **removed** |
+| Docxodus (before #631) | separators + the childless shell, matching Word byte-shape but shipping debris |
+
+`CT_FtnEdn` requires at least one block-level child, so the shell Word writes is
+schema-questionable, invisible in Word (nothing references it), and — per the
+positional-re-association entry above — actively dangerous in LibreOffice.
 
 #### What Docxodus does
 
@@ -401,9 +424,10 @@ LibreOffice, where a leftover definition shifts every subsequent reference→def
 (cited before, uncited after) and **blockless** (which can only happen when every block was
 deletion-marked — an unmarked paragraph always survives). That is what `DocxSession`'s resolve
 paths have done since #516, it is the schema-valid form, and it makes `Accept(Compare(l, r)) ≡ r`
-hold for the counterpart's note store. The redline-reversibility sweep (`RRS001`) compares the
-result to Word's oracle semantically, where a childless definition and an absent one are the same
-note store.
+hold for the counterpart's note store. The reversibility sweep (`RRS001`) stays green across the
+divergence — RP050 is pinned `acceptEquivalent: false` there, so the sweep asserts recovery
+through the coarser story-text check rather than modeled-semantic equivalence, and neither a
+childless shell nor its absence contributes story text.
 
 #### Relevant code
 


### PR DESCRIPTION
Closes #631

## The problem

Accepting a redline through the stateless path (`DocxDiffOps.AcceptRevisions`, which is what npm,
python, MCP and WASM all reach) did not reproduce the counterpart's note store. On the
`WC035-Footnote` pair — a real Word-authored document pair where the change deletes the only
footnote — accepting the comparison's redline left **1** footnote definition where the counterpart
has **0**, and `DocxSession.AcceptAllRevisions` on the very same redline produced **0**. Two
transports, same redline, different deliverables.

#625 had deliberately shipped the note-lifecycle rule on the reject side only, because a symmetric
implementation broke the other husk case: a counterpart that *keeps* a reference-less definition
(the shape a naive SDK edit leaves behind) is entitled to keep it through
`Accept(Compare(l, r)) ≡ r`. The issue's open question was whether the redline can even tell the
two cases apart.

## The finding: the redline already tells them apart

It can, and it already does — which makes the issue's option 1 ("represent the note-store
difference in the redline") mostly a matter of *reading* a representation the engine already
writes:

- **Case A — the counterpart kept its husk.** The note differ's reference-correspondence pass
  reconciles the baseline's cited definition with the counterpart's uncited-but-identical one into
  a matched, equal pair (`AppendUnreferencedNotes`), so the definition passes through the redline
  with its content **unmarked**.
- **Case B — the counterpart deleted the note.** The definition pairs with nothing, becomes
  all-`DeleteBlock` ops, and lands in the redline with **every block deletion-marked**: runs inside
  `w:del`, paragraph mark carrying `w:rPr/w:del`.

Accepting therefore treats them differently already: Case A's definition survives with its
content; Case B's is stripped to a childless `<w:footnote w:id=".."/>`. What was missing is the
last step: nothing removed that stripped-bare shell.

## The fix

The note-lifecycle rule (single owner: `Internal/NoteReferenceOps.cs`) gains an accept-side
variant, `PruneNotesEmptiedByAccept`: remove a definition whose last citation this accept removed
**and** which the accept left without block content. The blockless guard is exact — an unmarked
paragraph always survives an accept even when its runs are deleted, so a definition can only come
out bare when every one of its blocks was deletion-marked, i.e. when the redline said "this whole
note is deleted". Word's own tracked deletions carry exactly this shape: `RP050-Deleted-Footnote`
(Word-authored) marks every run of the definition `w:del` and deletes the paragraph mark. One
honest nuance, now recorded in `docs/ooxml_corner_cases.md`: Word's *accept* of that fixture left
a childless `<w:footnote w:id="1"/>` shell in the oracle rather than removing the element. We
remove it — the schema-valid form (`CT_FtnEdn` requires a block child), what the session has done
since #516, and materially safer in LibreOffice, which re-associates references to definitions
positionally and is thrown off by leftover definitions. The reversibility sweep compares against
Word's oracle semantically, where the two forms are the same note store, and stays green.

`RevisionProcessor`'s accept core captures the cited-note ids before the walk and prunes after it,
mirroring what the reject side has done since #614 — same scoping (only citations *this* operation
removed; a pre-existing dangling note is left alone), same whole-package citation scan (a note
still cited from a header survives). Because the rule sits in the shared accept core, every place
an *accepted view* of a document is computed — the stateless accept, `DocxDiff`'s
`PreAcceptInputRevisions` flatten, `IrReader`'s revision view, and `WmlComparer`'s input flatten —
now agrees about what accepting a wholly-deleted note means, instead of leaving a bare husk to
ride into downstream redlines as debris.

No policy setting was added: with the representation read correctly, accept reproduces the
counterpart in both cases and there is no decision left to push onto callers.

## Tests

- **`DS432_StatelessAccept_TakesAWhollyDeletedNoteWithItsCitation`** (new, red before the fix:
  1 note instead of 0): on the WC035 pair compared in the deleting direction, the stateless accept
  now matches the counterpart's note count, agrees with `DocxSession.AcceptAllRevisions` on the
  same redline, and the stateless reject still reproduces the baseline.
- **`DS430_StatelessAccept_PreservesACounterpartsOwnOrphanedNote`** — the Case A pin the issue
  flagged for revisiting — passes unchanged; only its rationale comment was updated. The guard is
  what keeps it true.
- DS418/DS419/DS429/DS431 (the session-side rule, its scoping, the stateless reject, the
  header-citation scan) all pass unchanged.
- Full suite: 4,222 passed, 0 failed, 3 skipped (7m55s).

## Corpus differential

Baseline on a main worktree, `--check` on this branch, 678 documents: **exactly 1 mismatch of
12,882 observations** — `RP/RP050-Deleted-Footnote.docx#preaccept/redline`, on the result channel
only. That is the one corpus fixture whose defining feature is a Word-authored tracked note
deletion: under `PreAcceptInputRevisions` the input flatten's accepted view now drops the emptied
husk instead of letting a childless `<w:footnote/>` ride into the rendered redline as debris. No
other row moved, and every other channel stayed `clean`/`stable`/unchanged.

## Docs

`docs/architecture/docx_mutation_api.md`'s note-lifecycle section now describes the accept-side
guard instead of the old "accept deliberately does not apply it" contract; `CHANGELOG.md` records
the behaviour change under Fixed; `docs/ooxml_corner_cases.md` gains the RP050 finding with its
minimal XML reproducer and a Word / LibreOffice / Docxodus comparison table.

## After adversarial review (second commit)

A multi-verifier review of this diff confirmed one coverage gap and two prose overclaims, all
fixed here, and two *pre-existing* neighbouring defects, filed as #636 rather than bolted on:

- **`DS433_AcceptFunnel_TakesAWordAuthoredNoteDeletionsDefinition`** (new, red on main): every
  accept in the library funnels through one private core — the stateless facade, the
  `PreAcceptInputRevisions` flatten, `IrReader`'s revision view, `WmlComparer`'s input flatten,
  `WmlToHtmlConverter`'s accept — and DS432 pinned only the facade. DS433 pins the funnel itself
  on the Word-authored RP050 fixture (an assertion the existing RP001/RRS001 sweeps were verified
  to be structurally blind to).
- **The transport-agreement claim is scoped to the shape it is true for.** Session and stateless
  accept agree about a wholly-deleted note; on the counterpart-kept husk they remain deliberately
  distinct contracts (DS430 vs DS418), and the docs now say so instead of implying general parity.
- **The corner-case entry's RRS001 explanation was wrong** (RP050 is pinned
  `acceptEquivalent: false` there; recovery is asserted through story text, not modeled-semantic
  equivalence) — corrected, and the entry gains the reproducer/table the house rules require.
- **The rule's rationale now lives once** on `NoteReferenceOps.PruneNotesEmptiedByAccept`
  (`RevisionProcessor`'s two comments shrink to pointers), `IsBlockless` documents why a
  direct-children check is sufficient after accept's coalescing pass, and `ReferencedNoteIds`
  early-outs on documents with no notes parts instead of walking every story twice per resolution.
- **#636** records the two confirmed pre-existing defects: the reject side has the exact mirror
  of this bug but its guard collides with #614's deliberate unmarked-definition choice (needs its
  own design round), and an accept can ship a schema-degenerate *cited* childless note when the
  definition is emptied while its citation survives.
