### PR TITLE
Count four cartridge chips in the dock guards (#620)

### DIFF
--- a/npm/tests/demo-arcade.spec.ts
+++ b/npm/tests/demo-arcade.spec.ts
@@ -230,7 +230,7 @@ test.describe('THE DOCX ARCADE page', () => {
     expect(state.text).toContain('PILCROW');      // HUD present
     expect(state.text).toContain('│');            // bezel present
     expect(state.fallback).toBeNull();            // per-frame path stayed incremental
-    expect(state.cartButtons).toBe(3);
+    expect(state.cartButtons).toBe(4);
     // Computed visibility, not the `hidden` attribute: the overlay/dock carry
     // explicit display values, which would silently defeat the attribute.
     await expect(page.locator('#dock')).toBeVisible();

--- a/npm/tests/social-demo.spec.ts
+++ b/npm/tests/social-demo.spec.ts
@@ -397,7 +397,7 @@ test.describe('The landing page on a phone', () => {
     await expect(page.locator('#dockcarts')).toBeHidden();
     await page.locator('#dockmore').click();
     await expect(page.locator('#dockcarts')).toBeVisible();
-    expect(await page.locator('#dockcarts button').count()).toBe(3);
+    expect(await page.locator('#dockcarts button').count()).toBe(4);
     await expect(page.locator('#restart')).toBeVisible();
     // The pad sits a fixed distance above the dock, so an opened sheet grows
     // the dock up underneath it: the D-pad covered the cartridge buttons and


### PR DESCRIPTION
Fixes the Playwright `test` failure on #620's head `b22a7a5`, introduced by the E1M1 restoration merged in #639.

The restoration added a fourth cartridge, and the dock renders one chip per entry in the carts array — but two specs still asserted the chip row holds exactly **three** buttons, and both failed with `Expected: 3, Received: 4` across all retries:

- `demo-arcade.spec.ts:233` — the boot test's `cartButtons` count of `#dockcarts button`
- `social-demo.spec.ts:400` — the phone floating-controls test counting the same row inside the compact dock's `⋯` sheet

Both now expect four. These were the run's only two failures (669 passed, including the restored `demo-arcade-freedoom.spec.ts`, the four-cartridge boot/save loops, and the mobile grid checks), and a repo-wide search for other hardcoded cartridge counts (`#dockcarts button`, `cartButtons`, cart-related `toBe(3)`) finds no other site. `npx tsc --noEmit` is clean; the change is two assertion literals, so no other suite is affected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhwcBuT6ns5iQDTgAzRLiH)_