### PR TITLE
fix: retire the NoWarn list and fix the bugs CS8073 was flagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,23 @@ All notable changes to this project will be documented in this file.
   resolving theme fonts for a paragraph whose accumulated properties don't carry a paragraph-mark
   run-properties element (`w:rPr`) — it now skips theme-font resolution for that paragraph mark
   instead of crashing.
+- `DocumentBuilder.CopyFontTable` no longer treats every embedded font in a merged document as
+  already present in the output — a relationship lookup returning a value type was compared to
+  `null`, which is always true for that type, so the actual font-copy logic beneath it was
+  unreachable. No `DocumentBuilder` merge has ever embedded a font.
+- `DocumentBuilder`'s image, OLE-object, and chart-data relationship copying no longer misses the
+  case where a reference points at an *external* relationship rather than a same-package part —
+  the same always-true value-type comparison meant the external-relationship fallback in
+  `CopyRelatedImage`, the OLE-object copy loop, and `CopyChartObjects` could never run.
+- `DocumentBuilder`'s chart (`c:chart`) and chart-drawing (`c:userShapes`) part copying no longer
+  crashes when a referenced relationship doesn't resolve — same root cause, but these two paths
+  had no fallback at all, so a document with a stray reference could abort the whole merge instead
+  of the reference being skipped.
+- `MetricsGetter`'s `ReferenceToNullImage` metric can now actually be reported — the same
+  value-type/`null` comparison meant it could never increment, even for a document with a
+  genuinely dangling image relationship.
+- `DocumentBuilder`'s three `catch (DocumentBuilderInternalException) { throw dbie; }` rethrows
+  now preserve the original stack trace (`throw;`) instead of resetting it to the rethrow point.
 
 ## [11.0.0] - 2026-09-01
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,9 @@ nullable-checked by default, so a new file needs no directive. The inherited
 OpenXmlPowerTools core has fully migrated (issue #645): no file under `Docxodus/`
 carries a `#nullable disable` header anymore. `grep -l "^#nullable disable" Docxodus/*.cs`
 should return nothing — reintroducing the header on a new or refactored file is a
-regression, not a shortcut. `CS8632` still sits in the project's `NoWarn` list; issue
-#651 tracks retiring it now that no opted-out file needs the inert `?` annotations it
-was covering.
+regression, not a shortcut. `Docxodus.csproj` no longer has a `NoWarn` property at all
+(issue #651) — `CS8632`, `CS8073` and `CA2200` are gone along with the last opted-out
+file that could fire them.
 
 ### Warnings
 

--- a/Docxodus.Tests/DocumentBuilderTests.cs
+++ b/Docxodus.Tests/DocumentBuilderTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Validation;
 using DocumentFormat.OpenXml.Wordprocessing;
@@ -763,6 +764,67 @@ namespace OxPt
                 var styles = wDoc.MainDocumentPart.StyleDefinitionsPart.GetXDocument().Root.Elements(W.docDefaults).ToArray();
                 Assert.Single(styles);
             }
+        }
+
+        [Fact]
+        public void DB0017_EmbeddedFontTable_FontPartSurvivesMerge()
+        {
+            // Regression test: CopyFontTable located the destination's own already-copied
+            // relationship with Parts.FirstOrDefault(...), whose return type (IdPartPair) is a
+            // struct, then compared the result to null. FirstOrDefault() on a struct sequence
+            // returns default(IdPartPair) on a miss, never null, so "already copied, skip" was
+            // always taken and the actual font-copy logic beneath it was unreachable -
+            // DocumentBuilder never embedded a font, for any source document, ever.
+            byte[] fontBytes = { 1, 2, 3, 4, 5, 6, 7, 8 };
+            WmlDocument source = BuildDocWithEmbeddedFont("hello", "rIdEmbedded1", fontBytes);
+
+            List<Source> sources = new List<Source>()
+            {
+                new Source(source, true),
+            };
+            WmlDocument result = DocumentBuilder.BuildDocument(sources);
+
+            using (var stream = new MemoryStream(result.DocumentByteArray))
+            using (WordprocessingDocument wDoc = WordprocessingDocument.Open(stream, false))
+            {
+                var fontTablePart = wDoc.MainDocumentPart!.FontTablePart;
+                Assert.NotNull(fontTablePart);
+                var fontPart = fontTablePart.FontParts.SingleOrDefault();
+                Assert.NotNull(fontPart);
+                using (var fontStream = fontPart.GetStream())
+                using (var ms = new MemoryStream())
+                {
+                    fontStream.CopyTo(ms);
+                    Assert.Equal(fontBytes, ms.ToArray());
+                }
+            }
+        }
+
+        private static WmlDocument BuildDocWithEmbeddedFont(string text, string relId, byte[] fontBytes)
+        {
+            using var stream = new MemoryStream();
+            using (var doc = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document))
+            {
+                var main = doc.AddMainDocumentPart();
+                main.Document = new Document(new Body(new Paragraph(new Run(new Text(text)))));
+                var fontTable = main.AddNewPart<FontTablePart>();
+                var fontPart = fontTable.AddFontPart("application/x-font-ttf", relId);
+                using (var fontStream = fontPart.GetStream(FileMode.Create))
+                    fontStream.Write(fontBytes, 0, fontBytes.Length);
+                using (var writer = new StreamWriter(fontTable.GetStream(FileMode.Create)))
+                {
+                    writer.Write(
+                        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+                        "<w:fonts xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\" " +
+                        "xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">" +
+                        "<w:font w:name=\"Custom Embedded Font\">" +
+                        $"<w:embedRegular r:id=\"{relId}\"/>" +
+                        "</w:font>" +
+                        "</w:fonts>");
+                }
+                doc.Save();
+            }
+            return new WmlDocument("embedded-font.docx", stream.ToArray());
         }
 
         [Theory]

