### PR TITLE
Retire the resolved note-pruning finding from the form-document benchmark

### DIFF
--- a/Docxodus.Tests/DocxSessionNotePruneTests.cs
+++ b/Docxodus.Tests/DocxSessionNotePruneTests.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
@@ -16,7 +17,8 @@ namespace Docxodus.Tests;
 /// part via the same Word-faithful pruner revision resolution has used since issue #516 —
 /// scoped strictly to ids the op itself unreferenced, so a pre-existing dangling note is
 /// untouched and the part (with its Word-reserved separator notes) always survives.
-/// Test IDs use the DS64x range.
+/// Test IDs use the DS64x range; DS650 re-proves the same property on the real form
+/// document the defect was originally found on.
 /// </summary>
 public class DocxSessionNotePruneTests
 {
@@ -43,12 +45,17 @@ public class DocxSessionNotePruneTests
             .First(t => t.Anchor.Scope == "body" && t.Anchor.Kind is "p" or "h"
                 && t.TextPreview.Contains(contains)).Anchor.Id;
 
-    private static void AssertSchemaValid(byte[] bytes)
+    private static List<string> SchemaFindings(byte[] bytes)
     {
         using var ms = new MemoryStream(bytes);
         using var wDoc = WordprocessingDocument.Open(ms, false);
-        var errors = new OpenXmlValidator().Validate(wDoc)
+        return new OpenXmlValidator().Validate(wDoc)
             .Select(e => $"{e.Path?.XPath}: {e.Description}").ToList();
+    }
+
+    private static void AssertSchemaValid(byte[] bytes)
+    {
+        var errors = SchemaFindings(bytes);
         Assert.True(errors.Count == 0, "OOXML schema errors:\n" + string.Join("\n", errors));
     }
 
@@ -301,5 +308,52 @@ public class DocxSessionNotePruneTests
         Assert.Equal(new[] { 1, 2, 7 }, UserNoteIds(footnotes, W + "footnote"));
         Assert.Contains("Solo note.",
             footnotes.Descendants(W + "t").Select(t => (string)t));
+    }
+
+    /// <summary>
+    /// The defect this suite closes was found by the complex-form-doc benchmark on a real
+    /// charter, not on a built fixture: 94 footnotes, every one cited exactly once, and a
+    /// deleted paragraph left its commentary sitting in the package. The programmatic
+    /// fixtures above pin the pruner's edge cases; this one pins the case that was actually
+    /// reported, so `benchmarks/complex-form-doc/FINDINGS.md` can cite coverage on the same
+    /// document it observed the defect on.
+    /// </summary>
+    [Fact]
+    public void DS650_DeleteBlock_PrunesTheOrphanedFootnoteOnTheRealCharter()
+    {
+        var bytes = File.ReadAllBytes(
+            Path.Combine("../../../../TestFiles/", "NVCA-Model-COI.docx"));
+        var before = UserNoteIds(PartXml(bytes, m => m.FootnotesPart), W + "footnote");
+        Assert.Equal(94, before.Length);
+
+        using var session = new DocxSession(bytes);
+        // An optional-provision paragraph that cites one note, carries no bookmark endpoint,
+        // and is the only place in the charter this wording appears. Its note holds drafting
+        // commentary a delete must not leave behind — the confidentiality-adjacent leak the
+        // benchmark called out.
+        var anchor = AnchorByPreview(
+            session, "Notwithstanding anything in Section 2.3.1 to the contrary");
+        var result = session.DeleteBlock(anchor);
+        Assert.True(result.Success, result.Error?.Message);
+
+        var saved = session.Save();
+        var after = UserNoteIds(PartXml(saved, m => m.FootnotesPart), W + "footnote");
+        var pruned = before.Except(after).ToArray();
+        Assert.Single(pruned);
+        Assert.Equal(93, after.Length);
+
+        // The pruned definition is reported alongside the block it belonged to.
+        Assert.Contains(result.Removed, a => a.Kind == "fn");
+
+        // A real charter carries validator findings of its own — Word writes attributes the
+        // published schema never declared. The contract is that the delete adds none, not
+        // that the document was ever clean. Counted rather than matched, because every
+        // finding is reported at an XPath a removed paragraph renumbers.
+        var baseline = SchemaFindings(bytes).Count;
+        var findings = SchemaFindings(saved);
+        Assert.True(
+            findings.Count <= baseline,
+            $"delete added OOXML findings ({baseline} -> {findings.Count}):\n"
+            + string.Join("\n", findings));
     }
 }

