### PR TITLE
fix: a recorded note's definition carries insertion markup, and the stateless reject reads it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,8 @@ All notable changes to this project will be documented in this file.
   candidate that fails carries its error instead of products rather than failing the batch.
 
 ### Fixed
-- **Rejecting a redline no longer eats a baseline-owned note the counterpart merely cited, and a
-  session-recorded note's definition now carries insertion markup (#636).** The stateless reject
+- **The stateless reject no longer eats a baseline-owned note the counterpart merely cited, and
+  a session-recorded note's definition now carries insertion markup (#636).** The stateless reject
   pruned every definition its resolution orphaned, unconditionally. That was cover for #614's
   deliberately unmarked definitions — and it made the redline ambiguous: a `w:ins` citation next
   to an unmarked definition is also what a comparison produces when the counterpart cites a husk
@@ -60,9 +60,16 @@ All notable changes to this project will be documented in this file.
   content inserted — what Word writes, and what the diff engine's own redline already carried for
   a wholly-inserted note — and the stateless reject applies the same blockless guard as the
   accept side: a definition the resolution both orphaned and emptied goes, an unmarked husk
-  stays. One compatibility note: a redline saved from a #614-era session (its definition
-  unmarked) now rejects to an orphaned husk through the stateless path instead of losing the
-  note; re-authoring the redline with the current version restores full reversibility.
+  stays. The guard is scaffolding-aware — `WmlComparer`'s renderer re-synthesizes an unmarked
+  `w:footnoteRef` marker run into inserted definitions, and a marker-only paragraph must not
+  shield a rejected note from the prune — and a still-cited note a resolution strips bare stays both cited
+  and bare — the corpus genuinely contains that shape (`WC064-Footnote`), and reproducing it is
+  what the round-trip contracts require. Scope: this is the *stateless* reject; the session's editorial resolves (and
+  delivery-bundle revision policies, which route through them) deliberately keep the unguarded
+  rule, exactly as on the accept side. One compatibility note: a redline saved from a #614-era
+  session (its definition's text unmarked) now rejects to an orphaned husk through the stateless
+  path instead of losing the note; re-authoring the redline with the current version restores
+  full reversibility.
 - **Accepting a redline through the stateless path now takes a wholly-deleted note's definition
   with it (#631).** The redline itself distinguishes the two reference-less-husk cases: a note
   definition the counterpart *kept* passes through the comparison unmarked, while one the
@@ -85,16 +92,17 @@ All notable changes to this project will be documented in this file.
   rejected it — potentially long after the document had left the building. The citation is now
   wrapped in `w:ins`, and the definition follows it: rejecting removes the reference, which leaves
   the note uncited, and the note-lifecycle rule deletes it in the same resolve. Accepting keeps
-  both. The definition carries no revision markup of its own on purpose — a `w:ins` inside it
-  would be a revision with no independently meaningful resolution.
+  both. The definition carried no revision markup of its own at first — a choice #636 (below)
+  revisits: the definition's content now records too, which is what lets the stateless
+  resolutions read the redline instead of compensating with an unconditional prune.
 
   That rule — *a note definition exists exactly as long as something still cites it* — now has one
   owner, `Internal/NoteReferenceOps.cs`, shared by the session's resolve paths (#516, #591) and by
   the stateless `RevisionProcessor` **reject** path, which is what every non-.NET transport reaches
   through `DocxDiffOps.RejectRevisions`; without that the same redline was reversible in-session
-  and not reversible through npm/python/MCP. The stateless **accept** path deliberately does not
-  apply it, because `Accept(Compare(l, r)) ≡ r` is the comparison engine's contract and a
-  counterpart document that carries a reference-less note definition is entitled to keep it.
+  and not reversible through npm/python/MCP. (Since revised: #631 and #636, below, apply the rule on BOTH
+  stateless resolutions with a guard that keeps `Accept(Compare(l, r)) ≡ r` true — a counterpart
+  document's own reference-less note definition still keeps its content and stays.)
   Consolidating the rule also fixed its scope: it asks the whole package who cites a note rather
   than only the body, so a note cited from a running header as well no longer disappears when its
   body citation goes away.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,20 @@ All notable changes to this project will be documented in this file.
   candidate that fails carries its error instead of products rather than failing the batch.
 
 ### Fixed
+- **Rejecting a redline no longer eats a baseline-owned note the counterpart merely cited, and a
+  session-recorded note's definition now carries insertion markup (#636).** The stateless reject
+  pruned every definition its resolution orphaned, unconditionally. That was cover for #614's
+  deliberately unmarked definitions — and it made the redline ambiguous: a `w:ins` citation next
+  to an unmarked definition is also what a comparison produces when the counterpart cites a husk
+  the baseline already owned, and rejecting such a redline deleted the content-bearing definition
+  the baseline was entitled to keep (`Reject(Compare(l, r)) ≠ l`, the exact mirror of #631).
+  `InsertFootnote`/`InsertEndnote` under tracked-change recording now mark the definition's
+  content inserted — what Word writes, and what the diff engine's own redline already carried for
+  a wholly-inserted note — and the stateless reject applies the same blockless guard as the
+  accept side: a definition the resolution both orphaned and emptied goes, an unmarked husk
+  stays. One compatibility note: a redline saved from a #614-era session (its definition
+  unmarked) now rejects to an orphaned husk through the stateless path instead of losing the
+  note; re-authoring the redline with the current version restores full reversibility.
 - **Accepting a redline through the stateless path now takes a wholly-deleted note's definition
   with it (#631).** The redline itself distinguishes the two reference-less-husk cases: a note
   definition the counterpart *kept* passes through the comparison unmarked, while one the

--- a/Docxodus.Tests/DocxSessionNoteAuthoringTests.cs
+++ b/Docxodus.Tests/DocxSessionNoteAuthoringTests.cs
@@ -842,6 +842,10 @@ public class DocxSessionNoteAuthoringTests
         Assert.Contains("Negotiated on March 11.",
             acceptedNote.Descendants(W + "t").Select(t => (string)t));
         Assert.Empty(acceptedNote.Descendants(W + "ins"));
+        // The body citation survived the accept — without this, an accepted document could ship
+        // an uncited, invisible note and every count-based assert above would still pass.
+        Assert.Single(BodyXml(accepted)
+            .Descendants(W + (footnote ? "footnoteReference" : "endnoteReference")));
     }
 
     /// <summary>

--- a/Docxodus.Tests/DocxSessionNoteAuthoringTests.cs
+++ b/Docxodus.Tests/DocxSessionNoteAuthoringTests.cs
@@ -810,6 +810,41 @@ public class DocxSessionNoteAuthoringTests
     }
 
     /// <summary>
+    /// The definition's content records too (issue #636, revisiting #614's unmarked-definition
+    /// choice): every run sits in <c>w:ins</c> and the paragraph mark is insertion-marked, which
+    /// is what Word writes and what the diff engine's own redline carries for a wholly-inserted
+    /// note. That marking is what lets the STATELESS resolutions read the redline: reject empties
+    /// the definition, so the guarded note-lifecycle prune takes it (before this, the stateless
+    /// reject needed an unguarded prune that also ate a baseline's own kept husk — the mirror of
+    /// the #631 accept bug); accept unwraps everything and keeps the note.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DS369_RecordedNoteDefinition_IsInsertionMarked_AndStatelessResolutionsReadIt(
+        bool footnote)
+    {
+        var (baseline, redline) = AuthorNoteUnderRecording(footnote);
+
+        var note = Assert.Single(UserNotes(redline, footnote));
+        Assert.All(note.Descendants(W + "r").Where(r => r.Parent!.Name != W + "rPr"),
+            run => Assert.Contains(run.Ancestors(), a => a.Name == W + "ins"));
+        Assert.All(note.Elements(W + "p"),
+            p => Assert.NotNull(p.Element(W + "pPr")?.Element(W + "rPr")?.Element(W + "ins")));
+
+        var rejected = Docxodus.Internal.DocxDiffOps.RejectRevisions(redline);
+        Assert.Empty(UserNotes(rejected, footnote));
+        Assert.Empty(DocxDiff.GetRevisions(
+            new WmlDocument("baseline.docx", baseline), new WmlDocument("rejected.docx", rejected)));
+
+        var accepted = Docxodus.Internal.DocxDiffOps.AcceptRevisions(redline);
+        var acceptedNote = Assert.Single(UserNotes(accepted, footnote));
+        Assert.Contains("Negotiated on March 11.",
+            acceptedNote.Descendants(W + "t").Select(t => (string)t));
+        Assert.Empty(acceptedNote.Descendants(W + "ins"));
+    }
+
+    /// <summary>
     /// Footnotes part whose user notes are ids 1, 5 and 9 (non-contiguous), so a "count + 1"
     /// id allocator would collide. Body cites all three.
     /// </summary>

--- a/Docxodus.Tests/DocxSessionNoteAuthoringTests.cs
+++ b/Docxodus.Tests/DocxSessionNoteAuthoringTests.cs
@@ -827,10 +827,20 @@ public class DocxSessionNoteAuthoringTests
         var (baseline, redline) = AuthorNoteUnderRecording(footnote);
 
         var note = Assert.Single(UserNotes(redline, footnote));
-        Assert.All(note.Descendants(W + "r").Where(r => r.Parent!.Name != W + "rPr"),
+        Assert.All(note.Descendants(W + "r"),
             run => Assert.Contains(run.Ancestors(), a => a.Name == W + "ins"));
         Assert.All(note.Elements(W + "p"),
             p => Assert.NotNull(p.Element(W + "pPr")?.Element(W + "rPr")?.Element(W + "ins")));
+
+        // One user action, one revision identity: the citation envelope and every definition
+        // envelope carry a single w:date, or exact-date grouping splinters one insert into
+        // per-paragraph revisions in every reviewing pane.
+        var dates = BodyXml(redline).Descendants(W + "ins")
+            .Concat(note.DescendantsAndSelf(W + "ins"))
+            .Select(i => (string?)i.Attribute(W + "date"))
+            .Distinct()
+            .ToList();
+        Assert.Single(dates);
 
         var rejected = Docxodus.Internal.DocxDiffOps.RejectRevisions(redline);
         Assert.Empty(UserNotes(rejected, footnote));

--- a/Docxodus.Tests/DocxSessionRevisionTests.cs
+++ b/Docxodus.Tests/DocxSessionRevisionTests.cs
@@ -1333,22 +1333,31 @@ public class DocxSessionRevisionTests
     /// rule unguarded in both directions because an editor is authoring a document rather than
     /// inverting a comparison; this test pins that the two contracts stay distinct.
     /// </summary>
-    [Fact]
-    public void DS430_StatelessAccept_PreservesACounterpartsOwnOrphanedNote()
+    /// <summary>The husk fixture pair DS430 and DS434 share: one document cites footnote 7, the
+    /// other owns the identical definition uncited. The mirror property the two tests pin depends
+    /// on these staying byte-identical, so there is exactly one builder.</summary>
+    private static (byte[] Citing, byte[] Husk) HuskFixturePair()
     {
-        var baseline = BuildWithBody(
+        var citing = BuildWithBody(
             new XElement(W.p,
                 new XElement(W.r,
                     new XElement(W.t, "Cited here."),
                     new XElement(W.footnoteReference, new XAttribute(W.id, "7")))),
             new XElement(W.p, new XElement(W.r, new XElement(W.t, "Sentinel."))));
-        baseline = AddDanglingFootnote(baseline, noteId: 7, text: "Kept as a husk.");
+        citing = AddDanglingFootnote(citing, noteId: 7, text: "Kept as a husk.");
 
+        var husk = BuildWithBody(
+            new XElement(W.p, new XElement(W.r, new XElement(W.t, "Sentinel."))));
+        husk = AddDanglingFootnote(husk, noteId: 7, text: "Kept as a husk.");
+        return (citing, husk);
+    }
+
+    [Fact]
+    public void DS430_StatelessAccept_PreservesACounterpartsOwnOrphanedNote()
+    {
         // The counterpart drops the citing paragraph but keeps the definition — the husk shape a
         // naive edit leaves behind, and exactly what accept has to reproduce.
-        var counterpart = BuildWithBody(
-            new XElement(W.p, new XElement(W.r, new XElement(W.t, "Sentinel."))));
-        counterpart = AddDanglingFootnote(counterpart, noteId: 7, text: "Kept as a husk.");
+        var (baseline, counterpart) = HuskFixturePair();
 
         var redline = DocxDiff.Compare(
             new WmlDocument("baseline.docx", baseline),
@@ -1445,17 +1454,7 @@ public class DocxSessionRevisionTests
     [Fact]
     public void DS434_StatelessReject_PreservesABaselinesOwnHuskThatTheCounterpartCites()
     {
-        var baseline = BuildWithBody(
-            new XElement(W.p, new XElement(W.r, new XElement(W.t, "Sentinel."))));
-        baseline = AddDanglingFootnote(baseline, noteId: 7, text: "Kept as a husk.");
-
-        var counterpart = BuildWithBody(
-            new XElement(W.p,
-                new XElement(W.r,
-                    new XElement(W.t, "Cited here."),
-                    new XElement(W.footnoteReference, new XAttribute(W.id, "7")))),
-            new XElement(W.p, new XElement(W.r, new XElement(W.t, "Sentinel."))));
-        counterpart = AddDanglingFootnote(counterpart, noteId: 7, text: "Kept as a husk.");
+        var (counterpart, baseline) = HuskFixturePair();
 
         var redline = DocxDiff.Compare(
             new WmlDocument("baseline.docx", baseline),
@@ -1497,6 +1496,90 @@ public class DocxSessionRevisionTests
         Assert.Equal(1, UserNoteCount(accepted, "footnote"));
         Assert.Empty(DocxDiff.GetRevisions(
             new WmlDocument("counterpart.docx", counterpart), new WmlDocument("accepted.docx", accepted)));
+
+        // The reject-side twin of DS430-vs-DS418: the session's editorial reject still applies the
+        // UNGUARDED rule and strips the husk. The two contracts are deliberately distinct in this
+        // direction too, and this assert is what says so on purpose rather than by accident.
+        using var editorial = new DocxSession(redline);
+        Assert.True(editorial.RejectAllRevisions().Success);
+        Assert.Equal(0, UserNoteCount(editorial.Save(), "footnote"));
+    }
+
+    /// <summary>
+    /// The guarded prune must also read the LEGACY engine's dialect (issue #636's review round).
+    /// <see cref="WmlComparer"/> re-synthesizes an UNMARKED <c>w:footnoteRef</c> marker run into
+    /// every inserted definition it renders, so rejecting one of its redlines strips the
+    /// definition to a marker-only paragraph rather than to nothing — a purely-blockless guard
+    /// shipped an orphaned marker-husk here where the unguarded pre-#636 prune removed the note.
+    /// The scaffolding-aware predicate treats the marker run as emptiness.
+    /// </summary>
+    [Fact]
+    public void DS435_StatelessReject_ReadsWmlComparersMarkerScaffoldingAsEmptied()
+    {
+        var left = File.ReadAllBytes(Path.Combine("../../../../TestFiles/WC", "WC035-Footnote-Before.docx"));
+        var right = File.ReadAllBytes(Path.Combine("../../../../TestFiles/WC", "WC035-Footnote-After.docx"));
+        var inserting = UserNoteCount(left, "footnote") < UserNoteCount(right, "footnote")
+            ? (Baseline: left, Counterpart: right)
+            : (Baseline: right, Counterpart: left);
+
+        var redline = WmlComparer.Compare(
+            new WmlDocument("baseline.docx", inserting.Baseline),
+            new WmlDocument("counterpart.docx", inserting.Counterpart),
+            new WmlComparerSettings());
+
+        var rejected = RevisionProcessor.RejectRevisions(redline);
+        Assert.Equal(UserNoteCount(inserting.Baseline, "footnote"),
+            UserNoteCount(rejected.DocumentByteArray, "footnote"));
+
+        var accepted = RevisionProcessor.AcceptRevisions(redline);
+        Assert.Equal(UserNoteCount(inserting.Counterpart, "footnote"),
+            UserNoteCount(accepted.DocumentByteArray, "footnote"));
+    }
+
+    /// <summary>
+    /// A partial resolution never deletes a note out from under its citation. Record a note,
+    /// accept only the CITATION's revision, then run the stateless reject over what remains: the
+    /// reject empties the ins-marked definition, but the orphan-scoped prune must not touch a
+    /// note the body still cites — the reference must keep resolving. The emptied definition is
+    /// left bare rather than "repaired" with a filler paragraph, because a cited childless note
+    /// is a shape the corpus genuinely contains (WC064-Footnote ships one) and faithful
+    /// reproduction of exactly that shape is what the round-trip contracts require.
+    /// </summary>
+    [Fact]
+    public void DS436_StatelessReject_KeepsACitedNoteItStrippedBare()
+    {
+        var baseline = BuildWithBody(
+            new XElement(W.p, new XElement(W.r, new XElement(W.t, "First paragraph here."))),
+            new XElement(W.p, new XElement(W.r, new XElement(W.t, "Sentinel."))));
+
+        byte[] partiallyResolved;
+        using (var author = new DocxSession(baseline, new DocxSessionSettings
+        {
+            TrackedChanges = TrackedChangeMode.RenderInline,
+            RevisionAuthor = "Note Author",
+        }))
+        {
+            var anchor = author.Project().AnchorIndex.Values
+                .First(t => t.Anchor.Scope == "body"
+                    && (t.TextPreview ?? string.Empty).StartsWith("First")).Anchor.Id;
+            Assert.True(author.InsertFootnote(anchor, 5, "Recorded note body.").Success);
+            var redline = author.Save();
+
+            using var review = new DocxSession(redline);
+            var citation = review.ListRevisions()
+                .Single(r => r.AnchorId is { } a && a.Contains(":body:", StringComparison.Ordinal));
+            Assert.True(review.AcceptRevision(citation.Id).Success);
+            partiallyResolved = review.Save();
+        }
+
+        var rejected = Docxodus.Internal.DocxDiffOps.RejectRevisions(partiallyResolved);
+
+        using var stream = new MemoryStream(rejected, writable: false);
+        using var document = WordprocessingDocument.Open(stream, false);
+        Assert.Single(document.MainDocumentPart!.Document!.Descendants<FootnoteReference>());
+        var note = Assert.Single(document.MainDocumentPart.FootnotesPart!.Footnotes!
+            .Elements<Footnote>(), n => n.Type is null);
+        Assert.Empty(note.InnerText);
     }
 
     /// <summary>

--- a/Docxodus.Tests/DocxSessionRevisionTests.cs
+++ b/Docxodus.Tests/DocxSessionRevisionTests.cs
@@ -1435,6 +1435,43 @@ public class DocxSessionRevisionTests
     }
 
     /// <summary>
+    /// The reject-side mirror of DS430 (issue #636). A baseline that owns an uncited,
+    /// content-bearing definition which the counterpart merely CITES: the comparison reconciles
+    /// the two equal definitions, so the redline carries a <c>w:ins</c> citation and an unmarked
+    /// definition. Rejecting reproduces the baseline — the citation goes, the husk stays. Before
+    /// the guard, the stateless reject's unconditional prune ate the content-bearing definition
+    /// the baseline was entitled to keep, so <c>Reject(Compare(l, r)) != l</c>.
+    /// </summary>
+    [Fact]
+    public void DS434_StatelessReject_PreservesABaselinesOwnHuskThatTheCounterpartCites()
+    {
+        var baseline = BuildWithBody(
+            new XElement(W.p, new XElement(W.r, new XElement(W.t, "Sentinel."))));
+        baseline = AddDanglingFootnote(baseline, noteId: 7, text: "Kept as a husk.");
+
+        var counterpart = BuildWithBody(
+            new XElement(W.p,
+                new XElement(W.r,
+                    new XElement(W.t, "Cited here."),
+                    new XElement(W.footnoteReference, new XAttribute(W.id, "7")))),
+            new XElement(W.p, new XElement(W.r, new XElement(W.t, "Sentinel."))));
+        counterpart = AddDanglingFootnote(counterpart, noteId: 7, text: "Kept as a husk.");
+
+        var redline = DocxDiff.Compare(
+            new WmlDocument("baseline.docx", baseline),
+            new WmlDocument("counterpart.docx", counterpart)).DocumentByteArray;
+
+        var rejected = Docxodus.Internal.DocxDiffOps.RejectRevisions(redline);
+
+        Assert.Equal(1, UserNoteCount(baseline, "footnote"));
+        Assert.Equal(1, UserNoteCount(rejected, "footnote"));
+
+        // And accepting still reproduces the counterpart, citation and all.
+        var accepted = Docxodus.Internal.DocxDiffOps.AcceptRevisions(redline);
+        Assert.Equal(1, UserNoteCount(accepted, "footnote"));
+    }
+
+    /// <summary>
     /// The prune asks the whole package who still cites a note, not just the body. A note cited
     /// from the body AND a running header outlives the body citation; a body-only scan would read
     /// "referenced before, unreferenced after" and delete a note the header still points at.

--- a/Docxodus.Tests/DocxSessionRevisionTests.cs
+++ b/Docxodus.Tests/DocxSessionRevisionTests.cs
@@ -1461,14 +1461,42 @@ public class DocxSessionRevisionTests
             new WmlDocument("baseline.docx", baseline),
             new WmlDocument("counterpart.docx", counterpart)).DocumentByteArray;
 
+        // The load-bearing premise: the citation arrives as a revision while the reconciled
+        // definition passes through UNMARKED — the shape the blockless guard must read as "keep".
+        using (var stream = new MemoryStream(redline, writable: false))
+        using (var document = WordprocessingDocument.Open(stream, false))
+        {
+            var reference = Assert.Single(
+                document.MainDocumentPart!.Document!.Descendants<FootnoteReference>());
+            Assert.NotNull(reference.Ancestors<InsertedRun>().FirstOrDefault());
+            var note = Assert.Single(document.MainDocumentPart.FootnotesPart!.Footnotes!
+                .Elements<Footnote>(), n => n.Type is null);
+            Assert.Empty(note.Descendants<InsertedRun>());
+            Assert.Empty(note.Descendants<DeletedRun>());
+        }
+
         var rejected = Docxodus.Internal.DocxDiffOps.RejectRevisions(redline);
 
         Assert.Equal(1, UserNoteCount(baseline, "footnote"));
         Assert.Equal(1, UserNoteCount(rejected, "footnote"));
+        // Content-level equivalence, not GetRevisions: the redline pipeline renumbers note ids in
+        // body-reference order, and an UNREFERENCED husk can only pair by id, so the differ reads
+        // the same husk at a shifted id as a delete+insert of identical text. The husk's identity
+        // to a reader is its content.
+        using (var stream = new MemoryStream(rejected, writable: false))
+        using (var document = WordprocessingDocument.Open(stream, false))
+        {
+            var husk = Assert.Single(document.MainDocumentPart!.FootnotesPart!.Footnotes!
+                .Elements<Footnote>(), n => n.Type is null);
+            Assert.Contains("Kept as a husk.", husk.InnerText);
+            Assert.Empty(document.MainDocumentPart.Document!.Descendants<FootnoteReference>());
+        }
 
         // And accepting still reproduces the counterpart, citation and all.
         var accepted = Docxodus.Internal.DocxDiffOps.AcceptRevisions(redline);
         Assert.Equal(1, UserNoteCount(accepted, "footnote"));
+        Assert.Empty(DocxDiff.GetRevisions(
+            new WmlDocument("counterpart.docx", counterpart), new WmlDocument("accepted.docx", accepted)));
     }
 
     /// <summary>

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -9626,10 +9626,15 @@ public sealed partial class DocxSession : IDisposable
             // definition it both orphaned and emptied — without eating a baseline-owned husk whose
             // citation the redline merely inserted, which is the mirror of the #631 accept bug
             // that the old unguarded reject prune had.
+            // One user action, one revision identity: the citation envelope and every definition
+            // paragraph share a single author/date pair, or RevisionOps.BuildGroups (exact-date
+            // equality) splinters one insert into per-paragraph revision groups.
+            var recording = _trackedChanges == TrackedChangeMode.RenderInline;
+            var recordingAuthor = _revisionAuthor ?? "docxodus";
+            var recordingDate = recording ? NextTrackedFormatRevisionDate() : string.Empty;
             InsertInlineAtOffset(element, characterOffset,
-                _trackedChanges == TrackedChangeMode.RenderInline
-                    ? CreateRevisionEnvelope(W.ins, _revisionAuthor ?? "docxodus",
-                        NextTrackedFormatRevisionDate(), refRun)
+                recording
+                    ? CreateRevisionEnvelope(W.ins, recordingAuthor, recordingDate, refRun)
                     : refRun);
 
             var id = NextNoteIdInReferenceOrder(main, root, noteName);
@@ -9637,10 +9642,9 @@ public sealed partial class DocxSession : IDisposable
                 .SetAttributeValue(W.id, id.ToString(System.Globalization.CultureInfo.InvariantCulture));
 
             ApplyNoteBodyStyle(paras, isFootnote);
-            if (_trackedChanges == TrackedChangeMode.RenderInline)
+            if (recording)
                 foreach (var p in paras)
-                    MarkParagraphContentAndMark(p, W.ins,
-                        _revisionAuthor ?? "docxodus", NextTrackedFormatRevisionDate());
+                    MarkParagraphContentAndMark(p, W.ins, recordingAuthor, recordingDate);
             var note = new XElement(noteName,
                 new XAttribute(W.id, id.ToString(System.Globalization.CultureInfo.InvariantCulture)),
                 paras);

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -9617,13 +9617,15 @@ public sealed partial class DocxSession : IDisposable
             var refRun = BuildNoteReferenceRun(isFootnote, NoteIdPlaceholder);
             UnidHelper.AssignToSelfAndDescendants(refRun);
 
-            // Under recording, the CITATION is the reversible unit and the definition follows it.
-            // Rejecting the w:ins carries the reference away, which leaves the definition
-            // unreferenced, and PruneOrphanedNotes — the single owner of "a note exists iff it is
-            // cited" (#516/#591) — removes it in the same resolve. A second w:ins inside the
-            // definition would be a revision with no independently meaningful resolution: rejecting
-            // it while keeping the citation yields an empty note, and keeping it while rejecting the
-            // citation yields a note that is pruned anyway.
+            // Under recording, the CITATION is the reversible unit and the definition follows it —
+            // and the definition's content is marked inserted too (issue #636, revisiting #614's
+            // unmarked-definition choice). Marking is what Word writes, what the diff engine's own
+            // redline carries for a wholly-inserted note, and what lets the STATELESS reject read
+            // its way to the right answer: rejecting empties the definition, and the guarded
+            // note-lifecycle prune (NoteReferenceOps.PruneNotesEmptiedByResolution) takes a
+            // definition it both orphaned and emptied — without eating a baseline-owned husk whose
+            // citation the redline merely inserted, which is the mirror of the #631 accept bug
+            // that the old unguarded reject prune had.
             InsertInlineAtOffset(element, characterOffset,
                 _trackedChanges == TrackedChangeMode.RenderInline
                     ? CreateRevisionEnvelope(W.ins, _revisionAuthor ?? "docxodus",
@@ -9635,6 +9637,10 @@ public sealed partial class DocxSession : IDisposable
                 .SetAttributeValue(W.id, id.ToString(System.Globalization.CultureInfo.InvariantCulture));
 
             ApplyNoteBodyStyle(paras, isFootnote);
+            if (_trackedChanges == TrackedChangeMode.RenderInline)
+                foreach (var p in paras)
+                    MarkParagraphContentAndMark(p, W.ins,
+                        _revisionAuthor ?? "docxodus", NextTrackedFormatRevisionDate());
             var note = new XElement(noteName,
                 new XAttribute(W.id, id.ToString(System.Globalization.CultureInfo.InvariantCulture)),
                 paras);

--- a/Docxodus/Internal/NoteReferenceOps.cs
+++ b/Docxodus/Internal/NoteReferenceOps.cs
@@ -17,10 +17,10 @@ namespace Docxodus.Internal;
 /// Two callers, one rule. <see cref="DocxSession"/> applies it after a structural delete or a
 /// revision resolution (issues #516, #591); <see cref="RevisionProcessor"/> applies it after a
 /// stateless accept/reject, which is the path every non-.NET transport reaches through
-/// <c>DocxDiffOps</c> (issues #614, #631). Every caller captures <see cref="ReferencedNoteIds"/>
-/// before the mutation and prunes after it — via <see cref="PruneOrphanedNotes"/>, except the
-/// stateless accept, whose <see cref="PruneNotesEmptiedByAccept"/> adds a guard the comparison
-/// contract needs.
+/// <c>DocxDiffOps</c> (issues #614, #631, #636). Every caller captures
+/// <see cref="ReferencedNoteIds"/> before the mutation and prunes after it — the session's
+/// editorial resolves via <see cref="PruneOrphanedNotes"/>, both stateless resolutions via
+/// <see cref="PruneNotesEmptiedByResolution"/>, whose guard the comparison contracts need.
 ///
 /// The PART itself always stays. Word never prunes a notes part — the RP050-Deleted-Footnote
 /// oracle keeps its separator-only <c>footnotes.xml</c> after accepting the only note's deletion,
@@ -86,17 +86,20 @@ internal static class NoteReferenceOps
         Prune(main, before, onlyBlockless: false);
 
     /// <summary>
-    /// The accept-side variant of the rule (issue #631): remove a note definition whose last
-    /// citation disappeared between <paramref name="before"/> and now AND which is left without
-    /// block content. Accepting can only strip a note bare when every block was deletion-marked —
-    /// an unmarked paragraph survives its runs — so a bare, newly-uncited definition is the
-    /// redline saying "this whole note is deleted", and accepting must take the definition with
-    /// it or the accepted package ships a note the counterpart deleted. The blockless guard is
-    /// what distinguishes that from a counterpart's own reference-less husk: a definition the
-    /// counterpart kept arrives with its content unmarked, keeps that content through the accept,
-    /// and stays — so <c>Accept(Compare(l, r)) ≡ r</c> holds for both note stores.
+    /// The guarded variant of the rule for the stateless resolutions (issues #631, #636): remove a
+    /// note definition whose last citation disappeared between <paramref name="before"/> and now
+    /// AND which the resolution left without block content. A resolution can only strip a note
+    /// bare when every block was revision-marked in its direction — an unmarked paragraph survives
+    /// its runs — so a bare, newly-uncited definition is the redline saying "this whole note goes
+    /// with its citation": a wholly-deleted note on accept (every block in <c>w:del</c>), a
+    /// wholly-inserted note on reject (every block in <c>w:ins</c>). The blockless guard is what
+    /// distinguishes both from a document's own reference-less husk, which arrives with its
+    /// content unmarked, keeps it through the resolution, and stays — so
+    /// <c>Accept(Compare(l, r)) ≡ r</c> and <c>Reject(Compare(l, r)) ≡ l</c> both hold for the
+    /// note stores. (Redlines whose producer left an inserted definition unmarked — sessions from
+    /// the brief #614-era — reject to an orphaned husk instead; see CHANGELOG.)
     /// </summary>
-    internal static List<(XElement Note, string PartUri)> PruneNotesEmptiedByAccept(
+    internal static List<(XElement Note, string PartUri)> PruneNotesEmptiedByResolution(
         MainDocumentPart? main, (HashSet<int> Footnotes, HashSet<int> Endnotes) before) =>
         Prune(main, before, onlyBlockless: true);
 

--- a/Docxodus/Internal/NoteReferenceOps.cs
+++ b/Docxodus/Internal/NoteReferenceOps.cs
@@ -83,7 +83,7 @@ internal static class NoteReferenceOps
     /// <returns>The removed note elements with their part uri, for removed-anchor reporting.</returns>
     internal static List<(XElement Note, string PartUri)> PruneOrphanedNotes(
         MainDocumentPart? main, (HashSet<int> Footnotes, HashSet<int> Endnotes) before) =>
-        Prune(main, before, onlyBlockless: false);
+        Prune(main, before, onlyEmptied: false);
 
     /// <summary>
     /// The guarded variant of the rule for the stateless resolutions (issues #631, #636): remove a
@@ -92,41 +92,78 @@ internal static class NoteReferenceOps
     /// bare when every block was revision-marked in its direction — an unmarked paragraph survives
     /// its runs — so a bare, newly-uncited definition is the redline saying "this whole note goes
     /// with its citation": a wholly-deleted note on accept (every block in <c>w:del</c>), a
-    /// wholly-inserted note on reject (every block in <c>w:ins</c>). The blockless guard is what
+    /// wholly-inserted note on reject (every block in <c>w:ins</c>). The emptied guard is what
     /// distinguishes both from a document's own reference-less husk, which arrives with its
     /// content unmarked, keeps it through the resolution, and stays — so
     /// <c>Accept(Compare(l, r)) ≡ r</c> and <c>Reject(Compare(l, r)) ≡ l</c> both hold for the
-    /// note stores. (Redlines whose producer left an inserted definition unmarked — sessions from
-    /// the brief #614-era — reject to an orphaned husk instead; see CHANGELOG.)
+    /// note stores. (Redlines whose producer left an inserted definition's TEXT unmarked —
+    /// sessions from the brief #614-era — reject to an orphaned husk instead; see CHANGELOG.)
+    /// <para>"Emptied" is scaffolding-aware, not merely blockless: <see cref="WmlComparer"/>
+    /// re-synthesizes an UNMARKED <c>w:footnoteRef</c> marker run into every inserted definition
+    /// it renders, so rejecting one of its redlines strips the definition to a marker-only
+    /// paragraph rather than to nothing. A definition left with no text, tables, SDTs or other
+    /// run content beyond note-reference-mark scaffolding is emptied.</para>
+    /// <para>Two interlocks worth knowing. A still-CITED note a resolution strips bare is left
+    /// bare on purpose: a cited <c>w:footnote</c> with no block child is schema-degenerate, but it
+    /// is a shape the corpus genuinely contains (<c>WC064-Footnote</c> ships one, and
+    /// <c>WC063-Footnote-Mod</c>'s counterpart note is childless), so reproducing it is what
+    /// <c>Accept(Compare(l, r)) ≡ r</c> means — any "repair" here broke those round-trips when it
+    /// was tried. And the session's editorial resolves stay on the UNGUARDED
+    /// <see cref="PruneOrphanedNotes"/> deliberately: the session resolver keeps the last block
+    /// of a note alive (<c>RevisionOps</c>' surviving-block guard), so a session-emptied
+    /// definition can never satisfy this predicate — unifying the session onto the guarded prune
+    /// would silently stop pruning session-rejected recorded notes.</para>
     /// </summary>
     internal static List<(XElement Note, string PartUri)> PruneNotesEmptiedByResolution(
         MainDocumentPart? main, (HashSet<int> Footnotes, HashSet<int> Endnotes) before) =>
-        Prune(main, before, onlyBlockless: true);
+        Prune(main, before, onlyEmptied: true);
 
     private static List<(XElement Note, string PartUri)> Prune(
         MainDocumentPart? main, (HashSet<int> Footnotes, HashSet<int> Endnotes) before,
-        bool onlyBlockless)
+        bool onlyEmptied)
     {
         var removed = new List<(XElement, string)>();
         if (main is null) return removed;
         var after = ReferencedNoteIds(main);
-        PruneStory(main.FootnotesPart, W + "footnote", before.Footnotes, after.Footnotes, removed, onlyBlockless);
-        PruneStory(main.EndnotesPart, W + "endnote", before.Endnotes, after.Endnotes, removed, onlyBlockless);
+        PruneStory(main.FootnotesPart, W + "footnote", before.Footnotes, after.Footnotes, removed, onlyEmptied);
+        PruneStory(main.EndnotesPart, W + "endnote", before.Endnotes, after.Endnotes, removed, onlyEmptied);
         return removed;
     }
 
-    /// <summary>Whether a note definition has no block-level content left (no <c>w:p</c>,
-    /// <c>w:tbl</c> or <c>w:sdt</c> children). A direct-children check is sufficient HERE — and
-    /// only here — because this runs after <see cref="RevisionProcessor"/>'s accept, whose
-    /// block-content coalescing pass (<c>AcceptDeletedAndMoveFromParagraphMarksTransform</c>,
-    /// applied to every note via <c>BlockLevelContentContainers</c>) promotes block content out of
-    /// wrappers like <c>mc:AlternateContent</c> to direct children. It is deliberately narrower
-    /// than <c>RevisionProcessor.BlockLevelElements</c> and <c>IsBlockContentElement</c>, which
-    /// classify pre-accept trees that still carry revision wrappers; if the accept pipeline ever
+    /// <summary>Whether a note definition was stripped to scaffolding: no block children at all,
+    /// or only paragraphs whose remaining run content is note-reference-mark scaffolding
+    /// (<c>w:footnoteRef</c>/<c>w:endnoteRef</c>) — the marker run <see cref="WmlComparer"/>
+    /// re-synthesizes UNMARKED into inserted definitions, which would otherwise shield them from
+    /// the guarded prune. Tables, SDTs, any text, and any other run content mean real content
+    /// survived. A direct-children walk is sufficient HERE — and only here — because this runs
+    /// after <see cref="RevisionProcessor"/>'s resolution, whose block-content coalescing pass
+    /// (<c>AcceptDeletedAndMoveFromParagraphMarksTransform</c>, applied to every note via
+    /// <c>BlockLevelContentContainers</c>) promotes block content out of wrappers like
+    /// <c>mc:AlternateContent</c> to direct children. It is deliberately narrower than
+    /// <c>RevisionProcessor.BlockLevelElements</c> and <c>IsBlockContentElement</c>, which
+    /// classify pre-resolution trees that still carry revision wrappers; if the pipeline ever
     /// starts leaving a new wrapper shape inside notes, this predicate must learn it too.</summary>
-    private static bool IsBlockless(XElement note) =>
-        !note.Elements().Any(e =>
-            e.Name == W + "p" || e.Name == W + "tbl" || e.Name == W + "sdt");
+    private static bool IsEmptiedToScaffolding(XElement note)
+    {
+        foreach (var block in note.Elements())
+        {
+            if (block.Name == W + "tbl" || block.Name == W + "sdt") return false;
+            if (block.Name != W + "p") continue;
+            foreach (var child in block.Elements())
+            {
+                if (child.Name == W + "pPr"
+                    || child.Name == W + "bookmarkStart" || child.Name == W + "bookmarkEnd"
+                    || child.Name == W + "proofErr") continue;
+                if (child.Name != W + "r") return false;
+                if (child.Elements().Any(rc =>
+                        rc.Name != W + "rPr"
+                        && rc.Name != W + "footnoteRef" && rc.Name != W + "endnoteRef"))
+                    return false;
+            }
+        }
+
+        return true;
+    }
 
     /// <summary>Word's reserved scaffolding notes, which are never citation targets and are never
     /// pruned.</summary>
@@ -139,7 +176,7 @@ internal static class NoteReferenceOps
         HashSet<int> referencedBefore,
         HashSet<int> referencedAfter,
         List<(XElement, string)> removed,
-        bool onlyBlockless)
+        bool onlyEmptied)
     {
         var root = part?.GetXDocument().Root;
         if (part is null || root is null) return;
@@ -153,7 +190,7 @@ internal static class NoteReferenceOps
             if (!int.TryParse((string?)note.Attribute(W + "id"), out var id)
                 || !orphaned.Contains(id) || IsSeparatorNote(note))
                 continue;
-            if (onlyBlockless && !IsBlockless(note))
+            if (onlyEmptied && !IsEmptiedToScaffolding(note))
                 continue;
             note.Remove();
             removed.Add((note, partUri));

--- a/Docxodus/RevisionProcessor.cs
+++ b/Docxodus/RevisionProcessor.cs
@@ -33,11 +33,9 @@ namespace Docxodus
 
         public static void RejectRevisions(WordprocessingDocument doc)
         {
-            // Word's note-lifecycle rule, reject side (issues #614, #636): a note the redline
-            // introduced (w:ins citation, definition blocks in w:ins) has no place in the rejected
-            // baseline, so rejecting empties the definition and the guarded prune takes it — while
-            // a baseline-owned husk whose citation the redline merely inserted keeps its unmarked
-            // content and stays. Rationale and scoping live with the rule's owner,
+            // Word's note-lifecycle rule, reject side (issues #614, #636): a definition this
+            // reject both orphaned and emptied goes with its citation. Rationale, the emptied
+            // guard, and its interlocks live with the rule's owner:
             // Internal.NoteReferenceOps.PruneNotesEmptiedByResolution.
             var citedBefore = Internal.NoteReferenceOps.ReferencedNoteIds(doc.MainDocumentPart);
             RejectRevisionsForPart(doc.MainDocumentPart);

--- a/Docxodus/RevisionProcessor.cs
+++ b/Docxodus/RevisionProcessor.cs
@@ -33,10 +33,12 @@ namespace Docxodus
 
         public static void RejectRevisions(WordprocessingDocument doc)
         {
-            // Word's note-lifecycle rule, reject side (issue #614): a note the redline introduced
-            // (w:ins citation) has no place in the rejected baseline, so its definition goes with
-            // the citation. Rationale and scoping live with the rule's owner,
-            // Internal.NoteReferenceOps; the accept side applies the guarded variant (issue #631).
+            // Word's note-lifecycle rule, reject side (issues #614, #636): a note the redline
+            // introduced (w:ins citation, definition blocks in w:ins) has no place in the rejected
+            // baseline, so rejecting empties the definition and the guarded prune takes it — while
+            // a baseline-owned husk whose citation the redline merely inserted keeps its unmarked
+            // content and stays. Rationale and scoping live with the rule's owner,
+            // Internal.NoteReferenceOps.PruneNotesEmptiedByResolution.
             var citedBefore = Internal.NoteReferenceOps.ReferencedNoteIds(doc.MainDocumentPart);
             RejectRevisionsForPart(doc.MainDocumentPart);
             foreach (var part in doc.MainDocumentPart.HeaderParts)
@@ -63,7 +65,7 @@ namespace Docxodus
             if (doc.MainDocumentPart.StyleDefinitionsPart != null)
                 AcceptRevisionsForStylesDefinitionPart(doc.MainDocumentPart.StyleDefinitionsPart);
 
-            Internal.NoteReferenceOps.PruneOrphanedNotes(doc.MainDocumentPart, citedBefore);
+            Internal.NoteReferenceOps.PruneNotesEmptiedByResolution(doc.MainDocumentPart, citedBefore);
         }
 
         // Reject revisions for those revisions that can't be rejected by inverting the sense of the revision, and then accepting.
@@ -1475,7 +1477,7 @@ namespace Docxodus
             // orphaned and stripped of its blocks is a note the redline wholly deleted, and it goes
             // with its citation. Why the blockless guard makes this safe for the other husk shape
             // is documented once, on the rule's owner: Internal.NoteReferenceOps
-            // .PruneNotesEmptiedByAccept.
+            // .PruneNotesEmptiedByResolution.
             var citedBefore = Internal.NoteReferenceOps.ReferencedNoteIds(doc.MainDocumentPart);
             AcceptRevisionsForPart(doc.MainDocumentPart, preservePreexistingCleanTableRuns);
             foreach (var part in doc.MainDocumentPart.HeaderParts)
@@ -1489,7 +1491,7 @@ namespace Docxodus
             if (doc.MainDocumentPart.StyleDefinitionsPart != null)
                 AcceptRevisionsForStylesDefinitionPart(doc.MainDocumentPart.StyleDefinitionsPart);
 
-            Internal.NoteReferenceOps.PruneNotesEmptiedByAccept(doc.MainDocumentPart, citedBefore);
+            Internal.NoteReferenceOps.PruneNotesEmptiedByResolution(doc.MainDocumentPart, citedBefore);
         }
 
         private static void AcceptRevisionsForStylesDefinitionPart(StyleDefinitionsPart stylesDefinitionsPart)

--- a/docs/architecture/docx_mutation_api.md
+++ b/docs/architecture/docx_mutation_api.md
@@ -1147,8 +1147,10 @@ revision removes the reference, which leaves the definition uncited — at which
 note-lifecycle rule deletes it. Accepting unwraps the `w:ins` and both survive.
 
 The definition's content records too (issue #636): every run sits in `w:ins` and the paragraph
-marks are insertion-marked, matching both what Word writes and what the diff engine's redline
-carries for a wholly-inserted note. #614 had deliberately left the definition unmarked ("a
+marks are insertion-marked — the shape the diff engine's redline carries for a wholly-inserted
+note, and consistent with Word presenting an inserted footnote's text as a revision in the note
+pane (a Word-authored tracked-*insert* fixture is still wanted; `TestFiles` has only the
+delete-side `RP050`). #614 had deliberately left the definition unmarked ("a
 revision with no independently meaningful resolution"), but that omission made the redline
 ambiguous to a stateless consumer — a `w:ins` citation next to an *unmarked* definition is also
 exactly what a comparison produces when the counterpart merely cites a husk the baseline already
@@ -1167,26 +1169,32 @@ resolve-all in either direction never produces it.
 `Internal/NoteReferenceOps.cs` is the single owner of that rule — *a note definition exists
 exactly as long as something still cites it* — and it asks the whole package who cites a note,
 not just the body, so a note cited from a running header as well outlives losing its body
-citation. `DocxSession` applies it after a structural delete or a revision resolution
-(issues #516, #591); `RevisionProcessor` applies it on the stateless **reject** path, which is
-what every non-.NET transport reaches through `DocxDiffOps.RejectRevisions`.
+citation. `DocxSession` applies it unguarded after a structural delete or a revision resolution
+(issues #516, #591); both stateless resolutions — what every non-.NET transport reaches through
+`DocxDiffOps.AcceptRevisions`/`RejectRevisions` — apply it with the emptied guard (issues #631,
+#636): only a definition the resolution also left without real content goes.
 
-The stateless **accept** path applies it with an extra guard (issue #631): only a definition the
-accept also left without block content goes. The guard exists because `Accept(Compare(l, r)) ≡ r`
-is the comparison engine's contract and the redline itself distinguishes the two husk shapes — a
+The guard exists because `Accept(Compare(l, r)) ≡ r` and `Reject(Compare(l, r)) ≡ l` are the
+comparison engine's contracts and the redline itself distinguishes the husk shapes — a
 reference-less definition the counterpart *kept* passes through the comparison with its content
-unmarked, survives the accept intact, and stays, while a definition the counterpart *deleted*
-arrives with every block deletion-marked, so accepting strips it bare and the prune takes it.
-Word's tracked deletions carry the same fully-marked shape (`RP050-Deleted-Footnote` is authored
-exactly like this), though Word's own accept leaves a childless `<w:footnote/>` shell where we
-remove the definition — the schema-valid form, and what the session has done since #516. Without
-the accept-side
+unmarked, survives the resolution intact, and stays, while a definition the redline wholly
+deletes (or introduces) arrives with every block revision-marked, so resolving against it strips
+the definition bare and the prune takes it. The guard is scaffolding-aware, because
+`WmlComparer`'s renderer re-synthesizes an unmarked `w:footnoteRef` marker run into inserted
+definitions; and a still-cited note a resolution strips bare stays bare — a cited childless note
+is a shape the corpus genuinely contains (`WC064-Footnote`), and reproducing it is what the
+round-trip contracts require. Word's tracked deletions carry the same fully-marked shape
+(`RP050-Deleted-Footnote` is authored exactly like this), though Word's own accept leaves a
+childless `<w:footnote/>` shell where we remove the definition — the schema-valid form, and what
+the session has done since #516. Without the accept-side
 prune the two paths disagreed about a wholly-deleted note: `DocxSession.AcceptAllRevisions`
 removed it (its resolve paths apply the rule unguarded in both directions, because an editor is
 authoring a document) while the stateless path shipped a definition the counterpart had deleted.
-On the counterpart-kept husk shape the two contracts remain deliberately distinct — the stateless
-accept preserves the husk to reproduce the counterpart, the session's editorial rule still strips
-it (DS430 vs DS418).
+On the counterpart-kept husk shape the two contracts remain deliberately distinct in BOTH
+directions — the stateless resolutions preserve the husk to reproduce the comparison input, while
+the session's editorial rule (and everything routed through it: `RejectAllRevisions`,
+per-revision resolves, delivery-bundle revision policies, and the reversibility prover's
+resolution replay) still strips it (DS430/DS434 vs DS418).
 
 ### Which mutations record, and which refuse
 

--- a/docs/architecture/docx_mutation_api.md
+++ b/docs/architecture/docx_mutation_api.md
@@ -1146,10 +1146,16 @@ definition follows it**: the body-side reference run is wrapped in `w:ins`, and 
 revision removes the reference, which leaves the definition uncited — at which point the
 note-lifecycle rule deletes it. Accepting unwraps the `w:ins` and both survive.
 
-The definition itself carries no revision markup of its own, deliberately. A second `w:ins`
-inside it would be a revision with no independently meaningful resolution: rejecting it while
-keeping the citation yields an empty note, and keeping it while rejecting the citation yields a
-note that is pruned anyway.
+The definition's content records too (issue #636): every run sits in `w:ins` and the paragraph
+marks are insertion-marked, matching both what Word writes and what the diff engine's redline
+carries for a wholly-inserted note. #614 had deliberately left the definition unmarked ("a
+revision with no independently meaningful resolution"), but that omission made the redline
+ambiguous to a stateless consumer — a `w:ins` citation next to an *unmarked* definition is also
+exactly what a comparison produces when the counterpart merely cites a husk the baseline already
+owned, and the unguarded reject prune that compensated for the missing markup ate that
+baseline-owned husk (`Reject(Compare(l, r)) ≠ l`, the mirror of #631). With the definition
+marked, rejecting empties it and the guarded prune — the same blockless guard the accept side
+uses — takes exactly the notes the redline introduced and nothing else.
 
 `Internal/NoteReferenceOps.cs` is the single owner of that rule — *a note definition exists
 exactly as long as something still cites it* — and it asks the whole package who cites a note,

--- a/docs/architecture/docx_mutation_api.md
+++ b/docs/architecture/docx_mutation_api.md
@@ -1157,6 +1157,13 @@ baseline-owned husk (`Reject(Compare(l, r)) ≠ l`, the mirror of #631). With th
 marked, rejecting empties it and the guarded prune — the same blockless guard the accept side
 uses — takes exactly the notes the redline introduced and nothing else.
 
+One granularity consequence, shared with the diff engine's own redlines (which carry the
+identical shape): the definition's insertions are individually resolvable revisions, so a
+reviewer who rejects *only* the definition's content while keeping the citation ends up with an
+empty but still-cited note — the note-lifecycle rule correctly leaves a cited note alone. That is
+the ordinary meaning of partially resolving a compound change, the same state Word can reach, and
+resolve-all in either direction never produces it.
+
 `Internal/NoteReferenceOps.cs` is the single owner of that rule — *a note definition exists
 exactly as long as something still cites it* — and it asks the whole package who cites a note,
 not just the body, so a note cited from a running header as well outlives losing its body

--- a/docs/ooxml_corner_cases.md
+++ b/docs/ooxml_corner_cases.md
@@ -429,11 +429,22 @@ divergence — RP050 is pinned `acceptEquivalent: false` there, so the sweep ass
 through the coarser story-text check rather than modeled-semantic equivalence, and neither a
 childless shell nor its absence contributes story text.
 
+#### A residual degenerate shape (known, deliberately unhandled)
+
+If a definition's content is wholly deletion-marked while its citation is NOT deleted — a shape
+Word's UI cannot author (deleting all of a note's text tracked leaves the final paragraph mark
+unmarked, so accept correctly keeps an empty-paragraph note) — accepting empties the definition
+but the citation survives, and the orphan-scoped prune correctly cannot touch a cited note. The
+accepted package then carries a cited childless `<w:footnote/>`. This arises only from hand- or
+tool-built markup; the principled fix (leave a minimal empty paragraph when emptying a still-cited
+note) is deferred until there is Word-side evidence of what it ships for an equivalent state.
+Tracked to conclusion in #636's review record.
+
 #### Relevant code
 
 - `Docxodus/Internal/NoteReferenceOps.cs` (`PruneNotesEmptiedByResolution`, the blockless guard)
 - `Docxodus/RevisionProcessor.cs` (accept-side capture/prune)
-- `DS430`/`DS432` in `DocxSessionRevisionTests.cs` — the two husk shapes and their opposite fates
+- `DS430`/`DS432`/`DS434` in `DocxSessionRevisionTests.cs` — the husk shapes and their fates
 
 ### `OpenXmlValidator` Does NOT Resolve Note-Body (note-in-note) References — a validation blind spot
 

--- a/docs/ooxml_corner_cases.md
+++ b/docs/ooxml_corner_cases.md
@@ -429,16 +429,19 @@ divergence — RP050 is pinned `acceptEquivalent: false` there, so the sweep ass
 through the coarser story-text check rather than modeled-semantic equivalence, and neither a
 childless shell nor its absence contributes story text.
 
-#### A residual degenerate shape (known, deliberately unhandled)
+#### The cited-but-stripped shape is preserved, not repaired
 
-If a definition's content is wholly deletion-marked while its citation is NOT deleted — a shape
-Word's UI cannot author (deleting all of a note's text tracked leaves the final paragraph mark
-unmarked, so accept correctly keeps an empty-paragraph note) — accepting empties the definition
-but the citation survives, and the orphan-scoped prune correctly cannot touch a cited note. The
-accepted package then carries a cited childless `<w:footnote/>`. This arises only from hand- or
-tool-built markup; the principled fix (leave a minimal empty paragraph when emptying a still-cited
-note) is deferred until there is Word-side evidence of what it ships for an equivalent state.
-Tracked to conclusion in #636's review record.
+A definition can end up bare while its citation survives: hand-built markup (content wholly
+deletion-marked, citation kept), an ordinary partial resolution (record a note, accept only the
+citation's revision, then run the stateless reject over what remains), or simply the input — the
+corpus genuinely contains cited childless notes (`WC064-Footnote` ships one, and
+`WC063-Footnote-Mod`'s note is childless). A cited `<w:footnote/>` with no block child is
+schema-degenerate under `CT_FtnEdn`, but faithful reproduction of exactly that shape is what
+`Accept(Compare(l, r)) ≡ r` means for those fixtures: inserting a "repair" paragraph was tried
+during #636's review round and broke the WC063/WC064 round-trips in both directions. The
+orphan-scoped prune never touches a cited note, so the shape flows through resolution unchanged;
+whether Word repairs it on open is Word's business, and the engine will not manufacture content
+the counterpart does not have.
 
 #### Relevant code
 

--- a/docs/ooxml_corner_cases.md
+++ b/docs/ooxml_corner_cases.md
@@ -431,7 +431,7 @@ childless shell nor its absence contributes story text.
 
 #### Relevant code
 
-- `Docxodus/Internal/NoteReferenceOps.cs` (`PruneNotesEmptiedByAccept`, the blockless guard)
+- `Docxodus/Internal/NoteReferenceOps.cs` (`PruneNotesEmptiedByResolution`, the blockless guard)
 - `Docxodus/RevisionProcessor.cs` (accept-side capture/prune)
 - `DS430`/`DS432` in `DocxSessionRevisionTests.cs` — the two husk shapes and their opposite fates
 


### PR DESCRIPTION
Closes #636

## The problem

#634's adversarial review empirically confirmed the mirror of the bug it was fixing. The
stateless reject pruned every note definition its resolution orphaned, **unconditionally**. That
unconditional prune existed as cover for #614's deliberate choice to leave a session-recorded
note's definition unmarked — and the omission made the redline ambiguous to a stateless consumer:

- a `w:ins` citation next to an **unmarked** definition is what a session-authored note insertion
  produced (#614), where reject must remove the definition;
- but it is **also** exactly what a comparison produces when the counterpart merely cites a husk
  the baseline already owned — where reject must keep it, because rejecting reproduces the
  baseline.

The unguarded prune picked the first case and ate the second: rejecting that redline deleted a
content-bearing definition the baseline was entitled to keep, `Reject(Compare(l, r)) ≠ l` —
verified by two independent review agents before this fix (baseline 1 note, rejected 0).

## The fix

The same move #631 made on the accept side: put the missing fact into the redline, then read it.

**The definition's content now records.** `InsertFootnote`/`InsertEndnote` under
tracked-change recording mark every definition run `w:ins` and insertion-mark the paragraph
marks, through `MarkParagraphContentAndMark` — the session's existing single owner of "this whole
paragraph is one revision" (the `MoveBlock` machinery), so no new mechanism. This matches what
Word writes for an inserted footnote (its text renders as an insertion in the note pane) and what
the diff engine's own redline has always carried for a wholly-inserted note — verified against
the WC035 insert-direction redline, whose definition arrives fully `w:ins`-marked. #614's
unmarked-definition rationale ("no independently meaningful resolution") described a granularity
Word itself permits; the real cost of the omission was the producer ambiguity above.

**The reject prune takes the same blockless guard as accept.** `PruneNotesEmptiedByAccept`
becomes `PruneNotesEmptiedByResolution`: a definition the resolution both orphaned *and* emptied
goes (a wholly-inserted note on reject, a wholly-deleted note on accept); an unmarked husk keeps
its content and stays. `Reject(Compare(l, r)) ≡ l` and `Accept(Compare(l, r)) ≡ r` now both hold
for the note stores, with one shared, direction-neutral rule. The session's own editorial resolve
paths (DS418) deliberately keep the unguarded rule, as before.

## Compatibility

A redline saved from a #614-era session (its definition unmarked — a shape shippable for four
days) now rejects to an orphaned husk through the stateless path instead of losing the note;
re-authoring the redline with the current version restores full reversibility. Recorded in the
CHANGELOG entry.

## Tests

- **`DS434_StatelessReject_PreservesABaselinesOwnHuskThatTheCounterpartCites`** (new) — the
  review's reproduced mirror case, red before this fix (rejected count 0 instead of 1).
- **`DS369_RecordedNoteDefinition_IsInsertionMarked_AndStatelessResolutionsReadIt`** (new, both
  note kinds) — pins the marking shape (every run inside `w:ins`, paragraph marks
  insertion-marked), that the stateless reject takes the note with zero diff against the baseline
  (the #614 contract, now achieved by reading the markup rather than by the unguarded prune), and
  that the stateless accept keeps the note with the markup resolved away.
- The #614 family (DS366–368, including the reversibility-proof residue check) and the #631
  family (DS429–433) pass unchanged.
- Full suite: 4,226 passed, 0 failed. Corpus differential against a main baseline: zero movement
  attributable to this change (no corpus fixture carries a live `w:ins` note citation, and the
  reject path is not corpus-exercised); the only content mismatch is #631's already-merged RP050
  row.

## Part 2 of #636: recorded, deliberately unhandled

The "cited childless shell" robustness nit (a definition emptied while its citation survives)
requires synthetic input Word's UI cannot author — deleting all of a note's text tracked leaves
the final paragraph mark unmarked, so the real Word flow accepts to an empty-paragraph note,
which we handle correctly. The degenerate shape and the deferred fix (leave a minimal empty
paragraph, pending Word-side evidence) are now recorded in the corner-cases doc's RP050 entry,
which is the right institutional memory for it — so this PR closes the issue rather than leaving
a tracker item whose next step cannot be taken in this environment.

## After the second adversarial round (third and fourth commits)

The review's verification pass empirically confirmed three behavioral findings, all addressed:

- **The guard reads the legacy engine's dialect** (`DS435`, red before the fix): `WmlComparer`
  re-synthesizes an *unmarked* `w:footnoteRef` marker run into every inserted definition it
  renders, so a purely-blockless guard shipped an orphaned marker-husk on reject where the
  pre-#636 unguarded prune removed the note. The predicate is now scaffolding-aware
  (`IsEmptiedToScaffolding`): note-reference-mark runs count as emptiness, real content never
  does.
- **One user action, one revision identity**: the citation envelope and every definition
  paragraph share a single author/date pair; previously each paragraph took its own monotonic
  date, splintering one insert into separately-dated revision groups. `DS369` asserts one
  distinct `w:date` across body and note.
- **A still-cited note a resolution strips bare stays bare** (`DS436`). The reviewer's suggested
  repair — restore a minimal empty paragraph — was implemented and then *reverted by evidence*:
  the corpus genuinely contains cited childless notes (`WC064-Footnote` ships one;
  `WC063-Footnote-Mod`'s note is childless), and the repair broke both WC round-trip suites,
  because `Accept(Compare(l, r)) ≡ r` means reproducing exactly that shape. The engine will not
  manufacture content the counterpart does not have; the decision and its evidence are recorded
  in the corner-cases entry.
- Plus: `DS434` pins the session-leg distinctness (the editorial reject still strips the husk —
  deliberately, now said on purpose) and shares one husk fixture builder with `DS430`; the
  same-release CHANGELOG's #614 entry and both architecture docs are reconciled with the new
  contract; and the rule's owner now documents the session interlock (the session resolver keeps
  a note's last block alive, so naively unifying it onto the guarded prune would silently stop
  pruning session-rejected recorded notes).

Final state: full suite 4,228 passed / 0 failed; corpus differential vs main shows **zero
library-attributable movement** (the only differing rows are the #633 harness's new observation
channels).