### PR TITLE
fix: annotate nullable reference types in the CSS layer of the HTML->DOCX family

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,11 +24,12 @@ duplicated description is one that will go stale.
 
 `Docxodus.csproj` sets `<Nullable>enable</Nullable>` (issue #13): every file is
 nullable-checked by default, so a new file needs no directive. The exception is the
-inherited OpenXmlPowerTools core — 8 legacy files (`WmlToHtmlConverter` + `.Charts`, the
-`HtmlToWml*` family, `FormattingAssembler`, `DocumentBuilder`) carry an explicit
-`#nullable disable` header, tracked by issues #646–#649. They hold back a lot: stripping
-all 8 takes the library from its baseline to **2,272** (**2,157** distinct `CS86xx`
-sites). `grep -l "^#nullable disable" Docxodus/*.cs` lists the remaining debt; when
+inherited OpenXmlPowerTools core — 6 legacy files (`WmlToHtmlConverter` + `.Charts`,
+`HtmlToWmlConverter` + `HtmlToWmlConverterCore`, `FormattingAssembler`, `DocumentBuilder`)
+carry an explicit `#nullable disable` header, tracked by issues #646, #648 and #649
+(#647's CSS layer is done). They hold back a lot: stripping all 6 takes the library from
+its baseline to **2,079** (**1,966** distinct `CS86xx` sites).
+`grep -l "^#nullable disable" Docxodus/*.cs` lists the remaining debt; when
 substantially refactoring one of those files, consider removing its header and fixing
 that file's warnings. CS8632 stays in `NoWarn` deliberately: with the project context
 enabled it can only fire inside the opted-out files, where some inert `?` annotations
@@ -40,7 +41,7 @@ are kept for the day each file migrates.
 **`Docxodus.csproj` and `Docxodus.Tests.csproj` both override it to `false`**, so the core
 library and the test project do *not* fail on warnings. The CLI tools, MCP server,
 python-host and WASM project do inherit it. Current baseline: the library builds with
-**121 warnings**, the test project with **691** (mostly StyleCop `SA1633`/`SA1636` file
+**119 warnings**, the test project with **689** (mostly StyleCop `SA1633`/`SA1636` file
 headers and `SA1206` using-order). Don't add to either baseline. Measure with
 `--no-incremental` — a warm incremental build reports zero because nothing recompiles.
 

--- a/Docxodus/HtmlToWmlCssApplier.cs
+++ b/Docxodus/HtmlToWmlCssApplier.cs
@@ -1,6 +1,3 @@
-// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
-#nullable disable
-
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
@@ -171,7 +168,7 @@ namespace Docxodus.HtmlToWml
                 InitialValue = (element, settings) => new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = "normal", Type = Docxodus.HtmlToWml.CSS.CssTermType.String } } },
                 ComputedValue = (element, assignedValue, settings) =>
                 {
-                    CssExpression valueForPercentage = null;
+                    CssExpression? valueForPercentage = null;
                     if (element.Parent != null)
                         valueForPercentage = GetComputedPropertyValue(null, element, "font-size", settings);
                     return ComputeAbsoluteLength(element, assignedValue, settings, valueForPercentage);
@@ -367,7 +364,7 @@ namespace Docxodus.HtmlToWml
                 InitialValue = (element, settings) => new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = "0", Type = Docxodus.HtmlToWml.CSS.CssTermType.Number, Unit = CssUnit.PT, } } },
                 ComputedValue = (element, assignedValue, settings) =>
                 {
-                    CssExpression valueForPercentage = null;
+                    CssExpression? valueForPercentage = null;
                     if (element.Parent != null)
                         valueForPercentage = GetComputedPropertyValue(null, element.Parent, "width", settings);
                     return ComputeAbsoluteLength(element, assignedValue, settings, valueForPercentage);
@@ -581,7 +578,7 @@ namespace Docxodus.HtmlToWml
                     },
                 ComputedValue = (element, assignedValue, settings) =>
                 {
-                    CssExpression valueForPercentage = null;
+                    CssExpression? valueForPercentage = null;
                     if (element.Parent != null)
                         valueForPercentage = GetComputedPropertyValue(null, element.Parent, "width", settings);
                     return ComputeAbsoluteLength(element, assignedValue, settings, valueForPercentage);
@@ -610,7 +607,7 @@ namespace Docxodus.HtmlToWml
                 InitialValue = (element, settings) => new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = "0", Type = Docxodus.HtmlToWml.CSS.CssTermType.Number, Unit = CssUnit.PT, } } },
                 ComputedValue = (element, assignedValue, settings) =>
                 {
-                    CssExpression valueForPercentage = null;
+                    CssExpression? valueForPercentage = null;
                     if (element.Parent != null)
                         valueForPercentage = GetComputedPropertyValue(null, element.Parent, "width", settings);
                     return ComputeAbsoluteLength(element, assignedValue, settings, valueForPercentage);
@@ -642,7 +639,7 @@ namespace Docxodus.HtmlToWml
                 InitialValue = (element, settings) => new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = "0", Type = Docxodus.HtmlToWml.CSS.CssTermType.Number, Unit = CssUnit.PT, } } },
                 ComputedValue = (element, assignedValue, settings) =>
                 {
-                    CssExpression valueForPercentage = null;
+                    CssExpression? valueForPercentage = null;
                     if (element.Parent != null)
                         valueForPercentage = GetComputedPropertyValue(null, element.Parent, "width", settings);
                     return ComputeAbsoluteLength(element, assignedValue, settings, valueForPercentage);
@@ -902,16 +899,19 @@ namespace Docxodus.HtmlToWml
                         element.Name != XhtmlNoNamespace.table &&
                         assignedValue.IsAuto)
                     {
-                        PropertyInfo pi = PropertyInfoList.FirstOrDefault(p => p.Names.Contains("width"));
+                        // This lambda is only ever invoked after PropertyInfoList's static
+                        // initializer has fully completed, though the compiler can't see that
+                        // through the self-referential closure.
+                        PropertyInfo? pi = PropertyInfoList!.FirstOrDefault(p => p.Names.Contains("width"));
                         string display = GetComputedPropertyValue(pi, element, "display", settings).ToString();
                         if (display != "inline")
                         {
-                            CssExpression parentPropertyValue = GetComputedPropertyValue(pi, element.Parent, "width", settings);
+                            CssExpression parentPropertyValue = GetComputedPropertyValue(pi, element.Parent!, "width", settings);
                             return parentPropertyValue;
                         }
                     }
