### PR TITLE
Warm the WASM comparison engine before the first real comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- The browser build no longer hangs on a comparison that follows a session read. The first
+  comparison a WASM module instance runs executes the whole cold path of the engine — assembly
+  resolution, type loads, static constructors, and the first-time entry into every method the
+  diff and render stages touch — and much of that runs on the Mono interpreter rather than in
+  AOT-compiled code. Mono's collector pins conservatively from the interpreter stack, so every
+  nursery collection taken while that cold path is live pays a scan proportional to it, and a
+  comparison allocates a package's worth of XML. On a heap an earlier operation had already
+  filled — opening a `DocxSession` to read revisions, say — the two coincided and the comparison
+  stopped making meaningful progress: over ten minutes for an 11 KB pair that takes 25 ms
+  natively and about half a second warm in the browser. Every comparison entry point in the WASM
+  bridge now warms the engine first, against two one-paragraph in-memory documents that walk the
+  same cold path while allocating almost nothing. `DocumentComparer.Warmup` (the npm worker's
+  `prepare()`) still exists to move that cost off the critical path, but is no longer the
+  difference between working and hanging; it is now latched, so it truly costs nothing after the
+  first call. The first comparison of a module instance is about 250 ms slower; every later one
+  is unchanged. Tuning the collector is not an alternative — the collapse is not monotone in
+  nursery size, so no setting fixes it, while warming first survives every size measured.
 - `DocxDiff` no longer lets an empty paragraph act as an alignment anchor on its own. An empty
   paragraph has no words, so the only thing that can make its paragraph mark "the same paragraph"
   on both sides is the matched content it sits inside — a blank between two retained or edited

--- a/docs/architecture/wasm-packaging.md
+++ b/docs/architecture/wasm-packaging.md
@@ -169,6 +169,54 @@ The AOT-compiled `dotnet.native.wasm` is a different binary from the interpreter
 the trim canaries in `trim-validation.spec.ts` and the whole Playwright suite are what prove
 the tier did not change behaviour; both ran green on the AOT bundle before it shipped.
 
