### PR TITLE
Derive the MCP README's tool inventory from the catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `tools/mcp-server/README.md` now describes the tool surface the server actually advertises. It
+  claimed three lifecycle tools plus eighteen grouped-intent tools against a `ToolCatalog` of 22,
+  and omitted `docxodus_preview`, `docxodus_links`, `docxodus_images`,
+  `docxodus_content_controls` and `docxodus_verify_receipt` entirely, making shipped capabilities
+  undiscoverable to MCP hosts reading the package's quick start. The table now carries one row per
+  tool with its kind and a one-line purpose, matching the arithmetic in
+  `docs/architecture/docx_agent_server.md`, and a test holds it in step with `ToolCatalog.Tools`
+  so a tool cannot be added or removed without the README moving with it.
+
 - `OpenXmlRegex.Match` no longer throws a `NullReferenceException` when called without a callback
   on PowerPoint/DrawingML content (the `a:p`/`p:p` namespaced path) — it now returns the match
   count like the Wordprocessing path already did.

--- a/Docxodus.Tests/McpToolInventoryDocumentationTests.cs
+++ b/Docxodus.Tests/McpToolInventoryDocumentationTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Docxodus.McpServer;
+using Xunit;
+
+namespace Docxodus.Tests
+{
+    /// <summary>
+    /// Issue #673: <c>tools/mcp-server/README.md</c> is the quick-start contract an MCP host reads
+    /// before it ever calls <c>tools/list</c>, and it had drifted — advertising eighteen
+    /// grouped-intent tools against a catalog of twenty-two, and omitting five shipped tools
+    /// entirely, which makes real capabilities undiscoverable.
+    ///
+    /// <para>Nothing tied the prose to <see cref="ToolCatalog.Tools"/>, so nothing could notice.
+    /// These tests are that tie: the README's tool table and the advertised catalog must name
+    /// exactly the same tools, and the count the README states must be the live one.</para>
+    /// </summary>
+    public class McpToolInventoryDocumentationTests
+    {
+        private static readonly FileInfo ReadmeFile =
+            new FileInfo("../../../../tools/mcp-server/README.md");
+
+        private static string Readme()
+        {
+            Assert.True(ReadmeFile.Exists, $"expected the MCP server README at {ReadmeFile.FullName}");
+            return File.ReadAllText(ReadmeFile.FullName);
+        }
+
+        /// <summary>
+        /// Tool names in the README's inventory table: the backticked first cell of every row whose
+        /// name starts with the server's tool prefix. Prose mentions elsewhere in the file are not
+        /// table rows and are deliberately not collected.
+        /// </summary>
+        private static List<string> DocumentedTools() =>
+            Readme().Split('\n')
+                .Select(line => Regex.Match(line.Trim(), @"^\|\s*`(docxodus_[a-z_]+)`\s*\|"))
+                .Where(m => m.Success)
+                .Select(m => m.Groups[1].Value)
+                .ToList();
+
+        [Fact]
+        public void TheReadmeTableIsDiscoverable()
+        {
+            // Without this, an extraction regex that stops matching would make the comparisons
+            // below pass by comparing the catalog against nothing.
+            Assert.NotEmpty(DocumentedTools());
+            Assert.NotEmpty(ToolCatalog.Tools);
+        }
+
+        [Fact]
+        public void EveryAdvertisedToolIsDocumented()
+        {
+            var undocumented = ToolCatalog.Tools.Select(t => t.Name)
+                .Except(DocumentedTools(), StringComparer.Ordinal)
+                .ToList();
+
+            Assert.True(
+                undocumented.Count == 0,
+                "tools/list advertises tools the MCP README does not document: " +
+                string.Join(", ", undocumented));
+        }
+
+        [Fact]
+        public void EveryDocumentedToolIsAdvertised()
+        {
+            var phantom = DocumentedTools()
+                .Except(ToolCatalog.Tools.Select(t => t.Name), StringComparer.Ordinal)
+                .ToList();
+
+            Assert.True(
+                phantom.Count == 0,
+                "the MCP README documents tools the server does not advertise: " +
+                string.Join(", ", phantom));
+        }
+
+        [Fact]
+        public void TheReadmeTableListsEachToolExactlyOnce()
+        {
+            var duplicates = DocumentedTools()
+                .GroupBy(name => name, StringComparer.Ordinal)
+                .Where(g => g.Count() > 1)
+                .Select(g => g.Key)
+                .ToList();
+
+            Assert.True(
+                duplicates.Count == 0,
+                "the MCP README's tool table lists these more than once: " + string.Join(", ", duplicates));
+        }
+
+        [Fact]
+        public void TheReadmeStatesTheLiveToolCount()
+        {
+            // The stale count ("three lifecycle tools plus eighteen grouped-intent tools") was the
+            // most visible symptom, and a count written in prose cannot be derived from the table.
+            Assert.Contains($"**{ToolCatalog.Tools.Count} tools.**", Readme(), StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void EveryDocumentedToolCarriesAKindAndAPurpose()
+        {
+            var kinds = new[] { "lifecycle", "read", "grouped-intent", "sessionless" };
+
+            var rows = Readme().Split('\n')
+                .Select(line => Regex.Match(line.Trim(), @"^\|\s*`(docxodus_[a-z_]+)`\s*\|([^|]*)\|(.*)\|$"))
+                .Where(m => m.Success)
+                .ToList();
+
+            Assert.Equal(ToolCatalog.Tools.Count, rows.Count);
+            foreach (var row in rows)
+            {
+                var tool = row.Groups[1].Value;
+                var kind = row.Groups[2].Value.Trim();
+                var purpose = row.Groups[3].Value.Trim();
+
+                Assert.True(kinds.Contains(kind), $"{tool} has an unrecognised kind '{kind}'");
+                Assert.True(purpose.Length > 20, $"{tool} has no meaningful purpose text");
+            }
+        }
+    }
+}

--- a/tools/mcp-server/README.md
+++ b/tools/mcp-server/README.md
@@ -78,26 +78,41 @@ path stay as they are.
 
 ## Tool surface
 
-Three lifecycle tools plus eighteen grouped-intent tools, each addressed by the anchor ids the
-markdown projection and search tools return:
+**22 tools.** Three session-lifecycle tools, four read/preview tools, twelve grouped-intent
+mutation tools, and three sessionless operations — the same arithmetic as the tool reference in
+`docs/architecture/docx_agent_server.md`. Everything except the three sessionless tools takes the
+`sessionId` that `docxodus_open` returns, and addresses content by the anchor ids the markdown
+projection and search tools hand back. Each grouped tool takes an `action` discriminator plus
+action-specific arguments.
 
-| Tool | Purpose |
-|------|---------|
-| `docxodus_open` / `docxodus_save` / `docxodus_close` | Session lifecycle |
-| `docxodus_pagination` | Register, inspect, or query an externally materialized PageMap |
-| `docxodus_get_content` | Read markdown/HTML/text, block or section facts, styles, direct/effective formatting, mutation-ready inline spans, a complete deterministic package manifest, the opening-to-current semantic change set, or a default deliverable-verification report (`format: "verification"`) |
-| `docxodus_search` | Find text (literal/regex), or blocks by kind/annotation/bookmark |
-| `docxodus_edit` | Insert/replace/delete text and blocks, split/merge paragraphs, undo/redo |
-| `docxodus_format` | Character and paragraph formatting, list level |
-| `docxodus_create` | New paragraphs, headings, tables, horizontal rules, footnotes/endnotes, running headers/footers, page-number fields |
-| `docxodus_list` | Promote/demote/renumber list membership; restart numbering (Word's *Set Numbering Value…*) |
-| `docxodus_comment` | Native Word review comments (real `w:comment` markup): add on an anchor/span or tracked revision id, reply in-thread, resolve/reopen, update, remove, list |
-| `docxodus_annotate` | Anchor-addressed highlight/label annotations (a custom-XML overlay for external tools, distinct from comments) |
-| `docxodus_track_changes` | List tracked changes; accept/reject one by id, or all |
-| `docxodus_compare` | Sessionless: diff or N-way consolidate stored document versions into one author-attributed native redline written back into the document scope |
-| `docxodus_mutations` | Apply or safely preview a batch atomically by default; opt explicitly into best-effort |
-| `docxodus_deliver` | Build a verified delivery bundle from a named baseline and the current session; return its manifest and available artifact bytes |
-| `docxodus_table` | Create/read tables; resolve canonical cell anchors ↔ grid coordinates; edit rows/columns/cell content/style |
+| Tool | Kind | Purpose |
+|---|---|---|
+| `docxodus_open` | lifecycle | Open a `.docx` from the configured document scope into an in-memory session and return its `sessionId`. |
+| `docxodus_save` | lifecycle | Write the session's current bytes back into the scope, optionally to a different location. |
+| `docxodus_close` | lifecycle | Dispose the session and release its undo history and retry journal. |
+| `docxodus_get_content` | read | Read markdown/HTML/text, block or section facts, styles, direct/effective formatting, mutation-ready inline spans, a deterministic package manifest, the opening-to-current semantic change set, or a deliverable-verification report. |
+| `docxodus_preview` | read | Render the same HTML as `format: "html"` but shaped for an MCP Apps widget: the markup rides in `_meta` so a large render costs the model's context nothing. |
+| `docxodus_pagination` | read | Register, inspect, or query an externally materialized PageMap; the server never paginates or bundles a browser itself. |
+| `docxodus_search` | read | Find text (literal or regex), or find blocks by kind, annotation, or bookmark, returning reusable anchor ids. |
+| `docxodus_edit` | grouped-intent | Insert, replace, and delete text and blocks; split and merge paragraphs; undo and redo. |
+| `docxodus_format` | grouped-intent | Character and paragraph formatting, and list level. |
+| `docxodus_create` | grouped-intent | New paragraphs, headings, tables, horizontal rules, footnotes/endnotes, running headers/footers, and page-number fields. |
+| `docxodus_list` | grouped-intent | Promote, demote, and renumber list membership; restart numbering (Word's *Set Numbering Value…*). |
+| `docxodus_comment` | grouped-intent | Native Word review comments (real `w:comment` markup): add on an anchor/span or tracked revision id, reply in-thread, resolve/reopen, update, remove, list. |
+| `docxodus_annotate` | grouped-intent | Anchor-addressed highlight/label annotations — a custom-XML overlay for external tools, distinct from comments. |
+| `docxodus_links` | grouped-intent | Native hyperlinks and bookmarks — list, add, update, move, remove — plus REF-field cross-references that track their bookmark target when Word refreshes fields. |
+| `docxodus_images` | grouped-intent | Native Word images: list, insert, replace, resize, set metadata or floating layout, remove. Payloads cross the JSON boundary as base64 only — the server never fetches a URL or reads an image path. |
+| `docxodus_content_controls` | grouped-intent | List and fill native Word content controls (`w:sdt`) — text, rich text, checkbox, date, list item, picture, repeating items — preserving each control's wrapper and metadata. |
+| `docxodus_track_changes` | grouped-intent | List tracked changes; accept or reject one by id or all; switch the session's recording mode; prove redline reversibility. |
+| `docxodus_mutations` | grouped-intent | Apply or safely preview a batch atomically by default, with opt-in best-effort and MCP-only transaction idempotency. |
+| `docxodus_table` | grouped-intent | Create and read tables; resolve canonical cell anchors ↔ grid coordinates; edit rows, columns, cell content, and style. |
+| `docxodus_compare` | sessionless | Diff or N-way consolidate stored document versions into one author-attributed native redline, written back into the document scope. |
+| `docxodus_deliver` | sessionless | Build a verified delivery bundle from a named baseline and the current session; return its manifest and available artifact bytes. |
+| `docxodus_verify_receipt` | sessionless | Verify a portable delivery change receipt against the document it claims to describe. |
+
+`McpToolInventoryDocumentationTests` asserts this table and `ToolCatalog.Tools` name exactly the
+same set of tools, and that the count above is the live one, so a tool cannot be added or removed
+without this section moving with it.
 
 `docxodus_deliver` uses the same `DeliveryBundleService` as the .NET API and
 `docxodus-deliver` CLI. The MCP response returns canonical manifest bytes plus available artifacts

--- a/tools/mcp-server/ToolCatalog.cs
+++ b/tools/mcp-server/ToolCatalog.cs
@@ -11,10 +11,15 @@ namespace Docxodus.McpServer;
 internal sealed record ToolDefinition(string Name, string Description, string InputSchemaJson);
 
 /// <summary>
-/// The tool surface this server advertises: three lifecycle tools (open/save/close) plus eighteen
-/// read or grouped-intent tools. Grouped tools accept an <c>action</c> discriminator and
-/// action-specific arguments. See <c>docs/architecture/docx_agent_server.md</c> for the full contract, the
-/// mapping of every action onto the underlying Docxodus API, and the documented capability gaps.
+/// The tool surface this server advertises: three session-lifecycle tools (open/save/close), four
+/// read/preview tools, twelve grouped-intent mutation tools, and three sessionless operations.
+/// Grouped tools accept an <c>action</c> discriminator and action-specific arguments. See
+/// <c>docs/architecture/docx_agent_server.md</c> for the full contract, the mapping of every action
+/// onto the underlying Docxodus API, and the documented capability gaps.
+///
+/// <para>This list is the inventory of record. <c>tools/mcp-server/README.md</c> restates it for
+/// MCP hosts, and <c>McpToolInventoryDocumentationTests</c> holds the two in step, so adding or
+/// removing a definition here fails the build's tests until the README moves with it.</para>
 /// </summary>
 internal static class ToolCatalog
 {


### PR DESCRIPTION
## Why

`tools/mcp-server/README.md` told MCP hosts the server exposes *"three lifecycle tools plus eighteen grouped-intent tools."* `ToolCatalog` advertises **22**, under a different categorization, and the README's table omitted five shipped tools entirely:

`docxodus_preview`, `docxodus_links`, `docxodus_images`, `docxodus_content_controls`, `docxodus_verify_receipt`

That README is the package's quick-start contract — the thing an MCP host or agent author reads before ever calling `tools/list`. A stale surface description doesn't just misstate a number; it makes real, shipped capabilities undiscoverable, and it makes a tool-count smoke failure ambiguous about which side is wrong.

## What changed

**The table is rewritten against the live catalog**: one row per tool, each with its kind and a one-line purpose, using the arithmetic `docs/architecture/docx_agent_server.md` already carried — three session-lifecycle tools, four read/preview tools, twelve grouped-intent mutation tools, and three sessionless operations. The lead sentence states which tools are session-bound and which aren't.

Every purpose line was written from that tool's own `ToolDefinition` description and `action` enum rather than inferred, so the five newly-documented tools say what they actually do — e.g. `docxodus_content_controls` lists and *fills* controls (`list`, `fill_text`, `set_checked`, `set_date`, `select_item`, `fill_picture`, repeating items); it does not create them.

**The drift guard.** Nothing connected the prose to the catalog, which is why it rotted. `McpToolInventoryDocumentationTests` is that connection:

- set equality between the README table and `ToolCatalog.Tools`, in both directions;
- no tool listed twice;
- the count in the README derived from `ToolCatalog.Tools.Count`, not typed by hand;
- every row carries a recognised kind and a non-trivial purpose;
- and a vacuity guard, so an extraction regex that silently stops matching cannot make the comparisons pass against an empty set.

`ToolCatalog`'s own summary comment carried the same stale arithmetic; it now states the real categorization and names the test that keeps the two in step.

## Validation

- Six new tests pass.
- **Non-vacuous:** restoring only the old README makes three of them fail — the missing tools, the stale count, and the row-shape check.
- No behavioural change: `tools/list` output is untouched, and the existing `MCP100_ToolCatalog_HasExpectedDistinctNamedToolsWithValidSchemas` pin is unaffected.

Closes #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSnwkK1Nx6zZb2RnnoxKdx