-                    CssExpression valueForPercentage = null;
-                    XElement elementToQuery = element.Parent;
+                    CssExpression? valueForPercentage = null;
+                    XElement? elementToQuery = element.Parent;
                     while (elementToQuery != null)
                     {
                         valueForPercentage = GetComputedPropertyValue(null, elementToQuery, "width", settings);
@@ -949,7 +949,7 @@ namespace Docxodus.HtmlToWml
                 InitialValue = (element, settings) => new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = "0", Type = Docxodus.HtmlToWml.CSS.CssTermType.Number, Unit = CssUnit.PT, } } },
                 ComputedValue = (element, assignedValue, settings) =>
                 {
-                    CssExpression valueForPercentage = null;
+                    CssExpression? valueForPercentage = null;
                     if (element.Parent != null)
                         valueForPercentage = GetComputedPropertyValue(null, element.Parent, "width", settings);
                     return ComputeAbsoluteLength(element, assignedValue, settings, valueForPercentage);
@@ -978,7 +978,7 @@ namespace Docxodus.HtmlToWml
                 InitialValue = (element, settings) => new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = "none", Type = Docxodus.HtmlToWml.CSS.CssTermType.String, } } },
                 ComputedValue = (element, assignedValue, settings) =>
                 {
-                    CssExpression valueForPercentage = null;
+                    CssExpression? valueForPercentage = null;
                     if (element.Parent != null)
                         valueForPercentage = GetComputedPropertyValue(null, element.Parent, "width", settings);
                     return ComputeAbsoluteLength(element, assignedValue, settings, valueForPercentage);
@@ -1009,7 +1009,7 @@ namespace Docxodus.HtmlToWml
                 InitialValue = (element, settings) => new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = "auto", Type = Docxodus.HtmlToWml.CSS.CssTermType.String, } } },
                 ComputedValue = (element, assignedValue, settings) =>
                 {
-                    CssExpression valueForPercentage = null;
+                    CssExpression? valueForPercentage = null;
                     if (element.Parent != null)
                         valueForPercentage = GetComputedPropertyValue(null, element.Parent, "height", settings);
                     return ComputeAbsoluteLength(element, assignedValue, settings, valueForPercentage);
@@ -1038,7 +1038,7 @@ namespace Docxodus.HtmlToWml
                 InitialValue = (element, settings) => new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = "0", Type = Docxodus.HtmlToWml.CSS.CssTermType.Number, Unit = CssUnit.PT, } } },
                 ComputedValue = (element, assignedValue, settings) =>
                 {
-                    CssExpression valueForPercentage = null;
+                    CssExpression? valueForPercentage = null;
                     if (element.Parent != null)
                         valueForPercentage = GetComputedPropertyValue(null, element.Parent, "height", settings);
                     return ComputeAbsoluteLength(element, assignedValue, settings, valueForPercentage);
@@ -1067,7 +1067,7 @@ namespace Docxodus.HtmlToWml
                 InitialValue = (element, settings) => new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = "none", Type = Docxodus.HtmlToWml.CSS.CssTermType.String, } } },
                 ComputedValue = (element, assignedValue, settings) =>
                 {
-                    CssExpression valueForPercentage = null;
+                    CssExpression? valueForPercentage = null;
                     if (element.Parent != null)
                         valueForPercentage = GetComputedPropertyValue(null, element.Parent, "height", settings);
                     return ComputeAbsoluteLength(element, assignedValue, settings, valueForPercentage);
@@ -1275,12 +1275,12 @@ namespace Docxodus.HtmlToWml
       set the computed value
       return the computed value
 #endif
-        public static CssExpression GetComputedPropertyValue(PropertyInfo propertyInfo, XElement element, string propertyName,
+        public static CssExpression GetComputedPropertyValue(PropertyInfo? propertyInfo, XElement element, string propertyName,
             HtmlToWmlConverterSettings settings)
         {
             // if (property is already computed)
             //   return the computed value
-            Dictionary<string, CssExpression> computedValues = element.Annotation<Dictionary<string, CssExpression>>();
+            Dictionary<string, CssExpression>? computedValues = element.Annotation<Dictionary<string, CssExpression>>();
             if (computedValues == null)
             {
                 computedValues = new Dictionary<string, CssExpression>();
@@ -1300,7 +1300,7 @@ namespace Docxodus.HtmlToWml
                 if (propertyInfo == null)
                     throw new DocxodusException("all possible properties should be in the list");
             }
-            Dictionary<string, Property> propList = element.Annotation<Dictionary<string, Property>>();
+            Dictionary<string, Property>? propList = element.Annotation<Dictionary<string, Property>>();
             if (propList == null)
             {
                 CssExpression computedValue = GetInheritedOrInitializedValue(computedValues, propertyInfo, element, propertyName, false, settings);
@@ -1375,12 +1375,12 @@ namespace Docxodus.HtmlToWml
         }
 
         private static CssExpression ComputeAbsoluteLength(XElement element, CssExpression assignedValue, HtmlToWmlConverterSettings settings,
-            CssExpression lengthForPercentage)
+            CssExpression? lengthForPercentage)
         {
             if (assignedValue.Terms.Count != 1)
                 throw new DocxodusException("Should not have a unit with more than one term");
 
-            string value = assignedValue.Terms.First().Value;
+            string value = assignedValue.Terms.First().Value!;
             bool negative = assignedValue.Terms.First().Sign == '-';
 
             if (value == "thin")
@@ -1418,7 +1418,8 @@ namespace Docxodus.HtmlToWml
             if (unit == CssUnit.Percent)
             {
                 double ptSize;
-                if (!double.TryParse(lengthForPercentage.Terms.First().Value, NumberStyles.Float, CultureInfo.InvariantCulture, out ptSize))
+                // The unit == Percent && lengthForPercentage == null case already returned above.
+                if (!double.TryParse(lengthForPercentage!.Terms.First().Value, NumberStyles.Float, CultureInfo.InvariantCulture, out ptSize))
                     throw new DocxodusException("did not return a double?");
                 newPtSize = ptSize * decValue / 100d;
             }
@@ -1455,7 +1456,7 @@ namespace Docxodus.HtmlToWml
         {
             if (assignedValue.Terms.Count != 1)
                 throw new DocxodusException("Should not have a unit with more than one term, I think");
-            string value = assignedValue.Terms.First().Value;
+            string value = assignedValue.Terms.First().Value!;
             CssUnit? unit = assignedValue.Terms.First().Unit;
             if (unit == CssUnit.PT)
                 return assignedValue;
@@ -1465,7 +1466,7 @@ namespace Docxodus.HtmlToWml
             // todo what should the calculation be for computing larger / smaller?
             if (value == "larger" || value == "smaller")
             {
-                CssExpression parentFontSize = GetComputedPropertyValue(null, element.Parent, "font-size", settings);
+                CssExpression parentFontSize = GetComputedPropertyValue(null, element.Parent!, "font-size", settings);
                 double ptSize;
                 if (!double.TryParse(parentFontSize.Terms.First().Value, NumberStyles.Float, CultureInfo.InvariantCulture, out ptSize))
                     throw new DocxodusException("did not return a double?");
@@ -1508,7 +1509,7 @@ namespace Docxodus.HtmlToWml
             double? newPtSize = null;
             if (unit == CssUnit.EM || unit == CssUnit.EX || unit == CssUnit.Percent)
             {
-                CssExpression parentFontSize = GetComputedPropertyValue(null, element.Parent, "font-size", settings);
+                CssExpression parentFontSize = GetComputedPropertyValue(null, element.Parent!, "font-size", settings);
                 double ptSize;
                 if (!double.TryParse(parentFontSize.Terms.First().Value, NumberStyles.Float, CultureInfo.InvariantCulture, out ptSize))
                     throw new DocxodusException("did not return a double?");
@@ -1566,7 +1567,8 @@ namespace Docxodus.HtmlToWml
                         Property prop = new Property()
                         {
                             Name = declaration.Name.ToLower(),
-                            Expression = declaration.Expression,
+                            // Declaration()'s sole construction site always sets Expression.
+                            Expression = declaration.Expression!,
                             HighOrderSort = declaration.Important ? importantHighOrderSort : notImportantHighOrderSort,
                             IdAttributesInSelector = CountIdAttributesInSelector(selector),
                             AttributesInSelector = CountAttributesInSelector(selector),
@@ -1584,7 +1586,7 @@ namespace Docxodus.HtmlToWml
             XElement element)
         {
             int currentSimpleSelector = selector.SimpleSelectors.Count() - 1;
-            XElement currentElement = element;
+            XElement? currentElement = element;
             while (true)
             {
                 if (!DoesSimpleSelectorMatch(selector.SimpleSelectors[currentSimpleSelector], currentElement))
@@ -1653,9 +1655,9 @@ namespace Docxodus.HtmlToWml
                     {
                         if (simpleSelector.ID != null && simpleSelector.ID != "")
                         {
-                            string id = (string)element.Attribute("ID");
+                            string? id = (string?)element.Attribute("ID");
                             if (id == null)
-                                id = (string)element.Attribute("id");
+                                id = (string?)element.Attribute("id");
                             idMatch = simpleSelector.ID == id;
                         }
                         if (idMatch)
@@ -1677,13 +1679,15 @@ namespace Docxodus.HtmlToWml
 
         private static bool DoesAttributeMatch(Docxodus.HtmlToWml.CSS.CssAttribute attribute, XElement element)
         {
-            string attName = attribute.Operand.ToLower();
-            string attValue = (string)element.Attribute(attName);
+            // Attrib()'s sole construction site always sets Operand from a parsed identifier.
+            string attName = attribute.Operand!.ToLower();
+            string? attValue = (string?)element.Attribute(attName);
             if (attValue == null)
                 return false;
             if (attribute.Operator == null)
                 return true;
-            string value = attribute.Value;
+            // Attrib() defaults Value to "" and only ever sets it to a real (non-null) string.
+            string value = attribute.Value!;
             switch (attribute.Operator)
             {
                 case CssAttributeOperator.Equals:
@@ -1752,7 +1756,7 @@ namespace Docxodus.HtmlToWml
         {
             //if (property.Name == "direction")
             //    Console.WriteLine(1);
-            Dictionary<string, Property> propList = element.Annotation<Dictionary<string, Property>>();
+            Dictionary<string, Property>? propList = element.Annotation<Dictionary<string, Property>>();
             if (propList == null)
             {
                 propList = new Dictionary<string, Property>();
@@ -1784,7 +1788,7 @@ namespace Docxodus.HtmlToWml
 
         private static string[] ClassesOf(XElement element)
         {
-            string classesString = (string)element.Attribute("class");
+            string? classesString = (string?)element.Attribute("class");
             if (classesString == null)
                 return new string[0];
             return classesString.Split(' ');
@@ -1802,7 +1806,8 @@ namespace Docxodus.HtmlToWml
                 Property prop = new Property()
                 {
                     Name = declaration.Name.ToLower(),
-                    Expression = declaration.Expression,
+                    // Declaration()'s sole construction site always sets Expression.
+                    Expression = declaration.Expression!,
                     HighOrderSort = declaration.Important ? importantHighOrderSort : notImportantHighOrderSort,
                     IdAttributesInSelector = 0,
                     AttributesInSelector = 0,
@@ -1830,7 +1835,7 @@ namespace Docxodus.HtmlToWml
         {
             foreach (var element in xHtml.DescendantsAndSelf())
             {
-                XAttribute styleAtt = element.Attribute(XhtmlNoNamespace.style);
+                XAttribute? styleAtt = element.Attribute(XhtmlNoNamespace.style);
                 if (styleAtt != null)
                 {
                     string style = (string)styleAtt;
@@ -1845,7 +1850,7 @@ namespace Docxodus.HtmlToWml
                         Property.HighOrderPriority.StyleAttributeHigh,
                         ref propertySequence);
                 }
-                XAttribute dirAtt = element.Attribute(XhtmlNoNamespace.dir);
+                XAttribute? dirAtt = element.Attribute(XhtmlNoNamespace.dir);
                 if (dirAtt != null)
                 {
                     string dir = dirAtt.Value.ToLower();
@@ -1888,8 +1893,8 @@ namespace Docxodus.HtmlToWml
 
         private class ShorthandPropertiesInfo
         {
-            public string Name;
-            public string Pattern;
+            required public string Name;
+            required public string Pattern;
         }
 
         private static ShorthandPropertiesInfo[] ShorthandProperties = new[]
@@ -1931,7 +1936,7 @@ namespace Docxodus.HtmlToWml
 
         private static void ExpandShorthandPropertiesForElement(XElement element, HtmlToWmlConverterSettings settings)
         {
-            Dictionary<string, Property> propertyList = element.Annotation<Dictionary<string, Property>>();
+            Dictionary<string, Property>? propertyList = element.Annotation<Dictionary<string, Property>>();
             if (propertyList == null)
             {
                 propertyList = new Dictionary<string, Property>();
@@ -1942,9 +1947,9 @@ namespace Docxodus.HtmlToWml
                 Property p = kvp.Value;
                 if (p.Name == "border")
                 {
-                    CssExpression borderColor;
-                    CssExpression borderWidth;
-                    CssExpression borderStyle;
+                    CssExpression? borderColor;
+                    CssExpression? borderWidth;
+                    CssExpression? borderStyle;
                     if (p.Expression.Terms.Count == 1 && p.Expression.Terms.First().Value == "inherit")
                     {
                         borderColor = new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = "inherit", Type = CssTermType.String } } };
@@ -2025,9 +2030,9 @@ namespace Docxodus.HtmlToWml
                 }
                 if (p.Name == "border-top" || p.Name == "border-right" || p.Name == "border-bottom" || p.Name == "border-left")
                 {
-                    CssExpression borderColor;
-                    CssExpression borderWidth;
-                    CssExpression borderStyle;
+                    CssExpression? borderColor;
+                    CssExpression? borderWidth;
+                    CssExpression? borderStyle;
                     if (p.Expression.Terms.Count() == 1 && p.Expression.Terms.First().Value == "inherit")
                     {
                         borderColor = new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = "inherit", Type = CssTermType.String } } };
@@ -2106,9 +2111,9 @@ namespace Docxodus.HtmlToWml
 
                 if (p.Name == "list-style")
                 {
-                    CssExpression listStyleType;
-                    CssExpression listStylePosition;
-                    CssExpression listStyleImage;
+                    CssExpression? listStyleType;
+                    CssExpression? listStylePosition;
+                    CssExpression? listStyleImage;
                     if (p.Expression.Terms.Count == 1 && p.Expression.Terms.First().Value == "inherit")
                     {
                         listStyleType = new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = "inherit", Type = CssTermType.String } } };
@@ -2175,11 +2180,11 @@ namespace Docxodus.HtmlToWml
 
                 if (p.Name == "background")
                 {
-                    CssExpression backgroundColor;
-                    CssExpression backgroundImage;
-                    CssExpression backgroundRepeat;
-                    CssExpression backgroundAttachment;
-                    CssExpression backgroundPosition;
+                    CssExpression? backgroundColor;
+                    CssExpression? backgroundImage;
+                    CssExpression? backgroundRepeat;
+                    CssExpression? backgroundAttachment;
+                    CssExpression? backgroundPosition;
                     if (p.Expression.Terms.Count == 1 && p.Expression.Terms.First().Value == "inherit")
                     {
                         backgroundColor = new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = "inherit", Type = CssTermType.String } } };
@@ -2311,12 +2316,12 @@ namespace Docxodus.HtmlToWml
 
                 if (p.Name == "font")
                 {
-                    CssExpression fontStyle;
-                    CssExpression fontVarient;
-                    CssExpression fontWeight;
-                    CssExpression fontSize;
-                    CssExpression lineHeight;
-                    CssExpression fontFamily;
+                    CssExpression? fontStyle;
+                    CssExpression? fontVarient;
+                    CssExpression? fontWeight;
+                    CssExpression? fontSize;
+                    CssExpression? lineHeight;
+                    CssExpression? fontFamily;
                     if (p.Expression.Terms.Count() == 1 && p.Expression.Terms.First().Value == "inherit")
                     {
                         fontStyle = new CssExpression { Terms = new List<CssTerm> { new CssTerm { Value = "inherit", Type = CssTermType.String } } };
@@ -2575,9 +2580,9 @@ namespace Docxodus.HtmlToWml
         {
             if (term.IsColor)
                 return CssDataType.BackgroundColor;
-            if (BackgroundRepeatValues.Contains(term.Value.ToLower()))
+            if (BackgroundRepeatValues.Contains(term.Value!.ToLower()))
                 return CssDataType.BackgroundRepeat;
-            if (BackgroundAttachmentValues.Contains(term.Value.ToLower()))
+            if (BackgroundAttachmentValues.Contains(term.Value!.ToLower()))
                 return CssDataType.BackgroundAttachment;
             if (term.Function != null)
                 return CssDataType.BackgroundImage;
@@ -2589,7 +2594,7 @@ namespace Docxodus.HtmlToWml
                 term.Unit == CssUnit.PX ||
                 term.Unit == CssUnit.Percent)
                 return CssDataType.BackgroundPosition;
-            if (BackgroundPositionValues.Contains(term.Value.ToLower()))
+            if (BackgroundPositionValues.Contains(term.Value!.ToLower()))
                 return CssDataType.BackgroundPosition;
             return CssDataType.BackgroundPosition;
         }
@@ -2620,7 +2625,7 @@ namespace Docxodus.HtmlToWml
             {
                 return CssDataType.Color;
             }
-            if (BorderStyleValues.Contains(term.Value.ToLower()))
+            if (BorderStyleValues.Contains(term.Value!.ToLower()))
                 return CssDataType.BorderStyle;
             return CssDataType.BorderWidth;
         }
@@ -2645,9 +2650,9 @@ namespace Docxodus.HtmlToWml
 
         private static CssDataType GetDatatypeFromListStyleTerm(CssTerm term)
         {
-            if (ListStyleTypeValues.Contains(term.Value.ToLower()))
+            if (ListStyleTypeValues.Contains(term.Value!.ToLower()))
                 return CssDataType.ListStyleType;
-            if (ListStylePositionValues.Contains(term.Value.ToLower()))
+            if (ListStylePositionValues.Contains(term.Value!.ToLower()))
                 return CssDataType.ListStylePosition;
             return CssDataType.ListStyleImage;
         }
@@ -2681,13 +2686,13 @@ namespace Docxodus.HtmlToWml
 
         private static CssDataType GetDatatypeFromFontTerm(CssTerm term)
         {
-            if (FontStyleValues.Contains(term.Value.ToLower()))
+            if (FontStyleValues.Contains(term.Value!.ToLower()))
                 return CssDataType.FontStyle;
-            if (FontVarientValues.Contains(term.Value.ToLower()))
+            if (FontVarientValues.Contains(term.Value!.ToLower()))
                 return CssDataType.FontVarient;
-            if (FontWeightValues.Contains(term.Value.ToLower()))
+            if (FontWeightValues.Contains(term.Value!.ToLower()))
                 return CssDataType.FontWeight;
-            if (FontSizeMap.ContainsKey(term.Value.ToLower()))
+            if (FontSizeMap.ContainsKey(term.Value!.ToLower()))
                 return CssDataType.FontSize;
             if (term.Unit == CssUnit.CM ||
                 term.Unit == CssUnit.EM ||
@@ -2702,11 +2707,13 @@ namespace Docxodus.HtmlToWml
 
         public class PropertyInfo
         {
-            public string[] Names;
+            // Every one of the 42 entries in PropertyInfoList sets these four via object
+            // initializer; ComputedValue is genuinely optional (half the entries null it out).
+            required public string[] Names;
             public bool Inherits;
-            public Func<XElement, HtmlToWmlConverterSettings, bool> Includes;
-            public Func<XElement, HtmlToWmlConverterSettings, CssExpression> InitialValue;
-            public Func<XElement, CssExpression, HtmlToWmlConverterSettings, CssExpression> ComputedValue;
+            required public Func<XElement, HtmlToWmlConverterSettings, bool> Includes;
+            required public Func<XElement, HtmlToWmlConverterSettings, CssExpression> InitialValue;
+            public Func<XElement, CssExpression, HtmlToWmlConverterSettings, CssExpression>? ComputedValue;
         }
 
         private static void WriteXHtmlWithAnnotations(XElement element, StringBuilder sb)
@@ -2714,7 +2721,7 @@ namespace Docxodus.HtmlToWml
             int depth = element.Ancestors().Count() * 2;
             XElement dummyElement = new XElement(element.Name, element.Attributes());
             sb.Append(String.Format("{0}{1}", "".PadRight(depth), dummyElement) + Environment.NewLine);
-            Dictionary<string, Property> propList = element.Annotation<Dictionary<string, Property>>();
+            Dictionary<string, Property>? propList = element.Annotation<Dictionary<string, Property>>();
             if (propList != null)
             {
                 sb.Append("".PadRight(depth + 2) + "Properties from Stylesheets" + Environment.NewLine);
@@ -2729,7 +2736,7 @@ namespace Docxodus.HtmlToWml
                 }
                 sb.Append(Environment.NewLine);
             }
-            Dictionary<string, CssExpression> computedProperties = element.Annotation<Dictionary<string, CssExpression>>();
+            Dictionary<string, CssExpression>? computedProperties = element.Annotation<Dictionary<string, CssExpression>>();
             if (computedProperties != null)
             {
                 sb.Append("".PadRight(depth + 2) + "Computed Properties" + Environment.NewLine);
@@ -2762,19 +2769,19 @@ namespace Docxodus.HtmlToWml
             return sb.ToString();
         }
 
-        private static void DumpFunction(StringBuilder sb, int indent, CssFunction f)
+        private static void DumpFunction(StringBuilder sb, int indent, CssFunction? f)
         {
             Pr(sb, indent, "Function: {0}", f);
             if (f != null)
             {
                 indent++;
                 Pr(sb, indent, "Name: {0}", f.Name);
-                DumpExpression(sb, indent, f.Expression);
+                DumpExpression(sb, indent, f.Expression!);
                 indent--;
             }
         }
 
-        private static void DumpAttribute(StringBuilder sb, int indent, Docxodus.HtmlToWml.CSS.CssAttribute a)
+        private static void DumpAttribute(StringBuilder sb, int indent, Docxodus.HtmlToWml.CSS.CssAttribute? a)
         {
             Pr(sb, indent, "Attribute: {0}", a);
             if (a != null)
@@ -2788,7 +2795,7 @@ namespace Docxodus.HtmlToWml
             }
         }
 
-        private static void DumpSimpleSelector(StringBuilder sb, int indent, CssSimpleSelector s)
+        private static void DumpSimpleSelector(StringBuilder sb, int indent, CssSimpleSelector? s)
         {
             indent++;
             Pr(sb, indent, "SimpleSelector: {0}", s);
@@ -2852,7 +2859,8 @@ namespace Docxodus.HtmlToWml
             Pr(sb, indent, "Declaration >{0}<", d.ToString());
             indent++;
             Pr(sb, indent, "Name: {0}", d.Name);
-            DumpExpression(sb, indent, d.Expression);
+            // Declaration()'s sole construction site always sets Expression.
+            DumpExpression(sb, indent, d.Expression!);
             Pr(sb, indent, "Important: {0}", d.Important);
             indent--;
             indent--;
@@ -2873,7 +2881,7 @@ namespace Docxodus.HtmlToWml
             indent--;
         }
 
-        private static void Pr(StringBuilder sb, int indent, string format, object o)
+        private static void Pr(StringBuilder sb, int indent, string format, object? o)
         {
             if (o == null)
                 return;
@@ -2900,8 +2908,8 @@ namespace Docxodus.HtmlToWml
 
         public class Property : IComparable<Property>
         {
-            public string Name { get; set; }
-            public CssExpression Expression { get; set; }
+            required public string Name { get; set; }
+            required public CssExpression Expression { get; set; }
             public HighOrderPriority HighOrderSort { get; set; }
             public int IdAttributesInSelector { get; set; }
             public int AttributesInSelector { get; set; }
@@ -2922,30 +2930,31 @@ namespace Docxodus.HtmlToWml
                 UserHigh = 10,
             };
 
-            int System.IComparable<Property>.CompareTo(Property other)
+            int System.IComparable<Property>.CompareTo(Property? other)
             {
                 // if this is less than other, return -1
                 // if this is greater than other, return 1
 
+                Property o = other!;
                 int gt = 1;
                 int lt = -1;
-                if (this.HighOrderSort < other.HighOrderSort)
+                if (this.HighOrderSort < o.HighOrderSort)
                     return lt;
-                if (this.HighOrderSort > other.HighOrderSort)
+                if (this.HighOrderSort > o.HighOrderSort)
                     return gt;
-                if (this.IdAttributesInSelector < other.IdAttributesInSelector)
+                if (this.IdAttributesInSelector < o.IdAttributesInSelector)
                     return lt;
-                if (this.IdAttributesInSelector > other.IdAttributesInSelector)
+                if (this.IdAttributesInSelector > o.IdAttributesInSelector)
                     return gt;
-                if (this.AttributesInSelector < other.AttributesInSelector)
+                if (this.AttributesInSelector < o.AttributesInSelector)
                     return lt;
-                if (this.AttributesInSelector > other.AttributesInSelector)
+                if (this.AttributesInSelector > o.AttributesInSelector)
                     return gt;
-                if (this.ElementNamesInSelector < other.ElementNamesInSelector)
+                if (this.ElementNamesInSelector < o.ElementNamesInSelector)
                     return lt;
-                if (this.ElementNamesInSelector > other.ElementNamesInSelector)
+                if (this.ElementNamesInSelector > o.ElementNamesInSelector)
                     return gt;
-                return this.SequenceNumber.CompareTo(other.SequenceNumber);
+                return this.SequenceNumber.CompareTo(o.SequenceNumber);
             }
         }
 
@@ -2980,28 +2989,31 @@ namespace Docxodus.HtmlToWml
             if (color.Terms.Count() == 1)
             {
                 CssTerm term = color.Terms.First();
-                if (term.Type == CssTermType.Function && term.Function.Name.ToUpper() == "RGB" && term.Function.Expression.Terms.Count == 3)
+                // Paired with Type == Function, both set together by the same Term() branch.
+                if (term.Type == CssTermType.Function && term.Function!.Name.ToUpper() == "RGB" && term.Function.Expression!.Terms.Count == 3)
                 {
+                    // RGB arguments are always Number-type terms, never Function -- Value is non-null.
                     List<CssTerm> lt = term.Function.Expression.Terms;
                     if (lt.First().Unit == CssUnit.Percent)
                     {
-                        string v1 = lt.First().Value;
-                        string v2 = lt.ElementAt(1).Value;
-                        string v3 = lt.ElementAt(2).Value;
+                        string v1 = lt.First().Value!;
+                        string v2 = lt.ElementAt(1).Value!;
+                        string v3 = lt.ElementAt(2).Value!;
                         string colorInHex = String.Format("{0:x2}{1:x2}{2:x2}", (int)((float.Parse(v1) / 100.0) * 255),
                             (int)((float.Parse(v2) / 100.0) * 255), (int)((float.Parse(v3) / 100.0) * 255));
                         return colorInHex;
                     }
                     else
                     {
-                        string v1 = lt.First().Value;
-                        string v2 = lt.ElementAt(1).Value;
-                        string v3 = lt.ElementAt(2).Value;
+                        string v1 = lt.First().Value!;
+                        string v2 = lt.ElementAt(1).Value!;
+                        string v3 = lt.ElementAt(2).Value!;
                         string colorInHex = String.Format("{0:x2}{1:x2}{2:x2}", int.Parse(v1), int.Parse(v2), int.Parse(v3));
                         return colorInHex;
                     }
                 }
-                string value = term.Value;
+                // Type != Function here (handled above), so Value is non-null.
+                string value = term.Value!;
                 if (value.Substring(0, 1) == "#" && value.Length == 4)
                 {
                     string e = ConvertSingleDigit(value.Substring(1, 1)) +

--- a/Docxodus/HtmlToWmlCssApplier.cs
+++ b/Docxodus/HtmlToWmlCssApplier.cs
@@ -899,9 +899,10 @@ namespace Docxodus.HtmlToWml
                         element.Name != XhtmlNoNamespace.table &&
                         assignedValue.IsAuto)
                     {
-                        // This lambda is only ever invoked after PropertyInfoList's static
-                        // initializer has fully completed, though the compiler can't see that
-                        // through the self-referential closure.
+                        // The compiler can't see through this self-referential closure that
+                        // PropertyInfoList is non-null here: GetComputedPropertyValue (the only
+                        // invoker of a ComputedValue lambda) is never called from a static
+                        // initializer, so this always runs after PropertyInfoList is assigned.
                         PropertyInfo? pi = PropertyInfoList!.FirstOrDefault(p => p.Names.Contains("width"));
                         string display = GetComputedPropertyValue(pi, element, "display", settings).ToString();
                         if (display != "inline")

--- a/Docxodus/HtmlToWmlCssParser.cs
+++ b/Docxodus/HtmlToWmlCssParser.cs
@@ -1,6 +1,3 @@
-// Inherited OpenXmlPowerTools code that predates nullable annotations (issue #13).
-#nullable disable
-
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
@@ -29,11 +26,11 @@ namespace Docxodus.HtmlToWml.CSS
 {
     public class CssAttribute
     {
-        private string m_operand;
+        private string? m_operand;
         private CssAttributeOperator? m_op = null;
-        private string m_val;
+        private string? m_val;
 
-        public string Operand
+        public string? Operand
         {
             get {
                 return m_operand;
@@ -53,7 +50,7 @@ namespace Docxodus.HtmlToWml.CSS
             }
         }
 
-        public string CssOperatorString
+        public string? CssOperatorString
         {
             get {
                 if (this.m_op.HasValue)
@@ -66,11 +63,11 @@ namespace Docxodus.HtmlToWml.CSS
                 }
             }
             set {
-                this.m_op = (CssAttributeOperator)Enum.Parse(typeof(CssAttributeOperator), value);
+                this.m_op = (CssAttributeOperator)Enum.Parse(typeof(CssAttributeOperator), value!);
             }
         }
 
-        public string Value
+        public string? Value
         {
             get {
                 return m_val;
@@ -178,8 +175,10 @@ namespace Docxodus.HtmlToWml.CSS
 
     public class CssDeclaration
     {
-        private string m_name;
-        private CssExpression m_expression;
+        // Declaration()'s sole construction site always builds Name via string concatenation
+        // (never null).
+        private string m_name = "";
+        private CssExpression? m_expression;
         private bool m_important;
 
         public string Name
@@ -202,7 +201,7 @@ namespace Docxodus.HtmlToWml.CSS
             }
         }
 
-        public CssExpression Expression
+        public CssExpression? Expression
         {
             get {
                 return m_expression;
@@ -215,9 +214,10 @@ namespace Docxodus.HtmlToWml.CSS
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
+            // Declaration() always assigns Expression from Exprsn(), which always constructs one.
             sb.AppendFormat("{0}: {1}{2}",
                 m_name,
-                m_expression.ToString(),
+                m_expression!.ToString(),
                 m_important ? " !important" : "");
             return sb.ToString();
         }
@@ -226,8 +226,12 @@ namespace Docxodus.HtmlToWml.CSS
     public class CssDirective : ItfDeclarationContainer, ItfRuleSetContainer
     {
         private CssDirectiveType m_type;
-        private string m_name;
-        private CssExpression m_expression;
+        // Directive()'s sole construction site sets Name unconditionally as its first act.
+        // Expression is genuinely optional -- it's set on the "expression" grammar alternative
+        // but not the "medium list" one (e.g. @media has Mediums instead), and every ToString()
+        // path already null-checks it accordingly.
+        private string m_name = "";
+        private CssExpression? m_expression;
         private List<CssMedium> m_mediums = new List<CssMedium>();
         private List<CssDirective> m_directives = new List<CssDirective>();
         private List<CssRuleSet> m_rulesets = new List<CssRuleSet>();
@@ -253,7 +257,7 @@ namespace Docxodus.HtmlToWml.CSS
             }
         }
 
-        public CssExpression Expression
+        public CssExpression? Expression
         {
             get {
                 return this.m_expression;
@@ -500,9 +504,11 @@ namespace Docxodus.HtmlToWml.CSS
 
         private string ToCharSetString(string start)
         {
-            return string.Format("{2}{0} {1}", 
-                m_name, 
-                m_expression.ToString(), 
+            // Only reached for Type == Charset, whose grammar always carries a quoted-string
+            // expression (never the medium-list alternative that leaves Expression unset).
+            return string.Format("{2}{0} {1}",
+                m_name,
+                m_expression!.ToString(),
                 start);
         }
     }
@@ -591,18 +597,18 @@ namespace Docxodus.HtmlToWml.CSS
 
         public static explicit operator double(CssExpression e)
         {
-            return double.Parse(e.Terms.First().Value, CultureInfo.InvariantCulture);
+            return double.Parse(e.Terms.First().Value!, CultureInfo.InvariantCulture);
         }
 
         public static explicit operator Emu(CssExpression e)
         {
-            return Emu.PointsToEmus(double.Parse(e.Terms.First().Value, CultureInfo.InvariantCulture));
+            return Emu.PointsToEmus(double.Parse(e.Terms.First().Value!, CultureInfo.InvariantCulture));
         }
 
         // will only be called on expression that is in terms of points
         public static explicit operator TPoint(CssExpression e)
         {
-            return new TPoint(double.Parse(e.Terms.First().Value, CultureInfo.InvariantCulture));
+            return new TPoint(double.Parse(e.Terms.First().Value!, CultureInfo.InvariantCulture));
         }
 
         // will only be called on expression that is in terms of points
@@ -614,7 +620,7 @@ namespace Docxodus.HtmlToWml.CSS
                 if (term.Unit == CssUnit.PT)
                 {
                     double ptValue;
-                    if (double.TryParse(term.Value.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out ptValue))
+                    if (double.TryParse(term.Value, NumberStyles.Float, CultureInfo.InvariantCulture, out ptValue))
                     {
                         if (term.Sign == '-')
                             ptValue = -ptValue;
@@ -628,8 +634,10 @@ namespace Docxodus.HtmlToWml.CSS
 
     public class CssFunction
     {
-        private string m_name;
-        private CssExpression m_expression;
+        // Name is non-null: Term()'s only construction site always sets it from a just-parsed
+        // identifier.
+        private string m_name = "";
+        private CssExpression? m_expression;
 
         public string Name
         {
@@ -641,7 +649,7 @@ namespace Docxodus.HtmlToWml.CSS
             }
         }
 
-        public CssExpression Expression
+        public CssExpression? Expression
         {
             get {
                 return m_expression;
@@ -664,13 +672,13 @@ namespace Docxodus.HtmlToWml.CSS
                     {
                         first = false;
                     }
-                    else if (!t.Value.EndsWith("="))
+                    else if (!t.Value!.EndsWith("="))
                     {
                         sb.Append(", ");
                     }
 
                     bool quote = false;
-                    if (t.Type == CssTermType.String && !t.Value.EndsWith("="))
+                    if (t.Type == CssTermType.String && !t.Value!.EndsWith("="))
                     {
                         quote = true;
                     }
@@ -719,11 +727,13 @@ namespace Docxodus.HtmlToWml.CSS
         tv
     }
 
+    // Unused elsewhere in the codebase -- no construction site sets Value, so there is no real
+    // invariant to lean on here; nullable widening (rather than `!`) reflects that honestly.
     public class CssPropertyValue
     {
         private CssValueType m_type;
         private CssUnit m_unit;
-        private string m_value;
+        private string? m_value;
 
         public CssValueType Type
         {
@@ -745,7 +755,7 @@ namespace Docxodus.HtmlToWml.CSS
             }
         }
 
-        public string Value
+        public string? Value
         {
             get {
                 return this.m_value;
@@ -772,12 +782,13 @@ namespace Docxodus.HtmlToWml.CSS
         {
             get
             {
-                if (((m_type == CssValueType.Hex) 
-                    || (m_type == CssValueType.String && m_value.StartsWith("#"))) 
-                    && (m_value.Length == 6 || (m_value.Length == 7 && m_value.StartsWith("#"))))
+                string value = m_value ?? "";
+                if (((m_type == CssValueType.Hex)
+                    || (m_type == CssValueType.String && value.StartsWith("#")))
+                    && (value.Length == 6 || (value.Length == 7 && value.StartsWith("#"))))
                 {
                     bool hex = true;
-                    foreach (char c in m_value)
+                    foreach (char c in value)
                     {
                         if (!char.IsDigit(c)
                             && c != '#'
@@ -803,7 +814,7 @@ namespace Docxodus.HtmlToWml.CSS
                 else if (m_type == CssValueType.String)
                 {
                     bool number = true;
-                    foreach (char c in m_value)
+                    foreach (char c in value)
                     {
                         if (!char.IsDigit(c))
                         {
@@ -813,7 +824,7 @@ namespace Docxodus.HtmlToWml.CSS
                     }
                     if (number) { return false; }
 
-                    if (ColorParser.IsValidName(m_value))
+                    if (ColorParser.IsValidName(value))
                     {
                         return true;
                     }
@@ -825,20 +836,21 @@ namespace Docxodus.HtmlToWml.CSS
         public DocxColor ToColor()
         {
             string hex = "000000";
+            string value = m_value ?? "";
             if (m_type == CssValueType.Hex)
             {
-                if (m_value.Length == 7 && m_value.StartsWith("#"))
+                if (value.Length == 7 && value.StartsWith("#"))
                 {
-                    hex = m_value.Substring(1);
+                    hex = value.Substring(1);
                 }
-                else if (m_value.Length == 6)
+                else if (value.Length == 6)
                 {
-                    hex = m_value;
+                    hex = value;
                 }
             }
             else
             {
-                if (ColorParser.TryFromName(m_value, out var c))
+                if (ColorParser.TryFromName(value, out var c))
                 {
                     return c;
                 }
@@ -996,13 +1008,13 @@ namespace Docxodus.HtmlToWml.CSS
     public class CssSimpleSelector
     {
         private CssCombinator? m_combinator = null;
-        private string m_elementname;
-        private string m_id;
-        private string m_cls;
-        private CssAttribute m_attribute;
-        private string m_pseudo;
-        private CssFunction m_function;
-        private CssSimpleSelector m_child;
+        private string? m_elementname;
+        private string? m_id;
+        private string? m_cls;
+        private CssAttribute? m_attribute;
+        private string? m_pseudo;
+        private CssFunction? m_function;
+        private CssSimpleSelector? m_child;
 
         public CssCombinator? Combinator
         {
@@ -1013,7 +1025,7 @@ namespace Docxodus.HtmlToWml.CSS
                 m_combinator = value;
             }
         }
-        public string CombinatorString
+        public string? CombinatorString
         {
             get {
                 if (this.m_combinator.HasValue)
@@ -1026,11 +1038,11 @@ namespace Docxodus.HtmlToWml.CSS
                 }
             }
             set {
-                this.m_combinator = (CssCombinator)Enum.Parse(typeof(CssCombinator), value);
+                this.m_combinator = (CssCombinator)Enum.Parse(typeof(CssCombinator), value!);
             }
         }
 
-        public string ElementName
+        public string? ElementName
         {
             get {
                 return m_elementname;
@@ -1040,7 +1052,7 @@ namespace Docxodus.HtmlToWml.CSS
             }
         }
 
-        public string ID
+        public string? ID
         {
             get {
                 return m_id;
@@ -1050,7 +1062,7 @@ namespace Docxodus.HtmlToWml.CSS
             }
         }
 
-        public string Class
+        public string? Class
         {
             get {
                 return m_cls;
@@ -1060,7 +1072,7 @@ namespace Docxodus.HtmlToWml.CSS
             }
         }
 
-        public string Pseudo
+        public string? Pseudo
         {
             get {
                 return m_pseudo;
@@ -1070,7 +1082,7 @@ namespace Docxodus.HtmlToWml.CSS
             }
         }
 
-        public CssAttribute Attribute
+        public CssAttribute? Attribute
         {
             get {
                 return m_attribute;
@@ -1080,7 +1092,7 @@ namespace Docxodus.HtmlToWml.CSS
             }
         }
 
-        public CssFunction Function
+        public CssFunction? Function
         {
             get {
                 return m_function;
@@ -1090,7 +1102,7 @@ namespace Docxodus.HtmlToWml.CSS
             }
         }
 
-        public CssSimpleSelector Child
+        public CssSimpleSelector? Child
         {
             get {
                 return m_child;
@@ -1157,12 +1169,12 @@ namespace Docxodus.HtmlToWml.CSS
     public class CssTag
     {
         private CssTagType m_tagtype;
-        private string m_name;
-        private string m_cls;
-        private string m_pseudo;
-        private string m_id;
+        private string? m_name;
+        private string? m_cls;
+        private string? m_pseudo;
+        private string? m_id;
         private char m_parentrel = '\0';
-        private CssTag m_subtag;
+        private CssTag? m_subtag;
         private List<string> m_attribs = new List<string>();
 
         public CssTagType TagType
@@ -1203,7 +1215,7 @@ namespace Docxodus.HtmlToWml.CSS
             }
         }
 
-        public string Name
+        public string? Name
         {
             get {
                 return m_name;
@@ -1213,7 +1225,7 @@ namespace Docxodus.HtmlToWml.CSS
             }
         }
 
-        public string Class
+        public string? Class
         {
             get {
                 return m_cls;
@@ -1223,7 +1235,7 @@ namespace Docxodus.HtmlToWml.CSS
             }
         }
 
-        public string Pseudo
+        public string? Pseudo
         {
             get {
                 return m_pseudo;
@@ -1233,7 +1245,7 @@ namespace Docxodus.HtmlToWml.CSS
             }
         }
 
-        public string Id
+        public string? Id
         {
             get {
                 return m_id;
@@ -1253,7 +1265,7 @@ namespace Docxodus.HtmlToWml.CSS
             }
         }
 
-        public CssTag SubTag
+        public CssTag? SubTag
         {
             get {
                 return m_subtag;
@@ -1334,9 +1346,11 @@ namespace Docxodus.HtmlToWml.CSS
         private char? m_separator;
         private char? m_sign;
         private CssTermType m_type;
-        private string m_val;
+        // Non-null for every term shape except Function, where the parser's Term() production
+        // explicitly sets this to null once it repackages the term's text into Function.Name.
+        private string? m_val;
         private CssUnit? m_unit;
-        private CssFunction m_function;
+        private CssFunction? m_function;
 
         public char? Separator
         {
@@ -1347,7 +1361,7 @@ namespace Docxodus.HtmlToWml.CSS
                 m_separator = value;
             }
         }
-        public string SeparatorChar
+        public string? SeparatorChar
         {
             get {
                 return m_separator.HasValue ? this.m_separator.Value.ToString() : null;
@@ -1366,7 +1380,7 @@ namespace Docxodus.HtmlToWml.CSS
                 m_sign = value;
             }
         }
-        public string SignChar
+        public string? SignChar
         {
             get {
                 return this.m_sign.HasValue ? this.m_sign.Value.ToString() : null;
@@ -1386,7 +1400,7 @@ namespace Docxodus.HtmlToWml.CSS
             }
         }
 
-        public string Value
+        public string? Value
         {
             get {
                 return m_val;
@@ -1405,7 +1419,7 @@ namespace Docxodus.HtmlToWml.CSS
                 m_unit = value;
             }
         }
-        public string UnitString
+        public string? UnitString
         {
             get {
                 if (this.m_unit.HasValue)
@@ -1418,11 +1432,11 @@ namespace Docxodus.HtmlToWml.CSS
                 }
             }
             set {
-                this.m_unit = (CssUnit)Enum.Parse(typeof(CssUnit), value);
+                this.m_unit = (CssUnit)Enum.Parse(typeof(CssUnit), value!);
             }
         }
 
-        public CssFunction Function
+        public CssFunction? Function
         {
             get {
                 return m_function;
@@ -1438,7 +1452,7 @@ namespace Docxodus.HtmlToWml.CSS
 
             if (m_type == CssTermType.Function)
             {
-                sb.Append(m_function.ToString());
+                sb.Append(m_function!.ToString());
             }
             else if (m_type == CssTermType.Url)
             {
@@ -1446,11 +1460,12 @@ namespace Docxodus.HtmlToWml.CSS
             }
             else if (m_type == CssTermType.Unicode)
             {
-                sb.AppendFormat("U\\{0}", m_val.ToUpper());
+                // Only the Function branch ever leaves m_val null (see the field comment).
+                sb.AppendFormat("U\\{0}", m_val!.ToUpper());
             }
             else if (m_type == CssTermType.Hex)
             {
-                sb.Append(m_val.ToUpper());
+                sb.Append(m_val!.ToUpper());
             }
             else
             {
@@ -1480,8 +1495,8 @@ namespace Docxodus.HtmlToWml.CSS
             get
             {
                 if (((m_type == CssTermType.Hex)
-                    || (m_type == CssTermType.String && m_val.StartsWith("#")))
-                    && (m_val.Length == 6 || m_val.Length == 3 || ((m_val.Length == 7 || m_val.Length == 4)
+                    || (m_type == CssTermType.String && m_val!.StartsWith("#")))
+                    && (m_val!.Length == 6 || m_val.Length == 3 || ((m_val.Length == 7 || m_val.Length == 4)
                     && m_val.StartsWith("#"))))
                 {
                     bool hex = true;
@@ -1511,7 +1526,7 @@ namespace Docxodus.HtmlToWml.CSS
                 else if (m_type == CssTermType.String)
                 {
                     bool number = true;
-                    foreach (char c in m_val)
+                    foreach (char c in m_val!)
                     {
                         if (!char.IsDigit(c))
                         {
@@ -1530,28 +1545,32 @@ namespace Docxodus.HtmlToWml.CSS
                 }
                 else if (m_type == CssTermType.Function)
                 {
-                    if ((m_function.Name.ToLower().Equals("rgb") && m_function.Expression.Terms.Count == 3)
-                        || (m_function.Name.ToLower().Equals("rgba") && m_function.Expression.Terms.Count == 4)
+                    // Paired with Type == Function: the parser only sets one alongside the other,
+                    // both from the same Term() branch.
+                    CssFunction func = m_function!;
+                    CssExpression funcExpr = func.Expression!;
+                    if ((func.Name.ToLower().Equals("rgb") && funcExpr.Terms.Count == 3)
+                        || (func.Name.ToLower().Equals("rgba") && funcExpr.Terms.Count == 4)
                         )
                     {
-                        for (int i = 0; i < m_function.Expression.Terms.Count; i++)
+                        for (int i = 0; i < funcExpr.Terms.Count; i++)
                         {
-                            if (m_function.Expression.Terms[i].Type != CssTermType.Number) 
-                            { 
-                                return false; 
+                            if (funcExpr.Terms[i].Type != CssTermType.Number)
+                            {
+                                return false;
                             }
                         }
                         return true;
                     }
-                    else if ((m_function.Name.ToLower().Equals("hsl") && m_function.Expression.Terms.Count == 3)
-                      || (m_function.Name.ToLower().Equals("hsla") && m_function.Expression.Terms.Count == 4)
+                    else if ((func.Name.ToLower().Equals("hsl") && funcExpr.Terms.Count == 3)
+                      || (func.Name.ToLower().Equals("hsla") && funcExpr.Terms.Count == 4)
                       )
                     {
-                        for (int i = 0; i < m_function.Expression.Terms.Count; i++)
+                        for (int i = 0; i < funcExpr.Terms.Count; i++)
                         {
-                            if (m_function.Expression.Terms[i].Type != CssTermType.Number) 
-                            { 
-                                return false; 
+                            if (funcExpr.Terms[i].Type != CssTermType.Number)
+                            {
+                                return false;
                             }
                         }
                         return true;
@@ -1567,9 +1586,9 @@ namespace Docxodus.HtmlToWml.CSS
             {
                 if (t.Unit.HasValue && t.Unit.Value == Docxodus.HtmlToWml.CSS.CssUnit.Percent)
                 {
-                    return (int)(255f * float.Parse(t.Value) / 100f);
+                    return (int)(255f * float.Parse(t.Value!) / 100f);
                 }
-                return int.Parse(t.Value);
+                return int.Parse(t.Value!);
             }
             catch { }
             return 0;
@@ -1579,7 +1598,7 @@ namespace Docxodus.HtmlToWml.CSS
         {
             try
             {
-                return (int)(float.Parse(t.Value) * 255f / 360f);
+                return (int)(float.Parse(t.Value!) * 255f / 360f);
             }
             catch { }
             return 0;
@@ -1590,7 +1609,7 @@ namespace Docxodus.HtmlToWml.CSS
             string hex = "000000";
             if (m_type == CssTermType.Hex)
             {
-                if ((m_val.Length == 7 || m_val.Length == 4) && m_val.StartsWith("#"))
+                if ((m_val!.Length == 7 || m_val.Length == 4) && m_val.StartsWith("#"))
                 {
                     hex = m_val.Substring(1);
                 }
@@ -1601,44 +1620,47 @@ namespace Docxodus.HtmlToWml.CSS
             }
             else if (m_type == CssTermType.Function)
             {
-                if ((m_function.Name.ToLower().Equals("rgb") && m_function.Expression.Terms.Count == 3)
-                    || (m_function.Name.ToLower().Equals("rgba") && m_function.Expression.Terms.Count == 4)
+                // Paired with Type == Function, both set together by the same Term() branch.
+                CssFunction func = m_function!;
+                CssExpression funcExpr = func.Expression!;
+                if ((func.Name.ToLower().Equals("rgb") && funcExpr.Terms.Count == 3)
+                    || (func.Name.ToLower().Equals("rgba") && funcExpr.Terms.Count == 4)
                     )
                 {
                     int fr = 0, fg = 0, fb = 0;
-                    for (int i = 0; i < m_function.Expression.Terms.Count; i++)
+                    for (int i = 0; i < funcExpr.Terms.Count; i++)
                     {
-                        if (m_function.Expression.Terms[i].Type != CssTermType.Number)
+                        if (funcExpr.Terms[i].Type != CssTermType.Number)
                         {
                             return DocxColor.Black;
                         }
                         switch (i)
                         {
-                            case 0: fr = GetRGBValue(m_function.Expression.Terms[i]);
+                            case 0: fr = GetRGBValue(funcExpr.Terms[i]);
                                 break;
-                            case 1: fg = GetRGBValue(m_function.Expression.Terms[i]);
+                            case 1: fg = GetRGBValue(funcExpr.Terms[i]);
                                 break;
-                            case 2: fb = GetRGBValue(m_function.Expression.Terms[i]);
+                            case 2: fb = GetRGBValue(funcExpr.Terms[i]);
                                 break;
                         }
                     }
                     return ColorHelper.FromArgb(fr, fg, fb);
                 }
-                else if ((m_function.Name.ToLower().Equals("hsl") && m_function.Expression.Terms.Count == 3)
-                  || (m_function.Name.Equals("hsla") && m_function.Expression.Terms.Count == 4)
+                else if ((func.Name.ToLower().Equals("hsl") && funcExpr.Terms.Count == 3)
+                  || (func.Name.Equals("hsla") && funcExpr.Terms.Count == 4)
                   )
                 {
                     int h = 0, s = 0, v = 0;
-                    for (int i = 0; i < m_function.Expression.Terms.Count; i++)
+                    for (int i = 0; i < funcExpr.Terms.Count; i++)
                     {
-                        if (m_function.Expression.Terms[i].Type != CssTermType.Number) { return DocxColor.Black; }
+                        if (funcExpr.Terms[i].Type != CssTermType.Number) { return DocxColor.Black; }
                         switch (i)
                         {
-                            case 0: h = GetHueValue(m_function.Expression.Terms[i]);
+                            case 0: h = GetHueValue(funcExpr.Terms[i]);
                                 break;
-                            case 1: s = GetRGBValue(m_function.Expression.Terms[i]);
+                            case 1: s = GetRGBValue(funcExpr.Terms[i]);
                                 break;
-                            case 2: v = GetRGBValue(m_function.Expression.Terms[i]);
+                            case 2: v = GetRGBValue(funcExpr.Terms[i]);
                                 break;
                         }
                     }
@@ -1648,7 +1670,7 @@ namespace Docxodus.HtmlToWml.CSS
             }
             else
             {
-                if (ColorParser.TryFromName(m_val, out var c))
+                if (ColorParser.TryFromName(m_val!, out var c))
                 {
                     return c;
                 }
@@ -1782,7 +1804,7 @@ namespace Docxodus.HtmlToWml.CSS
     public class CssParser
     {
         private List<string> m_errors = new List<string>();
-        private CssDocument m_doc;
+        private CssDocument? m_doc;
 
         public CssDocument ParseText(string content)
         {
@@ -1810,7 +1832,7 @@ namespace Docxodus.HtmlToWml.CSS
             return m_doc;
         }
 
-        public CssDocument CSSDocument
+        public CssDocument? CSSDocument
         {
             get { return m_doc; }
         }
@@ -2004,9 +2026,9 @@ namespace Docxodus.HtmlToWml.CSS
             return (left.Hue == right.Hue && left.Value == right.Value && left.Saturation == right.Saturation);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            return this == (HueSatVal)obj;
+            return this == (HueSatVal)obj!;
         }
 
         public override int GetHashCode()
@@ -2031,11 +2053,11 @@ namespace Docxodus.HtmlToWml.CSS
         public Scanner m_scanner;
         public Errors m_errors;
 
-        public CssToken m_lastRecognizedToken;
-        public CssToken m_lookaheadToken;
+        public CssToken m_lastRecognizedToken = new CssToken();
+        public CssToken m_lookaheadToken = new CssToken();
         int errDist = minErrDist;
 
-        public CssDocument CssDoc;
+        public CssDocument CssDoc = new CssDocument();
 
         bool IsInHex(string value)
         {
@@ -2176,8 +2198,8 @@ namespace Docxodus.HtmlToWml.CSS
         void Css3()
         {
             CssDoc = new CssDocument();
-            CssRuleSet rset = null;
-            CssDirective dir = null;
+            CssRuleSet? rset = null;
+            CssDirective? dir = null;
 
             while (m_lookaheadToken.m_tokenKind == 4)
             {
@@ -2227,8 +2249,8 @@ namespace Docxodus.HtmlToWml.CSS
         void RuleSet(out CssRuleSet rset)
         {
             rset = new CssRuleSet();
-            CssSelector sel = null;
-            CssDeclaration dec = null;
+            CssSelector? sel = null;
+            CssDeclaration? dec = null;
 
             Selector(out sel);
             rset.Selectors.Add(sel);
@@ -2302,11 +2324,11 @@ namespace Docxodus.HtmlToWml.CSS
         void Directive(out CssDirective dir)
         {
             dir = new CssDirective();
-            CssDeclaration dec = null;
-            CssRuleSet rset = null;
-            CssExpression exp = null;
-            CssDirective dr = null;
-            string ident = null;
+            CssDeclaration? dec = null;
+            CssRuleSet? rset = null;
+            CssExpression? exp = null;
+            CssDirective? dr = null;
+            string? ident = null;
             CssMedium m;
 
             Expect(23);
@@ -2692,7 +2714,7 @@ namespace Docxodus.HtmlToWml.CSS
         {
             exp = new CssExpression();
             char? sep = null;
-            CssTerm trm = null;
+            CssTerm? trm = null;
 
             Term(out trm);
             exp.Terms.Add(trm);
@@ -2737,7 +2759,7 @@ namespace Docxodus.HtmlToWml.CSS
         void Declaration(out CssDeclaration dec)
         {
             dec = new CssDeclaration();
-            CssExpression exp = null;
+            CssExpression? exp = null;
             string ident = "";
 
             if (m_lookaheadToken.m_tokenKind == 24)
@@ -2781,7 +2803,7 @@ namespace Docxodus.HtmlToWml.CSS
         void Selector(out CssSelector sel)
         {
             sel = new CssSelector();
-            CssSimpleSelector ss = null;
+            CssSimpleSelector? ss = null;
             CssCombinator? cb = null;
 
             SimpleSelector(out ss);
@@ -2833,10 +2855,10 @@ namespace Docxodus.HtmlToWml.CSS
         {
             ss = new CssSimpleSelector();
             ss.ElementName = "";
-            string psd = null;
-            Docxodus.HtmlToWml.CSS.CssAttribute atb = null;
+            string? psd = null;
+            Docxodus.HtmlToWml.CSS.CssAttribute? atb = null;
             CssSimpleSelector parent = ss;
-            string ident = null;
+            string? ident = null;
 
             if (StartOf(3))
             {
@@ -2950,8 +2972,8 @@ namespace Docxodus.HtmlToWml.CSS
         {
             atb = new Docxodus.HtmlToWml.CSS.CssAttribute();
             atb.Value = "";
-            string quote = null;
-            string ident = null;
+            string? quote = null;
+            string? ident = null;
 
             Expect(35);
             while (m_lookaheadToken.m_tokenKind == 4)
@@ -3036,8 +3058,8 @@ namespace Docxodus.HtmlToWml.CSS
         void Pseudo(out string pseudo)
         {
             pseudo = "";
-            CssExpression exp = null;
-            string ident = null;
+            CssExpression? exp = null;
+            string? ident = null;
 
             Expect(43);
             if (m_lookaheadToken.m_tokenKind == 43)
@@ -3078,8 +3100,8 @@ namespace Docxodus.HtmlToWml.CSS
         {
             trm = new CssTerm();
             string val = "";
-            CssExpression exp = null;
-            string ident = null;
+            CssExpression? exp = null;
+            string? ident = null;
 
             if (m_lookaheadToken.m_tokenKind == 7 || m_lookaheadToken.m_tokenKind == 8)
             {
@@ -3217,7 +3239,9 @@ namespace Docxodus.HtmlToWml.CSS
                         }
                         Exprsn(out exp);
                         CssFunction func = new CssFunction();
-                        func.Name = trm.Value;
+                        // trm.Value was just set to the parsed identifier a few lines up in this
+                        // same production, before the Function branch repackages it as func.Name.
+                        func.Name = trm.Value!;
                         func.Expression = exp;
                         trm.Value = null;
                         trm.Function = func;
@@ -3550,8 +3574,8 @@ namespace Docxodus.HtmlToWml.CSS
         public int m_tokenPositionInCharacters;
         public int m_tokenColumn;
         public int m_tokenLine;
-        public string m_tokenValue;
-        public CssToken m_nextToken;
+        public string m_tokenValue = "";
+        public CssToken? m_nextToken;
     }
 
     public class CssBuffer
@@ -3564,16 +3588,16 @@ namespace Docxodus.HtmlToWml.CSS
         int m_bufferLength;
         int m_inputStreamLength;
         int m_currentPositionInBuffer;
-        Stream m_inputStream;
+        Stream? m_inputStream;
         bool m_isUserStream;
 
         public CssBuffer(Stream s, bool isUserStream)
         {
             m_inputStream = s; this.m_isUserStream = isUserStream;
 
-            if (m_inputStream.CanSeek)
+            if (s.CanSeek)
             {
-                m_inputStreamLength = (int)m_inputStream.Length;
+                m_inputStreamLength = (int)s.Length;
                 m_bufferLength = Math.Min(m_inputStreamLength, MAX_BUFFER_LENGTH);
                 m_bufferStart = Int32.MaxValue;
             }
@@ -3587,7 +3611,7 @@ namespace Docxodus.HtmlToWml.CSS
                 Pos = 0;
             else
                 m_currentPositionInBuffer = 0;
-            if (m_bufferLength == m_inputStreamLength && m_inputStream.CanSeek)
+            if (m_bufferLength == m_inputStreamLength && s.CanSeek)
                 Close();
         }
 
@@ -3697,7 +3721,8 @@ namespace Docxodus.HtmlToWml.CSS
                 m_inputBuffer = newBuf;
                 free = m_bufferLength;
             }
-            int read = m_inputStream.Read(m_inputBuffer, m_bufferLength, free);
+            // Every call site checks m_inputStream != null before calling this method.
+            int read = m_inputStream!.Read(m_inputBuffer, m_bufferLength, free);
             if (read > 0)
             {
                 m_inputStreamLength = m_bufferLength = (m_bufferLength + read);
@@ -3763,7 +3788,7 @@ namespace Docxodus.HtmlToWml.CSS
 
         public CssBuffer m_scannerBuffer;
 
-        CssToken m_currentToken;
+        CssToken m_currentToken = new CssToken();
         int m_currentInputCharacter;
         int m_currentCharacterBytePosition;
         int m_unicodeCharacterPosition;
@@ -3772,8 +3797,8 @@ namespace Docxodus.HtmlToWml.CSS
         int m_eolInComment;
         static readonly Hashtable s_start;
 
-        CssToken m_tokensAlreadyPeeked;
-        CssToken m_currentPeekToken;
+        CssToken m_tokensAlreadyPeeked = new CssToken();
+        CssToken m_currentPeekToken = new CssToken();
 
         char[] m_textOfCurrentToken = new char[c_maxTokenLength];
         int m_lengthOfCurrentToken;
@@ -4023,7 +4048,8 @@ namespace Docxodus.HtmlToWml.CSS
             int state;
             if (s_start.ContainsKey(m_currentInputCharacter))
             {
-                state = (int)s_start[m_currentInputCharacter];
+                // s_start's generated initializer only ever boxes non-null ints.
+                state = (int)s_start[m_currentInputCharacter]!;
             }
             else {
                 state = 0;


### PR DESCRIPTION
## Summary

Part of #647 — the first two of the four files it lists (the issue's own suggested sequencing: do the CSS parser and its applier together, bottom-up, before the two larger converter files). `HtmlToWmlCssParser.cs` and `HtmlToWmlCssApplier.cs` together suppress 188 nullable warnings and, per #647's own analysis, are entirely self-contained — nothing outside the four-file HTML→DOCX family references either one, so this change can't destabilize anything else in the library.

## What's in each file

**`HtmlToWmlCssParser.cs`** (62 sites) is a Coco/R-generated CSS grammar (the `Parser`/`Scanner`/`CssBuffer`/`CssToken` machinery) plus a set of hand-written, mutable AST node types (`CssTerm`, `CssFunction`, `CssDeclaration`, `CssDirective`, `CssSimpleSelector`, `CssTag`, …) with no real constructors — each type's actual guarantees come only from tracing its single construction site inside the generated grammar. Two shapes recur:
- A field that's *always* set by the time real code touches it (e.g. `CssDeclaration.Name`, built by string concatenation that can never produce null) gets a safe non-null default, so nothing downstream needs a null-check it didn't have before.
- A field that's *genuinely* conditional (e.g. `CssTerm.Value`, which the parser explicitly nulls out when a term turns out to be a function call like `rgb(...)`; `CssDirective.Expression`, only set on one of two grammar alternatives — `@media` uses `Mediums` instead) stays nullable. The file's own `ToString()` methods already null-check these in every case I found, which is what confirmed each one.

The generated parser/scanner classes got a more pragmatic treatment — non-null field defaults rather than tracing dozens of read sites for internal plumbing that's only ever constructed once, from inside this same file.

**`HtmlToWmlCssApplier.cs`** (126 sites) is the much larger, hand-written property-resolution table (which CSS properties exist, their initial/inherited/computed values) plus the code that walks the parsed stylesheet and applies it to the HTML tree. `PropertyInfo` and `Property` — the two record-like types this table is built from — both got `required` on their always-set members: every one of their ~70 construction sites already uses object-initializer syntax, so nothing needed to change at any of them to satisfy it. A recurring shape — declare 2-3 `CssExpression` locals, leave them null in a fallback branch, only read them behind a null-check further down (the color/width/height/border/list-style/background/font shorthand-expansion code) — is genuinely optional data, not a missed initialization, so those stayed nullable throughout.

## Why no behavior change

Every warning here resolved to either a verified non-null invariant (marked with `!` and a short comment where the reasoning wasn't obvious from the surrounding code) or a pre-existing implicit assumption made explicit — never a new runtime check or an altered code path.

## Validation

- `dotnet build Docxodus/Docxodus.csproj --no-incremental`: 0 errors, and both files individually confirmed at 0 warnings.
- `dotnet build Docxodus.sln -c Release --no-incremental` (full solution, wasm-tools workload): 0 errors.
- `dotnet build tools/docx2oc/docx2oc.csproj`, plus the four **out-of-solution** tool projects not covered by the `.sln` (`tools/diffharness`, `tools/manifest-fuzz`, `tools/screenshots`, `benchmarks/docxdiff-stress` — these inherit `TreatWarningsAsErrors=true` and were the exact failure class that broke an earlier PR in this series' CI): all 0 errors. (`benchmarks/complex-form-doc` has one pre-existing, unrelated build error already present on `main` — confirmed by building it against `main` directly — and untouched by this change.)
- `dotnet test Docxodus.Tests/Docxodus.Tests.csproj`: 3923 passed, 3 pre-existing skips, 0 failures — including all 232 tests in `HwTests` (the HTML→DOCX conversion coverage `#647` calls out by name).
- Library warning baseline: 121 → 119 (two files' stale copyright-header StyleCop mismatches cleared, one per file, matching every other file in this nullable-annotation series). Test project: 691 → 689. `CLAUDE.md`'s legacy-file count and the "if all remaining files were stripped" projection are both updated in the same commit.
- `HtmlToWmlConverterCore.cs` and `HtmlToWmlConverter.cs` (the other two files `#647` lists) remain `#nullable disable`, tracked as the issue's next PR per its own sequencing note ("do not put all four in one diff").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSnwkK1Nx6zZb2RnnoxKdx