+### The cold path can collapse, so every comparison warms first (issues #695, #696)
+
+A stale profile costs speed, never correctness — but the *cold path* costs more than speed.
+The first comparison a module instance runs executes the engine's whole cold path (assembly
+resolution, type loads, static constructors, first-time entry into every method the diff and
+render stages touch), and a large part of that is outside any profile and therefore runs
+interpreted. **Mono's collector pins conservatively from the interpreter stack**, so a nursery
+collection taken while that cold path is live pays a root scan proportional to it. A comparison
+also allocates a package's worth of XML, so it takes many collections. On a heap that an
+earlier operation has already filled the two coincide and the comparison stops making
+meaningful progress — not "slow", but no longer finishing.
+
+Measured on `WC/WC007-Unmodified.docx` against `WC/WC007-Moved-into-Table.docx` (11 KB each)
+after one `DocxSession` revision read in the same page:
+
+| | first comparison |
+|---|---|
+| warm native (.NET 10 x64) | 25 ms |
+| browser, warm | ~0.5 s |
+| browser, cold, on a clean heap | ~0.6 s |
+| **browser, cold, after a session read** | **> 10 min (never observed to finish)** |
+
+Sampling the hung page with `Debugger.pause` put **14 of 14 stacks** in
+`collect_nursery → pin_from_roots → sgen_client_scan_thread_data → interp_mark_stack`.
+
+Three things this is *not*, each ruled out by measurement rather than argument:
+
+- **Not a diff-engine regression.** The redline this pair produces is byte-identical before and
+  after the change that first exposed it (#693) — only the revision timestamp differs — and warm
+  native is 24–26 ms at both commits.
+- **Not a stale profile.** Re-recording `docxodus.aotprofile` and rebuilding does not fix it.
+  (The jiterpreter is barely involved either: the shipped tier reports 0 traces and 264 B jitted
+  across the sequence, because the profile already covers the warm path.)
+- **Not a GC tuning problem.** The collapse is **not monotone in nursery size**: with
+  `MONO_GC_PARAMS=nursery-size=`, 4m, 6m and 12m all collapse while 8m and 16m do not. A value
+  that survives today is a lottery ticket, not a fix — which is why none is set.
+
+What does hold is warming the engine on input too small to take a collection.
+`DocxodusWasm/ComparisonEngine.EnsureWarm()` compares two one-paragraph in-memory documents:
+same cold path, almost no allocation. Every comparison export in `DocxDiffBridge` and
+`DocumentComparer` calls it before touching the caller's documents, and it is latched, so it
+runs once per module instance. It fixes the sequence under every nursery size measured above,
+including the three that collapse. The cost is about 250 ms on the first comparison and nothing
+after it; `DocumentComparer.Warmup` (the npm worker's `prepare()`) still exists to move that
+250 ms off the critical path, but is no longer the difference between working and hanging.
+`npm/tests/wasm-steady-state.spec.ts` pins the sequence — session read first, comparison second,
+both in a page that has run neither before, because comparing first makes it pass trivially.
+
 ## Compression and serving
 
 `build-wasm.sh` writes a brotli-11 `.br` sibling next to every `_framework` asset. The

--- a/npm/tests/wasm-steady-state.spec.ts
+++ b/npm/tests/wasm-steady-state.spec.ts
@@ -2,10 +2,11 @@
 // behind it (issue #652).
 //
 // The browser build runs the engine on the Mono interpreter, tiered by the jiterpreter
-// (hot interpreter traces compiled to WebAssembly at runtime). Two things can silently
+// (hot interpreter traces compiled to WebAssembly at runtime). Three things can silently
 // take that speed away: a build knob or feature switch that disables the jiterpreter,
-// and the jiterpreter's own budget of generated code (`jiterpreter-wasm-bytes-limit`),
-// past which no new trace is compiled. The first test pins both.
+// the jiterpreter's own budget of generated code (`jiterpreter-wasm-bytes-limit`), past
+// which no new trace is compiled, and a comparison entry point that runs the engine's
+// cold path on a real document instead of warming first. The first two tests pin those.
 //
 // The second test is a MEASUREMENT harness, not a fidelity pin: it runs the
 // representative workload in wasm-workload.ts (warm, N iterations) and prints
@@ -17,7 +18,7 @@
 import { test, expect, Page } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
-import { loadWorkloadInput, runWasmWorkload, WorkloadResult } from './wasm-workload';
+import { loadWorkloadInput, runWasmWorkload, WorkloadResult, WORKLOAD_TEST_FILES_DIR } from './wasm-workload';
 
 async function waitForDocxodus(page: Page) {
   await page.waitForFunction(() => (window as any).DocxodusReady === true, { timeout: 30000 });
@@ -103,5 +104,49 @@ test.describe('WASM steady-state (issue #652)', () => {
       fs.writeFileSync(path.join(outDir, 'steady-state.json'), JSON.stringify(rest, null, 2));
       fs.writeFileSync(path.join(outDir, 'heavy-variant.docx'), Buffer.from(variant!));
     }
+  });
+
+  // Issues #695, #696. A comparison that is the FIRST one a module instance runs executes the
+  // engine's cold path — much of it on the interpreter, which Mono's GC pins conservatively
+  // from — while allocating a package's worth of XML. On a heap an earlier operation has
+  // already filled, the two together stop the comparison making meaningful progress: this exact
+  // sequence ran for over ten minutes before ComparisonEngine.EnsureWarm() became an invariant
+  // of every comparison export, against ~25 ms natively and ~500 ms warm in the browser.
+  //
+  // The order is the whole test. A session read must come first and the comparison must be the
+  // first of the page: warming the engine by comparing first makes it pass trivially.
+  test('a comparison that follows a session read is not the engine cold path', async ({ page }) => {
+    test.setTimeout(180000);
+    await page.goto('/test-harness.html');
+    await waitForDocxodus(page);
+
+    const read = (rel: string) => Array.from(fs.readFileSync(path.join(WORKLOAD_TEST_FILES_DIR, rel)));
+    const revisionDoc = read('FA/RevTracking/014-MovedParagraph.docx');
+    const left = read('WC/WC007-Unmodified.docx');
+    const right = read('WC/WC007-Moved-into-Table.docx');
+
+    const revisions = await page.evaluate(
+      (bytes) => (window as any).DocxodusTests.getRevisions(new Uint8Array(bytes)),
+      revisionDoc);
+    expect(revisions.error, 'session revision read').toBeUndefined();
+    expect(revisions.revisions.length, 'the read has to do real work to fill the heap')
+      .toBeGreaterThan(0);
+
+    const t0 = Date.now();
+    const compared = await page.evaluate(
+      ([l, r]) => {
+        const result = (window as any).DocxodusTests.compareDocuments(new Uint8Array(l), new Uint8Array(r));
+        return { len: result.docxBytes ? result.docxBytes.length : -1, error: result.error };
+      },
+      [left, right]);
+    const elapsed = Date.now() - t0;
+
+    expect(compared.error).toBeUndefined();
+    expect(compared.len, 'the comparison produced a package').toBeGreaterThan(0);
+    // Warm in this browser is ~0.5 s including the warm-up; the collapse this pins is three
+    // orders of magnitude away, so the budget is deliberately loose enough to survive a slow
+    // CI machine and still fail the moment the cold path is back.
+    console.log(`first comparison after a session read: ${fmt(elapsed)}`);
+    expect(elapsed, 'first comparison after a session read').toBeLessThan(30000);
   });
 });