--- a/Docxodus.Tests/MetricsGetterTests.cs
+++ b/Docxodus.Tests/MetricsGetterTests.cs
@@ -8,6 +8,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
 using Docxodus;
 using Xunit;
 
@@ -68,6 +71,39 @@ namespace OxPt
 
             Assert.NotNull(metrics);
             Assert.Equal("", (string?)metrics.Attribute(H.FileName));
+        }
+
+        [Fact]
+        public void MG003_ReferenceToNullImage_DanglingBlipRelationship_IsCounted()
+        {
+            // Regression test: ValidateImageExists located the referenced part with
+            // Parts.FirstOrDefault(...), whose return type (IdPartPair) is a struct, then
+            // compared the result to null. FirstOrDefault() on a struct sequence returns
+            // default(IdPartPair) on a miss, never null, so the comparison was always false
+            // and ReferenceToNullImage could never be incremented, even for a document with a
+            // genuinely dangling image relationship.
+            XNamespace a = "http://schemas.openxmlformats.org/drawingml/2006/main";
+            XNamespace r = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
+            using var stream = new MemoryStream();
+            using (var doc = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document))
+            {
+                var mainPart = doc.AddMainDocumentPart();
+                mainPart.Document = new Document(new Body(new Paragraph(new Run(new Text("hello")))));
+                doc.Save();
+
+                var xDoc = mainPart.GetXDocument();
+                xDoc.Root!.Element(W.body)!.Add(
+                    new XElement(a + "blip", new XAttribute(r + "embed", "rIdDoesNotExist")));
+                mainPart.PutXDocument();
+            }
+
+            WmlDocument wmlDocument = new WmlDocument("dangling-image.docx", stream.ToArray());
+            XElement metrics = MetricsGetter.GetDocxMetrics(wmlDocument, new MetricsGetterSettings());
+
+            XElement? referenceToNullImage = metrics.Descendants(H.ReferenceToNullImage).FirstOrDefault();
+            Assert.NotNull(referenceToNullImage);
+            Assert.Equal(1, (int)referenceToNullImage!.Attribute(H.Val)!);
         }
     }
 }

