### PR TITLE
fix: annotate nullable reference types in the four smallest #650 files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- `OpenXmlRegex.Match` no longer throws a `NullReferenceException` when called without a callback
+  on PowerPoint/DrawingML content (the `a:p`/`p:p` namespaced path) — it now returns the match
+  count like the Wordprocessing path already did.
+- The `WmlDocument(WmlDocument, params XElement[])` replacement-part constructor now throws a
+  clear `DocxodusException` when a replacement part's `pt:Uri` attribute does not match any part
+  in the package, instead of a `NullReferenceException`.
+
 ## [11.0.0] - 2026-09-01
 
 ### Removed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ are kept for the day each file migrates.
 **`Docxodus.csproj` and `Docxodus.Tests.csproj` both override it to `false`**, so the core
 library and the test project do *not* fail on warnings. The CLI tools, MCP server,
 python-host and WASM project do inherit it. Current baseline: the library builds with
-**133 warnings**, the test project with **716** (mostly StyleCop `SA1633`/`SA1636` file
+**129 warnings**, the test project with **710** (mostly StyleCop `SA1633`/`SA1636` file
 headers and `SA1206` using-order). Don't add to either baseline. Measure with
 `--no-incremental` — a warm incremental build reports zero because nothing recompiles.
 

--- a/Docxodus.Tests/AnnotationManagerTests.cs
+++ b/Docxodus.Tests/AnnotationManagerTests.cs
@@ -334,6 +334,7 @@ namespace Docxodus.Tests
             var htmlString = html.ToString();
 
             // Debug: Check if the bookmark anchor is in HTML
+            Assert.NotNull(retrievedAnnotation.BookmarkName);
             Assert.Contains(retrievedAnnotation.BookmarkName, htmlString);
 
             Assert.Contains("annot-highlight", htmlString);

--- a/Docxodus.Tests/OpenXmlRegexTests.cs
+++ b/Docxodus.Tests/OpenXmlRegexTests.cs
@@ -380,6 +380,25 @@ namespace Docxodus.Tests
                 Assert.Equal("As stated in Article {__1} and this Section {__1.1}, this is described in Exhibit 4.", innerText);
             }
         }
+
+        [Fact]
+        public void CanCountMatchesInDrawingMlContentWithoutCallback()
+        {
+            // Regression test: Match(content, regex) passes a null replacement AND a null
+            // callback into the PowerPoint/DrawingML (a:p) content path, which used to invoke
+            // the callback unconditionally instead of checking for null first.
+            var paragraph = XElement.Parse(
+                @"<a:p xmlns:a=""http://schemas.openxmlformats.org/drawingml/2006/main"">
+                    <a:r><a:t>Hello world</a:t></a:r>
+                  </a:p>");
+
+            var content = new[] { paragraph };
+            var regex = new Regex("world");
+
+            int count = OpenXmlRegex.Match(content, regex);
+
+            Assert.Equal(1, count);
+        }
     }
 }
 

--- a/Docxodus.Tests/WmlDocumentTests.cs
+++ b/Docxodus.Tests/WmlDocumentTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using Wp = DocumentFormat.OpenXml.Wordprocessing;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+public class WmlDocumentTests
+{
+    private static WmlDocument CreateMinimalDocument()
+    {
+        using var stream = new MemoryStream();
+        using (var wordDocument = WordprocessingDocument.Create(
+            stream, DocumentFormat.OpenXml.WordprocessingDocumentType.Document))
+        {
+            var mainPart = wordDocument.AddMainDocumentPart();
+            mainPart.Document = new Wp.Document(
+                new Wp.Body(new Wp.Paragraph(new Wp.Run(new Wp.Text("original")))));
+        }
+        return new WmlDocument("test.docx", stream.ToArray());
+    }
+
+    [Fact]
+    public void ReplacementPartConstructorRoundTripsAnUnmodifiedPart()
+    {
+        var original = CreateMinimalDocument();
+        var mainDocumentPart = original.MainDocumentPart;
+
+        var replaced = new WmlDocument(original, mainDocumentPart);
+
+        using var streamDoc = new OpenXmlMemoryStreamDocument(replaced);
+        using var reopened = streamDoc.GetWordprocessingDocument();
+        XElement? root = reopened.MainDocumentPart?.GetXDocument().Root;
+        Assert.NotNull(root);
+        Assert.Equal("original", root!.Value);
+    }
+
+    [Fact]
+    public void ReplacementPartConstructorThrowsClearlyWhenUriMatchesNoPart()
+    {
+        var original = CreateMinimalDocument();
+
+        // A replacement part whose pt:Uri attribute does not correspond to any part in the
+        // package must fail with a clear error rather than a NullReferenceException.
+        var bogusPart = new XElement(
+            W.body,
+            new XAttribute(PtOpenXml.Uri, new Uri("/word/does-not-exist.xml", UriKind.Relative)));
+
+        var ex = Assert.Throws<DocxodusException>(() => new WmlDocument(original, bogusPart));
+        Assert.Contains("does not match any part", ex.Message);
+    }
+}