--- a/npm/tests/wasm-workload.ts
+++ b/npm/tests/wasm-workload.ts
@@ -18,6 +18,9 @@ import { fileURLToPath } from 'url';
 
 const TEST_FILES_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), '../../TestFiles');
 
+/** The same TestFiles root, for specs that read a fixture this module does not name. */
+export const WORKLOAD_TEST_FILES_DIR = TEST_FILES_DIR;
+
 /** Fixtures, relative to TestFiles/. */
 export const WORKLOAD_FIXTURES = {
   /** Two 11 KB revisions of one document — the "typical" compare. */

--- a/wasm/DocxodusWasm/ComparisonEngine.cs
+++ b/wasm/DocxodusWasm/ComparisonEngine.cs
@@ -1,0 +1,119 @@
+#nullable enable
+
+using System;
+using System.IO;
+using System.Runtime.Versioning;
+using Docxodus;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace DocxodusWasm;
+
+/// <summary>
+/// The comparison engine's one-time warm-up, and the invariant every JSExport that runs a
+/// comparison holds: <see cref="EnsureWarm"/> before the first real comparison of a module
+/// instance (issues #695, #696).
+///
+/// <para><b>Why this is mandatory in the browser and meaningless natively.</b> The first
+/// comparison a module instance runs is not merely slower than the ones after it — it executes
+/// the engine's whole cold path (assembly resolution, type loads, static constructors, and the
+/// first-time entry into every method the diff and render stages touch), and a large part of
+/// that cold path runs on the Mono interpreter rather than in AOT-compiled code. Mono's GC pins
+/// conservatively from the interpreter stack, so while that cold path is on the stack, every
+/// nursery collection pays a scan proportional to it. A comparison also allocates heavily — a
+/// package's worth of XML — so it triggers many collections. When those two coincide on a heap
+/// that some earlier operation has already filled (opening a <c>DocxSession</c> to read
+/// revisions, say), the collections stop being incidental and the comparison ceases to make
+/// meaningful progress: measured at over ten minutes for a pair that takes 25 ms natively and
+/// ~500 ms warm in the browser.</para>
+///
+/// <para>The seed comparison below is immune to that collapse because it is tiny — two
+/// one-paragraph in-memory documents allocate almost nothing — while still executing the same
+/// cold path. Paying it first therefore leaves the caller's real comparison warm, whatever its
+/// size. This holds where tuning the GC does not: the collapse is not monotone in nursery size
+/// (measured: 4m, 6m and 12m all collapse while 8m and 16m do not), so no nursery setting is a
+/// fix, whereas warming first survives every one of those configurations.</para>
+///
+/// <para><b>Not a substitute for <c>prepare()</c>.</b> The npm worker still calls
+/// <see cref="DocumentComparer.Warmup"/> up front to move this cost off the critical path.
+/// The difference is that a caller who does not can no longer land on the collapse: the cost is
+/// paid on the first comparison instead of before it, and it is paid once either way.</para>
+/// </summary>
+[SupportedOSPlatform("browser")]
+internal static class ComparisonEngine
+{
+    private static bool warmed;
+
+    /// <summary>
+    /// Run the seed comparison once per module instance. Subsequent calls return immediately.
+    /// </summary>
+    /// <returns><c>"ok"</c> on success, or a JSON error object.</returns>
+    /// <remarks>
+    /// Best-effort: a warm-up that throws has still forced the assemblies to load and the cold
+    /// path to run, so it is latched even on failure — a caller must not pay a failing warm-up
+    /// on every comparison. The failure is reported rather than thrown so a comparison entry
+    /// point can ignore it and proceed to the caller's real work.
+    /// </remarks>
+    internal static string EnsureWarm()
+    {
+        if (warmed)
+            return "ok";
+        warmed = true;
+
+        try
+        {
+            // Two minimal in-memory documents that differ by a single word, so DocxDiff produces
+            // a real insertion/deletion and walks its full alignment + markup path rather than an
+            // empty fast-exit.
+            var original = new WmlDocument("warmup-original.docx", BuildSeedDocx("warmup original"));
+            var modified = new WmlDocument("warmup-modified.docx", BuildSeedDocx("warmup modified"));
+
+            var settings = new DocxDiffSettings
+            {
+                AuthorForRevisions = "Docxodus",
+                DateTimeForRevisions = DateTime.UtcNow.ToString("o"),
+            };
+
+            var result = DocxCompare.Compare(original, modified, settings);
+
+            // Touch the revision-extraction path too, since callers that warm the compare path
+            // almost always read revisions next.
+            using (var warmSession = new DocxSession(result.DocumentByteArray))
+                _ = warmSession.ListRevisions();
+
+            return "ok";
+        }
+        catch (Exception ex)
+        {
+            return DocumentConverter.SerializeError(ex.Message, ex.GetType().Name);
+        }
+    }
+
+    /// <summary>
+    /// Build a minimal but valid DOCX package (one paragraph) in memory.
+    /// Includes the parts comparison expects (styles, settings).
+    /// </summary>
+    private static byte[] BuildSeedDocx(string text)
+    {
+        using var ms = new MemoryStream();
+        using (var doc = WordprocessingDocument.Create(ms, WordprocessingDocumentType.Document))
+        {
+            var mainPart = doc.AddMainDocumentPart();
+            mainPart.Document = new Document(new Body(
+                new Paragraph(
+                    new Run(
+                        new Text(text) { Space = SpaceProcessingModeValues.Preserve }))));
+
+            var stylesPart = mainPart.AddNewPart<StyleDefinitionsPart>();
+            stylesPart.Styles = new Styles();
+
+            var settingsPart = mainPart.AddNewPart<DocumentSettingsPart>();
+            settingsPart.Settings = new Settings();
+
+            mainPart.Document.Save();
+        }
+
+        return ms.ToArray();
+    }
+}

--- a/wasm/DocxodusWasm/DocumentComparer.cs
+++ b/wasm/DocxodusWasm/DocumentComparer.cs
@@ -3,15 +3,17 @@ using System.Runtime.Versioning;
 using System.Text.Json;
 using Docxodus;
 using Docxodus.Internal;
-using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
-using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace DocxodusWasm;
 
 /// <summary>
 /// JSExport methods for DOCX document comparison (redlining).
 /// These methods are callable from JavaScript.
+///
+/// <para><b>Invariant.</b> Every export here that runs a comparison calls
+/// <see cref="ComparisonEngine.EnsureWarm"/> first; a new one must too. See that class for why
+/// the browser cannot be left to discover the engine's cold path on a real document.</para>
 /// </summary>
 [SupportedOSPlatform("browser")]
 public partial class DocumentComparer
@@ -19,86 +21,21 @@ public partial class DocumentComparer
     /// <summary>
     /// Force the comparison code path fully hot.
     ///
-    /// Creating the WASM runtime does not exercise the comparison engine, so
-    /// the first real <see cref="CompareDocuments"/> pays a one-time warmup
-    /// cost — comparison-assembly initialization plus JIT of the diff/XML
-    /// stack — on top of the actual diff work (~2x the steady-state latency).
+    /// Creating the WASM runtime does not exercise the comparison engine, so the first real
+    /// comparison executes the engine's whole cold path on top of the actual diff work. Every
+    /// comparison entry point now pays that itself (see <see cref="ComparisonEngine"/>, which
+    /// explains why the browser cannot be left to discover it); this export exists so a caller
+    /// can pay it up front instead — the npm worker's <c>prepare()</c> — and keep the first
+    /// interactive comparison at steady-state latency.
     ///
-    /// <para>This method runs a complete comparison against two tiny seed
-    /// documents constructed in-memory, exercising the exact code path
-    /// <see cref="CompareDocuments"/> uses (<see cref="DocxCompare.Compare"/> through
-    /// the DocxDiff engine).
-    /// That resolves and JIT-compiles everything the engine touches, so a
-    /// subsequent real comparison runs at steady-state speed and triggers no
-    /// further <c>.wasm</c> fetches.</para>
-    ///
-    /// <para>Idempotent and self-contained: no caller IO, no seed fixtures to
-    /// ship. Safe to call repeatedly — the warmup work is only paid once.
-    /// Returns <c>"ok"</c> on success or a JSON error object; warmup is
-    /// best-effort, so even the error path has already warmed the engine.</para>
+    /// <para>Idempotent and self-contained: no caller IO, no seed fixtures to ship. Safe to call
+    /// repeatedly — the warm-up work is only paid once. Returns <c>"ok"</c> on success or a JSON
+    /// error object; warm-up is best-effort, so even the error path has already warmed the
+    /// engine.</para>
     /// </summary>
     /// <returns><c>"ok"</c> on success, or a JSON error object.</returns>
     [JSExport]
-    public static string Warmup()
-    {
-        try
-        {
-            // Two minimal in-memory documents that differ by a single word, so
-            // DocxDiff produces a real insertion/deletion and walks its full
-            // alignment + markup path rather than an empty fast-exit.
-            var original = new WmlDocument("warmup-original.docx", BuildSeedDocx("warmup original"));
-            var modified = new WmlDocument("warmup-modified.docx", BuildSeedDocx("warmup modified"));
-
-            var settings = new DocxDiffSettings
-            {
-                AuthorForRevisions = "Docxodus",
-                DateTimeForRevisions = DateTime.UtcNow.ToString("o"),
-            };
-
-            var result = DocxCompare.Compare(original, modified, settings);
-
-            // Touch the revision-extraction path too, since callers that warm
-            // the compare path almost always read revisions next.
-            using (var warmSession = new DocxSession(result.DocumentByteArray))
-                _ = warmSession.ListRevisions();
-
-            return "ok";
-        }
-        catch (Exception ex)
-        {
-            // The act of calling DocxCompare.Compare above has already forced
-            // the assemblies to load even if the comparison itself threw, so
-            // warmup has still served its purpose. Report the failure so a
-            // caller can surface it, but do not throw.
-            return DocumentConverter.SerializeError(ex.Message, ex.GetType().Name);
-        }
-    }
-
-    /// <summary>
-    /// Build a minimal but valid DOCX package (one paragraph) in memory.
-    /// Includes the parts comparison expects (styles, settings).
-    /// </summary>
-    private static byte[] BuildSeedDocx(string text)
-    {
-        using var ms = new MemoryStream();
-        using (var doc = WordprocessingDocument.Create(ms, WordprocessingDocumentType.Document))
-        {
-            var mainPart = doc.AddMainDocumentPart();
-            mainPart.Document = new Document(new Body(
-                new Paragraph(
-                    new Run(
-                        new Text(text) { Space = SpaceProcessingModeValues.Preserve }))));
-
-            var stylesPart = mainPart.AddNewPart<StyleDefinitionsPart>();
-            stylesPart.Styles = new Styles();
-
-            var settingsPart = mainPart.AddNewPart<DocumentSettingsPart>();
-            settingsPart.Settings = new Settings();
-
-            mainPart.Document.Save();
-        }
-        return ms.ToArray();
-    }
+    public static string Warmup() => ComparisonEngine.EnsureWarm();
 
     /// <summary>
     /// Compare two DOCX documents and return the result as a redlined DOCX (byte array).
@@ -125,6 +62,8 @@ public partial class DocumentComparer
         // byte-for-byte copy of the package they supplied.
         if (originalBytes.AsSpan().SequenceEqual(modifiedBytes))
             return (byte[])originalBytes.Clone();
+
+        ComparisonEngine.EnsureWarm();
 
         try
         {
@@ -186,6 +125,8 @@ public partial class DocumentComparer
         {
             return DocumentConverter.SerializeError("Missing document data");
         }
+
+        ComparisonEngine.EnsureWarm();
 
         try
         {
@@ -295,6 +236,8 @@ public partial class DocumentComparer
             return DocumentConverter.SerializeError("Missing document data");
         }
 
+        ComparisonEngine.EnsureWarm();
+
         try
         {
             var original = new WmlDocument("original.docx", originalBytes);
@@ -368,6 +311,8 @@ public partial class DocumentComparer
 
         if (originalBytes.AsSpan().SequenceEqual(modifiedBytes))
             return (byte[])originalBytes.Clone();
+
+        ComparisonEngine.EnsureWarm();
 
         try
         {

--- a/wasm/DocxodusWasm/DocxDiffBridge.cs
+++ b/wasm/DocxodusWasm/DocxDiffBridge.cs
@@ -19,6 +19,10 @@ namespace DocxodusWasm;
 /// comparisons. This bridge exposes its additional anchor-addressed revisions and
 /// diff-as-data edit script. Settings arrive as a JSON object (the transport mirror
 /// of <c>DocxDiffSettings</c>); an empty/whitespace string uses the defaults.</para>
+///
+/// <para><b>Invariant.</b> Every export here that runs a comparison calls
+/// <see cref="ComparisonEngine.EnsureWarm"/> first; a new one must too. See that class for why
+/// the browser cannot be left to discover the engine's cold path on a real document.</para>
 /// </summary>
 [SupportedOSPlatform("browser")]
 public static partial class DocxDiffBridge
@@ -34,6 +38,7 @@ public static partial class DocxDiffBridge
     [JSExport]
     public static byte[] Compare(byte[] leftBytes, byte[] rightBytes, string settingsJson)
     {
+        ComparisonEngine.EnsureWarm();
         try
         {
             return DocxDiffOps.Compare(leftBytes, rightBytes, settingsJson);
@@ -52,6 +57,7 @@ public static partial class DocxDiffBridge
     [JSExport]
     public static string GetRevisionsJson(byte[] leftBytes, byte[] rightBytes, string settingsJson)
     {
+        ComparisonEngine.EnsureWarm();
         try
         {
             return DocxDiffOps.GetRevisionsJson(leftBytes, rightBytes, settingsJson);
@@ -69,6 +75,7 @@ public static partial class DocxDiffBridge
     [JSExport]
     public static string GetEditScriptJson(byte[] leftBytes, byte[] rightBytes, string settingsJson)
     {
+        ComparisonEngine.EnsureWarm();
         try
         {
             return DocxDiffOps.GetEditScriptJson(leftBytes, rightBytes, settingsJson);
@@ -87,6 +94,7 @@ public static partial class DocxDiffBridge
     public static string GetSemanticChangesJson(
         byte[] leftBytes, byte[] rightBytes, string settingsJson)
     {
+        ComparisonEngine.EnsureWarm();
         try
         {
             return DocxDiffOps.GetSemanticChangesJson(leftBytes, rightBytes, settingsJson);
@@ -108,6 +116,7 @@ public static partial class DocxDiffBridge
     public static string CompareProductsJson(
         byte[] leftBytes, byte[] rightBytes, string settingsJson, string productsJson)
     {
+        ComparisonEngine.EnsureWarm();
         try
         {
             return DocxDiffOps.CompareProductsJson(leftBytes, rightBytes, settingsJson, productsJson);
@@ -129,6 +138,7 @@ public static partial class DocxDiffBridge
     public static string CompareBatchJson(
         byte[] baselineBytes, string candidatesJson, string settingsJson, string productsJson)
     {
+        ComparisonEngine.EnsureWarm();
         try
         {
             return DocxDiffOps.CompareBatchJson(baselineBytes, candidatesJson, settingsJson, productsJson);
@@ -190,6 +200,7 @@ public static partial class DocxDiffBridge
     [JSExport]
     public static byte[] Consolidate(byte[] baseBytes, string reviewersJson, string settingsJson)
     {
+        ComparisonEngine.EnsureWarm();
         try
         {
             return DocxDiffOps.Consolidate(baseBytes, reviewersJson, settingsJson);
@@ -209,6 +220,7 @@ public static partial class DocxDiffBridge
     [JSExport]
     public static string GetConsolidatedRevisionsJson(byte[] baseBytes, string reviewersJson, string settingsJson)
     {
+        ComparisonEngine.EnsureWarm();
         try
         {
             return DocxDiffOps.GetConsolidatedRevisionsJson(baseBytes, reviewersJson, settingsJson);
@@ -227,6 +239,7 @@ public static partial class DocxDiffBridge
     [JSExport]
     public static string GetConsolidatedEditScriptJson(byte[] baseBytes, string reviewersJson, string settingsJson)
     {
+        ComparisonEngine.EnsureWarm();
         try
         {
             return DocxDiffOps.GetConsolidatedEditScriptJson(baseBytes, reviewersJson, settingsJson);
@@ -245,6 +258,7 @@ public static partial class DocxDiffBridge
     [JSExport]
     public static string GetConflictsJson(byte[] baseBytes, string reviewersJson, string settingsJson)
     {
+        ComparisonEngine.EnsureWarm();
         try
         {
             return DocxDiffOps.GetConflictsJson(baseBytes, reviewersJson, settingsJson);


### PR DESCRIPTION
## What this fixes

The Playwright `test` job has been red on `main` and on every PR since #693: the WASM spec
*"move detection exposes MoveGroupId and IsMoveSource in revisions"* times out at 60 s inside
`compareDocuments`. Locally the same comparison never finishes at all — it was still running
after ten minutes. The same comparison takes **25 ms natively** and **~0.5 s in the browser**
when it is not the first one the page runs.

## The comparison engine is not the problem

Both issues assume the diff engine regressed in #693. It did not:

- The redline #693 produces for this exact fixture pair is **byte-identical** to the one the
  commit before it produces — only the revision timestamp differs.
- Warm native comparison is **24–26 ms at both commits** (#696 measured only the cold number,
  where JIT hides a delta this size).

So #695's suggested next step — a third gate in `TrimAndGate`, or a cap on the containment
scan — would have been fixing something that isn't happening. There is no window blowup to cap.

## What is actually happening

Sampling the hung page with the Chrome debugger put **14 of 14 stacks** in the same place:

```
interp_mark_stack  <-  sgen_client_scan_thread_data  <-  pin_from_roots
                   <-  collect_nursery  <-  sgen_perform_collection
```

All of the time is garbage collection, and specifically the part of a nursery collection that
scans roots conservatively from the **Mono interpreter stack**.

Two things have to line up for that to matter, and this test lines them up:

1. **The comparison is the first one the module instance runs.** It therefore executes the
   engine's whole cold path — assembly resolution, type loads, static constructors, first-time
   entry into every method the diff and render stages touch — much of which is outside the AOT
   profile and so runs interpreted. While that is live on the stack, every nursery collection
   pays a scan proportional to it.
2. **The heap is already full from an earlier operation.** The test opens a `DocxSession` to
   read revisions first. A comparison then allocates a package's worth of XML, so it takes many
   collections — each of them now expensive.

Either alone is fine. Together the comparison stops making meaningful progress. That is why it
hangs rather than merely being slow, why it is browser-only, and why it is invisible natively
(there is no interpreter to scan).

Ordering is the proof: `compare → getRevisions → compare` is fast at every step (68 ms for the
second comparison). Only *first* comparison after a session read collapses.

## The fix

`ComparisonEngine.EnsureWarm()` compares two one-paragraph in-memory documents before the
caller's real work. That walks the identical cold path while allocating almost nothing, so it
cannot take the collapse itself, and it leaves the caller's comparison warm however large it is.
It is latched, so it runs once per module instance, and every comparison export in
`DocxDiffBridge` and `DocumentComparer` calls it.

The seed-document warm-up is not new — `DocumentComparer.Warmup` has always done exactly this,
and the npm worker's `prepare()` calls it. What changes is that it is no longer something a
caller has to know to ask for. `Warmup` keeps its export (it still moves the ~250 ms off the
critical path) and is now genuinely once-only, as its documentation already claimed.

Cost: the **first** comparison in a page is about 250 ms slower — it was already paying the cold
path, and now also pays the seed comparison. Every comparison after it is unchanged.

## Two fixes I did not ship, and why

- **Re-recording `docxodus.aotprofile`.** It is stale — recorded before #693 added ~690 lines of
  alignment and render code — and it was the obvious suspect. I recorded a fresh one and rebuilt:
  **the hang is unchanged.** (#696 dismissed this on a magnitude argument; it is now settled by
  measurement instead. The jiterpreter is barely involved either — the shipped build reports 0
  traces and 264 B jitted across the whole sequence, because it is AOT-compiled.)
- **Enlarging the GC nursery.** `MONO_GC_PARAMS=nursery-size=8m` does make the hang disappear, at
  no measured boot cost, and it was tempting. But the collapse is **not monotone in nursery
  size** — 4m, 6m and 12m all hang while 8m and 16m do not. Any value that works is a lottery
  ticket that the next unrelated change can invalidate, which is precisely how #693 armed this in
  the first place. Warming first, by contrast, fixes the sequence under *every one* of those
  nursery sizes, including the three that collapse.

## Tests

`npm/tests/wasm-steady-state.spec.ts` already owns the browser runtime-configuration canaries
(is the jiterpreter on, is it inside its code budget), so the new one lives there: a session
revision read, then the first comparison of the page, asserted to finish. The order is the whole
test — warming the engine by comparing first makes it pass trivially, so the spec says so in a
comment.

Verified: `npm test -- docxodus.spec.ts wasm-steady-state.spec.ts` → **100 passed (4.2 min)**,
including the test that has been failing on `main`. The new canary reports 626 ms; before this
change the identical sequence timed out at 60 s on three of three attempts.

## Release note

This unblocks #693's six `DocxDiff` entries, which are sitting under `[Unreleased]` in
`CHANGELOG.md` because v12.0.0 had to be cut at `9be2dc06` rather than at main's tip. They ship
in the next release; nothing about them needs re-cutting.

Closes #695, Closes #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxehJkp2547AyP8LSd6uFS