--- a/Docxodus/DocumentBuilder.cs
+++ b/Docxodus/DocumentBuilder.cs
@@ -409,7 +409,7 @@ namespace Docxodus
                                             if (dbie.Message.Contains("{0}"))
                                                 throw new DocumentBuilderException(string.Format(dbie.Message, sourceNum2));
                                             else
-                                                throw dbie;
+                                                throw;
                                         }
                                     }
                                 }
@@ -454,7 +454,7 @@ namespace Docxodus
                                 if (dbie.Message.Contains("{0}"))
                                     throw new DocumentBuilderException(string.Format(dbie.Message, sourceNum2));
                                 else
-                                    throw dbie;
+                                    throw;
                             }
                         }
                     }
@@ -585,7 +585,7 @@ namespace Docxodus
                                             if (dbie.Message.Contains("{0}"))
                                                 throw new DocumentBuilderException(string.Format(dbie.Message, sourceNum));
                                             else
-                                                throw dbie;
+                                                throw;
                                         }
                                     }
                                 }
@@ -3155,7 +3155,9 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
 
             // First, find the source image part using the relationship ID from the old content part
             var ipp2 = oldContentPart.Parts.FirstOrDefault(ipp => ipp.RelationshipId == relId);
-            if (ipp2 != null)
+            // IdPartPair is a struct, so a not-found FirstOrDefault() is default(IdPartPair), not
+            // null — OpenXmlPart is the field that is actually null in that case.
+            if (ipp2.OpenXmlPart != null)
             {
                 var oldPart2 = ipp2.OpenXmlPart;
                 if (!(oldPart2 is ImagePart))
@@ -3210,7 +3212,8 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                         });
                         return rel != null;
                     });
