### PR TITLE
Clip the block drag handle to the editor's viewport, not the window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- The editor's block drag handle no longer escapes the editor when its block scrolls out of
+  view. The handle is a `position: fixed` element, so it is measured and placed in viewport
+  coordinates and no ancestor's overflow clips it — but its position was then clamped into the
+  *window* (`Math.max(4, ...)`). Mounted the way the ribbon mounts it, inside a bounded scrolling
+  region within a clipped card, a block scrolled past the top of that region left its handle
+  behind at the top of the page: a grip floating over the host's own chrome, pointing at a block
+  that was no longer on screen. The handle is now clipped to the editor's own viewport instead —
+  the window narrowed by every ancestor that clips its overflow, so a nested scroller and a
+  clipped card both count, and the test is the computed `overflow` rather than whether an element
+  happens to be scrolling right now. A block scrolled clear of that viewport withdraws its handle
+  rather than clamping it to an edge, and a block only partly in view keeps its handle pulled to
+  the edge it is disappearing past. Repositioning on scroll also no longer uses the handle's own
+  `display` as its memory of whether a handle is wanted, so a handle withdrawn by a scroll comes
+  back when its block scrolls into view again. A gesture already in flight keeps its handle
+  either way: the handle is the drag's own source element, and an open move menu is anchored to
+  it and hands focus back to it on Escape, so withdrawing it mid-gesture would strand a keyboard
+  user with nothing to return focus to.
+
 ## [12.0.1] - 2026-09-05
 
 ### Fixed

--- a/docs/architecture/editor_block_drag_handles.md
+++ b/docs/architecture/editor_block_drag_handles.md
@@ -532,6 +532,36 @@ paragraph it coalesces for a deleted/moved-away paragraph mark **without its att
 the surviving block lost its `pt:Unid` and rendered with no `data-anchor` — unaddressable,
 and invisible to the reconciler. Identity now comes from the same member the properties do.
 
+### The handle belongs to the editor's viewport, not the window
+
+The handle is `position: fixed`: it is measured with `getBoundingClientRect()` and placed in
+viewport coordinates, which is what lets it float in the page margin without being a child of the
+block it points at. Nothing in the document clips a fixed element, though, and its position was
+then clamped into the *window* (`Math.max(4, ...)`). Hosted the way the ribbon hosts it — the
+surface inside a bounded `.dxr-scroll` region, inside a card that clips — a block scrolled past
+the top of that region left its handle behind at the top of the *page*: a grip floating over the
+host's own chrome, pointing at a block that was no longer on screen. Measured on the demo surface
+(scroll region y 159–874), the handle sat at y=141 after a 200px scroll and at y=4 for every
+scroll beyond that, which is where the clamp puts it.
+
+The clip rectangle is now the window narrowed by every ancestor whose computed `overflow` is not
+`visible`, so a nested scroller and a clipping card both count. Gating on the computed overflow
+rather than on whether an element scrolls *right now* keeps the answer independent of how much
+content happens to be loaded. A block clear of that rectangle withdraws its handle rather than
+clamping it to an edge — a grip pinned to the top of the document area would point at a block
+that is not there — while a block only partly in view keeps its handle, pulled to the edge it is
+disappearing past.
+
+Repositioning on scroll also stopped using the handle's own `display` as its record of whether a
+handle is wanted; that intent is tracked separately now. Without the split, a handle withdrawn by
+the clip could never come back, and the focus-driven path — which keeps a handle for the focused
+block with no pointer hovering it — would lose its handle permanently on a scroll round trip.
+
+The clip does not fire mid-gesture, mirroring `hideBlockHandle`'s existing guard. The handle is
+the drag's own source element, and an open move menu is anchored to it and returns focus to it on
+Escape; withdrawing it from under a gesture is the same mistake as leaving it behind, in the
+other direction.
+
 ### Still open
 
 - Paginated dragging (handle is not mounted in paginated mode).
@@ -539,3 +569,10 @@ and invisible to the reconciler. Identity now comes from the same member the pro
   reconciles incrementally (~0.8 s).
 - No ribbon control toggles track changes; `trackedChanges`/`revisionAuthor` are mount-time
   options on `DocxEditor`/`mountRibbon`.
+- The drop line and the move menu are positioned the same way as the handle was (viewport
+  coordinates clamped into the window) and are not clipped to the editor's viewport. The menu is
+  placed once when it opens and never repositioned, so scrolling with it open leaves it behind:
+  measured, its top stayed at y=274 while the block it belongs to scrolled away under it. It
+  stays inside the viewport in that case rather than escaping, and both surfaces are only on
+  screen during an interaction that keeps the pointer or the focus inside the editor, so they
+  were left alone rather than changed speculatively.

