### PR TITLE
State that preserving invalid math-run revision markup is deliberate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Documented, as a deliberate position rather than an accident, that Docxodus preserves
+  schema-invalid tracked-revision markup nested inside an Office Math run (`w:ins`/`w:del` as a
+  direct child of `m:r`) instead of silently rewriting it. `WmlComparer` repaired that shape as a
+  side effect of rebuilding the whole package — the same reserialization that made it drop content
+  elsewhere — and nothing replaced the repair when the engine was removed in v11.0.0. No consumer
+  we can test fails on the shape: LibreOffice renders it, and the only symptom is one validator
+  finding the input already carried. See "Office Math: revision wrappers nested inside `m:r`" in
+  `docs/ooxml_corner_cases.md` for the reasoning and for where a repair would belong if one is ever
+  warranted.
+
 ### Fixed
 
 - The complex-form benchmark harness (`benchmarks/complex-form-doc`) compiles again. Removing the

--- a/Docxodus.Tests/DocxCompareTests.cs
+++ b/Docxodus.Tests/DocxCompareTests.cs
@@ -96,7 +96,9 @@ public class DocxCompareTests
         // returns the source bytes unchanged, same validation error), so the guard bought nothing but a
         // full comparison and went with the engine that motivated it. This pins the honest replacement
         // behavior: the shortcut is taken, and invalid input survives rather than being silently
-        // rewritten. Repairing it is tracked as issue #642.
+        // rewritten. Issue #642 settled that as the deliberate position — see "Office Math: revision
+        // wrappers nested inside m:r" in docs/ooxml_corner_cases.md for the reasoning and for where a
+        // repair would belong if a consumer is ever found that needs one.
         var source = new WmlDocument(Path.GetFullPath(Path.Combine(
             "../../../../TestFiles", "WC", "WC012-Math-After.docx")));
         var samePackage = new WmlDocument(source);

--- a/Docxodus/DocxCompare.cs
+++ b/Docxodus/DocxCompare.cs
@@ -68,7 +68,9 @@ public static class DocxCompare
     /// preprocessing repaired as a side effect, so routing through the engine was strictly better than
     /// cloning. <see cref="DocxDiff"/> performs no such repair: on that input it returns the source
     /// bytes unchanged, with the same validation error. The guard therefore bought nothing but a full
-    /// comparison, and was removed with the engine that motivated it. Tracked as issue #642.</para>
+    /// comparison, and was removed with the engine that motivated it. Preserving that invalid input
+    /// rather than silently rewriting it is a decided position, not an oversight — see "Office Math:
+    /// revision wrappers nested inside <c>m:r</c>" in <c>docs/ooxml_corner_cases.md</c> (issue #642).</para>
     /// </summary>
     internal static bool CanReturnExactNoOp(WmlDocument left, WmlDocument right) =>
         HasIdenticalPackageBytes(left, right);

--- a/docs/ooxml_corner_cases.md
+++ b/docs/ooxml_corner_cases.md
@@ -988,6 +988,73 @@ single author; the leak when the flag is off.
 
 ---
 