--- a/Docxodus/DocumentAnnotation.cs
+++ b/Docxodus/DocumentAnnotation.cs
@@ -1,6 +1,3 @@
-// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
-#nullable disable
-
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
@@ -16,30 +13,31 @@ namespace Docxodus
     public class DocumentAnnotation
     {
         /// <summary>
-        /// Unique annotation identifier.
+        /// Unique annotation identifier. Null until assigned — either by the
+        /// caller, or by auto-generation on <see cref="DocxSession.AddAnnotation"/>.
         /// </summary>
-        public string Id { get; set; }
+        public string? Id { get; set; }
 
         /// <summary>
         /// Label category/type identifier (e.g., "CLAUSE_TYPE_A", "DATE_REF").
         /// Used for categorizing and filtering annotations.
         /// </summary>
-        public string LabelId { get; set; }
+        public string? LabelId { get; set; }
 
         /// <summary>
         /// Human-readable label text displayed in the UI.
         /// </summary>
-        public string Label { get; set; }
+        public string? Label { get; set; }
 
         /// <summary>
         /// Highlight color in hex format (e.g., "#FFEB3B").
         /// </summary>
-        public string Color { get; set; }
+        public string? Color { get; set; }
 
         /// <summary>
         /// Author who created the annotation.
         /// </summary>
-        public string Author { get; set; }
+        public string? Author { get; set; }
 
         /// <summary>
         /// Creation timestamp.
@@ -50,7 +48,7 @@ namespace Docxodus
         /// Internal bookmark name linking to document range.
         /// Format: _Docxodus_Ann_{Id}
         /// </summary>
-        public string BookmarkName { get; set; }
+        public string? BookmarkName { get; set; }
 
         /// <summary>
         /// Cached start page number (may be stale if document changed).
@@ -80,7 +78,7 @@ namespace Docxodus
         /// <summary>
         /// The annotated text content (populated when reading from document).
         /// </summary>
-        public string AnnotatedText { get; set; }
+        public string? AnnotatedText { get; set; }
 
         /// <summary>
         /// Creates a new DocumentAnnotation with default values.
@@ -111,7 +109,7 @@ namespace Docxodus
         /// <summary>
         /// Search for text and annotate the Nth occurrence.
         /// </summary>
-        public string SearchText { get; set; }
+        public string? SearchText { get; set; }
 
         /// <summary>
         /// Which occurrence to annotate (1-based). Default: 1
@@ -121,7 +119,7 @@ namespace Docxodus
         /// <summary>
         /// Use an existing bookmark by name instead of creating a new one.
         /// </summary>
-        public string ExistingBookmarkName { get; set; }
+        public string? ExistingBookmarkName { get; set; }
 
         /// <summary>
         /// Start paragraph index (0-based).

--- a/Docxodus/DocxSession.cs
+++ b/Docxodus/DocxSession.cs
@@ -3971,7 +3971,7 @@ public sealed partial class DocxSession : IDisposable
     private static MutationBatchChangeSet<T> SafeChangeSet<T>(
         IReadOnlyList<T>? before,
         IReadOnlyList<T>? after,
-        Func<T, string> key,
+        Func<T, string?> key,
         Func<T, T, bool> equivalent,
         string kind,
         List<string> warnings)
@@ -3989,12 +3989,12 @@ public sealed partial class DocxSession : IDisposable
     private static MutationBatchChangeSet<T> ChangeSet<T>(
         IReadOnlyList<T> before,
         IReadOnlyList<T> after,
-        Func<T, string> key,
+        Func<T, string?> key,
         Func<T, T, bool> equivalent)
     {
         static Dictionary<string, List<int>> IndexByKey(
             IReadOnlyList<T> items,
-            Func<T, string> selectKey)
+            Func<T, string?> selectKey)
         {
             var groups = new Dictionary<string, List<int>>(StringComparer.Ordinal);
             for (var index = 0; index < items.Count; index++)
@@ -4901,6 +4901,7 @@ public sealed partial class DocxSession : IDisposable
         {
             if (!string.Equals(ann.LabelId, labelId, StringComparison.Ordinal)) continue;
             if (string.IsNullOrEmpty(ann.BookmarkName)) continue;
+            if (ann.Id is null) continue;
             var anchors = ResolveBookmarkAnchors(ann.BookmarkName)
                 .Select(target => AttachCitation(target, citationRequest)).ToArray();
             if (anchors.Length > 0) map[ann.Id] = anchors;

--- a/Docxodus/FieldRetriever.cs
+++ b/Docxodus/FieldRetriever.cs
@@ -151,7 +151,8 @@ namespace Docxodus
                                     FiStack = fis,
                                 };
                             };
-                            // A well-formed separate/end always follows a begin, which pushed FiStack above.
+                            // An orphan separate/end with no preceding begin throws here (NullReferenceException
+                            // via FiStack!), exactly as it did before this file was nullable-annotated.
                             if (e.Attribute(w + "fldCharType")!.Value == "separate")
                             {
                                 Stack<FieldElementTypeInfo> fis = new Stack<FieldElementTypeInfo>(s.FiStack!.Reverse());

--- a/Docxodus/FieldRetriever.cs
+++ b/Docxodus/FieldRetriever.cs
@@ -1,6 +1,3 @@
-// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
-#nullable disable
-
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
@@ -43,10 +40,14 @@ namespace Docxodus
             var relevantElements = cachedAnnotationInformation[id];
 #endif
 
+            // Every element reachable here came from cachedAnnotationInformation, which
+            // AnnotateWithFieldInfo populates only from elements that already carry a non-null
+            // Stack<FieldElementTypeInfo> annotation — so the Annotation<>() calls below are
+            // guaranteed non-null.
             var groupedSubFields = relevantElements
                 .GroupAdjacent(e =>
                 {
-                    Stack<FieldElementTypeInfo> s = e.Annotation<Stack<FieldElementTypeInfo>>();
+                    Stack<FieldElementTypeInfo> s = e.Annotation<Stack<FieldElementTypeInfo>>()!;
                     var stackElement = s.FirstOrDefault(z => z.Id == id);
                     var elementsBefore = s.TakeWhile(z => z != stackElement);
                     return elementsBefore.Any();
@@ -60,8 +61,10 @@ namespace Docxodus
                     {
                         return g.Select(e =>
                         {
-                            Stack<FieldElementTypeInfo> s = e.Annotation<Stack<FieldElementTypeInfo>>();
-                            var stackElement = s.FirstOrDefault(z => z.Id == id);
+                            Stack<FieldElementTypeInfo> s = e.Annotation<Stack<FieldElementTypeInfo>>()!;
+                            // e is a member of its own stack's grouping, so a stack entry with
+                            // Id == id (namely e's own entry) is guaranteed present.
+                            var stackElement = s.FirstOrDefault(z => z.Id == id)!;
                             if (stackElement.FieldElementType == FieldElementTypeEnum.InstrText &&
                                 e.Name == w + "instrText")
                                 return e.Value;
@@ -71,7 +74,7 @@ namespace Docxodus
                     }
                     else
                     {
-                        Stack<FieldElementTypeInfo> s = g.First().Annotation<Stack<FieldElementTypeInfo>>();
+                        Stack<FieldElementTypeInfo> s = g.First().Annotation<Stack<FieldElementTypeInfo>>()!;
                         var stackElement = s.FirstOrDefault(z => z.Id == id);
                         var elementBefore = s.TakeWhile(z => z != stackElement).Last();
                         var subFieldId = elementBefore.Id;
@@ -116,7 +119,7 @@ namespace Docxodus
         {
             XNamespace w = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
 
-            XElement root = part.GetXDocument().Root;
+            XElement root = part.GetXDocument().Root!;
             var r = root.DescendantsAndSelf()
                 .Rollup(
                     new FieldElementTypeStack
@@ -126,9 +129,10 @@ namespace Docxodus
                     },
                     (e, s) =>
                     {
+                        // w:fldChar always carries w:fldCharType per the WordprocessingML schema.
                         if (e.Name == w + "fldChar")
                         {
-                            if (e.Attribute(w + "fldCharType").Value == "begin")
+                            if (e.Attribute(w + "fldCharType")!.Value == "begin")
                             {
                                 Stack<FieldElementTypeInfo> fis;
                                 if (s.FiStack == null)
@@ -147,9 +151,10 @@ namespace Docxodus
                                     FiStack = fis,
                                 };
                             };
-                            if (e.Attribute(w + "fldCharType").Value == "separate")
+                            // A well-formed separate/end always follows a begin, which pushed FiStack above.
+                            if (e.Attribute(w + "fldCharType")!.Value == "separate")
                             {
-                                Stack<FieldElementTypeInfo> fis = new Stack<FieldElementTypeInfo>(s.FiStack.Reverse());
+                                Stack<FieldElementTypeInfo> fis = new Stack<FieldElementTypeInfo>(s.FiStack!.Reverse());
                                 FieldElementTypeInfo wfi = fis.Pop();
                                 fis.Push(
                                     new FieldElementTypeInfo
@@ -163,9 +168,9 @@ namespace Docxodus
                                     FiStack = fis,
                                 };
                             }
-                            if (e.Attribute(w + "fldCharType").Value == "end")
+                            if (e.Attribute(w + "fldCharType")!.Value == "end")
                             {
-                                Stack<FieldElementTypeInfo> fis = new Stack<FieldElementTypeInfo>(s.FiStack.Reverse());
+                                Stack<FieldElementTypeInfo> fis = new Stack<FieldElementTypeInfo>(s.FiStack!.Reverse());
                                 FieldElementTypeInfo wfi = fis.Pop();
                                 return new FieldElementTypeStack
                                 {
@@ -211,7 +216,7 @@ namespace Docxodus
                         }
                         if (wfi3.FieldElementType == FieldElementTypeEnum.End)
                         {
-                            Stack<FieldElementTypeInfo> fis = new Stack<FieldElementTypeInfo>(s.FiStack.Reverse());
+                            Stack<FieldElementTypeInfo>? fis = new Stack<FieldElementTypeInfo>(s.FiStack!.Reverse());
                             fis.Pop();
                             if (!fis.Any())
                                 fis = null;
@@ -257,7 +262,7 @@ namespace Docxodus
             var cachedAnnotationInformation = new Dictionary<int, List<XElement>>();
             foreach (var desc in root.DescendantsTrimmed(d => d.Name == W.rPr || d.Name == W.pPr))
             {
-                Stack<FieldElementTypeInfo> s = desc.Annotation<Stack<FieldElementTypeInfo>>();
+                Stack<FieldElementTypeInfo>? s = desc.Annotation<Stack<FieldElementTypeInfo>>();
 
                 if (s != null )
                 {
@@ -397,7 +402,7 @@ namespace Docxodus
 
             if (field.Length == 0)
                 return emptyField;
-            string fieldType = field.TrimStart().Split(' ').FirstOrDefault();
+            string? fieldType = field.TrimStart().Split(' ').FirstOrDefault();
             if (fieldType == null)
                 return emptyField;
             if (fieldType.ToUpper() != "HYPERLINK" &&
@@ -421,9 +426,9 @@ namespace Docxodus
 
         public class FieldInfo
         {
-            public string FieldType;
-            public string[] Switches;
-            public string[] Arguments;
+            public string FieldType = "";
+            public string[] Switches = Array.Empty<string>();
+            public string[] Arguments = Array.Empty<string>();
         }
 
         public enum FieldElementTypeEnum
@@ -444,7 +449,7 @@ namespace Docxodus
         public class FieldElementTypeStack
         {
             public int Id;
-            public Stack<FieldElementTypeInfo> FiStack;
+            public Stack<FieldElementTypeInfo>? FiStack;
         }
     }
 }

--- a/Docxodus/Internal/AnnotationsCustomXml.cs
+++ b/Docxodus/Internal/AnnotationsCustomXml.cs
@@ -79,6 +79,9 @@ internal static class AnnotationsCustomXml
 
     public static void Write(WordprocessingDocument doc, DocumentAnnotation annotation)
     {
+        if (string.IsNullOrEmpty(annotation.Id))
+            throw new ArgumentException("Annotation must have an Id before it can be persisted.", nameof(annotation));
+
         var part = GetOrCreate(doc);
         var xdoc = part.GetXDocument();
         var existing = xdoc.Root?
@@ -105,8 +108,9 @@ internal static class AnnotationsCustomXml
 
     private static XElement Serialize(DocumentAnnotation a)
     {
+        // Only reachable via Write, which has already rejected a null/empty Id.
         var element = new XElement(Ann + "annotation",
-            new XAttribute("id", a.Id),
+            new XAttribute("id", a.Id!),
             new XAttribute("labelId", a.LabelId ?? ""),
             new XAttribute("label", a.Label ?? ""),
             new XAttribute("color", a.Color ?? "#FFFF00"));

--- a/Docxodus/OpenXmlRegex.cs
+++ b/Docxodus/OpenXmlRegex.cs
@@ -1,6 +1,3 @@
-// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
-#nullable disable
-
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
@@ -78,7 +75,7 @@ namespace Docxodus
         ///     Then the callback can return true / false to indicate whether to delete or not
         /// </summary>
         public static int Replace(IEnumerable<XElement> content, Regex regex, string replacement,
-            Func<XElement, Match, bool> doReplacement)
+            Func<XElement, Match, bool>? doReplacement)
         {
             return ReplaceInternal(content, regex, replacement, doReplacement, false, null, true);
         }
@@ -87,7 +84,7 @@ namespace Docxodus
         /// This overload enables not coalescing content, for callers that need runs left as-is.
         /// </summary>
         public static int Replace(IEnumerable<XElement> content, Regex regex, string replacement,
-            Func<XElement, Match, bool> doReplacement, bool coalesceContent)
+            Func<XElement, Match, bool>? doReplacement, bool coalesceContent)
         {
             return ReplaceInternal(content, regex, replacement, doReplacement, false, null, coalesceContent);
         }
@@ -108,13 +105,13 @@ namespace Docxodus
         ///     Then code throws an exception
         /// </summary>
         public static int Replace(IEnumerable<XElement> content, Regex regex, string replacement,
-            Func<XElement, Match, bool> doReplacement, bool trackRevisions, string author)
+            Func<XElement, Match, bool>? doReplacement, bool trackRevisions, string author)
         {
             return ReplaceInternal(content, regex, replacement, doReplacement, trackRevisions, author, true);
         }
 
-        private static int ReplaceInternal(IEnumerable<XElement> content, Regex regex, string replacement,
-            Func<XElement, Match, bool> callback, bool trackRevisions, string revisionTrackingAuthor,
+        private static int ReplaceInternal(IEnumerable<XElement> content, Regex regex, string? replacement,
+            Func<XElement, Match, bool>? callback, bool trackRevisions, string? revisionTrackingAuthor,
             bool coalesceContent)
         {
             if (content == null) throw new ArgumentNullException("content");
@@ -122,7 +119,7 @@ namespace Docxodus
 
             IEnumerable<XElement> contentList = content as IList<XElement> ?? content.ToList();
 
-            XElement first = contentList.FirstOrDefault();
+            XElement? first = contentList.FirstOrDefault();
             if (first == null)
                 return 0;
 
@@ -153,16 +150,18 @@ namespace Docxodus
                 foreach (XElement item in revTrackingWithoutId)
                     item.Add(new XAttribute(W.id, nextId++));
 
+                // Every RevTrackMarkupWithId element was just given a w:id above, so the lookup
+                // below is guaranteed non-null.
                 List<IGrouping<int, XElement>> revTrackingWithDuplicateIds = root
                     .DescendantsAndSelf()
                     .Where(d => RevTrackMarkupWithId.Contains(d.Name))
-                    .GroupBy(d => (int) d.Attribute(W.id))
+                    .GroupBy(d => (int) d.Attribute(W.id)!)
                     .Where(g => g.Count() > 1)
                     .ToList();
                 foreach (IGrouping<int, XElement> group in revTrackingWithDuplicateIds)
                     foreach (XElement gc in group.Skip(1))
                     {
-                        XAttribute xAttribute = gc.Attribute(W.id);
+                        XAttribute? xAttribute = gc.Attribute(W.id);
                         if (xAttribute != null) xAttribute.Value = nextId.ToString();
                         nextId++;
                     }
@@ -188,8 +187,8 @@ namespace Docxodus
             return 0;
         }
 
-        private static object WmlSearchAndReplaceTransform(XNode node, Regex regex, string replacement,
-            Func<XElement, Match, bool> callback, bool trackRevisions, string revisionTrackingAuthor,
+        private static object WmlSearchAndReplaceTransform(XNode node, Regex regex, string? replacement,
+            Func<XElement, Match, bool>? callback, bool trackRevisions, string? revisionTrackingAuthor,
             ReplaceInternalInfo replInfo, bool coalesceContent)
         {
             var element = node as XElement;
@@ -250,12 +249,14 @@ namespace Docxodus
                         // uses the Skip / Take special semantics of array to implement efficient finding of sub array
 
                         XElement firstRun = runCollection.First();
-                        XElement firstRunProperties = firstRun.Elements(W.rPr).FirstOrDefault();
+                        XElement? firstRunProperties = firstRun.Elements(W.rPr).FirstOrDefault();
 
                         // save away first run properties
 
                         if (trackRevisions)
                         {
+                            // The only caller that sets trackRevisions also requires a non-null
+                            // author (see the public Replace(..., trackRevisions, author) overload).
                             if (replacement != "")
                             {
                                 // We coalesce runs because a caller can pass coalesceContent:false
@@ -264,7 +265,7 @@ namespace Docxodus
                                 List<XElement> newRuns = UnicodeMapper.StringToCoalescedRunList(newTextValue,
                                     firstRunProperties);
                                 var newIns = new XElement(W.ins,
-                                    new XAttribute(W.author, revisionTrackingAuthor),
+                                    new XAttribute(W.author, revisionTrackingAuthor!),
                                     new XAttribute(W.date, DateTime.UtcNow.ToString("s") + "Z"),
                                     newRuns);
 
@@ -276,14 +277,15 @@ namespace Docxodus
 
                             foreach (XElement run in runCollection)
                             {
-                                bool isInIns = run.Parent != null && run.Parent.Name == W.ins;
+                                XElement? runParent = run.Parent;
+                                bool isInIns = runParent != null && runParent.Name == W.ins;
                                 if (isInIns)
                                 {
-                                    XElement parentIns = run.Parent;
-                                    XElement grandParentParagraph = parentIns.Parent;
+                                    XElement parentIns = runParent!;
+                                    XElement? grandParentParagraph = parentIns.Parent;
                                     if (grandParentParagraph != null)
                                     {
-                                        if ((string) parentIns.Attributes(W.author).FirstOrDefault() ==
+                                        if ((string?) parentIns.Attributes(W.author).FirstOrDefault() ==
                                             revisionTrackingAuthor)
                                         {
                                             List<XElement> parentInsSiblings = grandParentParagraph
@@ -300,7 +302,7 @@ namespace Docxodus
                                                     ? new XElement(W.ins,
                                                         parentIns.Attributes(),
                                                         new XElement(W.del,
-                                                            new XAttribute(W.author, revisionTrackingAuthor),
+                                                            new XAttribute(W.author, revisionTrackingAuthor!),
                                                             new XAttribute(W.date, DateTime.UtcNow.ToString("s") + "Z"),
                                                             parentIns.Elements().Select(TransformToDelText)))
                                                     : c)
@@ -312,7 +314,7 @@ namespace Docxodus
                                 else
                                 {
                                     var delRun = new XElement(W.del,
-                                        new XAttribute(W.author, revisionTrackingAuthor),
+                                        new XAttribute(W.author, revisionTrackingAuthor!),
                                         new XAttribute(W.date, DateTime.UtcNow.ToString("s") + "Z"),
                                         TransformToDelText(run));
                                     run.ReplaceWith(delRun);
@@ -420,8 +422,8 @@ namespace Docxodus
                 element.Nodes().Select(TransformToDelText));
         }
 
-        private static object PmlSearchAndReplaceTransform(XNode node, Regex regex, string replacement,
-            Func<XElement, Match, bool> callback, ReplaceInternalInfo counter)
+        private static object PmlSearchAndReplaceTransform(XNode node, Regex regex, string? replacement,
+            Func<XElement, Match, bool>? callback, ReplaceInternalInfo counter)
         {
             var element = node as XElement;
             if (element == null) return node;
@@ -445,7 +447,7 @@ namespace Docxodus
                 var charsAndRuns = runsTrimmed
                     .Select(r =>
                         r.Element(A.t) != null
-                            ? new { Ch = r.Element(A.t).Value, r }
+                            ? new { Ch = r.Element(A.t)!.Value, r }
                             : new { Ch = "\x01", r })
                     .ToList();
 
@@ -456,8 +458,9 @@ namespace Docxodus
                 counter.Count += matchCollection.Count;
                 if (replacement == null)
                 {
-                    foreach (Match match in matchCollection.Cast<Match>())
-                        callback(paragraph, match);
+                    if (callback != null)
+                        foreach (Match match in matchCollection.Cast<Match>())
+                            callback(paragraph, match);
                 }
                 else
                 {
@@ -508,7 +511,7 @@ namespace Docxodus
                                 if ((ce.Elements().Count(e => e.Name != A.rPr) != 1) || (ce.Element(A.t) == null))
                                     return DontConsolidate;
 
-                                XElement rPr = ce.Element(A.rPr);
+                                XElement? rPr = ce.Element(A.rPr);
                                 return rPr == null ? "" : rPr.ToString(SaveOptions.None);
                             });
                     var paragraphWithConsolidatedRuns = new XElement(A.p,
@@ -517,7 +520,9 @@ namespace Docxodus
                             if (g.Key == DontConsolidate)
                                 return (object) g;
 
-                            string textValue = g.Select(r => r.Element(A.t).Value).StringConcatenate();
+                            // Grouped by GroupAdjacent above, which routed every run without an
+                            // A.t element into the DontConsolidate group already handled above.
+                            string textValue = g.Select(r => r.Element(A.t)!.Value).StringConcatenate();
                             XAttribute xs = XmlUtil.GetXmlSpaceAttribute(textValue);
                             return new XElement(A.r,
                                 g.First().Elements(A.rPr),

--- a/Docxodus/UnicodeMapper.cs
+++ b/Docxodus/UnicodeMapper.cs
@@ -247,9 +247,9 @@ namespace Docxodus
         /// Each run will have the specified run properties.
         /// </summary>
         /// <param name="textValue">The text value to transform.</param>
-        /// <param name="runProperties">The run properties to apply.</param>
+        /// <param name="runProperties">The run properties to apply, or null for a run with none.</param>
         /// <returns>A list of runs representing the text value.</returns>
-        public static List<XElement> StringToCoalescedRunList(string textValue, XElement runProperties)
+        public static List<XElement> StringToCoalescedRunList(string textValue, XElement? runProperties)
         {
             return textValue
                 .Select(CharToRunChild)
@@ -265,9 +265,9 @@ namespace Docxodus
         /// text element with that text value. The run will have the specified run properties.
         /// </summary>
         /// <param name="textValue">The text value to transform.</param>
-        /// <param name="runProperties">The run properties to apply.</param>
+        /// <param name="runProperties">The run properties to apply, or null for a run with none.</param>
         /// <returns>A list with a single run.</returns>
-        public static IEnumerable<XElement> StringToSingleRunList(string textValue, XElement runProperties)
+        public static IEnumerable<XElement> StringToSingleRunList(string textValue, XElement? runProperties)
         {
             var run = new XElement(W.r,
                 runProperties,

--- a/Docxodus/WmlDocument.cs
+++ b/Docxodus/WmlDocument.cs
@@ -1,6 +1,3 @@
-// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
-#nullable disable
-
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
@@ -20,17 +17,17 @@ namespace Docxodus
     {
         private WmlDocument ParentWmlDocument;
 
-        public PtWordprocessingCommentsPart WordprocessingCommentsPart
+        public PtWordprocessingCommentsPart? WordprocessingCommentsPart
         {
             get
             {
                 using (MemoryStream ms = new MemoryStream(ParentWmlDocument.DocumentByteArray))
                 using (WordprocessingDocument wDoc = WordprocessingDocument.Open(ms, false))
                 {
-                    WordprocessingCommentsPart commentsPart = wDoc.MainDocumentPart.WordprocessingCommentsPart;
+                    WordprocessingCommentsPart? commentsPart = wDoc.MainDocumentPart!.WordprocessingCommentsPart;
                     if (commentsPart == null)
                         return null;
-                    XElement partElement = commentsPart.GetXDocument().Root;
+                    XElement partElement = commentsPart.GetXDocument().Root!;
                     var childNodes = partElement.Nodes().ToList();
                     foreach (var item in childNodes)
                         item.Remove();
@@ -74,11 +71,11 @@ namespace Docxodus
                 using (MemoryStream ms = new MemoryStream(this.DocumentByteArray))
                 using (WordprocessingDocument wDoc = WordprocessingDocument.Open(ms, false))
                 {
-                    XElement partElement = wDoc.MainDocumentPart.GetXDocument().Root;
+                    XElement partElement = wDoc.MainDocumentPart!.GetXDocument().Root!;
                     var childNodes = partElement.Nodes().ToList();
                     foreach (var item in childNodes)
                         item.Remove();
-                    return new PtMainDocumentPart(this, wDoc.MainDocumentPart.Uri, partElement.Name, partElement.Attributes(), childNodes);
+                    return new PtMainDocumentPart(this, wDoc.MainDocumentPart!.Uri, partElement.Name, partElement.Attributes(), childNodes);
                 }
             }
         }
@@ -97,11 +94,13 @@ namespace Docxodus
                 {
                     foreach (var replacementPart in replacementParts)
                     {
-                        XAttribute uriAttribute = replacementPart.Attribute(PtOpenXml.Uri);
+                        XAttribute? uriAttribute = replacementPart.Attribute(PtOpenXml.Uri);
                         if (uriAttribute == null)
                             throw new DocxodusException("Replacement part does not contain a Uri as an attribute");
                         String uri = uriAttribute.Value;
                         var part = package.GetParts().FirstOrDefault(p => p.Uri.ToString() == uri);
+                        if (part == null)
+                            throw new DocxodusException($"Replacement part Uri '{uri}' does not match any part in the package");
                         using (Stream partStream = part.GetStream(FileMode.Create, FileAccess.Write))
                         using (XmlWriter partXmlWriter = XmlWriter.Create(partStream))
                             replacementPart.Save(partXmlWriter);

--- a/wasm/DocxodusWasm/DocumentConverter.cs
+++ b/wasm/DocxodusWasm/DocumentConverter.cs
@@ -468,10 +468,10 @@ public partial class DocumentConverter
             {
                 Annotations = annotations.Select(a => new AnnotationInfo
                 {
-                    Id = a.Id,
-                    LabelId = a.LabelId,
-                    Label = a.Label,
-                    Color = a.Color,
+                    Id = a.Id ?? "",
+                    LabelId = a.LabelId ?? "",
+                    Label = a.Label ?? "",
+                    Color = a.Color ?? "",
                     Author = a.Author,
                     Created = a.Created?.ToString("o"),
                     BookmarkName = a.BookmarkName,
@@ -552,10 +552,10 @@ public partial class DocumentConverter
                 DocumentBytes = Convert.ToBase64String(resultDoc.DocumentByteArray),
                 Annotation = addedAnnotation != null ? new AnnotationInfo
                 {
-                    Id = addedAnnotation.Id,
-                    LabelId = addedAnnotation.LabelId,
-                    Label = addedAnnotation.Label,
-                    Color = addedAnnotation.Color,
+                    Id = addedAnnotation.Id ?? "",
+                    LabelId = addedAnnotation.LabelId ?? "",
+                    Label = addedAnnotation.Label ?? "",
+                    Color = addedAnnotation.Color ?? "",
                     Author = addedAnnotation.Author,
                     Created = addedAnnotation.Created?.ToString("o"),
                     BookmarkName = addedAnnotation.BookmarkName,
@@ -760,10 +760,10 @@ public partial class DocumentConverter
                 DocumentBytes = resultDoc.DocumentByteArray,
                 Annotation = addedAnnotation != null ? new AnnotationInfo
                 {
-                    Id = addedAnnotation.Id,
-                    LabelId = addedAnnotation.LabelId,
-                    Label = addedAnnotation.Label,
-                    Color = addedAnnotation.Color,
+                    Id = addedAnnotation.Id ?? "",
+                    LabelId = addedAnnotation.LabelId ?? "",
+                    Label = addedAnnotation.Label ?? "",
+                    Color = addedAnnotation.Color ?? "",
                     Author = addedAnnotation.Author,
                     Created = addedAnnotation.Created?.ToString("o"),
                     BookmarkName = addedAnnotation.BookmarkName,


### PR DESCRIPTION
## Summary

Part of #650. Removes `#nullable disable` from the four smallest/lowest-risk files in that
issue's "long tail" list — `DocumentAnnotation.cs` (4 sites), `WmlDocument.cs` (10),
`OpenXmlRegex.cs` (20, zero internal consumers), and `FieldRetriever.cs` (21) — and annotates
the ~55 nullable-warning sites that removing it exposes.

Most of this is mechanical: a property or parameter that genuinely can be absent (e.g.
`DocumentAnnotation.Id` is unset until `DocxSession.AddAnnotation` auto-generates one; a run's
`w:rPr` element that may not exist) gets `?`. A handful of sites got a `!` instead, each with a
one-line comment naming the invariant that makes it safe — for example, every `XElement` reached
through `FieldRetriever`'s cached annotation map was put there because it already carries a
non-null stack annotation, so the lookup can't actually come back empty.

## Two real bugs, found by the compiler

Turning nullable checking on for these files surfaced two latent `NullReferenceException` bugs
that had been invisible under the suppression:

1. **`OpenXmlRegex.Match(content, regex)` crashed on PowerPoint/DrawingML content.** The
   Wordprocessing (`w:p`) match path already null-checked its callback before invoking it; the
   PowerPoint (`a:p`) path a few lines below did not. Calling the 2-argument `Match()` overload
   (which intentionally passes a null callback — "just count the matches") on `a:p` content threw.
   Fixed to match the Wordprocessing path's existing behavior, with a regression test.
2. **`WmlDocument`'s replacement-part constructor crashed with a raw NRE** instead of a clear
   error when a replacement part's `pt:Uri` attribute didn't match any part in the package. Now
   throws `DocxodusException` with a message naming the offending URI, with a regression test
   (plus a new happy-path round-trip test for a constructor that had no coverage at all before).

## How this was verified

- `dotnet build Docxodus/Docxodus.csproj --no-incremental`: 133 → 129 warnings (net *fewer* than
  baseline — the four files also carried a misleading "inherited OpenXmlPowerTools" comment above
  their real copyright header that was tripping a StyleCop header-mismatch warning; removing it
  fixed that incidentally). No new warnings anywhere else in the library.
- `dotnet build Docxodus.Tests/Docxodus.Tests.csproj --no-incremental`: 716 → 710 (one new warning
  surfaced in `AnnotationManagerTests.cs` from the `DocumentAnnotation.BookmarkName` change, fixed
  with an `Assert.NotNull` the test should have had anyway).
- `dotnet test Docxodus.Tests/Docxodus.Tests.csproj`: full suite green, 3921 passed / 3 skipped
  (pre-existing skips), including 2 new regression tests and one existing test file's assertion
  tightened.
- `CLAUDE.md`'s warning baseline updated in this commit (133/716 → 129/710) per its own
  instructions.

## Test plan

- [x] `dotnet build Docxodus/Docxodus.csproj --no-incremental` — 129 warnings, 0 errors
- [x] `dotnet build Docxodus.Tests/Docxodus.Tests.csproj --no-incremental` — 710 warnings, 0 errors
- [x] `dotnet test Docxodus.Tests/Docxodus.Tests.csproj` — 3921 passed, 0 failed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSnwkK1Nx6zZb2RnnoxKdx