--- a/npm/src/editor.ts
+++ b/npm/src/editor.ts
@@ -355,6 +355,16 @@ interface BlockDropZone {
   marginAfter: number;
 }
 
+/** The floating handle's own box and its gap to the block, as `ensureBlockDragStyles` sizes it. */
+const BLOCK_HANDLE_WIDTH = 26;
+const BLOCK_HANDLE_HEIGHT = 28;
+const BLOCK_HANDLE_GAP = 6;
+
+/** `value` pulled into [`low`, `high`]; `low` wins when the range is narrower than the box. */
+function clampToRange(value: number, low: number, high: number): number {
+  return Math.max(low, Math.min(value, high));
+}
+
 function ensureBlockDragStyles(doc: Document): void {
   if (blockDragStyledDocuments.has(doc)) return;
   blockDragStyledDocuments.add(doc);
@@ -1081,6 +1091,10 @@ export class DocxEditor {
   private blockMoveMenu: HTMLElement | null = null;
   private blockMoveLive: HTMLElement | null = null;
   private blockDragSource: HTMLElement | null = null;
+  /** Whether hover or focus currently wants a handle for `blockDragSource`.
+   *  Tracked apart from the handle's `display`, which the viewport clip also drives: a handle
+   *  withdrawn because its block scrolled out of view has to come back when it scrolls in. */
+  private blockHandleWanted = false;
   private blockDragCleanup: Array<() => void> = [];
   /** Block boxes measured at drag start — see `BlockDropZone`. Empty when no drag is in flight. */
   private dropZones: BlockDropZone[] = [];
@@ -1572,11 +1586,48 @@ export class DocxEditor {
     return null;
   }
 
+  /**
+   * The rectangle the floating handle may occupy: the window, narrowed by every ancestor that
+   * clips its overflow.
+   *
+   * The handle is `position: fixed`, so it is placed in viewport coordinates and no ancestor's
+   * overflow clips it for us. But the editor is routinely mounted inside a bounded scroller —
+   * the ribbon puts its surface in one, inside a clipped card — and a block scrolled out of that
+   * scroller has to take its handle with it rather than leave it parked over the host's chrome.
+   *
+   * Gated on the computed `overflow` rather than on whether an element scrolls right now, so the
+   * answer does not depend on how much content happens to be loaded.
+   */
+  private blockHandleClipRect(): { top: number; right: number; bottom: number; left: number } {
+    const view = this.container.ownerDocument.defaultView;
+    const clip = {
+      top: 0,
+      left: 0,
+      right: view?.innerWidth ?? Number.MAX_SAFE_INTEGER,
+      bottom: view?.innerHeight ?? Number.MAX_SAFE_INTEGER,
+    };
+    for (let el: HTMLElement | null = this.editRoot; el; el = el.parentElement) {
+      const style = view?.getComputedStyle(el);
+      if (!style || (style.overflowX === "visible" && style.overflowY === "visible")) continue;
+      const box = el.getBoundingClientRect();
+      if (style.overflowY !== "visible") {
+        clip.top = Math.max(clip.top, box.top);
+        clip.bottom = Math.min(clip.bottom, box.bottom);
+      }
+      if (style.overflowX !== "visible") {
+        clip.left = Math.max(clip.left, box.left);
+        clip.right = Math.min(clip.right, box.right);
+      }
+    }
+    return clip;
+  }
+
   private showBlockHandle(unit: HTMLElement): void {
     const handle = this.blockDragHandle;
     if (!handle || !this.isMovableBlockUnit(unit)) return;
     const changed = unit !== this.blockDragSource;
     this.blockDragSource = unit;
+    this.blockHandleWanted = true;
     // A block the engine will not move anywhere — one owning a section break, or already carrying
     // revision markup a tracked move would have to re-wrap — gets no handle rather than a handle
     // that always fails. Asking costs an engine round trip, so hovering only ever CONSUMES a
@@ -1589,21 +1640,46 @@ export class DocxEditor {
     }
     if (changed && known === undefined) this.prefetchBlockMoveTargets(unit);
     const rect = unit.getBoundingClientRect();
+    // The handle belongs to the editor's viewport, not the window's. A block scrolled out of that
+    // viewport gets no handle at all: clamping one back into view would leave a grip sitting next
+    // to a block that is not there — and clamping to the WINDOW, as this used to, parked it on
+    // whatever chrome the host draws above the editor.
+    const clip = this.blockHandleClipRect();
+    if (
+      rect.bottom <= clip.top || rect.top >= clip.bottom
+      || rect.right <= clip.left || rect.left >= clip.right
+    ) {
+      // A gesture in flight owns the handle: it is the drag's own source element, and an open
+      // move menu is anchored to it and hands focus back to it on Escape. Withdrawing it
+      // mid-gesture is the same mistake as leaving it behind — mirror `hideBlockHandle`'s guard
+      // and leave it where the gesture put it.
+      if (!this.blockDragging && this.blockMoveMenu?.style.display !== "block")
+        handle.style.display = "none";
+      return;
+    }
     handle.style.display = "flex";
-    handle.style.left = `${Math.max(4, rect.left - 32)}px`;
-    handle.style.top = `${Math.max(4, rect.top + (unit.tagName === "TABLE" ? 6 : Math.max(0, (rect.height - 28) / 2)))}px`;
+    // A block only partly in view keeps its handle, pulled to the edge it is disappearing past.
+    const top = rect.top
+      + (unit.tagName === "TABLE" ? 6 : Math.max(0, (rect.height - BLOCK_HANDLE_HEIGHT) / 2));
+    handle.style.left = `${clampToRange(
+      rect.left - (BLOCK_HANDLE_WIDTH + BLOCK_HANDLE_GAP),
+      clip.left,
+      clip.right - BLOCK_HANDLE_WIDTH,
+    )}px`;
+    handle.style.top = `${clampToRange(top, clip.top, clip.bottom - BLOCK_HANDLE_HEIGHT)}px`;
     const preview = blockPreviewText(unit);
     handle.setAttribute("aria-label", preview ? `Move block: ${preview}` : "Move block");
   }
 
   private hideBlockHandle(): void {
     if (this.blockDragging || this.blockMoveMenu?.style.display === "block") return;
+    this.blockHandleWanted = false;
     if (this.blockDragHandle) this.blockDragHandle.style.display = "none";
   }
 
   private positionBlockHandle(): void {
     const source = this.currentBlockDragSource();
-    if (source && this.blockDragHandle?.style.display !== "none") this.showBlockHandle(source);
+    if (source && this.blockHandleWanted) this.showBlockHandle(source);
   }
 
   /** Draw the drop line on `zone`'s requested edge, or take it away when there is no target. */
@@ -2093,6 +2169,7 @@ export class DocxEditor {
     this.blockMoveMenu = null;
     this.blockMoveLive = null;
     this.blockDragSource = null;
+    this.blockHandleWanted = false;
     this.blockDragging = false;
     this.blockDragPointerDown = false;
   }

--- a/npm/tests/editor-block-drag.spec.ts
+++ b/npm/tests/editor-block-drag.spec.ts
@@ -31,6 +31,48 @@ async function openParagraphDocument(page: Page, names: string[], options: Recor
   });
 }
 
