### PR TITLE
test: give DS468's entry waits room on a starved runner

### DIFF
--- a/Docxodus.Tests/DocxSessionPreviewBatchTests.cs
+++ b/Docxodus.Tests/DocxSessionPreviewBatchTests.cs
@@ -437,7 +437,13 @@ public class DocxSessionPreviewBatchTests
         Task<EditResult>? concurrentTask = null;
         try
         {
-            Assert.True(receiptInspectionEntered.Wait(TimeSpan.FromSeconds(10)),
+            // Reaching the hook needs a thread-pool thread to pick up the Task.Run and complete
+            // a full mutation; on a loaded 2-core CI runner with the suite's heavier comparison
+            // collections executing in parallel, that has been observed to exceed 10 s (issue
+            // #635). The window is not part of the claim — the claim is ORDERING, asserted by the
+            // Assert.False below — so it is generous: the event either fires or the batch is
+            // genuinely wedged, and a wedged batch fails at any timeout.
+            Assert.True(receiptInspectionEntered.Wait(TimeSpan.FromSeconds(60)),
                 "batch did not reach receipt enrichment");
             concurrentTask = Task.Run(() =>
             {
@@ -446,7 +452,7 @@ public class DocxSessionPreviewBatchTests
                     preconditions: null,
                     s => s.ReplaceText(anchors[1], "Concurrent mutation."));
             });
-            Assert.True(concurrentMutationStarted.Wait(TimeSpan.FromSeconds(10)),
+            Assert.True(concurrentMutationStarted.Wait(TimeSpan.FromSeconds(60)),
                 "concurrent mutation task did not start");
             Assert.False(concurrentTask.Wait(TimeSpan.FromSeconds(1)),
                 "concurrent mutation interleaved with batch receipt enrichment");


### PR DESCRIPTION
Closes #635

## What this fixes

`DS468_ReceiptEnrichment_IsSerializedWithConcurrentMutations` failed on PR #633's `build-and-test`
run — a benchmarks-only diff that cannot affect it — with `batch did not reach receipt enrichment`
after 10 s, and passed on immediate rerun. The failure log shows why: the batch runs on
`Task.Run`, and reaching the receipt-enrichment hook requires a thread-pool thread to pick it up
and complete a full `ReplaceText` mutation while xUnit is executing the suite's heavier comparison
collections in parallel on a 2-core runner (an 868 ms `WC003_Compare` case completed *after* the
window expired in the failing run).

## The change

The two *entry* waits (reach the hook; concurrent task started) widen from 10 s to 60 s, with a
comment recording why the window is not part of the claim: the test's actual claim is
**ordering** — the concurrent mutation must not interleave with receipt enrichment — and that is
carried by the 1-second `Assert.False(concurrentTask.Wait(...))`, which stays exactly as it was.
The entry event either fires or the batch is genuinely wedged, and a wedged batch fails at any
timeout, so the wide window costs passing runs nothing.

No CHANGELOG entry: test-infrastructure only, no library behaviour changes.
