### PR TITLE
Explain the AOT bundle's boot-time jiterpreter table messages, and pin the case that isn't benign

### DIFF
--- a/docs/architecture/wasm-packaging.md
+++ b/docs/architecture/wasm-packaging.md
@@ -169,6 +169,68 @@ The AOT-compiled `dotnet.native.wasm` is a different binary from the interpreter
 the trim canaries in `trim-validation.spec.ts` and the whole Playwright suite are what prove
 the tier did not change behaviour; both ran green on the AOT bundle before it shipped.
 
+### `Jiterpreter table N is not yet initialized` on the console
+
+The AOT bundle logs a short burst of these during boot, and only during boot:
+
+```
+MONO_WASM: Jiterpreter table 3 is not yet initialized
+MONO_WASM: Jiterpreter table 12 is not yet initialized
+MONO_WASM: Jiterpreter table 31 is not yet initialized
+...
+```
+
+It is **cosmetic runtime noise, not a Docxodus fault and not a broken tier** — but it is worth
+understanding, because a genuinely broken jiterpreter looks exactly the same in the console.
+
+The jiterpreter reserves 38 slices of the WebAssembly indirect function table: one for compiled
+traces, one for `do_jit_call` thunks, and 36 for *interp_entry* thunks — the wrappers that
+handle a call crossing **from AOT-compiled native code into an interpreted method**. There is
+one interp_entry table per call shape, which is what the number in the message decodes to:
+
+| Table | Shape |
+|---|---|
+| 0 | compiled traces |
+| 1 | `do_jit_call` thunks |
+| 2–10 | static, `void` return, 0–8 arguments |
+| 11–19 | static, returns a value, 0–8 arguments |
+| 20–28 | instance, `void` return, 0–8 arguments |
+| 29–37 | instance, returns a value, 0–8 arguments |
+
+The runtime allocates all 38 in `jiterpreter_allocate_tables()`, which `start_runtime()` calls
+on the line *after* `mono_wasm_load_runtime()` returns. Runtime startup itself crosses the
+AOT→interp boundary a handful of times, and each first crossing for a given method builds its
+entry thunk eagerly (`interp_create_method_pointer_llvmonly` in `interp/interp.c`, which caches
+the result on `imethod->jit_entry`). Those few crossings happen while the tables are still
+zeroed, so `mono_jiterp_allocate_table_entry` prints the message and returns 0 — and the caller
+falls back to the runtime's generic entry wrapper, which is the pre-jiterpreter path and is
+explicitly handled: *"Compiling a trampoline can fail for various reasons, so in that case we
+will fall back to the pre-existing ones below."* The cost is that those specific startup methods
+never get a specialized thunk. Everything after `start_runtime()` — i.e. every method the
+workload touches — allocates normally.
+
+This is why it arrived with the AOT tier and was never seen on the interpreter build: with no
+AOT code there are no AOT→interp transitions to wrap. Measured on this bundle (HC031, Chromium,
+2026-09):
+
+| | Boot-time messages | During workload | Jiterpreter stats after the workload | DOCX→HTML |
+|---|---|---|---|---|
+| Interpreter build (`RunAOTCompilation=false`) | 0 | 0 | `567 KB jitted; 500 traces; 0 jit_calls; 0 interp_entries` | 853 ms |
+| Shipped profile-guided AOT | 9 | 0 | `6.6 KB jitted; 8 traces; 6 jit_calls; 11 interp_entries` | 249 ms |
+
+Nine is deterministic across runs, and the tables *do* get allocated: the same boot logs
+`Allocated 122881 function table entries for jiterpreter`, and interp_entry thunks are compiled
+normally afterwards.
+
+**The failure mode this hides.** If `jiterpreter_allocate_tables()` ever threw — a future SDK
+growing the reservation past what `WebAssembly.Table.grow` will give, say — *no* table would be
+initialized, every trace and thunk would silently fall back to the interpreter, and the console
+would show the same message with different numbers. `npm/tests/wasm-steady-state.spec.ts` pins
+the difference: the allocation line must be present, the messages must name only interp_entry
+tables (never table 0 or 1), and none may appear after boot. There is no supported knob that
+reorders the two calls, so the noise itself stays; silencing it would mean
+`--jiterpreter-interp-entry-enabled=0`, which turns the thunks off rather than fixing anything.
+
 ## Compression and serving
 
 `build-wasm.sh` writes a brotli-11 `.br` sibling next to every `_framework` asset. The