--- a/benchmarks/complex-form-doc/FINDINGS.md
+++ b/benchmarks/complex-form-doc/FINDINGS.md
@@ -4,9 +4,9 @@
 
 | | |
 |---|---|
-| Commit | `18eb50ea` (main) |
-| Date | 2026-09-02 |
-| Runtime | .NET SDK 10.0.301, Linux x64, Release build |
+| Commit | `9474a170` (main) |
+| Date | 2026-09-03 |
+| Runtime | .NET SDK 10.0.400, Linux x64, Release build |
 | Input | `TestFiles/NVCA-Model-COI.docx`, 147,622 bytes |
 | Input SHA-256 | `d75600769c12724990de48149d7a2bb161f3522daa54b1783672f93697d87d29` |
 | Edit script | `edits/nvca-coi.json` (8 edits) |
@@ -39,17 +39,23 @@ threshold is asserted on them — they exist to catch order-of-magnitude drift.
 
 | Stage | Time | Output |
 |---|---|---|
-| `html (footnotes+headers rendered)` | 1,569 ms | 214,469 chars |
-| `markdown projection` | 542 ms | 462 anchors, all 94 footnotes projected inline |
-| `DocxDiff compatibility probe` | 108 ms | 0 warnings |
-| `no-edit session round-trip` | 725 ms | — |
-| `tracked session: full edit script` | 3,814 ms | 8/8 edits applied, 11 native revisions, author `Series A Counsel` |
-| `clean session: same edit script untracked` | 1,793 ms | — |
-| `DocxDiff.Compare` | 1,397 ms | — |
-| `DocxDiff.GetRevisions` | 721 ms | 20 revisions |
-| `DocxDiff edit script + semantic changes` | 2,659 ms | 46,460 / 67,164 chars |
-| `DocxDiff round-trip invariants` | 1,960 ms | — |
-| `redline -> HTML with tracked-change markup` | 1,095 ms | — |
+| `html (footnotes+headers rendered)` | 1,469 ms | — |
+| `markdown projection` | 384 ms | 214,469 chars, 462 anchors, all 94 footnotes projected inline |
+| `DocxDiff compatibility probe` | 71 ms | 0 warnings |
+| `no-edit session round-trip` | 365 ms | — |
+| `tracked session: full edit script` | 3,723 ms | 8/8 edits applied, 11 native revisions, author `Series A Counsel` |
+| `clean session: same edit script untracked` | 1,182 ms | — |
+| `DocxDiff.Compare` | 667 ms | — |
+| `DocxDiff.GetRevisions` | 285 ms | 20 revisions |
+| `DocxDiff edit script + semantic changes` | 1,397 ms | 46,460 / 67,164 chars |
+| `DocxDiff round-trip invariants` | 779 ms | — |
+| `redline -> HTML with tracked-change markup` | 499 ms | — |
+
+The harness prints a stage's own detail line before its timing line, so read the two
+together per row above rather than in program output order — the earlier table here paired
+the markdown projection's size with the HTML stage. Times are from a different machine than
+the 2026-09-02 run and are uniformly lower; nothing changed by an order of magnitude, which
+is all these numbers are for.
 
 Revision counts are one-run observations of a specific edit script against a specific
 document; they are reported, not asserted. The 8-edit script yields 11 tracked-session
@@ -58,29 +64,38 @@ granularity over the same edits).
 
 ## Open issues this benchmark surfaced
 
-1. **`DocxSession.DeleteBlock` leaves orphaned footnote definitions.** Deleting a
-   paragraph whose text carries a footnote reference removes the reference but leaves
-   the footnote body in `word/footnotes.xml`. Word renders nothing (the note is
-   unreferenced), but the text still ships inside the file — for legal workflows this is
-   a confidentiality-adjacent leak: "deleted" drafting commentary survives in the
-   package. Options: prune unreferenced notes on delete, prune on `Save()`, or expose a
-   `CompactFootnotes`-style op; whichever is chosen should be revision-aware (a tracked
-   delete must keep the note until the revision is accepted).
-
-2. **Formatting-only edits that cross a field envelope surface as delete+insert pairs
+1. **Formatting-only edits that cross a field envelope surface as delete+insert pairs
    in the native redline.** Italicizing a span that intersects a cross-reference field
    produces a full del+ins of the field region rather than a formatting revision —
    correct OOXML, but noisy for a human reviewer. The semantic changeset already
    classifies it precisely (`run_formatting` modify on the exact token span plus a
    `field` envelope change), so this is a markup-shaping improvement, not a diff bug.
 