+/**
+ * Mount the editor inside a bounded, scrolling viewport with page above it. The shipped ribbon
+ * has exactly this shape — the editor surface lives in a `.dxr-scroll` region inside the card —
+ * and it is the shape in which a window-clamped floating handle becomes visible as a grip
+ * hovering over the host's chrome.
+ */
+async function openScrollingDocument(page: Page, names: string[]) {
+  await page.evaluate(() => {
+    const D = (window as any).Docxodus;
+    const scroller = document.createElement('div');
+    scroller.id = 'block-drag-scroller';
+    scroller.style.cssText =
+      'width:700px;height:100px;overflow:auto;margin:160px auto 0;background:#eee';
+    const container = document.createElement('div');
+    container.id = 'block-drag-host';
+    container.style.cssText = 'padding:16px;background:white';
+    scroller.appendChild(container);
+    document.body.appendChild(scroller);
+    const editor = D.DocxEditor.open(container, D.DocxSessionBridge.CreateBlankDocx(), D, {
+      blockDrag: true,
+    });
+    (window as any).__drag = { editor, container, scroller };
+    (container.querySelector('p[data-anchor][contenteditable="true"]') as HTMLElement).focus();
+  });
+  for (let i = 0; i < names.length; i++) {
+    if (i > 0) await page.keyboard.press('Enter');
+    await page.keyboard.type(names[i]);
+  }
+  await page.evaluate(() => {
+    (document.activeElement as HTMLElement)?.blur();
+    (window as any).__drag.editor['remount']();
+  });
+}
+
+/** Scroll the bounded viewport and let the handle's scroll listener settle. */
+async function scrollViewportTo(page: Page, top: number) {
+  await page.evaluate(async (value) => {
+    (window as any).__drag.scroller.scrollTop = value;
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+  }, top);
+}
+
 const unitState = (page: Page) => page.evaluate(() => {
   const { editor } = (window as any).__drag;
   return (editor['bodyUnitNodes']() as HTMLElement[]).map((el) => ({
@@ -357,5 +399,89 @@ test.describe('DocxEditor — block drag handle', () => {
     // plan's per-unit content signature makes it diff as changed; if that ever stops holding the
     // op falls back to a whole-document remount, which is seconds on a real document.
     expect(review.fallback).toBeNull();
+  });
+
+  // The handle is `position: fixed`, so nothing in the document clips it and it was clamped into
+  // the WINDOW (`Math.max(4, ...)`). Mounted in a bounded scroller — which is how the shipped
+  // ribbon mounts it — a block scrolled out of the editor's viewport left its handle behind,
+  // parked over the host's own chrome, pointing at a block no longer there. The handle belongs
+  // to the editor's viewport, not the window's.
+  test('the handle is clipped to the editor viewport, not the window', async ({ page }) => {
+    await openScrollingDocument(page, [
+      'One', 'Two', 'Three', 'Four', 'Five', 'Six',
+      'Seven', 'Eight', 'Nine', 'Ten', 'Eleven', 'Twelve',
+    ]);
+    const first = page.locator('#block-drag-host p[data-anchor]').filter({ hasText: 'One' });
+    const handle = page.locator('.docx-block-handle');
+    await first.hover();
+    await expect(handle).toBeVisible();
+
+    // Guard the fixture itself: with content that fits, nothing here scrolls out of view and
+    // every assertion below would hold whether or not the handle is clipped.
+    const geometry = await page.evaluate(() => {
+      const { scroller } = (window as any).__drag;
+      const box = scroller.getBoundingClientRect();
+      return {
+        maxScroll: scroller.scrollHeight - scroller.clientHeight,
+        top: box.top,
+        bottom: box.bottom,
+      };
+    });
+    expect(geometry.maxScroll).toBeGreaterThan(60);
+    expect(geometry.top).toBeGreaterThan(100); // there IS chrome above for a handle to escape onto
+
+    // At every offset the handle is either withdrawn or inside the editor's viewport.
+    for (let top = 0; top <= geometry.maxScroll; top += 20) {
+      await scrollViewportTo(page, top);
+      const box = await handle.boundingBox();
+      if (!box) continue; // withdrawn — its block is out of view
+      expect(box.y).toBeGreaterThanOrEqual(geometry.top - 1);
+      expect(box.y + box.height).toBeLessThanOrEqual(geometry.bottom + 1);
+    }
+
+    // Scrolled clear past its block, the handle is gone rather than clamped to an edge.
+    await scrollViewportTo(page, geometry.maxScroll);
+    expect(await page.evaluate(() => {
+      const one = Array.from(document.querySelectorAll<HTMLElement>('#block-drag-host p[data-anchor]'))
+        .find((el) => el.textContent?.includes('One'))!;
+      const { scroller } = (window as any).__drag;
+      return one.getBoundingClientRect().bottom <= scroller.getBoundingClientRect().top;
+    })).toBe(true);
+    await expect(handle).toBeHidden();
+
+    // ...and it comes back with its block. Hiding must not latch: `positionBlockHandle` used the
+    // handle's own `display` as its memory, so one withdrawn by the clip would never return.
+    await scrollViewportTo(page, 0);
+    await expect(handle).toBeVisible();
+    const back = (await handle.boundingBox())!;
+    const block = (await first.boundingBox())!;
+    expect(Math.abs(back.y - block.y)).toBeLessThan(20);
+  });
+
+  // The clip must not fire mid-gesture. An open move menu is anchored to the handle and hands
+  // focus back to it on Escape, so a handle withdrawn from under its own menu would strand a
+  // keyboard user with no focus to return to.
+  test('an open move menu keeps its handle even when the block scrolls out of view', async ({ page }) => {
+    await openScrollingDocument(page, [
+      'One', 'Two', 'Three', 'Four', 'Five', 'Six',
+      'Seven', 'Eight', 'Nine', 'Ten', 'Eleven', 'Twelve',
+    ]);
+    const handle = page.locator('.docx-block-handle');
+    await page.locator('#block-drag-host p[data-anchor]').filter({ hasText: 'One' }).hover();
+    await handle.click();
+    await expect(page.locator('.docx-block-move-menu')).toBeVisible();
+
+    await page.evaluate(async () => {
+      const { scroller } = (window as any).__drag;
+      scroller.scrollTop = scroller.scrollHeight;
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    });
+    await expect(handle).toBeVisible();
+
+    // Escape closes the menu and returns focus to the handle it was opened from.
+    await page.keyboard.press('Escape');
+    await expect(page.locator('.docx-block-move-menu')).toBeHidden();
+    expect(await page.evaluate(() =>
+      document.activeElement?.classList.contains('docx-block-handle'))).toBe(true);
   });
 });


### PR DESCRIPTION
## What's wrong

The editor's block drag handle scrolls up and out of the editor. Hover a block, scroll the document down, and the grip detaches from its block and parks at the very top of the browser window — floating above the editor's chrome, pointing at a paragraph that is no longer on screen.

## Why it happens

The handle is a `position: fixed` element. That is deliberate: it lets the grip float in the page margin without being a child of the block it points at. It also means the handle is measured with `getBoundingClientRect()` and placed in **viewport** coordinates, and that no ancestor's `overflow` clips it.

Its position was then clamped with `Math.max(4, ...)` — into the *window*. That is the right frame only when the editor fills the window. The shipped ribbon does not: it puts the editor surface inside a bounded `.dxr-scroll` region, inside a card that clips. So as a block scrolled past the top of that region, the handle followed it out of the region, and once the arithmetic went negative the clamp pinned it at 4px from the top of the page.

Measured on the demo surface, with the scroll region occupying y 159–874:

| Scroll offset | Handle top (before) | Handle top (after) |
|---|---|---|
| 0 | 341 | 341 |
| 200 | **141** — above the region | 159 — pinned to the region's edge |
| 400 | **4** — top of the window | withdrawn |
| 800 | **4** | withdrawn |
| 1600 | **4** | withdrawn |

The `y=4` rows are the screenshot in the report.

## The fix

The clip rectangle is now the window narrowed by every ancestor whose computed `overflow` is not `visible`, so a nested scroller and a clipping card both count, and each axis is narrowed only by the ancestors that actually clip that axis. The test is the computed `overflow` rather than whether an element happens to be scrolling at that moment, so the answer does not change with how much content is loaded.

Given that rectangle:

- A block scrolled clear of it **withdraws** its handle rather than clamping it to an edge. Clamping would leave a grip pinned to the top of the document area still pointing at a block that is not there — trading one wrong position for another.
- A block only partly in view **keeps** its handle, pulled to the edge it is disappearing past.
- The horizontal axis gets the same treatment; it had the same window clamp.

Two supporting changes fell out of it:

**Hiding must not latch.** `positionBlockHandle` used the handle's own `display` as its record of whether a handle was wanted. Once the clip could hide the handle, that record became wrong — a handle withdrawn by a scroll would never come back. The intent is now tracked separately. Without this, the focus-driven path (which keeps a handle for the focused block with no pointer hovering it) would lose its handle permanently on a scroll round trip.

**The clip must not fire mid-gesture.** The handle is the drag's own source element, and an open move menu is anchored to it and hands focus back to it on Escape. Withdrawing it from under a gesture is the same mistake in the other direction, so the clip mirrors `hideBlockHandle`'s existing guard.

## How it was validated

- A new test mounts the editor in a bounded scroller and asserts the handle is either withdrawn or inside that viewport at **every** scroll offset, then that it returns when its block scrolls back in. It guards its own fixture first: with content that fits, nothing scrolls out of view and every assertion would pass whether or not the handle is clipped, so it asserts the scroller genuinely overflows before testing anything. Both were confirmed to fail on `main` before the fix, for the right reason (the handle 3px above the viewport, then climbing).
- A second test opens the move menu, scrolls the block away, and asserts the handle survives and still takes focus back on Escape. Confirmed to fail without the gesture guard.
- Before/after measured on the real ribbon surface, not just the synthetic fixture — that is the table above.
- 9/9 block-drag tests, plus 63 editor, reconcile, comments, header/footer, table, and ribbon-surface tests.
- The hover path runs the ancestor walk on every pointer move, so the move-latency bench is the guard that matters: on the NVCA charter (234 body units) hover measures **11.0ms against a 100ms budget**, unchanged in practice.

## Note on the demo pages

`docs/demo/` loads the library from jsDelivr and is pinned to `docxodus@12.0.0`, so the page in the original report does not pick this up on merge — it needs a release and the usual post-release re-pin. Those pins are deliberately left alone here.