--- a/npm/tests/wasm-steady-state.spec.ts
+++ b/npm/tests/wasm-steady-state.spec.ts
@@ -71,6 +71,63 @@ test.describe('WASM steady-state (issue #652)', () => {
     expect(stats.jittedBytes).toBeLessThan(status.wasmBytesLimit / 2);
   });
 
+  // The AOT bundle prints a handful of "Jiterpreter table N is not yet initialized" lines
+  // while booting: the runtime allocates the 38 function-table slices in
+  // jiterpreter_allocate_tables(), which start_runtime() calls on the line AFTER
+  // mono_wasm_load_runtime() returns, and runtime startup itself crosses the AOT->interp
+  // boundary a few times before that. Each such crossing builds its entry thunk eagerly, finds
+  // the table still zeroed, and falls back to the runtime's generic entry wrapper. Cosmetic —
+  // see docs/architecture/wasm-packaging.md.
+  //
+  // A jiterpreter that is genuinely broken logs the SAME message, so this pins the difference
+  // rather than the noise: the allocation must have completed, the fallbacks must be confined
+  // to boot, and they must never name the trace (0) or do_jit_call (1) tables — those two carry
+  // the whole tier, and losing them would drop the engine back to the plain interpreter with
+  // nothing but console output to say so.
+  test('the jiterpreter function tables are allocated, and only boot-time interp_entry thunks fall back', async ({ page }) => {
+    test.setTimeout(300000);
+    const logs: { afterBoot: boolean; text: string }[] = [];
+    let afterBoot = false;
+    page.on('console', (m) => logs.push({ afterBoot, text: m.text() }));
+
+    await page.goto('/test-harness.html?jiterpStats=1');
+    await waitForDocxodus(page);
+    afterBoot = true;
+
+    // jiterpreter_allocate_tables() reserves traceTableSize + jitCallTableSize +
+    // 36 * interpEntryTableSize + 1 entries and logs the total under --jiterpreter-stats-enabled.
+    // Its absence means the call threw and NO table was initialized.
+    const allocated = logs
+      .map((l) => /Allocated (\d+) function table entries for jiterpreter/.exec(l.text))
+      .find((m) => m !== null);
+    expect(allocated, 'jiterpreter function-table allocation line (did allocate_tables throw?)')
+      .toBeTruthy();
+    // 38 slices at minimum one entry each, plus the spare. Anything smaller means the loop
+    // over the interp_entry tables did not run to completion.
+    expect(Number(allocated![1])).toBeGreaterThan(38);
+
+    // Enough work to drive the tiering heuristics well past startup.
+    const input = loadWorkloadInput({
+      warmup: 0,
+      iterations: { compareSmall: 3, compareHeavy: 0, convert: 2, convertHeavy: 0, sessionRefresh: 20 },
+    });
+    await page.evaluate(runWasmWorkload, input);
+
+    const uninitialized = logs
+      .map((l) => ({ l, m: /Jiterpreter table (\d+) is not yet initialized/.exec(l.text) }))
+      .filter((x) => x.m !== null)
+      .map((x) => ({ afterBoot: x.l.afterBoot, table: Number(x.m![1]) }));
+    console.log(`interp_entry fallbacks: ${JSON.stringify(uninitialized)}`);
+
+    // Tables 0 (traces) and 1 (do_jit_call) are allocated first and must never be reported.
+    expect(uninitialized.filter((u) => u.table <= 1)).toEqual([]);
+    // Every fallback belongs to startup; once the tables exist, allocation always succeeds.
+    expect(uninitialized.filter((u) => u.afterBoot)).toEqual([]);
+    // 36 interp_entry tables; a handful of boot crossings is expected (9 on the 2026-09 AOT
+    // bundle), a flood is not.
+    expect(uninitialized.length).toBeLessThanOrEqual(36);
+  });
+
   test('steady-state latency of the representative workload', async ({ page }) => {
     test.setTimeout(900000);
     await page.goto('/test-harness.html');


### PR DESCRIPTION
## Why this exists

Since the browser build moved to profile-guided AOT, loading it prints a short burst of runtime messages on the console that the old interpreter build never produced:

```
MONO_WASM: Jiterpreter table 3 is not yet initialized
MONO_WASM: Jiterpreter table 12 is not yet initialized
MONO_WASM: Jiterpreter table 31 is not yet initialized
...
```

They look alarming and there was nothing written down about them. This PR is the answer, plus a test — because the genuinely bad version of this failure prints the *same* message and would otherwise be indistinguishable from the harmless one.

Nothing in the library changes. Documentation and one Playwright case only.

## What is actually happening

The Mono jiterpreter reserves 38 slices of the WebAssembly indirect function table. One holds compiled interpreter traces, one holds `do_jit_call` thunks, and the remaining 36 hold *interp_entry* thunks — the wrappers that handle a call crossing from AOT-compiled native code into a method that is still interpreted. There is one interp_entry table per call shape (static or instance × returns void or a value × 0–8 arguments), and that is exactly what the number in the message decodes to. Table 3 is "static, void, one argument"; table 31 is "instance, returns a value, two arguments".

All 38 are reserved in the runtime's `jiterpreter_allocate_tables()`, which `start_runtime()` calls on the line *after* `mono_wasm_load_runtime()` returns. Runtime startup itself crosses the AOT→interpreter boundary a handful of times before that line is reached. Each first crossing for a given method builds its entry thunk eagerly and caches it on the method, so those few crossings find the tables still zeroed, log the message, and get back 0. The runtime then falls back to its generic entry wrapper — the pre-jiterpreter path, which it handles deliberately ("Compiling a trampoline can fail for various reasons, so in that case we will fall back to the pre-existing ones below").

So the cost is that a few runtime-startup methods never get a specialized thunk. Every method the workload touches is allocated after `start_runtime()` finishes and is unaffected.

This is also why it arrived with the AOT tier and not before: with no AOT-compiled code there are no AOT→interpreter transitions to wrap at all.

## How it was checked

Both bundles were built from this tree and driven through the same document (HC031) in Chromium, capturing every console line and tagging each one as before or after the runtime finished booting:

| | Messages while booting | Messages during the workload | Jiterpreter stats after the workload | DOCX→HTML |
|---|---|---|---|---|
| Interpreter build (`RunAOTCompilation=false`) | 0 | 0 | 567 KB jitted, 500 traces, 0 jit_calls, 0 interp_entries | 853 ms |
| Shipped profile-guided AOT | 9 | 0 | 6.6 KB jitted, 8 traces, 6 jit_calls, 11 interp_entries | 249 ms |

Nine is deterministic across repeated runs, and the same boot that logs them also logs `Allocated 122881 function table entries for jiterpreter` and goes on to compile 11 interp_entry thunks — so the tables do get reserved, and the fallbacks really are confined to startup.

## The failure this would otherwise hide

If `jiterpreter_allocate_tables()` ever failed outright — a future SDK growing the reservation past what `WebAssembly.Table.grow` will hand back, for instance — then *no* table would be reserved, every trace and thunk would silently drop back to the plain interpreter, and the console would show the same message with different numbers. That is a 3–4× slowdown announced by nothing but log noise we would by then have learned to ignore.

The new case in `npm/tests/wasm-steady-state.spec.ts` pins the difference rather than the noise:

- the allocation line must be present and must cover all 38 slices, which fails if the reservation threw;
- the reported tables must all be interp_entry tables — never table 0 (traces) or table 1 (`do_jit_call`), the two that carry the whole tier;
- none may appear after the runtime has booted.

It passes on the profile-guided AOT bundle (9 fallbacks, all pre-boot) and on the interpreter bundle (none), so it does not become a trap for anyone building with AOT switched off. Ran alongside the existing "jiterpreter is active" case in the same file; both green. `npx tsc -p tsconfig.tests.json` is clean.

## What is not in here

There is no supported knob that reorders the runtime's two startup calls, so the messages themselves stay. The only switch that would silence them is `--jiterpreter-interp-entry-enabled=0`, which turns the thunks off rather than fixing anything, and would cost real speed. The full explanation, including the table-number decoding table, is now in `docs/architecture/wasm-packaging.md` under the AOT section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NZAntSeyd5HZ4fH4PVvy6

---
_Generated by [Claude Code](https://claude.ai/code/session_014NZAntSeyd5HZ4fH4PVvy6)_