+## Office Math: revision wrappers nested inside `m:r` are invalid, and Docxodus preserves them
+
+**Status:** Deliberate — not repaired (decided 2026-09-02, issue #642)
+
+### The behavior
+
+A small set of older Word documents place a tracked-revision wrapper (`w:ins`/`w:del`) *directly
+inside* an Office Math run, as `m:r`'s child. The schema does not allow it: `m:r`'s content model
+is `m:rPr?`, `w:rPr?`, then the text elements, and revision marking on a math run belongs inside
+`w:rPr`. `OpenXmlValidator` reports exactly one finding per occurrence:
+
+```text
+[Schema] The element has invalid child element 'w:ins'.
+  List of possible elements expected: <m:rPr>.
+  path: /w:document[1]/w:body[1]/w:p[2]/m:oMathPara[1]/m:oMath[1]/m:r[2]
+```
+
+### Minimal reproducer
+
+`TestFiles/WC/WC012-Math-After.docx` carries the shape verbatim:
+
+```xml
+<m:r>
+  <w:ins w:id="0" w:author="Eric White" w:date="2016-04-21T19:17:00Z">
+    <w:rPr><w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/></w:rPr>
+    <m:t>2</m:t>
+  </w:ins>
+</m:r>
+```
+
+### Consumer comparison
+
+| Consumer | Result |
+|---|---|
+| `OpenXmlValidator` | 1 schema finding |
+| LibreOffice 25.8 | loads and renders the document without complaint |
+| `DocxDiff` / `DocxCompare` | returns the input's bytes unchanged, finding included |
+| `WmlComparer` (removed in v11.0.0) | emitted a repaired package — 0 findings, different bytes |
+
+### The decision
+
+**Docxodus preserves the shape rather than rewriting it.** Repairing it would mean silently
+changing bytes a caller did not ask us to change, in a package that no consumer we can test is
+actually choking on. `WmlComparer` did repair it, but only as a side effect of rebuilding the whole
+document from its own model — the same whole-package reserialization that made it drop content
+elsewhere (it also took this document's validator findings from 80 to 29 on unrelated markup). That
+is not a property worth reconstructing deliberately.
+
+The consequence is stated rather than implicit: an invalid input stays invalid on the way out, and
+Docxodus is not a document-repair tool. A caller that needs the shape normalized should validate its
+inputs before feeding them in. If a consumer is ever found that genuinely fails on this markup, the
+right home for a repair is `StrictOoxmlNormalizer`, so every entry point benefits rather than only
+comparison.
+
+This also explains why `DocxCompare.CanReturnExactNoOp` is now plain byte equality. Through v10 it
+deliberately refused the exact-clone shortcut for this shape, so the document would be routed
+through the repairing legacy path instead. With no engine repairing it, that guard only bought a
+full comparison that returned the same bytes and the same finding.
+
+### Tests
+
+`Docxodus.Tests/DocxCompareTests.cs` —
+`ByteIdenticalMalformedMathRevision_PassesThroughUnrepaired` pins the behavior: the shortcut is
+taken, and the schema finding survives on both sides.
+
+---
+
 ## Headers/footers: a first/even part can outlive its `w:titlePg` / `w:evenAndOddHeaders` flag
 
 ### The behavior


### PR DESCRIPTION
## What this is

#642 does not ask for a fix. It asks for a **decision**, and offers three legitimate resolutions with no preference implied. The code side already landed with the `WmlComparer` removal — `DocxCompare.CanReturnExactNoOp` has collapsed to plain byte equality, and `ByteIdenticalMalformedMathRevision_PassesThroughUnrepaired` is already a live reproducer in the suite. What was missing was the decision itself.

This PR makes it: **option 3 — Docxodus preserves the invalid input rather than silently rewriting it** — and records why, so it reads as a position rather than an oversight.

## The shape

A small set of older Word documents nest a tracked-revision wrapper directly inside an Office Math run:

```xml
<m:r>
  <w:ins w:id="0" w:author="Eric White" w:date="2016-04-21T19:17:00Z">
    <w:rPr><w:rFonts w:ascii="Cambria Math" w:hAnsi="Cambria Math"/></w:rPr>
    <m:t>2</m:t>
  </w:ins>
</m:r>
```

`m:r`'s content model allows `m:rPr?`, `w:rPr?` and text — not `w:ins`. `TestFiles/WC/WC012-Math-After.docx` carries it verbatim.

## Why preserve rather than repair

I checked what actually breaks, rather than assuming the schema finding implies a broken consumer:

| Consumer | Result |
|---|---|
| `OpenXmlValidator` | 1 schema finding |
| **LibreOffice 25.8** | **loads and renders the document without complaint** |
| `DocxDiff` / `DocxCompare` | returns the input's bytes unchanged, finding included |
| `WmlComparer` (removed in v11.0.0) | emitted a repaired package — 0 findings, different bytes |

Nothing we can test fails on this markup. Against that, repairing means silently changing bytes the caller did not ask us to change, and costs `DocxDiff` its byte-identical-in/byte-identical-out property.

The legacy repair is also worth being honest about: `WmlComparer` did not target this shape. It rebuilt the whole document from its own model, and the malformed nesting simply never got re-emitted — the same whole-package reserialization that made it drop an empty footnote paragraph on the NVCA charter and move that document's validator findings from 80 to 29 on unrelated markup. That is not a property worth reconstructing deliberately.

## What changed

- A `docs/ooxml_corner_cases.md` entry in the file's house style: the behaviour, the validator message and XPath verbatim, the minimal reproducer, the consumer comparison above, the decision and its reasoning — and, so a future reversal starts from analysis rather than a blank page, the note that `StrictOoxmlNormalizer` is where a repair would belong if a failing consumer is ever found.
- The entry also explains why `CanReturnExactNoOp` is now plain byte equality: the old guard existed only to route this shape through the repairing legacy path, and with nothing repairing it, it bought a full comparison that returned the same bytes and the same finding.
- `DocxCompare`'s guard comment and the existing reproducer test now cite the documented decision instead of pointing at an open issue.
- A `### Changed` CHANGELOG entry, since this is a stated behavioural position even though no behaviour moved.

## Validation

No behaviour change — this is documentation plus two comment updates. `DocxCompareTests` (7 tests, including the reproducer) passes unchanged.

Closes #642

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSnwkK1Nx6zZb2RnnoxKdx