### PR TITLE
Assert the revision list the MCP smoke actually produces, and gate it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,15 @@ jobs:
           dotnet build tools/manifest-fuzz/replay/replay.csproj -c Release
           dotnet build tools/screenshots/redline/redline-screenshot.csproj -c Release
 
+      # The epic #435 acceptance smoke is the only end-to-end exercise of the MCP
+      # surface — lifecycle, atomic apply, transaction replay, the refusals, save and
+      # reopen. It was documented as a by-hand run, so its committed assertions went
+      # stale on main and nobody noticed for a release (#687). Roughly a minute.
+      - name: Run MCP acceptance smoke
+        run: |
+          dotnet build tools/mcp-server/mcpserver.csproj -c Release
+          ./scripts/mcp-smoke.sh
+
       - name: Run tests
         env:
           DOCXODUS_EVAL_ARTIFACTS: ${{ github.workspace }}/eval-artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- The epic #435 MCP acceptance smoke and its reopen validation now assert the revision list
+  the engine actually produces, and CI runs both on every pull request (#687). Their committed
+  assertions expected four revisions where the workflow produces six, so the documented runs
+  had been failing on main. Both extra entries are correct: a single `insert_footnote` step
+  yields the note body in `word/footnotes.xml` *and* the reference run in the body — a genuine
+  tracked insertion whose text is empty, because `w:footnoteReference` carries none, and whose
+  rejection is what removes the reference. The revision contract now has one declaration shared
+  by both fixtures instead of two hand-maintained copies that drifted apart, and it is keyed on
+  revision type, text, part and scope rather than on list position, which was never part of the
+  contract. `scripts/mcp-smoke.sh` is the gate: it regenerates the fixtures, fails if the
+  committed JSON differs, runs both workflows, and re-checks the five refusals and the
+  byte-exact transaction replay that the runner reports but does not enforce.
+
 - `WmlToHtmlConverter` now carries a font's document-declared alternate into the CSS font stack.
   ECMA-376's `w:altName` in `word/fontTable.xml` is exactly "use this family when the primary one
   is unavailable", and real documents lean on it for names no vendor ships:

--- a/scripts/mcp-smoke.sh
+++ b/scripts/mcp-smoke.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Runs the epic #435 MCP acceptance smoke — the workflow and its reopen validation —
+# against a scratch copy of TestFiles/NVCA-Model-COI.docx.
+#
+# Why this exists: both fixtures were checked in with revision assertions nobody
+# re-ran, and they sat wrong on main for as long as it took someone to run the README
+# by hand (#687). The fixtures are generated, so this script also regenerates them and
+# fails if the committed JSON differs — a stale fixture is caught at the same moment as
+# a broken engine.
+#
+# The gate is a superset of the assertions: mcp_probe.py exits nonzero for a transport
+# error, an MCP tool error, an edit result with success:false, a batch that reports
+# failed/partial, or any failed `expect`/`expectMembers` assertion. On top of that this
+# script re-checks the two properties the runner reports rather than enforces — the five
+# calls that must fail closed, and the byte-exact transaction replay.
+#
+# Usage:  scripts/mcp-smoke.sh [path/to/docxodus-mcp]
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+SERVER="${1:-tools/mcp-server/bin/Release/net10.0/docxodus-mcp}"
+if [[ ! -x "$SERVER" ]]; then
+  echo "mcp-smoke: server not found at $SERVER" >&2
+  echo "  build it with: dotnet build tools/mcp-server/mcpserver.csproj -c Release" >&2
+  exit 1
+fi
+
+python3 tools/mcp-server/smoke/build_epic_435_fixtures.py --check
+
+# The run SAVES. Pointing the storage root at TestFiles/ would overwrite a committed
+# fixture, so it gets a scratch copy that goes away with the directory.
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+export DOCXODUS_STORAGE_ROOT="$WORK"
+cp TestFiles/NVCA-Model-COI.docx "$WORK/local.docx"
+
+run() {
+  local fixture="$1" trace="$WORK/$2"
+  python3 tools/mcp-server/smoke/mcp_probe.py \
+    --calls "tools/mcp-server/smoke/$fixture" \
+    --trace "$trace" \
+    --quiet-server -- "$SERVER" >"$WORK/$2.summary"
+  cat "$WORK/$2.summary"
+  python3 - "$WORK/$2.summary" "$3" "$4" <<'PY'
+import json
+import sys
+
+summary = json.load(open(sys.argv[1]))
+expected = {"expectedFailures": int(sys.argv[2]), "replayComparisons": int(sys.argv[3])}
+wrong = {k: (summary.get(k), v) for k, v in expected.items() if summary.get(k) != v}
+if wrong:
+    for key, (actual, want) in wrong.items():
+        print(f"mcp-smoke: {key} = {actual}, expected {want}", file=sys.stderr)
+    sys.exit(1)
+PY
+}
+
+# The refusals and the replay are properties under test, not incidental counts: an
+# engine that stopped refusing, or a fixture that stopped exercising the retry, would
+# otherwise pass a run with zero failed assertions.
+run epic-435-workflow.json workflow-trace.json 5 1
+run epic-435-validation.json validation-trace.json 0 0
+
+echo "mcp-smoke: OK"

--- a/tools/mcp-server/smoke/README.md
+++ b/tools/mcp-server/smoke/README.md
@@ -10,14 +10,29 @@ and exercises a broader but less guarded operation mix.
 editing* — inspect, isolated preview, atomic apply under a transaction id, a retry proving
 byte-exact replay, an intentional stale request, an intentional atomic failure, an audit
 that nothing moved, a page citation, then save. `epic-435-validation.json` reopens the
-saved package and checks what persisted. Neither file is edited by hand: the first is
-emitted by `build_epic_435_workflow.py`, because the preview, the apply and the retry must
-send a byte-identical step array or the retry is a `transaction_conflict` rather than a
-replay.
+saved package and checks what persisted.
+
+Neither file is edited by hand. Both are emitted by `build_epic_435_fixtures.py`, for two
+reasons: the preview, the apply and the retry must send a byte-identical step array or the
+retry is a `transaction_conflict` rather than a replay; and the two files assert the *same*
+revision list, which drifted out of both when each was maintained separately (#687). That
+list now has one declaration, `REVISION_MEMBERS`.
+
+`scripts/mcp-smoke.sh` runs the whole gate — regenerate, check the committed fixtures are
+what the generator emits, run both workflows, and re-check the refusal and replay counts
+the runner reports but does not enforce. CI runs it on every pull request; run it locally
+the same way:
+
+```bash
+dotnet build tools/mcp-server/mcpserver.csproj -c Release
+./scripts/mcp-smoke.sh
+```
+
+To drive the two runs by hand instead:
 
 ```bash
 dotnet build tools/mcp-server/mcpserver.csproj
-python3 tools/mcp-server/smoke/build_epic_435_workflow.py
+python3 tools/mcp-server/smoke/build_epic_435_fixtures.py
 
 # Copy the source document into a scratch storage root — the run SAVES, and pointing
 # the root at TestFiles/ would overwrite a committed fixture.
@@ -35,8 +50,20 @@ python3 tools/mcp-server/smoke/mcp_probe.py \
   --quiet-server -- tools/mcp-server/bin/Debug/net10.0/docxodus-mcp
 ```
 
-Expected: 64 calls / 212 assertions and 13 calls / 27 assertions, both with zero failures,
+Expected: 64 calls / 211 assertions and 15 calls / 24 assertions, both with zero failures,
 five expected failures in the first, and `replayMismatches: 0`.
+
+### The six revisions
+
+The five tracked steps settle into six revisions, and the count surprises people, so it is
+worth stating: `insert_footnote` accounts for two of them. The note body lands in
+`word/footnotes.xml`, and the reference run lands in the body — a real tracked insertion
+whose `text` is empty, because a `w:footnoteReference` carries no text to report. Rejecting
+that revision is what takes the reference back out, so suppressing it from the list would
+hide a change an agent is entitled to see.
+
+The order the engine enumerates them in is not part of the contract, so the fixtures match
+them as members (see `expectMembers` below) keyed on type, text, part and scope.
 
 Five calls are *supposed* to fail, and the runner treats a success there as the defect
 (`unexpectedSuccesses`): a bookmark and a table insert refused under tracked recording, a
@@ -53,6 +80,7 @@ Beyond `name`/`arguments`/`capture`/`expect`, honored by `mcp_probe.py`:
 | `expectFailure` | This call must fail. Its failure stops counting against the run, and a *success* becomes an `unexpectedSuccess`. |
 | `expectSameAs` | Compare this call's raw response text to that of the named earlier call. Byte-exact, before JSON parsing normalizes key order — which is what transaction replay actually promises. |
 | `expectNonEmpty` | List of result paths that must resolve to a non-empty string, array, or object. Used for generated payloads such as preview HTML and package hashes where pinning fixture-specific bytes would be brittle. |
+| `expectMembers` | Map of list path → expected member objects. Each member must match exactly one not-yet-claimed entry on that list, in any order, comparing only the keys the member names. Use it where a collection's contents are the contract but its enumeration order is not. |
 
 `expect` values substitute `$variables` too, so one call can be asserted against another's
 captured value (the apply's `resultVersion` against the preview's prediction).

--- a/tools/mcp-server/smoke/build_epic_435_fixtures.py
+++ b/tools/mcp-server/smoke/build_epic_435_fixtures.py
@@ -1,29 +1,96 @@
 #!/usr/bin/env python3
-"""Generate the epic #435 acceptance workflow for `mcp_probe.py`.
+"""Generate the epic #435 acceptance fixtures for `mcp_probe.py`.
 
-The preview, the apply, and the retry must send a *byte-identical* step array —
-that is what the transaction fingerprint is computed over, and a retry whose
-fingerprint differs is a `transaction_conflict` rather than a replay. Writing the
-array once and emitting it three times is the point of generating this file
-instead of hand-maintaining the JSON.
+Two files come out of here, and both are generated for the same reason: a
+contract stated twice drifts.
 
-Run:  python3 tools/mcp-server/smoke/build_epic_435_workflow.py
+`epic-435-workflow.json` — the preview, the apply, and the retry must send a
+*byte-identical* step array. That is what the transaction fingerprint is
+computed over, and a retry whose fingerprint differs is a
+`transaction_conflict` rather than a replay. Writing the array once and
+emitting it three times is the point of generating the file.
+
+`epic-435-validation.json` — reopens the saved package and re-asserts what
+persisted, including the same revision list the workflow audits live. That list
+was maintained by hand in both places and went stale in both (#687), so it now
+has a single declaration, `REVISION_MEMBERS`.
+
+Run:  python3 tools/mcp-server/smoke/build_epic_435_fixtures.py
 """
 
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 TRANSACTION_ID = "epic435-smoke-restated-certificate"
+AUTHOR = "Smoke Counsel"
 CORPORATION = "Northstar Robotics, Inc."
 PLACEHOLDER = "[_______________]"
 RENDERER = "epic435-smoke-renderer-1"
 HISTORY_SENTINEL = "History cursor sentinel — this paragraph exists only on redo."
+CERTIFICATION = (
+    "The undersigned further certifies that this Restated Certificate "
+    "has been duly adopted in accordance with Sections 242 and 245 of the DGCL."
+)
+FOOTNOTE = "Adopted by written consent of the stockholders."
+
+BODY = "/word/document.xml"
+NOTES = "/word/footnotes.xml"
 
 
 def step(tool: str, **args: object) -> dict:
     return {"tool": tool, "args": args}
+
+
+def revision(text: str, kind: str = "insert", **fields: object) -> dict:
+    return {"type": kind, "text": text, "author": AUTHOR, **fields}
+
+
+# The five tracked steps below settle into exactly six revisions, and *which* six
+# is the contract this smoke guards. Two of them come from the single
+# `insert_footnote` step: the reference run in the body — a genuine tracked
+# insertion that carries no text, because `w:footnoteReference` has none to
+# carry — and the note body over in word/footnotes.xml. The engine's enumeration
+# ORDER is not part of the contract, so these are matched as members rather than
+# by index (#687); `expectMembers` still demands exactly one entry per member,
+# so a duplicated or vanished revision fails just as loudly.
+REVISION_MEMBERS = [
+    revision("", partUri=BODY, scope="body", anchorId="$certify_anchor"),
+    revision(CERTIFICATION + "¶", partUri=BODY, scope="body"),
+    revision(PLACEHOLDER, "delete", partUri=BODY, scope="body", anchorId="$name_anchor"),
+    revision(CORPORATION, partUri=BODY, scope="body", anchorId="$name_anchor"),
+    revision(CORPORATION, "format", partUri=BODY, scope="body", anchorId="$name_anchor"),
+    revision(" " + FOOTNOTE + "¶", partUri=NOTES, scope="fn"),
+]
+
+# Both runs discover the two anchors REVISION_MEMBERS keys on the same way, from
+# text that neither the edit script nor the save disturbs.
+ANCHOR_DISCOVERY = [
+    {
+        "id": "inspect_name_clause",
+        "name": "docxodus_search",
+        "arguments": {
+            "sessionId": "$session_id",
+            "mode": "text",
+            "query": "The name of this corporation is",
+            "maxResults": 2,
+        },
+        "capture": {"name_anchor": "matches.1.enclosingAnchor.id"},
+    },
+    {
+        "id": "inspect_certification",
+        "name": "docxodus_search",
+        "arguments": {
+            "sessionId": "$session_id",
+            "mode": "text",
+            "query": "DOES HEREBY CERTIFY",
+            "maxResults": 1,
+        },
+        "capture": {"certify_anchor": "matches.0.enclosingAnchor.id"},
+    },
+]
 
 
 # The substantive tracked edit: a counsel filling in and annotating a restated
@@ -44,21 +111,20 @@ TRACKED_STEPS = [
         action="insert_paragraph",
         anchorId="$certify_anchor",
         position="after",
-        markdown="The undersigned further certifies that this Restated Certificate "
-        "has been duly adopted in accordance with Sections 242 and 245 of the DGCL.",
+        markdown=CERTIFICATION,
     ),
     step(
         "docxodus_create",
         action="insert_footnote",
         anchorId="$certify_anchor",
         characterOffset=19,
-        markdown="Adopted by written consent of the stockholders.",
+        markdown=FOOTNOTE,
     ),
     step(
         "docxodus_comment",
         action="add",
         anchorId="$name_anchor",
-        author="Smoke Counsel",
+        author=AUTHOR,
         initials="SC",
         markdown="Confirm the exact legal name against the charter before filing.",
     ),
@@ -158,28 +224,7 @@ def workflow() -> list[dict]:
             },
             "expect": {"version": 0, "sectionInfo.pageNumberFormat": "lowerRoman"},
         },
-        {
-            "id": "inspect_name_clause",
-            "name": "docxodus_search",
-            "arguments": {
-                "sessionId": "$session_id",
-                "mode": "text",
-                "query": "The name of this corporation is",
-                "maxResults": 2,
-            },
-            "capture": {"name_anchor": "matches.1.enclosingAnchor.id"},
-        },
-        {
-            "id": "inspect_certification",
-            "name": "docxodus_search",
-            "arguments": {
-                "sessionId": "$session_id",
-                "mode": "text",
-                "query": "DOES HEREBY CERTIFY",
-                "maxResults": 1,
-            },
-            "capture": {"certify_anchor": "matches.0.enclosingAnchor.id"},
-        },
+        *ANCHOR_DISCOVERY,
         {
             "id": "inspect_list_item",
             "name": "docxodus_search",
@@ -704,16 +749,8 @@ def workflow() -> list[dict]:
             "id": "audit_applied_text_present_in_revisions",
             "name": "docxodus_track_changes",
             "arguments": {"sessionId": "$session_id", "action": "list"},
-            "expect": {
-                "revisions.length": 4,
-                "revisions.1.type": "delete",
-                "revisions.1.text": PLACEHOLDER,
-                "revisions.2.type": "insert",
-                "revisions.2.text": CORPORATION,
-                "revisions.2.author": "Smoke Counsel",
-                "revisions.3.type": "format",
-                "revisions.3.text": CORPORATION,
-            },
+            "expect": {"revisions.length": len(REVISION_MEMBERS)},
+            "expectMembers": {"revisions": REVISION_MEMBERS},
         },
         {
             # Regression guard for the defect this smoke found: text inserted under
@@ -923,11 +960,163 @@ def workflow() -> list[dict]:
     return calls
 
 
-def main() -> None:
-    target = Path(__file__).with_name("epic-435-workflow.json")
-    target.write_text(json.dumps(workflow(), indent=2) + "\n", encoding="utf-8")
-    print(f"wrote {target} ({len(workflow())} calls)")
+def validation() -> list[dict]:
+    """Reopen the saved package and assert what survived the round trip.
+
+    Independent of the workflow's session: this run reopens `smoke-output.docx`
+    from scratch and re-discovers its anchors, so what it proves is that the
+    edits are in the *package*, not in a live session's memory.
+    """
+    return [
+        {
+            "id": "reopen_saved_output",
+            "name": "docxodus_open",
+            "arguments": {"path": "smoke-output.docx", "trackedChanges": "accept"},
+            "capture": {"session_id": "sessionId"},
+        },
+        {
+            "id": "package_reopens_with_intact_structure",
+            "name": "docxodus_get_content",
+            "arguments": {"sessionId": "$session_id", "format": "info"},
+            "capture": {"reopened_anchors": "editSummary.totalAnchors"},
+            "expect": {
+                "version": 0,
+                "sectionInfo.pageNumberFormat": "lowerRoman",
+                "sectionInfo.headerRefs.0.kind": "first",
+                "sectionInfo.footerRefs.0.kind": "even",
+            },
+        },
+        *ANCHOR_DISCOVERY,
+        {
+            "id": "tracked_edits_persisted_as_revisions",
+            "name": "docxodus_track_changes",
+            "arguments": {"sessionId": "$session_id", "action": "list"},
+            "expect": {"revisions.length": len(REVISION_MEMBERS)},
+            "expectMembers": {"revisions": REVISION_MEMBERS},
+        },
+        {
+            "id": "comment_persisted",
+            "name": "docxodus_comment",
+            "arguments": {"sessionId": "$session_id", "action": "list"},
+            "expect": {"comments.length": 1, "comments.0.author": AUTHOR},
+        },
+        {
+            "id": "bookmark_persisted",
+            "name": "docxodus_search",
+            "arguments": {
+                "sessionId": "$session_id",
+                "mode": "bookmark",
+                "query": "SmokeDelawareRationale",
+            },
+            "expect": {"matches.length": 1},
+        },
+        {
+            "id": "hyperlink_persisted_as_external_relationship",
+            "name": "docxodus_links",
+            "arguments": {
+                "sessionId": "$session_id",
+                "action": "list_hyperlinks",
+                "scope": "body",
+            },
+            "expect": {
+                "hyperlinks.length": 1,
+                "hyperlinks.0.kind": "external",
+                "hyperlinks.0.target": "https://delcode.delaware.gov/title8/c001/",
+            },
+        },
+        {
+            "id": "table_persisted",
+            "name": "docxodus_search",
+            "arguments": {"sessionId": "$session_id", "mode": "kind", "query": "tbl"},
+            "expect": {"matches.length": 1},
+            "capture": {"table_anchor": "matches.0.id"},
+        },
+        {
+            "id": "table_grid_is_addressable",
+            "name": "docxodus_table",
+            "arguments": {
+                "sessionId": "$session_id",
+                "action": "get_metadata",
+                "tableAnchorId": "$table_anchor",
+            },
+            "expect": {"metadata.rows.length": 2, "metadata.columns.length": 2},
+        },
+        {
+            "id": "footnote_persisted",
+            "name": "docxodus_search",
+            "arguments": {
+                "sessionId": "$session_id",
+                "mode": "text",
+                "query": "Adopted by written consent",
+                "scope": "all",
+            },
+            "expect": {"matches.length": 1},
+        },
+        {
+            "id": "inserted_paragraph_persisted_and_findable",
+            "name": "docxodus_search",
+            "arguments": {
+                "sessionId": "$session_id",
+                "mode": "text",
+                "query": "The undersigned further certifies",
+                "scope": "body",
+            },
+            "expect": {"matches.length": 1},
+        },
+        {
+            "id": "rolled_back_text_never_persisted",
+            "name": "docxodus_search",
+            "arguments": {
+                "sessionId": "$session_id",
+                "mode": "text",
+                "query": "must be rolled back",
+                "scope": "all",
+            },
+            "expect": {"matches.length": 0},
+        },
+        {
+            "id": "refused_text_never_persisted",
+            "name": "docxodus_search",
+            "arguments": {
+                "sessionId": "$session_id",
+                "mode": "text",
+                "query": "must never reach the document",
+                "scope": "all",
+            },
+            "expect": {"matches.length": 0},
+        },
+        {
+            "id": "close",
+            "name": "docxodus_close",
+            "arguments": {"sessionId": "$session_id"},
+        },
+    ]
+
+
+def main() -> int:
+    check = "--check" in sys.argv[1:]
+    stale = []
+    for name, calls in (
+            ("epic-435-workflow.json", workflow()),
+            ("epic-435-validation.json", validation())):
+        target = Path(__file__).with_name(name)
+        rendered = json.dumps(calls, indent=2) + "\n"
+        if check:
+            # Asserts the committed fixture is what this generator emits, without
+            # consulting git — a working tree mid-edit is not the question.
+            current = target.read_text(encoding="utf-8") if target.exists() else None
+            print(f"{'stale' if current != rendered else 'fresh'}: {target}")
+            if current != rendered:
+                stale.append(target)
+            continue
+        target.write_text(rendered, encoding="utf-8")
+        print(f"wrote {target} ({len(calls)} calls)")
+    if stale:
+        print(
+            "regenerate with: python3 tools/mcp-server/smoke/"
+            f"{Path(__file__).name}", file=sys.stderr)
+    return 1 if stale else 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tools/mcp-server/smoke/epic-435-validation.json
+++ b/tools/mcp-server/smoke/epic-435-validation.json
@@ -2,14 +2,24 @@
   {
     "id": "reopen_saved_output",
     "name": "docxodus_open",
-    "arguments": { "path": "smoke-output.docx", "trackedChanges": "accept" },
-    "capture": { "session_id": "sessionId" }
+    "arguments": {
+      "path": "smoke-output.docx",
+      "trackedChanges": "accept"
+    },
+    "capture": {
+      "session_id": "sessionId"
+    }
   },
   {
     "id": "package_reopens_with_intact_structure",
     "name": "docxodus_get_content",
-    "arguments": { "sessionId": "$session_id", "format": "info" },
-    "capture": { "reopened_anchors": "editSummary.totalAnchors" },
+    "arguments": {
+      "sessionId": "$session_id",
+      "format": "info"
+    },
+    "capture": {
+      "reopened_anchors": "editSummary.totalAnchors"
+    },
     "expect": {
       "version": 0,
       "sectionInfo.pageNumberFormat": "lowerRoman",
@@ -18,27 +28,103 @@
     }
   },
   {
+    "id": "inspect_name_clause",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "text",
+      "query": "The name of this corporation is",
+      "maxResults": 2
+    },
+    "capture": {
+      "name_anchor": "matches.1.enclosingAnchor.id"
+    }
+  },
+  {
+    "id": "inspect_certification",
+    "name": "docxodus_search",
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "text",
+      "query": "DOES HEREBY CERTIFY",
+      "maxResults": 1
+    },
+    "capture": {
+      "certify_anchor": "matches.0.enclosingAnchor.id"
+    }
+  },
+  {
     "id": "tracked_edits_persisted_as_revisions",
     "name": "docxodus_track_changes",
-    "arguments": { "sessionId": "$session_id", "action": "list" },
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "list"
+    },
     "expect": {
-      "revisions.length": 4,
-      "revisions.0.type": "insert",
-      "revisions.0.text": "The undersigned further certifies that this Restated Certificate has been duly adopted in accordance with Sections 242 and 245 of the DGCL.\u00b6",
-      "revisions.1.type": "delete",
-      "revisions.1.text": "[_______________]",
-      "revisions.2.type": "insert",
-      "revisions.2.text": "Northstar Robotics, Inc.",
-      "revisions.2.author": "Smoke Counsel",
-      "revisions.3.type": "format",
-      "revisions.3.text": "Northstar Robotics, Inc."
+      "revisions.length": 6
+    },
+    "expectMembers": {
+      "revisions": [
+        {
+          "type": "insert",
+          "text": "",
+          "author": "Smoke Counsel",
+          "partUri": "/word/document.xml",
+          "scope": "body",
+          "anchorId": "$certify_anchor"
+        },
+        {
+          "type": "insert",
+          "text": "The undersigned further certifies that this Restated Certificate has been duly adopted in accordance with Sections 242 and 245 of the DGCL.\u00b6",
+          "author": "Smoke Counsel",
+          "partUri": "/word/document.xml",
+          "scope": "body"
+        },
+        {
+          "type": "delete",
+          "text": "[_______________]",
+          "author": "Smoke Counsel",
+          "partUri": "/word/document.xml",
+          "scope": "body",
+          "anchorId": "$name_anchor"
+        },
+        {
+          "type": "insert",
+          "text": "Northstar Robotics, Inc.",
+          "author": "Smoke Counsel",
+          "partUri": "/word/document.xml",
+          "scope": "body",
+          "anchorId": "$name_anchor"
+        },
+        {
+          "type": "format",
+          "text": "Northstar Robotics, Inc.",
+          "author": "Smoke Counsel",
+          "partUri": "/word/document.xml",
+          "scope": "body",
+          "anchorId": "$name_anchor"
+        },
+        {
+          "type": "insert",
+          "text": " Adopted by written consent of the stockholders.\u00b6",
+          "author": "Smoke Counsel",
+          "partUri": "/word/footnotes.xml",
+          "scope": "fn"
+        }
+      ]
     }
   },
   {
     "id": "comment_persisted",
     "name": "docxodus_comment",
-    "arguments": { "sessionId": "$session_id", "action": "list" },
-    "expect": { "comments.length": 1, "comments.0.author": "Smoke Counsel" }
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "list"
+    },
+    "expect": {
+      "comments.length": 1,
+      "comments.0.author": "Smoke Counsel"
+    }
   },
   {
     "id": "bookmark_persisted",
@@ -48,12 +134,18 @@
       "mode": "bookmark",
       "query": "SmokeDelawareRationale"
     },
-    "expect": { "matches.length": 1 }
+    "expect": {
+      "matches.length": 1
+    }
   },
   {
     "id": "hyperlink_persisted_as_external_relationship",
     "name": "docxodus_links",
-    "arguments": { "sessionId": "$session_id", "action": "list_hyperlinks", "scope": "body" },
+    "arguments": {
+      "sessionId": "$session_id",
+      "action": "list_hyperlinks",
+      "scope": "body"
+    },
     "expect": {
       "hyperlinks.length": 1,
       "hyperlinks.0.kind": "external",
@@ -63,9 +155,17 @@
   {
     "id": "table_persisted",
     "name": "docxodus_search",
-    "arguments": { "sessionId": "$session_id", "mode": "kind", "query": "tbl" },
-    "expect": { "matches.length": 1 },
-    "capture": { "table_anchor": "matches.0.id" }
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "kind",
+      "query": "tbl"
+    },
+    "expect": {
+      "matches.length": 1
+    },
+    "capture": {
+      "table_anchor": "matches.0.id"
+    }
   },
   {
     "id": "table_grid_is_addressable",
@@ -75,13 +175,23 @@
       "action": "get_metadata",
       "tableAnchorId": "$table_anchor"
     },
-    "expect": { "metadata.rows.length": 2, "metadata.columns.length": 2 }
+    "expect": {
+      "metadata.rows.length": 2,
+      "metadata.columns.length": 2
+    }
   },
   {
     "id": "footnote_persisted",
     "name": "docxodus_search",
-    "arguments": { "sessionId": "$session_id", "mode": "text", "query": "Adopted by written consent", "scope": "all" },
-    "expect": { "matches.length": 1 }
+    "arguments": {
+      "sessionId": "$session_id",
+      "mode": "text",
+      "query": "Adopted by written consent",
+      "scope": "all"
+    },
+    "expect": {
+      "matches.length": 1
+    }
   },
   {
     "id": "inserted_paragraph_persisted_and_findable",
@@ -92,7 +202,9 @@
       "query": "The undersigned further certifies",
       "scope": "body"
     },
-    "expect": { "matches.length": 1 }
+    "expect": {
+      "matches.length": 1
+    }
   },
   {
     "id": "rolled_back_text_never_persisted",
@@ -103,7 +215,9 @@
       "query": "must be rolled back",
       "scope": "all"
     },
-    "expect": { "matches.length": 0 }
+    "expect": {
+      "matches.length": 0
+    }
   },
   {
     "id": "refused_text_never_persisted",
@@ -114,11 +228,15 @@
       "query": "must never reach the document",
       "scope": "all"
     },
-    "expect": { "matches.length": 0 }
+    "expect": {
+      "matches.length": 0
+    }
   },
   {
     "id": "close",
     "name": "docxodus_close",
-    "arguments": { "sessionId": "$session_id" }
+    "arguments": {
+      "sessionId": "$session_id"
+    }
   }
 ]

--- a/tools/mcp-server/smoke/epic-435-workflow.json
+++ b/tools/mcp-server/smoke/epic-435-workflow.json
@@ -950,14 +950,57 @@
       "action": "list"
     },
     "expect": {
-      "revisions.length": 4,
-      "revisions.1.type": "delete",
-      "revisions.1.text": "[_______________]",
-      "revisions.2.type": "insert",
-      "revisions.2.text": "Northstar Robotics, Inc.",
-      "revisions.2.author": "Smoke Counsel",
-      "revisions.3.type": "format",
-      "revisions.3.text": "Northstar Robotics, Inc."
+      "revisions.length": 6
+    },
+    "expectMembers": {
+      "revisions": [
+        {
+          "type": "insert",
+          "text": "",
+          "author": "Smoke Counsel",
+          "partUri": "/word/document.xml",
+          "scope": "body",
+          "anchorId": "$certify_anchor"
+        },
+        {
+          "type": "insert",
+          "text": "The undersigned further certifies that this Restated Certificate has been duly adopted in accordance with Sections 242 and 245 of the DGCL.\u00b6",
+          "author": "Smoke Counsel",
+          "partUri": "/word/document.xml",
+          "scope": "body"
+        },
+        {
+          "type": "delete",
+          "text": "[_______________]",
+          "author": "Smoke Counsel",
+          "partUri": "/word/document.xml",
+          "scope": "body",
+          "anchorId": "$name_anchor"
+        },
+        {
+          "type": "insert",
+          "text": "Northstar Robotics, Inc.",
+          "author": "Smoke Counsel",
+          "partUri": "/word/document.xml",
+          "scope": "body",
+          "anchorId": "$name_anchor"
+        },
+        {
+          "type": "format",
+          "text": "Northstar Robotics, Inc.",
+          "author": "Smoke Counsel",
+          "partUri": "/word/document.xml",
+          "scope": "body",
+          "anchorId": "$name_anchor"
+        },
+        {
+          "type": "insert",
+          "text": " Adopted by written consent of the stockholders.\u00b6",
+          "author": "Smoke Counsel",
+          "partUri": "/word/footnotes.xml",
+          "scope": "fn"
+        }
+      ]
     }
   },
   {

--- a/tools/mcp-server/smoke/mcp_probe.py
+++ b/tools/mcp-server/smoke/mcp_probe.py
@@ -241,6 +241,42 @@ def main() -> int:
                 if unresolved:
                     assertion["unresolved"] = unresolved
                 assertions.append(assertion)
+            # Order-independent membership. A revision or match list's *contents* are
+            # the contract; the order the engine happens to enumerate them in is not,
+            # so pinning entries by absolute index made these fixtures fail on a
+            # reordering that changed nothing about the document (#687). Each expected
+            # member must match exactly one not-yet-claimed entry, which keeps the
+            # assertion as strict as an indexed one: a duplicated or missing entry
+            # still fails.
+            for path, members in substitute(
+                    call.get("expectMembers", {}), variables).items():
+                try:
+                    collection = capture_path(decoded, path)
+                    unresolved = (
+                        None if isinstance(collection, list)
+                        else f"TypeError: {path} is not a list")
+                except (KeyError, IndexError, TypeError, ValueError) as error:
+                    collection, unresolved = None, f"{type(error).__name__}: {error}"
+                claimed: set[int] = set()
+                for member in members:
+                    matched = [
+                        index
+                        for index, item in enumerate(collection or [])
+                        if index not in claimed
+                        and isinstance(item, dict)
+                        and all(item.get(k) == v for k, v in member.items())
+                    ]
+                    if len(matched) == 1:
+                        claimed.add(matched[0])
+                    assertion = {
+                        "path": path,
+                        "expected": member,
+                        "actual": {"matchedIndices": matched},
+                        "passed": unresolved is None and len(matched) == 1,
+                    }
+                    if unresolved:
+                        assertion["unresolved"] = unresolved
+                    assertions.append(assertion)
             if assertions:
                 entry["assertions"] = assertions
             responses.append(entry)


### PR DESCRIPTION
Fixes #687.

## What was wrong

The epic #435 acceptance workflow and its reopen validation both asserted a four-entry revision list. The workflow produces six. Because the README framed both runs as something a person does by hand, nothing caught the mismatch — the two documented runs had been failing their own assertions on `main`, while completing with no transport error, no tool error and no unexpected success.

## Are the two extra revisions a bug?

No, and the surprising one is worth naming plainly. A single `insert_footnote` step yields **two** revisions:

- the note body, in `word/footnotes.xml`;
- the reference run, in the body. This one reports empty text, because a `w:footnoteReference` has no text to report. It is nevertheless a genuine tracked insertion — rejecting it is what takes the reference back out of the paragraph — so suppressing it from the list would hide a change from the agent that made it.

The second extra entry is the inserted certification paragraph, which the workflow's own preview already predicted (`predictedRevisionAdds: 6`). Only the hand-written assertions disagreed.

## How it is fixed

**The contract is declared once.** It lived in two hand-maintained files and drifted out of both. `epic-435-validation.json` is now emitted by the same generator as `epic-435-workflow.json`, off a shared `REVISION_MEMBERS` list, and the generator (renamed `build_epic_435_fixtures.py`) grows a `--check` mode that fails when the committed JSON is not what it emits.

**Assertions are keyed on what the contract actually covers.** `mcp_probe.py` gains an `expectMembers` field: each expected member must match exactly one not-yet-claimed entry on the named list, in any order, comparing only the keys the member spells out. That keeps the strictness of an indexed assertion — a duplicated or vanished revision still fails — while dropping a dependency on enumeration order that was never promised. The six members are keyed on revision type, text, part URI and scope, plus, for three of them, the anchor they sit on; both runs now discover those two anchors the same way, from text neither the edit script nor the save disturbs.

**The runs become a gate rather than a ritual.** `scripts/mcp-smoke.sh` regenerates the fixtures, checks they are fresh, copies the committed `TestFiles/NVCA-Model-COI.docx` into a scratch storage root (the run saves), runs both workflows, and re-checks the five refusals and the byte-exact transaction replay — properties `mcp_probe.py` reports in its summary but does not enforce. CI calls the script on every pull request, right after building the server.

## Validation

Ran the gate against a Release build of the server:

```
workflow:   64 calls / 211 assertions / 0 failed / 5 expected failures / 0 replay mismatches
validation: 15 calls /  24 assertions / 0 failed
```

Confirmed the new assertions are not vacuous, two ways: perturbing one member's expected text makes the run report a failed assertion and exit nonzero, and truncating a committed fixture makes `--check` report it stale and exit nonzero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9S4EiaRU1pddjqkYmtYfd

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9S4EiaRU1pddjqkYmtYfd)_