### PR TITLE
Arcade: give the touch pad the cartridge's own control map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- The Arcade's touch controls are now the cartridge's own control map rather than a fixed set
+  of four arrows and a FIRE button. Each cartridge declares a touch profile beside the keyboard
+  map it mirrors (`cart.touch`), and `arcade-dock.js` fills its fixed pad slots from it: the
+  platformer gets walk and jump; the two raycasters add strafe and a sprint latch; Doom adds
+  **USE** and a tray holding its seven weapons, the automap, its own menu and the Enter that
+  works it. What a phone could reach before was movement and fire, so a touch player could walk
+  Freedoom's E1M1 as far as its first door and no further — a door is a key press, and there was
+  no key to press. Slots a cartridge does not use are hidden and lose their key code, so a
+  button can never send a key the cartridge ignores. On the attract screen the pad shows one
+  round **START**, since nothing on a title card is steerable.
+  RUN latches instead of asking to be held: on a phone the hand that would hold Shift is the one
+  steering. Pad presses are tracked per pointer, so firing with one thumb while turning with the
+  other lifts only the key that was released, and pausing releases everything the pad is holding
+  — a latched sprint no longer survives into the paused document. The pad's buttons are wired by
+  delegation and read their key at press time, which is what lets one set of buttons follow the
+  cartridge.
+
 ## [12.0.1] - 2026-09-05
 
 ### Fixed

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -45,11 +45,39 @@ is narrow.
 | | |
 |---|---|
 | **wide** | One bar under the document: cartridges, transport, pacing, embed, telemetry, hint. Unchanged from the cabinet's original dock. |
-| **compact** | A slim HUD strip keeps the two controls you touch mid-game (play/pause and pacing); cartridges, restart, embed, telemetry and the hint move behind a `⋯` sheet. A thumb D-pad and a round **FIRE** button float over the bottom corners of the game. Nothing is dropped, only re-placed. |
+| **compact** | A slim HUD strip keeps the two controls you touch mid-game (play/pause and pacing); cartridges, restart, embed, telemetry and the hint move behind a `⋯` sheet. A thumb D-pad and an action cluster float over the bottom corners of the game. Nothing is dropped, only re-placed. |
 
 `FIRE` sends `Space` — jump in the platformer, the weapon in the raycasters and
 in Doom, and the coin drop on the attract screen. The old touch row had no
 Space at all, so the shooters could be walked but never fought on a phone.
+
+**What the pad offers is the cartridge's call.** Each cartridge declares a touch
+profile beside the keyboard map it mirrors (`cart.touch`), and the dock fills
+its fixed slots from it through `setPad` — geometry here, control map there:
+
+| cartridge | pad |
+|---|---|
+| ¶ Pilcrow's Quest | walk `←/→`, `▲` and a round **JUMP** |
+| ▓ Dungeon · ☩ Freedoom E1M1 | forward/back, turn (`↺ ↻`), strafe (`◀ ▶`), **FIRE**, **RUN** |
+| ☩ DOOM | all of the above plus **USE**, and a **KEYS** tray: weapons 1–7, **MAP**, **MENU**, `⏎` |
+| attract screen | one round **START** — nothing on a title card is steerable |
+
+Turning rotates and strafing translates, so the two pairs of side buttons never
+wear the same arrow. `RUN` latches rather than asking to be held — on a phone
+that hand is steering. A slot the cartridge does not use is hidden *and* loses
+its `data-code`, so a button can never send a key the cartridge ignores; the
+driver wires the pad by delegation and reads each button's code at press time,
+which is what lets one set of buttons follow the cartridge. Presses are tracked
+per pointer, so firing with one thumb while turning with the other releases only
+the key that came up, and pausing releases everything the pad holds.
+
+This is the gap the pad's first version left: movement and fire are the whole
+control map of the platformer and about half of a Doom-format level's. On a
+touch screen Doom could be walked as far as E1M1's first door and no further —
+a door is a key press (`E`), and a phone had no key to press. The headless
+checks in `tools/ascii-arcade.test.mjs` hold every profile to the keyboard map
+beside it, including that a thumb can reach every function Doom gives a
+keyboard.
 
 Doom's complete keyboard map also appears immediately above the framebuffer as
 four centered 18pt document paragraphs. Each line is deliberately short enough

--- a/docs/demo/arcade-dock.js
+++ b/docs/demo/arcade-dock.js
@@ -17,9 +17,17 @@
 //   compact a slim HUD strip keeps the two controls you touch mid-game
 //           (play/pause and pacing); cartridges, restart, embed, telemetry and
 //           the hint move behind a "⋯" sheet. A thumb D-pad and an action
-//           button float over the bottom corners of the game — where the
+//           cluster float over the bottom corners of the game — where the
 //           thumbs already are, and clear of the centre of the screen they are
 //           steering. Nothing is dropped, only re-placed.
+//
+// WHAT THE PAD OFFERS IS THE CARTRIDGE'S CALL, not this module's. `setPad`
+// takes a touch profile — fixed slots, because the geometry is fixed — and a
+// cartridge fills in only the slots it has a key for: the platformer wants
+// three buttons, the raycasters want strafe and a run latch, and Doom wants
+// USE, its own menu, the automap and seven weapons as well. A phone that can
+// only walk and shoot cannot open a door, and E1M1's first door is thirty
+// seconds in, which is where this started.
 //
 // The pad is deliberately NOT a descendant of the editor root. The driver
 // pauses on any pointerdown inside the document — "the frame you clicked is
@@ -33,6 +41,16 @@
 // its listeners to those nodes once and never learns that layout exists.
 
 const BREAKPOINT = 640;
+
+/** What the pad offers before any cartridge has spoken for it — the arcade's
+ *  common denominator, and what a host that never calls `setPad` keeps. */
+const DEFAULT_PAD = {
+  up: { code: 'KeyW', glyph: '▲', label: 'Forward / jump' },
+  down: { code: 'KeyS', glyph: '▼', label: 'Back' },
+  left: { code: 'ArrowLeft', glyph: '◀', label: 'Left / turn left' },
+  right: { code: 'ArrowRight', glyph: '▶', label: 'Right / turn right' },
+  fire: { code: 'Space', glyph: 'FIRE', label: 'Fire / jump / start' },
+};
 
 const CSS = `
 .dxa-controls { position: fixed; inset: 0; z-index: 60; pointer-events: none; }
@@ -127,22 +145,67 @@ const CSS = `
   font: 16px/1 system-ui, sans-serif; cursor: pointer;
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
 }