-                    if (refRel != null)
+                    // Same IdPartPair-is-a-struct caveat as above.
+                    if (refRel.OpenXmlPart != null)
                     {
                         imageReference.Attribute(attributeName)!.Value = temp.ContentPartRelTypeIdList.First(cpr =>
                         {
@@ -3340,7 +3343,8 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
 
                 // Look for the part in the source document
                 var ipp4 = oldContentPart.Parts.FirstOrDefault(z => z.RelationshipId == relId);
-                if (ipp4 != null)
+                // IdPartPair is a struct: not-found is default(IdPartPair), not null.
+                if (ipp4.OpenXmlPart != null)
                 {
                     OpenXmlPart oldPart = oldContentPart.GetPartById(relId);
                     // newPart stays null if newContentPart is a part type not covered by the checks
@@ -3407,7 +3411,8 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
 
                 // Look for the part in the source document
                 var ipp3 = oldContentPart.Parts.FirstOrDefault(p => p.RelationshipId == relId);
-                if (ipp3 == null)
+                // IdPartPair is a struct: not-found is default(IdPartPair), not null.
+                if (ipp3.OpenXmlPart == null)
                     continue;
                 ChartPart oldPart = (ChartPart)ipp3.OpenXmlPart;
                 XDocument oldChart = oldPart.GetXDocument();
@@ -3427,7 +3432,8 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
 
                 // Look for the part in the source document
                 var ipp5 = oldContentPart.Parts.FirstOrDefault(p => p.RelationshipId == relId);
-                if (ipp5 != null)
+                // IdPartPair is a struct: not-found is default(IdPartPair), not null.
+                if (ipp5.OpenXmlPart != null)
                 {
                     ChartDrawingPart oldPart = (ChartDrawingPart)ipp5.OpenXmlPart;
                     XDocument oldXDoc = oldPart.GetXDocument();
@@ -3452,9 +3458,9 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                     continue;
 
                 var ipp1 = newFontTablePart.Parts.FirstOrDefault(z => z.RelationshipId == relId);
-                if (ipp1 != null)
+                // IdPartPair is a struct: not-found is default(IdPartPair), not null.
+                if (ipp1.OpenXmlPart != null)
                 {
-                    OpenXmlPart tempPart = ipp1.OpenXmlPart;
                     continue;
                 }
 
@@ -3489,7 +3495,8 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
                 string relId = dataReference.Attribute(R.id)!.Value;
 
                 var ipp1 = oldChart.Parts.FirstOrDefault(z => z.RelationshipId == relId);
-                if (ipp1 != null)
+                // IdPartPair is a struct: not-found is default(IdPartPair), not null.
+                if (ipp1.OpenXmlPart != null)
                 {
                     var oldRelatedPart = ipp1.OpenXmlPart;
                     if (oldRelatedPart is EmbeddedPackagePart)

--- a/Docxodus/Docxodus.csproj
+++ b/Docxodus/Docxodus.csproj
@@ -22,7 +22,6 @@
 
     <!-- Disable TreatWarningsAsErrors for legacy code - too many existing warnings -->
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);CS8073;CA2200;CS8632</NoWarn>
 
     <!-- ReadyToRun: Pre-compile to native code during publish to eliminate JIT warmup -->
     <PublishReadyToRun>true</PublishReadyToRun>

--- a/Docxodus/MetricsGetter.cs
+++ b/Docxodus/MetricsGetter.cs
@@ -463,7 +463,8 @@ namespace Docxodus
         private static void ValidateImageExists(OpenXmlPart part, string relId, Dictionary<XName, int> metrics)
         {
             var imagePart = part.Parts.FirstOrDefault(ipp => ipp.RelationshipId == relId);
-            if (imagePart == null)
+            // IdPartPair is a struct: not-found is default(IdPartPair), not null.
+            if (imagePart.OpenXmlPart == null)
                 IncrementMetric(metrics, H.ReferenceToNullImage);
         }
 

--- a/Docxodus/WmlToHtmlConverter.cs
+++ b/Docxodus/WmlToHtmlConverter.cs
@@ -10153,7 +10153,6 @@ namespace Docxodus
             if (imageRid == null) return null;
 
             var pp3 = ownerPart.Parts.FirstOrDefault(pp => pp.RelationshipId == imageRid);
-            if (pp3 == null) return null;
 
             // Broken packages can point drawing image markup at any relationship target (for
             // example custom XML). Treat a non-image target the same as a missing image instead
@@ -10361,7 +10360,6 @@ namespace Docxodus
             try
             {
                 var pp = ownerPart.Parts.FirstOrDefault(pp2 => pp2.RelationshipId == imageRid);
-                if (pp == null) return null;
 
                 // VML <v:imagedata> can be malformed in exactly the same way as DrawingML:
                 // tolerate a relationship to a non-image part and simply omit the unusable image.


### PR DESCRIPTION
## Summary

Closes #651 (part of the #645 nullable/warning-suppression campaign). Removes `Docxodus.csproj`'s `NoWarn` property entirely — `CS8073`, `CA2200`, and `CS8632` were the last three project-wide suppressions.

`CS8632` needed no work: it can only fire inside a file carrying `#nullable disable`, and #649 (merged earlier today) removed the last one. The other two required actually reading and fixing what they were hiding.

## `CA2200` — three rethrows that discarded the original stack trace

All three are in `DocumentBuilder.cs`: `catch (DocumentBuilderInternalException dbie) { ... throw dbie; }`. Rethrowing the caught variable resets the exception's stack trace to the rethrow point, which makes a merge/split failure's diagnostics point at the wrong place. Changed to a bare `throw;`, which preserves the original throw site. No behavior change beyond better diagnostics.

## `CS8073` — ten "this comparison is always true/false" sites, one root cause

`Parts.FirstOrDefault(...)` on an `OpenXmlPart`'s relationship collection returns `IdPartPair`, which is a **struct**. A miss returns `default(IdPartPair)`, never `null` — so every `if (pair != null)` / `if (pair == null)` in this codebase was dead code, always evaluating to the same constant regardless of whether the relationship was actually found. The fix throughout is to check `pair.OpenXmlPart != null` (`OpenXmlPart` is the field that's genuinely null on a miss) instead of comparing the struct itself.

**Two of the ten are no-op fixes.** Both are in `WmlToHtmlConverter.cs`, where the dead check is immediately followed by `... as ImagePart; if (imagePart == null) return null;` — that check already handles both "not found" and "found but wrong type" correctly on its own, so the preceding dead check was pure redundancy. Deleted rather than fixed; behavior is identical either way.

**The other eight are genuine behavior fixes** — dead code that was silently skipping graceful-fallback or error-recovery logic the surrounding code had already been written to expect:

- **`DocumentBuilder.CopyFontTable`** (the most severe): the dead check made "this font is already in the output, skip" unconditional, so the actual font-copy logic beneath it — the only place `DocumentBuilder` embeds a font — was unreachable. **No merge has ever actually embedded a font.** Covered by a new regression test (`DB0017_EmbeddedFontTable_FontPartSurvivesMerge`) that round-trips real bytes through a merged `FontPart`, and fails against the pre-fix code.
- **`MetricsGetter.ValidateImageExists`**: the dead check meant the `ReferenceToNullImage` diagnostic metric could never increment, even for a document with a genuinely dangling image relationship. Covered by a new regression test (`MG003_ReferenceToNullImage_DanglingBlipRelationship_IsCounted`), same pattern.
- **`DocumentBuilder`'s image (`CopyRelatedImage`), OLE-object, and chart-data (`CopyChartObjects`) relationship copying**: each already has a written-and-commented external-relationship fallback for when a reference isn't a same-package part. That fallback was dead code; it's live now.
- **`DocumentBuilder`'s chart and chart-drawing (`c:userShapes`) copying**: these two had *no* fallback at all — a document with a stray/unresolvable reference used to crash the whole merge with a `NullReferenceException` instead of the reference simply being skipped.

I did not add fixtures for the last six — OLE embedding, chart, and chart-drawing all need real embedded-object/chart XML to exercise meaningfully, and the two `WmlToHtmlConverter.cs` sites are provably no-ops. Verified those by reading the surrounding code (each has an explicit comment or an already-written fallback proving the intended behavior), not by a fixture built just to poke a rare path.

## Validation

- `dotnet build Docxodus/Docxodus.csproj --no-incremental`: 0 errors, warning baseline unchanged at 113 (no files added or removed).
- `dotnet build Docxodus.sln --no-incremental` (Debug and `-c Release`): 0 errors.
- `dotnet test Docxodus.Tests/Docxodus.Tests.csproj`: 3925 passed (3923 baseline + the 2 new regression tests), 3 skipped, 0 failed. Test-project warning baseline unchanged at 689 (the new test code is annotated cleanly).
- Both new tests independently verified to be non-vacuous: each was checked against the pre-fix code and fails there (`Assert.NotNull() Failure: Value is null` in both cases), then confirmed to pass against the fix.
- `./scripts/build-wasm.sh`: succeeds, wire size 4877 KB (budget 5120 KB).
- The six out-of-solution tool/benchmark projects build clean; `benchmarks/complex-form-doc` fails the same pre-existing, unrelated way as before (issue #662).
- `npm run build`, `npm run typecheck`: clean.
- `npm test` (Playwright, full suite, run sharded to fit within CI-style time limits): 666 passed, 11 skipped, 5 failed — exactly the established baseline. The 5 are the known host-only `tabs-visual.spec.ts` screenshot tests (missing Times New Roman locally; green in CI).

## Docs

CLAUDE.md's nullable-reference-types section now says `Docxodus.csproj` has no `NoWarn` property at all. CHANGELOG.md gets entries for the eight behavior fixes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSnwkK1Nx6zZb2RnnoxKdx