-3. **`DocxDiffRevision` has no useful `ToString()`** — logging a revision prints the type
+2. **`DocxDiffRevision` has no useful `ToString()`** — logging a revision prints the type
    name. Minor, but it makes agent traces harder to read.
 
-4. **Two tracked-changes knobs are easy to conflate.** The projection-side knob
+3. **Two tracked-changes knobs are easy to conflate.** The projection-side knob
    (`ProjectionSettings.TrackedChanges`) is separate from the mutation-recording knob
    (`SetTrackedChanges`): an agent that records tracked edits and then projects sees
    clean text unless it also sets the projection mode.
+
+## Fixed since this benchmark reported them
+
+**`DocxSession.DeleteBlock` left orphaned footnote definitions** (fixed by #591). Deleting a
+paragraph whose text carried a footnote reference removed the reference but left the
+footnote body in `word/footnotes.xml`. Word rendered nothing, the note being unreferenced,
+but the text still shipped inside the file — for legal workflows a confidentiality-adjacent
+leak, where "deleted" drafting commentary survives in the package.
+
+`Docxodus/Internal/NoteReferenceOps.cs` now prunes definitions whose last reference an op
+removed, through the same Word-faithful pruner revision resolution has used since #516. It
+is revision-aware, as the finding asked: a tracked delete keeps the note until the revision
+is accepted. `Docxodus.Tests/DocxSessionNotePruneTests.cs` holds the regression net —
+`DS640`–`DS649` cover `DeleteBlock`, shared references, pre-existing danglers, endnotes,
+tracked deletion, range and section deletes, table row/column deletes and undo on built
+fixtures, and `DS650` re-proves the case as this benchmark reported it, by deleting a
+footnote-bearing paragraph of `TestFiles/NVCA-Model-COI.docx` and asserting the charter's
+94 note definitions become 93 with no new validator finding.
 
 ## Historical: the 2026-08-26 run (superseded)
 


### PR DESCRIPTION
Fixes #686.

## What was wrong

`benchmarks/complex-form-doc/FINDINGS.md` still listed orphaned footnote definitions after `DocxSession.DeleteBlock` under **"Open issues this benchmark surfaced"**. That defect was fixed by #591 and has had regression coverage ever since, so anyone reading the benchmark was told a shipped confidentiality problem — deleted drafting commentary surviving inside the package — was still open.

## What changed

**The finding moves rather than disappears.** It now sits under "Fixed since this benchmark reported them", with what closed it: `Docxodus/Internal/NoteReferenceOps.cs`, and the fact that the pruner is revision-aware — a tracked delete keeps the note until the revision is accepted — which is a constraint the finding itself asked for and is worth keeping beside the code that satisfies it. The remaining three open findings renumber.

**Re-ran the benchmark to write that honestly**, which turned up two more things:

- *The measurements table was mis-paired.* It listed the markdown projection's output size against the HTML stage. The harness prints a stage's detail line *before* its timing line, and the table had been read in program output order. Corrected, and refreshed against a current run of `9474a170` — all eight stable checks pass, source validator baseline 80, no output exceeds it. Times are from a different machine and are uniformly lower; the table now says so, since these numbers exist only to catch order-of-magnitude drift.

- *The coverage gap the finding left behind.* `DocxSessionNotePruneTests` proved the pruner on programmatic fixtures — ten of them, covering shared references, pre-existing danglers, endnotes, tracked deletes, ranges, table rows and columns, and undo — but the defect was reported on a real charter, and nothing re-proved it there.

## Test

`DS650_DeleteBlock_PrunesTheOrphanedFootnoteOnTheRealCharter` deletes a footnote-bearing paragraph of `TestFiles/NVCA-Model-COI.docx` (94 footnotes, each cited exactly once) and asserts:

- the charter's note definitions go 94 → 93, and exactly one id disappears;
- the pruned definition is reported on the delete's own receipt (`result.Removed` carries an `fn` anchor);
- the save adds no OOXML validator finding.

That last assertion is counted against the source document's own baseline rather than demanding a clean package: a real charter carries 80 findings Word wrote itself, and removing a paragraph renumbers the XPath every one of them is reported at, so a set difference compares noise. The target paragraph is chosen for carrying no bookmark endpoint — with one, the engine correctly refuses the structural delete, which is a different property with its own tests.

`dotnet test --filter FullyQualifiedName~NotePrune` — 11 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9S4EiaRU1pddjqkYmtYfd

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9S4EiaRU1pddjqkYmtYfd)_