+/* A slot the current cartridge does not use is hidden, and the author
+   author display value above would otherwise beat the UA's [hidden] rule. */
+.dxa-pad button[hidden] { display: none; }
 .dxa-pad button:active { color: #5eead4; background: #123a34; border-color: #14b8a6; }
+/* Latched modifiers (RUN) read as pressed until you tap them off. */
+.dxa-pad button[aria-pressed="true"] { color: #5eead4; background: #123a34; border-color: #14b8a6; }
+
+/* Movement, as a 3 × 3 whose corners the cartridge fills in only if it has
+   something to put there: turning rotates (↺ ↻) on the middle row, sidestep
+   translates (◀ ▶) on the bottom corners beside it, so the two pairs never
+   read as the same control. The platformer has neither and uses the middle
+   row to walk. */
 .dxa-dpad {
   position: absolute; left: 12px; bottom: 0;
   display: grid; gap: 4px;
   grid-template-columns: repeat(3, 46px); grid-template-rows: repeat(3, 42px);
 }
-.dxa-dpad button { width: 46px; height: 42px; }
+.dxa-dpad button { width: 46px; height: 42px; font-size: 19px; font-weight: 600; }
 .dxa-up { grid-area: 1 / 2; }
 .dxa-left { grid-area: 2 / 1; }
 .dxa-right { grid-area: 2 / 3; }
 .dxa-down { grid-area: 3 / 2; }
-.dxa-fire {
-  position: absolute; right: 14px; bottom: 6px;
-  width: 74px; height: 74px; border-radius: 50% !important;
-  font-size: 11px !important; font-weight: 700; letter-spacing: .08em;
-  color: #5eead4 !important; border-color: #14b8a6 !important;
+.dxa-strafe-left { grid-area: 3 / 1; }
+.dxa-strafe-right { grid-area: 3 / 3; }
+
+/* Actions, stacked under the right thumb: FIRE where the thumb rests, USE
+   directly above it (Doom's other one-hand-on-the-phone verb), RUN beside it,
+   and the tray toggle on top — the rows collapse for a cartridge that wants
+   none of them. */
+.dxa-actions {
+  position: absolute; right: 12px; bottom: 0;
+  display: grid; gap: 8px; justify-items: end; align-items: end;
+  grid-template-areas: "keys keys" "run use" "fire fire";
+}
+.dxa-pad .dxa-keys {
+  grid-area: keys; min-width: 58px; height: 34px;
+  font-size: 11px; letter-spacing: .06em;
+}
+.dxa-pad .dxa-run { grid-area: run; width: 58px; height: 56px; font-size: 11px; font-weight: 700; }
+.dxa-pad .dxa-use {
+  grid-area: use; width: 58px; height: 56px; border-radius: 50%;
+  font-size: 11px; font-weight: 700;
+}
+.dxa-pad .dxa-fire {
+  grid-area: fire; width: 74px; height: 74px; border-radius: 50%;
+  font-size: 11px; font-weight: 700; letter-spacing: .08em;
+  color: #5eead4; border-color: #14b8a6;
+}
+
+/* The tray: the keys a Doom player reaches for between fights rather than
+   during one — weapons, the automap, Doom's own menu and its Enter. It opens
+   over the game above the action cluster (180px of buttons + its gap) and
+   stays open, because working Doom's menu takes several taps in a row. */
+.dxa-extras {
+  position: absolute; right: 12px; left: 12px; bottom: 190px;
+  display: none; flex-wrap: wrap; gap: 6px; justify-content: flex-end;
+}
+.dxa-extras[data-open="true"] { display: flex; }
+.dxa-pad .dxa-extras button {
+  min-width: 40px; height: 38px; padding: 0 8px;
+  border-radius: 10px; font-size: 12px; font-weight: 600;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -217,24 +280,84 @@ export function mountArcadeDock(host, { anchor = 'viewport', embed = null, ids =
   const strip = el('div', { className: 'row dxa-strip' });
   const dock = el('div', { className: 'dxa-dock', ...id('dock'), hidden: true }, [sheet, strip]);
 
-  const padButton = (code, cls, glyph, label) => {
-    const button = el('button', { className: cls, type: 'button', textContent: glyph });
-    button.setAttribute('data-code', code);
-    button.setAttribute('aria-label', label);
-    return button;
+  const padButton = (cls) => el('button', { className: cls, type: 'button' });
+  const slots = {
+    up: padButton('dxa-up'),
+    down: padButton('dxa-down'),
+    left: padButton('dxa-left'),
+    right: padButton('dxa-right'),
+    strafeLeft: padButton('dxa-strafe-left'),
+    strafeRight: padButton('dxa-strafe-right'),
+    // Space is jump in the platformer, fire in the raycasters and in Doom, and
+    // the coin drop on the attract screen — the one button a phone was missing
+    // entirely, which is why Freedoom could be walked but not fought on a
+    // touch screen. USE is the one it was missing after that: doors.
+    fire: padButton('dxa-fire'),
+    use: padButton('dxa-use'),
+    run: padButton('dxa-run'),
   };
-  const dpad = el('div', { className: 'dxa-dpad' }, [
-    padButton('KeyW', 'dxa-up', '▲', 'Forward / jump'),
-    padButton('ArrowLeft', 'dxa-left', '◀', 'Left / turn left'),
-    padButton('ArrowRight', 'dxa-right', '▶', 'Right / turn right'),
-    padButton('KeyS', 'dxa-down', '▼', 'Back'),
-  ]);
-  // Space is jump in the platformer, fire in the raycasters, and the coin drop
-  // on the attract screen — the one button a phone was missing entirely, which
-  // is why Freedoom could be walked but not fought on a touch screen.
-  const fire = padButton('Space', 'dxa-fire', 'FIRE', 'Fire / jump / start');
-  const pad = el('div', { className: 'dxa-pad', ...id('pad') }, [dpad, fire]);
+  const dpad = el('div', { className: 'dxa-dpad' },
+    [slots.up, slots.left, slots.right, slots.down, slots.strafeLeft, slots.strafeRight]);
+
+  const extras = el('div', { className: 'dxa-extras', ...id('padextras') });
+  extras.setAttribute('aria-label', 'More game keys');
+  const keys = el('button', { className: 'dxa-keys', ...id('padkeys'), type: 'button' });
+  keys.setAttribute('aria-label', 'More game keys');
+  keys.setAttribute('aria-expanded', 'false');
+  keys.textContent = 'KEYS';
+
+  const actions = el('div', { className: 'dxa-actions' }, [keys, slots.run, slots.use, slots.fire]);
+  const pad = el('div', { className: 'dxa-pad', ...id('pad') }, [extras, dpad, actions]);
   pad.setAttribute('aria-label', 'Touch controls');
+
+  const setTray = (open) => {
+    extras.dataset.open = String(open && extras.childElementCount > 0);
+    keys.setAttribute('aria-expanded', extras.dataset.open);
+  };
+  keys.addEventListener('click', () => setTray(extras.dataset.open !== 'true'));
+  setTray(false);
+
+  /** Fill one pad slot from a profile entry, or hide it. A hidden slot keeps
+   *  its grid cell — the pad must not re-flow under a thumb when a cartridge
+   *  changes — but loses its `data-code`, so a stale key can never be sent. */
+  const applySlot = (button, spec) => {
+    if (!spec) {
+      button.hidden = true;
+      button.removeAttribute('data-code');
+      button.removeAttribute('data-mode');
+      button.removeAttribute('aria-pressed');
+      return;
+    }
+    button.hidden = false;
+    button.setAttribute('data-code', spec.code);
+    button.textContent = spec.glyph;
+    button.setAttribute('aria-label', spec.label);
+    button.title = spec.label;
+    if (spec.toggle) {
+      button.dataset.mode = 'toggle';
+      if (!button.hasAttribute('aria-pressed')) button.setAttribute('aria-pressed', 'false');
+    } else {
+      button.removeAttribute('data-mode');
+      button.removeAttribute('aria-pressed');
+    }
+  };
+
+  /** Point the pad at a cartridge's touch profile. Slots the profile omits are
+   *  hidden; `extras` (empty for every cartridge but Doom) fills the tray and
+   *  supplies — or withdraws — its toggle. */
+  function setPad(profile = DEFAULT_PAD) {
+    for (const name of Object.keys(slots)) applySlot(slots[name], profile[name] ?? null);
+    extras.replaceChildren(...(profile.extras ?? []).map((spec) => {
+      const chip = el('button', { type: 'button', textContent: spec.glyph });
+      chip.setAttribute('data-code', spec.code);
+      chip.setAttribute('aria-label', spec.label);
+      chip.title = spec.label;
+      return chip;
+    }));
+    keys.hidden = extras.childElementCount === 0;
+    if (keys.hidden) setTray(false);
+  }
+  setPad();
 
   const controls = el('div', { className: 'dxa-controls' }, [dock, pad]);
   controls.dataset.anchor = anchor;
@@ -299,7 +422,8 @@ export function mountArcadeDock(host, { anchor = 'viewport', embed = null, ids =
     /** Reveal the controls — hosts keep them hidden until the arcade boots. */
     show: () => { dock.hidden = false; },
     isCompact: () => compact,
-    ui: { carts, playpause, restart, pace, stats, hint, pad },
+    setPad,
+    ui: { carts, playpause, restart, pace, stats, hint, pad, setPad },
     destroy: () => {
       observer.disconnect();
       coarse.removeEventListener('change', remeasure);

--- a/docs/demo/ascii-arcade.js
+++ b/docs/demo/ascii-arcade.js
@@ -113,7 +113,10 @@ function hash2(x, y) {
 // blocks do. While the game plays it claims ONLY the game keys (never a
 // chorded shortcut — Ctrl/Cmd/Alt pass through untouched); paused, it claims
 // nothing, which is why typing into the document just works.
-const GAME_CODES = new Set([
+/** The keys the arcade claims from the document while a cartridge is playing.
+ *  Exported so the headless logic checks can hold the touch pad to it: a pad
+ *  button whose code is not in here sends a key the game never receives. */
+export const ARCADE_KEY_CODES = new Set([
   'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown',
   'KeyW', 'KeyA', 'KeyS', 'KeyD', 'Space', 'KeyR',
   'ShiftLeft', 'ShiftRight',
@@ -122,6 +125,38 @@ const GAME_CODES = new Set([
   // reason: unclaimed, it would split the screen paragraph in two.
   ...DOOM_KEY_CODES,
 ]);
+
+// ─── Touch: the same map, for a thumb ─────────────────────────────────
+// A cartridge declares what the on-screen pad should offer the same way it
+// declares its keyboard `controls` line — beside the keys themselves, so the
+// two cannot drift. `arcade-dock.js` owns the geometry (fixed slots); a
+// cartridge fills in only the slots it has a key for, and the pad hides the
+// rest rather than offering a button that sends a key nothing reads.
+//
+// Turning ROTATES (↺ ↻) and strafing TRANSLATES (◀ ▶): two pairs of side
+// buttons that do different things must not wear the same arrow.
+export const TOUCH = {
+  /** The platformer walks with the middle row and jumps with everything else;
+   *  it has no back, no strafe and no sprint. */
+  quest: {
+    up: { code: 'KeyW', glyph: '▲', label: 'Jump' },
+    left: { code: 'ArrowLeft', glyph: '◀', label: 'Run left' },
+    right: { code: 'ArrowRight', glyph: '▶', label: 'Run right' },
+    fire: { code: 'Space', glyph: 'JUMP', label: 'Jump' },
+  },
+  /** Both raycasters: forward/back, turn, strafe, and Shift as a LATCH —
+   *  a thumb cannot hold a modifier and steer with the same hand. */
+  raycaster: {
+    up: { code: 'KeyW', glyph: '▲', label: 'Forward' },
+    down: { code: 'KeyS', glyph: '▼', label: 'Back' },
+    left: { code: 'ArrowLeft', glyph: '↺', label: 'Turn left' },
+    right: { code: 'ArrowRight', glyph: '↻', label: 'Turn right' },
+    strafeLeft: { code: 'KeyA', glyph: '◀', label: 'Strafe left' },
+    strafeRight: { code: 'KeyD', glyph: '▶', label: 'Strafe right' },
+    fire: { code: 'Space', glyph: 'FIRE', label: 'Fire' },
+    run: { code: 'ShiftLeft', glyph: 'RUN', label: 'Run (stays on until tapped again)', toggle: true },
+  },
+};
 
 function createInput(isPlaying) {
   const down = new Set();
@@ -136,7 +171,7 @@ function createInput(isPlaying) {
   };
   const onKeyDown = (e) => {
     if (!isPlaying() || e.metaKey || e.ctrlKey || e.altKey) return;
-    if (!GAME_CODES.has(e.code)) return;
+    if (!ARCADE_KEY_CODES.has(e.code)) return;
     e.preventDefault();
     e.stopPropagation();
     if (!down.has(e.code)) { pressed.add(e.code); log(e.code, true); }
@@ -421,6 +456,7 @@ export function platformerCart() {
   return {
     name: 'quest',
     label: '¶ Pilcrow’s Quest',
+    touch: TOUCH.quest,
     controls: [
       'CONTROLS · RUN A/D or ←/→',
       'JUMP W/↑/SPACE',
@@ -583,6 +619,7 @@ const DUNGEON_MAP = [
  *  corridors survive the grid — hence its doubled stride and wall height. */
 const DUNGEON_PACK = {
   name: 'dungeon',
+  touch: TOUCH.raycaster,
   label: '▓ The Docx Dungeon',
   controls: [
     'CONTROLS · MOVE W/S · STRAFE A/D',
@@ -607,6 +644,7 @@ const DUNGEON_PACK = {
 
 const FREEDOOM_PACK = {
   name: 'e1m1',
+  touch: TOUCH.raycaster,
   label: '☩ Freedoom E1M1',
   controls: [
     'CONTROLS · MOVE W/S · STRAFE A/D',
@@ -1160,6 +1198,7 @@ function raycastCart(pack) {
   return {
     name: pack.name,
     label: pack.label,
+    touch: pack.touch,
     controls: pack.controls,
     caption: pack.caption,
     hint: pack.hint,
@@ -1405,6 +1444,10 @@ export function introFrame(t) {
  */
 export const IMAGE_ENGINE_MINIMUM = '11.0.0';
 
+/** The attract screen's one live control: Space is the coin drop, so the pad's
+ *  round button says so rather than offering to fire at a title card. */
+const INTRO_FIRE = { code: 'Space', glyph: 'START', label: 'Start the selected cartridge' };
+
 /**
  * Seed the Arcade into a ribbon-hosted editor's session and run the game loop
  * against it. Owns the dock (cartridge switch, pause/resume, restart, pace,
@@ -1414,7 +1457,8 @@ export const IMAGE_ENGINE_MINIMUM = '11.0.0';
  * commits on blur), re-parses the game world from the session's XML, and
  * hands the keyboard back to the game.
  *
- * `ui`: { carts, playpause, restart, pace, stats, hint, pad? } — dock DOM.
+ * `ui`: { carts, playpause, restart, pace, stats, hint, pad?, setPad? } — dock DOM,
+ * plus the hook that re-points the touch pad at the selected cartridge's keys.
  * `intro` (default true) opens on the attract screen — the same canvas
  * paragraph running the title card until Space (or any dock action) drops
  * the coin. Returns the controller the host page publishes as
@@ -1463,6 +1507,22 @@ export function startArcade({ editor, session, ui, cart: startCart, intro = true
 
   const input = createInput(() => playing);
 
+  // What the on-screen pad is currently holding down: pressed buttons keyed by
+  // the pointer holding them, plus the latched modifiers (RUN) that stay down
+  // after the thumb leaves. Declared here, beside the input they feed, because
+  // pausing releases them and pausing can happen before the pad is wired.
+  const padHeld = new Map();
+  const padLatched = new Map();
+  function releasePad() {
+    for (const { code } of padHeld.values()) input.set(code, false);
+    padHeld.clear();
+    for (const [button, code] of padLatched) {
+      input.set(code, false);
+      button.setAttribute('aria-pressed', 'false');
+    }
+    padLatched.clear();
+  }
+
   const unidOf = (anchor) => anchor.split(':')[2];
   const canvasEl = () => editor.root.querySelector(`[data-anchor="${unidOf(canvasAnchor)}"]`);
   const controlsEls = () => seeded.controlsAnchors.map((anchor) =>
@@ -1483,6 +1543,9 @@ export function startArcade({ editor, session, ui, cart: startCart, intro = true
   }
 
   function setCaption() {
+    // The pad follows the cartridge — and stands down on the attract screen,
+    // where nothing steers anything and the only live control is the coin.
+    ui.setPad?.(mode === 'intro' ? { fire: INTRO_FIRE } : cart.touch);
     if (mode === 'intro') {
       setControls([
         'CONTROLS · START SPACE',
@@ -1761,6 +1824,9 @@ export function startArcade({ editor, session, ui, cart: startCart, intro = true
       loop();
     } else {
       playing = false;
+      // A latched RUN (or a key still down when the frame froze) must not
+      // survive into the paused document, nor into the next resume.
+      releasePad();
       clearTimeout(timer);
       ui.playpause.textContent = '▶ Resume';
       ui.stats.innerHTML = lastSurface === 'image'
@@ -1783,6 +1849,9 @@ export function startArcade({ editor, session, ui, cart: startCart, intro = true
   function setCart(name) {
     const next = carts.find((c) => c.name === name);
     if (!next) return;
+    // The pad is about to be re-pointed at another cartridge's keys; anything
+    // it is holding down belongs to the one being left.
+    releasePad();
     cart = next;
     cart.reset();
     cartBtns.forEach((b, n) => b.setAttribute('aria-pressed', String(n === name)));
@@ -1900,17 +1969,46 @@ export function startArcade({ editor, session, ui, cart: startCart, intro = true
     editor.refresh();
   });
 
-  // On-screen pad (touch): buttons carry data-code="ArrowLeft" etc.
+  // On-screen pad (touch): buttons carry data-code="ArrowLeft" etc. Wired by
+  // DELEGATION, and reading the code at event time, because the dock re-points
+  // those buttons whenever the cartridge changes and mints the tray's keys on
+  // the spot — a listener that captured a code at boot would go on sending the
+  // previous cartridge's key.
+  //
+  // Presses are tracked BY POINTER ID: steering with one thumb while firing
+  // with the other is two live pointers, and releasing one must not lift the
+  // other's key. The release listener sits on the window so a thumb that
+  // slides off the button it pressed still lifts that key rather than leaving
+  // it stuck down for the rest of the game.
   if (ui.pad) {
-    ui.pad.querySelectorAll('[data-code]').forEach((btn) => {
-      const code = btn.getAttribute('data-code');
-      const press = (e) => { e.preventDefault(); if (!playing) setPlaying(true); input.set(code, true); };
-      const release = (e) => { e.preventDefault(); input.set(code, false); };
-      btn.addEventListener('pointerdown', press);
-      btn.addEventListener('pointerup', release);
-      btn.addEventListener('pointercancel', release);
-      btn.addEventListener('pointerleave', release);
+    ui.pad.addEventListener('pointerdown', (e) => {
+      const button = e.target.closest?.('[data-code]');
+      if (!button) return;
+      e.preventDefault();
+      if (!playing) setPlaying(true);
+      const code = button.getAttribute('data-code');
+      // data-mode="toggle" LATCHES (RUN): holding a modifier is a keyboard
+      // affordance, and on a phone that hand is busy steering.
+      if (button.dataset.mode === 'toggle') {
+        const latched = padLatched.has(button);
+        if (latched) padLatched.delete(button);
+        else padLatched.set(button, code);
+        button.setAttribute('aria-pressed', String(!latched));
+        input.set(code, !latched);
+        return;
+      }
+      try { button.setPointerCapture(e.pointerId); } catch { /* mouse rigs */ }
+      padHeld.set(e.pointerId, { button, code });
+      input.set(code, true);
     });
+    const release = (e) => {
+      const entry = padHeld.get(e.pointerId);
+      if (!entry) return;
+      padHeld.delete(e.pointerId);
+      input.set(entry.code, false);
+    };
+    window.addEventListener('pointerup', release);
+    window.addEventListener('pointercancel', release);
   }
 
   setCaption();

--- a/docs/demo/doom-cart.js
+++ b/docs/demo/doom-cart.js
@@ -82,7 +82,7 @@ const KEY = {
 // Esc is NOT in this table on purpose: the arcade owns Esc (it pauses the
 // game and hands the paragraph back to the editor), so Doom's own menu is on
 // Q instead. Everything else is where a Doom player's hands expect it.
-const KEY_MAP = {
+export const DOOM_KEY_MAP = {
   KeyW: KEY.UPARROW, ArrowUp: KEY.UPARROW,
   KeyS: KEY.DOWNARROW, ArrowDown: KEY.DOWNARROW,
   KeyA: KEY.STRAFE_L, KeyD: KEY.STRAFE_R,
@@ -100,7 +100,38 @@ const KEY_MAP = {
 /** The arcade key codes this cartridge wants to be handed. ascii-arcade.js
  *  unions this into the set its capture-phase listener claims while playing,
  *  so Doom gets Enter/E/Q/M/digits without the other cartridges caring. */
-export const DOOM_KEY_CODES = [...Object.keys(KEY_MAP)];
+export const DOOM_KEY_CODES = [...Object.keys(DOOM_KEY_MAP)];
+
+/** What the on-screen pad offers a thumb — the same map as the table above,
+ *  minus the aliases a keyboard has room for. Doom is the cartridge that
+ *  needed this: a pad with movement and fire can walk E1M1 up to its first
+ *  door and no further, because USE is a key and a phone had none. Its rarer
+ *  keys — seven weapons, the automap, Doom's own menu and the Enter that
+ *  works it — go in the pad's tray rather than under a thumb, since they are
+ *  what you reach for between fights, not during one. */
+export const DOOM_TOUCH = {
+  up: { code: 'KeyW', glyph: '▲', label: 'Forward' },
+  down: { code: 'KeyS', glyph: '▼', label: 'Back' },
+  left: { code: 'ArrowLeft', glyph: '↺', label: 'Turn left' },
+  right: { code: 'ArrowRight', glyph: '↻', label: 'Turn right' },
+  strafeLeft: { code: 'KeyA', glyph: '◀', label: 'Strafe left' },
+  strafeRight: { code: 'KeyD', glyph: '▶', label: 'Strafe right' },
+  fire: { code: 'Space', glyph: 'FIRE', label: 'Fire' },
+  use: { code: 'KeyE', glyph: 'USE', label: 'Open doors and switches' },
+  run: { code: 'ShiftLeft', glyph: 'RUN', label: 'Run (stays on until tapped again)', toggle: true },
+  extras: [
+    { code: 'Digit1', glyph: '1', label: 'Fist / chainsaw' },
+    { code: 'Digit2', glyph: '2', label: 'Pistol' },
+    { code: 'Digit3', glyph: '3', label: 'Shotgun' },
+    { code: 'Digit4', glyph: '4', label: 'Chaingun' },
+    { code: 'Digit5', glyph: '5', label: 'Rocket launcher' },
+    { code: 'Digit6', glyph: '6', label: 'Plasma rifle' },
+    { code: 'Digit7', glyph: '7', label: 'BFG 9000' },
+    { code: 'KeyM', glyph: 'MAP', label: 'Automap' },
+    { code: 'KeyQ', glyph: 'MENU', label: 'Doom’s own menu' },
+    { code: 'Enter', glyph: '⏎', label: 'Enter — confirm in Doom’s menu' },
+  ],
+};
 
 // ─── Grid helpers ─────────────────────────────────────────────────────
 function makeGrid() {
@@ -800,7 +831,7 @@ export function doomCart(options = {}) {
     // cartridge wants the log rather than the held/pressed sets the other two
     // cartridges use.
     for (const { code, down } of input.drain?.() ?? []) {
-      const key = KEY_MAP[code];
+      const key = DOOM_KEY_MAP[code];
       if (key !== undefined) handle.keys.push([key, down ? 1 : 0]);
     }
 
@@ -859,6 +890,7 @@ export function doomCart(options = {}) {
   return {
     name: 'doom',
     label: '☩ DOOM',
+    touch: DOOM_TOUCH,
     controls: [
       'CONTROLS · MOVE W/S · STRAFE A/D',
       'TURN ←/→ · FIRE SPACE · USE E',

--- a/docs/demo/tools/ascii-arcade.test.mjs
+++ b/docs/demo/tools/ascii-arcade.test.mjs
@@ -4,7 +4,10 @@ import { dirname, join } from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
-import { dungeonCart, freedoomCart, rowsFromXml } from '../ascii-arcade.js';
+import {
+  ARCADE_KEY_CODES, TOUCH, dungeonCart, freedoomCart, platformerCart, rowsFromXml,
+} from '../ascii-arcade.js';
+import { DOOM_KEY_MAP, DOOM_TOUCH, doomCart } from '../doom-cart.js';
 import { frameXml } from '../ascii-scenes.js';
 
 const DEMO_DIR = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -279,3 +282,107 @@ test(`the fast headless ${packName} run reaches every objective and the exit`, (
   assert.equal(final.mode, 'won');
 });
 }
+
+// ─── The touch pad's control map ──────────────────────────────────────
+// A phone reaches the games through `arcade-dock.js`'s pad, and the pad only
+// offers what the cartridge declares in its `touch` profile. These checks hold
+// that declaration to the keyboard map beside it: the pad shipped with
+// movement and fire, so on a touch screen Doom could be walked to E1M1's first
+// door and no further — USE is a key, and a phone had no way to send one.
+
+/** Every button a profile puts on the pad, tray included. */
+function touchButtons(profile) {
+  const { extras = [], ...slots } = profile;
+  return [...Object.values(slots), ...extras];
+}
+
+test('every touch button sends a key the arcade actually claims', () => {
+  for (const cart of [platformerCart(), dungeonCart(), freedoomCart(), doomCart()]) {
+    assert.ok(cart.touch, `${cart.name} declares no touch profile`);
+    for (const button of touchButtons(cart.touch)) {
+      assert.ok(ARCADE_KEY_CODES.has(button.code),
+        `${cart.name}: the pad's "${button.glyph}" sends ${button.code}, which the arcade `
+        + 'does not claim while playing — the press would reach the document, not the game');
+      assert.ok(button.glyph && button.label, `${cart.name}: ${button.code} needs a glyph and a label`);
+    }
+  }
+});
+
+test('a thumb can reach every function Doom gives a keyboard', () => {
+  // Compared as Doom's OWN key bytes, not as browser codes: the keyboard map
+  // has aliases (ArrowUp for KeyW, ShiftRight for ShiftLeft) that a pad has no
+  // reason to draw twice. What may not go missing is a Doom function.
+  const byTouch = new Set(touchButtons(DOOM_TOUCH).map((button) => {
+    const key = DOOM_KEY_MAP[button.code];
+    assert.ok(key !== undefined, `the pad's ${button.code} means nothing to Doom`);
+    return key;
+  }));
+  const byKeyboard = new Set(Object.values(DOOM_KEY_MAP));
+  const missing = [...byKeyboard].filter((key) => !byTouch.has(key));
+  assert.deepEqual(missing, [],
+    'Doom functions a keyboard can reach and a thumb cannot: '
+    + missing.map((key) => `0x${key.toString(16)}`).join(', '));
+});
+
+test('turning and strafing never wear the same arrow', () => {
+  // Two pairs of side buttons that do different things; told apart by shape
+  // (rotate vs translate), because on a phone they sit one row apart.
+  for (const cart of [dungeonCart(), freedoomCart(), doomCart()]) {
+    const { left, right, strafeLeft, strafeRight } = cart.touch;
+    assert.ok(strafeLeft && strafeRight, `${cart.name} moves in a Doom-format level and must strafe`);
+    assert.notEqual(left.glyph, strafeLeft.glyph, `${cart.name}: turn and strafe look identical`);
+    assert.notEqual(right.glyph, strafeRight.glyph, `${cart.name}: turn and strafe look identical`);
+    const labels = touchButtons(cart.touch).map((button) => button.label);
+    assert.equal(new Set(labels).size, labels.length, `${cart.name} has two buttons with one name`);
+  }
+});
+
+test('a modifier a steering thumb cannot hold is offered as a latch', () => {
+  for (const cart of [dungeonCart(), freedoomCart(), doomCart()]) {
+    assert.equal(cart.touch.run.code, 'ShiftLeft');
+    assert.equal(cart.touch.run.toggle, true, `${cart.name}: RUN must latch, not ask for a held thumb`);
+  }
+  // The platformer runs by walking and has no sprint key to offer.
+  assert.equal(platformerCart().touch.run, undefined);
+  assert.equal(platformerCart().touch.strafeLeft, undefined);
+});
+
+test('the code the pad labels "strafe" sidesteps without turning', () => {
+  // The pad draws turning and strafing as two pairs of side buttons one row
+  // apart. This is the claim that makes that worth the pixels: the strafe
+  // code moves the player perpendicular to where they are looking, and leaves
+  // where they are looking alone. Driven through TOUCH's own codes, so a
+  // profile that quietly re-pointed strafe at the turn keys fails here.
+  const cart = dungeonCart();
+  const input = new TestInput();
+  const tick = (code, ticks = 10) => {
+    for (let i = 0; i < ticks; i++) {
+      input.set(code, true);
+      cart.tick(0.05, input);
+      input.endTick();
+    }
+    input.set(code, false);
+  };
+
+  // Face up the open hall first: the spawn looks along a corridor one cell
+  // wide, where a sidestep in either direction is a wall.
+  const spawn = cart.state().player;
+  while (Math.abs(cart.state().player.dy + 1) > 0.02) tick(TOUCH.raycaster.left.code, 1);
+  const facing = cart.state().player;
+  assert.ok(Math.abs(facing.x - spawn.x) < 1e-9 && Math.abs(facing.y - spawn.y) < 1e-9,
+    'turning must not move the player');
+
+  tick(TOUCH.raycaster.strafeRight.code, 20);
+  const after = cart.state().player;
+  const move = { x: after.x - facing.x, y: after.y - facing.y };
+  const distance = Math.hypot(move.x, move.y);
+  // Perpendicular to the heading, not merely "moved": a sidestep and a step
+  // forward are both movement, and only one of them is a strafe.
+  const forward = Math.abs(move.x * facing.dx + move.y * facing.dy) / distance;
+  const rightOfHeading = -facing.dy * move.x + facing.dx * move.y;
+  assert.ok(distance > 0.3, `strafing must move the player, moved ${distance.toFixed(3)}`);
+  assert.ok(forward < 0.05, `a sidestep is not a step forward (${forward.toFixed(3)} along the heading)`);
+  assert.ok(rightOfHeading > 0, 'strafe right must step to the player\'s right');
+  assert.ok(Math.abs(after.dx - facing.dx) < 1e-9 && Math.abs(after.dy - facing.dy) < 1e-9,
+    'strafing must not turn the player');
+});

--- a/npm/tests/demo-arcade-mobile.spec.ts
+++ b/npm/tests/demo-arcade-mobile.spec.ts
@@ -431,8 +431,11 @@ test.describe('The pad takes its controls from the cartridge', () => {
     await page.goto('/demo-arcade.html?boot=tap'); // boot=tap: nothing streams a runtime
     return page.evaluate(async () => {
       document.getElementById('boot')?.remove(); // …and nothing over the controls
+      // Loaded through a computed specifier, as the CDN specs do: these modules
+      // are served to the browser beside the page, not resolvable from here.
+      const load = (name: string) => import(/* @vite-ignore */ `./${name}.js`);
       const [{ mountArcadeDock }, { TOUCH }, { DOOM_TOUCH }] = await Promise.all([
-        import('./arcade-dock.js'), import('./ascii-arcade.js'), import('./doom-cart.js'),
+        load('arcade-dock'), load('ascii-arcade'), load('doom-cart'),
       ]);
       const host = document.createElement('div');
       host.style.cssText = 'position:relative;width:100%;height:420px';

--- a/npm/tests/demo-arcade-mobile.spec.ts
+++ b/npm/tests/demo-arcade-mobile.spec.ts
@@ -208,6 +208,13 @@ test.describe('Arcade on a phone-shaped viewport', () => {
     await waitForBoot(page);
     await inflateDocumentText(page);
     await page.waitForFunction(() => (window as any).__arcade.frames() >= 50, { timeout: 60000 });
+
+    // The attract screen has one live control — the coin — so the pad offers
+    // that and nothing else: a D-pad steering a title card is a lie about what
+    // the buttons do.
+    await expect(page.locator('#pad .dxa-fire')).toHaveText('START');
+    await expect(page.locator('.dxa-dpad button:not([hidden])')).toHaveCount(0);
+
     await page.evaluate(() => (window as any).__arcade.pause());
 
     expect(await canvasLineBoxes(page)).toBe(26);
@@ -404,5 +411,198 @@ test.describe('Arcade on a phone-shaped viewport', () => {
     expect(measured.cells, 'characters that do not advance one cell tilt every row they appear in')
       .toEqual([]);
     expect(measured.marks, 'formatting marks must stay zero-width').toEqual([]);
+  });
+});
+
+// ─── The pad's control map ────────────────────────────────────────────
+// The thumb pad shipped with four arrows and FIRE, which is every control the
+// platformer has and about half of the ones a Doom-format level needs. On a
+// phone that meant no strafe, no sprint, no weapon switch, no automap, no way
+// into Doom's own menu — and, decisively, no USE: E1M1's first door is thirty
+// seconds in, and a door is a key press. The pad now takes its buttons from
+// the cartridge (`cart.touch`), so what a thumb can reach is what that
+// cartridge's keyboard map says exists.
+
+test.describe('The pad takes its controls from the cartridge', () => {
+  /** The dock alone, on a host of its own: no engine, no document, no game —
+   * just the control surface, driven through the same `setPad` the arcade
+   * driver calls on every cartridge change. */
+  async function mountBareDock(page: Page) {
+    await page.goto('/demo-arcade.html?boot=tap'); // boot=tap: nothing streams a runtime
+    return page.evaluate(async () => {
+      document.getElementById('boot')?.remove(); // …and nothing over the controls
+      const [{ mountArcadeDock }, { TOUCH }, { DOOM_TOUCH }] = await Promise.all([
+        import('./arcade-dock.js'), import('./ascii-arcade.js'), import('./doom-cart.js'),
+      ]);
+      const host = document.createElement('div');
+      host.style.cssText = 'position:relative;width:100%;height:420px';
+      document.body.append(host);
+      const dock = mountArcadeDock(host, { anchor: 'host', ids: false });
+      dock.show();
+      (window as any).__dock = dock;
+      (window as any).__profiles = { ...TOUCH, doom: DOOM_TOUCH };
+      return dock.isCompact();
+    });
+  }
+
+  /** Which slots the pad is offering, and what each one would send. */
+  async function padMap(page: Page): Promise<Record<string, string | null>> {
+    return page.evaluate(() => {
+      const map: Record<string, string | null> = {};
+      for (const button of Array.from(document.querySelectorAll('.dxa-pad button'))) {
+        // Tray chips are minted per cartridge and carry no slot class.
+        const name = Array.from(button.classList).find((c) => c.startsWith('dxa-'))?.slice(4);
+        if (!name) continue;
+        map[name] = (button as HTMLElement).hidden ? null : button.getAttribute('data-code');
+      }
+      return map;
+    });
+  }
+
+  const setProfile = (page: Page, cart: string) => page.evaluate(
+    (name) => (window as any).__dock.setPad((window as any).__profiles[name]), cart);
+
+  test('each cartridge gets its own buttons, and only its own', async ({ page }) => {
+    expect(await mountBareDock(page), 'a phone rig is always the compact layout').toBe(true);
+
+    // The platformer: walk and jump. Offering it a strafe button would send a
+    // key its simulation never reads.
+    await setProfile(page, 'quest');
+    expect(await padMap(page)).toMatchObject({
+      up: 'KeyW', left: 'ArrowLeft', right: 'ArrowRight', fire: 'Space',
+      down: null, 'strafe-left': null, 'strafe-right': null, use: null, run: null,
+    });
+    await expect(page.locator('.dxa-keys')).toBeHidden();
+
+    // A Doom-format level: strafe and a sprint latch as well.
+    await setProfile(page, 'raycaster');
+    expect(await padMap(page)).toMatchObject({
+      up: 'KeyW', down: 'KeyS', left: 'ArrowLeft', right: 'ArrowRight',
+      'strafe-left': 'KeyA', 'strafe-right': 'KeyD', fire: 'Space', run: 'ShiftLeft',
+      use: null,
+    });
+    await expect(page.locator('.dxa-run')).toHaveAttribute('data-mode', 'toggle');
+
+    // Doom: everything above, plus the door key.
+    await setProfile(page, 'doom');
+    expect(await padMap(page)).toMatchObject({ use: 'KeyE', 'strafe-left': 'KeyA', run: 'ShiftLeft' });
+
+    // …and back down again. A slot the cartridge does not want loses its code
+    // as well as its pixels: a hidden button must never be able to send a key.
+    await setProfile(page, 'quest');
+    const use = page.locator('.dxa-use');
+    await expect(use).toBeHidden();
+    expect(await use.getAttribute('data-code')).toBeNull();
+  });
+
+  test('the rarer Doom keys ride in a tray instead of under a thumb', async ({ page }) => {
+    await mountBareDock(page);
+
+    // Nothing to open for a cartridge with no extra keys…
+    await setProfile(page, 'raycaster');
+    await expect(page.locator('.dxa-keys')).toBeHidden();
+    await expect(page.locator('.dxa-extras')).toBeHidden();
+
+    // …and for Doom, one tap away rather than crowding the game screen.
+    await setProfile(page, 'doom');
+    await expect(page.locator('.dxa-keys')).toBeVisible();
+    await expect(page.locator('.dxa-extras')).toBeHidden();
+    await page.locator('.dxa-keys').click();
+    await expect(page.locator('.dxa-extras')).toBeVisible();
+    expect(await page.locator('.dxa-extras button').evaluateAll(
+      (buttons) => buttons.map((b) => b.getAttribute('data-code')))).toEqual(
+      ['Digit1', 'Digit2', 'Digit3', 'Digit4', 'Digit5', 'Digit6', 'Digit7',
+        'KeyM', 'KeyQ', 'Enter']);
+    // It stays open: working Doom's menu is several taps in a row.
+    await expect(page.locator('.dxa-extras')).toBeVisible();
+    await page.locator('.dxa-keys').click();
+    await expect(page.locator('.dxa-extras')).toBeHidden();
+
+    // Switching to a cartridge without extras withdraws the toggle with them.
+    await page.locator('.dxa-keys').click();
+    await setProfile(page, 'quest');
+    await expect(page.locator('.dxa-keys')).toBeHidden();
+    await expect(page.locator('.dxa-extras')).toBeHidden();
+    expect(await page.locator('.dxa-extras button').count()).toBe(0);
+  });
+
+  test('strafe reaches the game, and RUN latches instead of asking for a third thumb', async ({ page }) => {
+    // The raycaster: the pad's two new movement controls, on the cartridge
+    // that has somewhere to use them. That the strafe CODE sidesteps rather
+    // than turns is proved against the simulation itself in
+    // docs/demo/tools/ascii-arcade.test.mjs; what is proved here is the touch
+    // path — the button exists on a phone, and its press lands in the input
+    // the cartridge reads, without turning the player on the way.
+    await page.goto(`/demo-arcade.html?${OVERRIDE}&boot=tap&intro=0&cart=dungeon`);
+    await page.locator('#boot').click();
+    await waitForBoot(page);
+    await page.waitForFunction(() => (window as any).__arcade.frames() >= 3, { timeout: 60000 });
+
+    await expect(page.locator('#pad .dxa-strafe-left')).toBeVisible();
+    const before = await page.evaluate(() => (window as any).__arcade.game().player);
+    await page.locator('.dxa-strafe-right').dispatchEvent('pointerdown');
+    expect(await page.evaluate(() => (window as any).__arcade.input.held('KeyD'))).toBe(true);
+    const from = await page.evaluate(() => (window as any).__arcade.frames());
+    await page.waitForFunction((n) => (window as any).__arcade.frames() >= n, from + 5,
+      { timeout: 60000 });
+    await page.locator('.dxa-strafe-right').dispatchEvent('pointerup');
+    const after = await page.evaluate(() => (window as any).__arcade.game().player);
+    expect(await page.evaluate(() => (window as any).__arcade.input.held('KeyD'))).toBe(false);
+    expect(Math.abs(after.dx - before.dx), 'strafing must not turn the player').toBeLessThan(0.01);
+    expect(Math.abs(after.dy - before.dy), 'strafing must not turn the player').toBeLessThan(0.01);
+
+    // RUN is Shift, which a thumb steering with the same hand cannot hold, so
+    // it stays down after the tap and comes up on the next one.
+    const run = page.locator('.dxa-run');
+    await run.dispatchEvent('pointerdown');
+    await run.dispatchEvent('pointerup');
+    await expect(run).toHaveAttribute('aria-pressed', 'true');
+    expect(await page.evaluate(() => (window as any).__arcade.input.held('ShiftLeft'))).toBe(true);
+    await run.dispatchEvent('pointerdown');
+    await run.dispatchEvent('pointerup');
+    await expect(run).toHaveAttribute('aria-pressed', 'false');
+    expect(await page.evaluate(() => (window as any).__arcade.input.held('ShiftLeft'))).toBe(false);
+
+    // A latch must not survive into the paused document, where the same key is
+    // an ordinary Shift again.
+    await run.dispatchEvent('pointerdown');
+    expect(await page.evaluate(() => (window as any).__arcade.input.held('ShiftLeft'))).toBe(true);
+    await page.evaluate(() => (window as any).__arcade.pause());
+    await expect(run).toHaveAttribute('aria-pressed', 'false');
+    expect(await page.evaluate(() => (window as any).__arcade.input.held('ShiftLeft'))).toBe(false);
+  });
+
+  test('Doom hands the phone its door key, and its weapons', async ({ page }) => {
+    // The reported gap, at the cartridge it actually blocked: USE. The pad is
+    // pointed at Doom's keys the moment the cartridge is selected, so this
+    // asserts the input path rather than waiting on a 10 MB IWAD to render.
+    test.setTimeout(150000);
+    await page.goto(`/demo-arcade.html?${OVERRIDE}&boot=tap&intro=0&cart=doom`);
+    await page.locator('#boot').click();
+    await waitForBoot(page);
+
+    const use = page.locator('#pad .dxa-use');
+    await expect(use).toBeVisible();
+    await expect(use).toHaveAttribute('aria-label', /door/i);
+    await use.dispatchEvent('pointerdown');
+    expect(await page.evaluate(() => (window as any).__arcade.input.held('KeyE'))).toBe(true);
+    await use.dispatchEvent('pointerup');
+    expect(await page.evaluate(() => (window as any).__arcade.input.held('KeyE'))).toBe(false);
+
+    // A weapon is a digit; the tray sends it the same way, through the same
+    // transition log Doom's own input layer drains.
+    await page.locator('#padkeys').click();
+    const shotgun = page.locator('#padextras button[data-code="Digit3"]');
+    await shotgun.dispatchEvent('pointerdown');
+    expect(await page.evaluate(() => (window as any).__arcade.input.held('Digit3'))).toBe(true);
+    await shotgun.dispatchEvent('pointerup');
+    expect(await page.evaluate(() => (window as any).__arcade.input.held('Digit3'))).toBe(false);
+
+    // Switch cartridge and the pad follows: no USE button for a game with no
+    // doors, and nothing left holding a key from the cartridge you left.
+    await page.evaluate(() => (window as any).__arcade.setCart('dungeon'));
+    await expect(page.locator('#pad .dxa-use')).toBeHidden();
+    await expect(page.locator('#padkeys')).toBeHidden();
+    expect(await page.evaluate(() => (window as any).__arcade.input.held('KeyE'))).toBe(false);
   });
 });


### PR DESCRIPTION
## Why

The Arcade plays well on a desktop and only partly on a phone. The thumb pad shipped with four arrows and a round FIRE button — which is every control the platformer has, and about half of the ones a Doom-format level needs.

Missing on touch: strafe, sprint, weapon switching, the automap, Doom's own menu, and — decisively — **USE**. Freedoom's E1M1 puts its first door about thirty seconds in, and a door is a key press (`E`). A phone had no key to press, so the real Doom cartridge could be walked that far and no further.

## What changed

The pad's buttons now come from the cartridge instead of being fixed in the dock. Each cartridge declares a touch profile beside the keyboard map it mirrors (`cart.touch`), and `arcade-dock.js` fills its fixed slots from that profile through a new `setPad`, which `startArcade` calls on every cartridge change:

| cartridge | pad |
|---|---|
| ¶ Pilcrow's Quest | walk `←/→`, `▲`, round **JUMP** |
| ▓ Dungeon · ☩ Freedoom E1M1 | forward/back, turn (`↺ ↻`), strafe (`◀ ▶`), **FIRE**, **RUN** |
| ☩ DOOM | all of the above plus **USE**, and a **KEYS** tray: weapons 1–7, **MAP**, **MENU**, `⏎` |
| attract screen | one round **START** — nothing on a title card is steerable |

Geometry stays in the dock; the control map stays with the cartridge, next to the keyboard `controls` line it has to agree with. A slot the cartridge does not use is hidden *and* loses its `data-code`, so a button can never send a key the cartridge ignores. Turning rotates (`↺ ↻`) and strafing translates (`◀ ▶`), so the two pairs of side buttons — one row apart on the same D-pad — never wear the same arrow. Doom's rarer keys ride in a tray above the action cluster rather than crowding the game screen, because they are what you reach for between fights rather than during one.

## Mechanism

Three touch behaviours the keyboard never needed:

- **RUN latches.** Shift is a held modifier; on a phone the hand that would hold it is the one steering. Tap it on, tap it off, with `aria-pressed` showing which.
- **Presses are tracked per pointer id.** Firing with one thumb while turning with the other is two live pointers, and releasing one must lift only its own key. The pressed button also captures the pointer, so a thumb sliding off it still releases the key rather than leaving it stuck down.
- **Pausing releases whatever the pad holds** (so does switching cartridge). A latched sprint must not survive into the paused document, where the same key is an ordinary Shift again.

The pad is wired by delegation and reads each button's code at press time. That is what lets one set of DOM nodes follow the cartridge and lets the tray mint its keys on the spot — a listener that captured a code at boot would go on sending the previous cartridge's key.

## Validation

Headless checks (`docs/demo/tools/ascii-arcade.test.mjs`, run by `npm run test:demo-logic`) hold every profile to the keyboard map beside it:

- every touch button sends a key the arcade actually claims while playing (a code outside that set would reach the document, not the game);
- a thumb can reach every function Doom gives a keyboard — compared as Doom's own key bytes, so keyboard aliases don't paper over a missing function. Deleting USE from the profile fails this check with `0xa2` missing, which is the bug this PR fixes;
- turn and strafe never share a glyph, and no two buttons in a profile share a name;
- the code the pad labels "strafe" moves the player *perpendicular to their heading* without turning them — driven through the real raycaster simulation, so a profile that quietly re-pointed strafe at the turn keys fails.

Browser specs (`npm/tests/demo-arcade-mobile.spec.ts`, phone-shaped project) cover the dock in isolation — each cartridge's slots, the tray opening and being withdrawn, a hidden slot losing its code — and the live arcade: strafe and the RUN latch on the raycaster, USE and a weapon chip on Doom, the latch not surviving a pause, and the pad following a cartridge switch. The attract-screen assertion rides the existing intro spec.

Locally I ran the headless suites (green) and exercised the dock and its event path in a real Chromium on a Pixel 5 viewport — profile switching, tray, latch, release-on-pause, tray chips. The Playwright specs themselves need the WASM bundle, which this container cannot build (no .NET SDK), so they run for the first time in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJWJUpxAvfMfopNVxtwbvW

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJWJUpxAvfMfopNVxtwbvW)_