### PR TITLE
Keep the keyboard in the find bar while a query is being typed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- The editor's find bar no longer loses the keyboard the moment a query matches. It re-scanned on
+  every keystroke and then *selected* the first hit, and selecting inside a contenteditable block
+  focuses that block — so as soon as a partial query matched, the caret jumped into the document
+  and the rest of the query was typed into the text: searching for "fox" left an "ox" behind. The
+  jump-to-hit is kept, but expressed as a painted highlight instead of a selection: `showFindMatches`
+  registers the matches with the CSS Custom Highlight API (all hits washed, the current one
+  stronger) and scrolls the active one into view without moving focus, so typing goes on refining
+  the search. The caret is handed the match by `selectMatch` when the bar closes, which is when the
+  user is going back to the document anyway. Find-bar buttons now swallow `mousedown` like the
+  format buttons do, so clicking Next or Replace does not end the query either, and `replaceMatch`
+  / `replaceAll` take `focus: false` for the same reason. Browsers without the highlight registry
+  fall back to painting the active hit with the document selection — still without focusing it.
+
 ## [12.1.0] - 2026-09-05
 
 ### Changed

--- a/docs/architecture/editor_ui_surface.md
+++ b/docs/architecture/editor_ui_surface.md
@@ -95,7 +95,16 @@ from editor state.
 | Line spacing menu | `setLineSpacing(multiple)` | `SetParagraphFormat` (`LineSpacing` in 240ths, rule `auto`) |
 | Style gallery | `setParagraphStyle(id)` | `SetParagraphStyle` |
 | Delete block | `deleteBlock()` | `DeleteBlock` — inert inside a table and when it is the only editable block |
-| Find / Replace | `find(query)`, `selectMatch`, `replaceMatch`, `replaceAll` | text scan over the rendered blocks; `ReplaceTextAtSpan` per replacement |
+| Find / Replace | `find(query)`, `showFindMatches`, `clearFindMatches`, `selectMatch`, `replaceMatch`, `replaceAll` | text scan over the rendered blocks; `ReplaceTextAtSpan` per replacement |
+
+While the find bar is open the current hit is **painted, not selected**: `showFindMatches` puts
+the matches into the CSS Custom Highlight registry (`::highlight(docxodus-find)` and
+`docxodus-find-active`) and scrolls the active one into view without touching focus, because
+selecting inside a contenteditable block focuses that block — which would send the next character
+of the query into the document. `selectMatch` is the commit step the bar runs when it closes: it
+drops the painting and puts the caret on the hit, so editing resumes where the search stopped. The
+find-bar buttons swallow `mousedown` for the same reason the format buttons do, and `replaceMatch`
+/ `replaceAll` take `focus: false` so a Replace press does not pull the caret out of the bar.
 
 The font menu lists the families the open document actually uses first, then the fonts every
 Word install has. The style gallery is read from the document (`ListStyles`: paragraph styles,

--- a/npm/src/editor.ts
+++ b/npm/src/editor.ts
@@ -982,25 +982,95 @@ function selectionSpanIn(block: HTMLElement): { start: number; length: number } 
   return span.length > 0 ? span : null;
 }
 
-/** Restore a content-text selection spanning [start, start+length) within `el` (skips markers). */
-function selectRange(el: HTMLElement, start: number, length: number): void {
-  const sel = typeof window !== "undefined" ? window.getSelection() : null;
+/**
+ * A DOM Range over the content text spanning [start, start+length) within `el` (skips markers),
+ * or null when the block is detached or the offsets do not resolve. Building the range is kept
+ * separate from selecting it so a caller that only wants to PAINT a span (find preview) does not
+ * have to touch the selection — and therefore focus — at all.
+ */
+function contentRangeIn(el: HTMLElement, start: number, length: number): Range | null {
   // The block may have been swapped out of the document by a re-render before this runs
   // (e.g. a focus-stealing toolbar control firing twice). addRange on a detached range
   // throws "the given range isn't in document" — skip rather than warn.
-  if (!sel || !el.isConnected) return;
-  el.focus();
-  const range = document.createRange();
+  if (!el.isConnected) return null;
+  const doc = el.ownerDocument;
+  const range = doc.createRange();
   const from = contentPositionIn(el, start);
   const to = contentPositionIn(el, start + length);
   try {
     range.setStart(from.node, from.offset);
     range.setEnd(to.node, to.offset);
   } catch {
-    return;
+    return null;
   }
+  return range;
+}
+
+/** Restore a content-text selection spanning [start, start+length) within `el` (skips markers). */
+function selectRange(el: HTMLElement, start: number, length: number): void {
+  const sel = typeof window !== "undefined" ? window.getSelection() : null;
+  if (!sel || !el.isConnected) return;
+  el.focus();
+  const range = contentRangeIn(el, start, length);
+  if (!range) return;
   sel.removeAllRanges();
   sel.addRange(range);
+}
+
+// ─── Find painting ──────────────────────────────────────────────────────────
+//
+// A find box has to show WHERE the hits are while the user is still typing into it, so it cannot
+// express "the current match" as a selection: putting a caret in a contenteditable block focuses
+// that block, and the next keystroke lands in the document instead of the search field. These
+// highlights paint the same information with no focus and no DOM mutation — the CSS Custom
+// Highlight API takes plain Ranges over the live text and styles them from the stylesheet.
+
+/** Every match currently on screen. */
+const FIND_HIGHLIGHT = "docxodus-find";
+/** The one the find bar's counter is pointing at. */
+const FIND_HIGHLIGHT_ACTIVE = "docxodus-find-active";
+/** Ranges are cheap, but a pathological query ("e" in a book) is not worth painting in full. */
+const FIND_PAINT_LIMIT = 500;
+
+const findHighlightStyledDocuments = new WeakSet<Document>();
+/**
+ * Which editor last painted into the shared registry. Only that instance may clear it, so a
+ * second surface on the page cannot wipe the first one's find painting when its own find bar
+ * closes. Two live searches still share one painting — the newer one wins, which is what a
+ * single visible "current match" should mean.
+ */
+let findPaintOwner: object | null = null;
+
+function ensureFindHighlightStyles(doc: Document): void {
+  if (findHighlightStyledDocuments.has(doc)) return;
+  findHighlightStyledDocuments.add(doc);
+  const style = doc.createElement("style");
+  style.dataset.docxodusFindHighlight = "true";
+  style.textContent = `
+::highlight(${FIND_HIGHLIGHT}) { background-color: rgba(15, 118, 110, .16); }
+::highlight(${FIND_HIGHLIGHT_ACTIVE}) { background-color: rgba(15, 118, 110, .38); }
+`;
+  (doc.head ?? doc.documentElement).appendChild(style);
+}
+
+/** The highlight registry is global to the document, so two editors on one page share it. */
+interface HighlightRegistry {
+  set(name: string, highlight: unknown): void;
+  delete(name: string): void;
+}
+
+function highlightRegistry(): HighlightRegistry | null {
+  if (typeof CSS === "undefined") return null;
+  const registry = (CSS as unknown as { highlights?: HighlightRegistry }).highlights;
+  const ctor = (globalThis as unknown as { Highlight?: unknown }).Highlight;
+  return registry && typeof ctor === "function" ? registry : null;
+}
+
+function makeHighlight(ranges: Range[]): unknown {
+  const ctor = (globalThis as unknown as {
+    Highlight: new (...ranges: Range[]) => unknown;
+  }).Highlight;
+  return new ctor(...ranges);
 }
 
 /**
@@ -1425,6 +1495,7 @@ export class DocxEditor {
       document.removeEventListener("mouseup", this.onMouseUp, true);
     }
     this.clearDragSelection();
+    this.clearFindMatches();
     this.teardownBlockDrag();
     this.gutter?.dispose();
     this.gutter = null;
@@ -4215,16 +4286,75 @@ export class DocxEditor {
     return out;
   }
 
-  /** Select a match and scroll it into view. */
+  /**
+   * Select a match, focus its block and scroll it into view — the caret lands on the hit, so
+   * typing continues in the document. A find box that is still being typed into wants
+   * `showFindMatches` instead; this is the commit step (closing the bar, jumping in to edit).
+   */
   selectMatch(match: EditorMatch): void {
     if (!match.block.isConnected) return;
+    this.clearFindMatches();
     this.activeBlock = match.block;
     selectRange(match.block, match.start, match.length);
     match.block.scrollIntoView({ block: "center", behavior: "smooth" });
   }
 
-  /** Replace one match's text (formatting of the surrounding run is inherited). */
-  replaceMatch(match: EditorMatch, replacement: string): boolean {
+  /**
+   * Paint `matches` and scroll the one at `activeIndex` into view WITHOUT moving focus or the
+   * caret. This is what a find field calls on every keystroke: the document shows where the hits
+   * are and rides to the current one, while the keyboard stays in the search box.
+   *
+   * Falls back to the document selection where the CSS Custom Highlight API is missing — still
+   * without focusing the block, so the next character typed goes to the search field either way.
+   */
+  showFindMatches(matches: EditorMatch[], activeIndex: number): void {
+    const active = matches[activeIndex];
+    this.clearFindMatches();
+    if (!active || !active.block.isConnected) return;
+    this.activeBlock = active.block;
+    const activeRange = contentRangeIn(active.block, active.start, active.length);
+    const registry = highlightRegistry();
+    if (registry && activeRange) {
+      ensureFindHighlightStyles(this.container.ownerDocument);
+      const rest: Range[] = [];
+      for (let i = 0; i < matches.length && rest.length < FIND_PAINT_LIMIT; i++) {
+        if (i === activeIndex) continue;
+        const range = contentRangeIn(matches[i].block, matches[i].start, matches[i].length);
+        if (range) rest.push(range);
+      }
+      if (rest.length > 0) registry.set(FIND_HIGHLIGHT, makeHighlight(rest));
+      registry.set(FIND_HIGHLIGHT_ACTIVE, makeHighlight([activeRange]));
+      findPaintOwner = this;
+    } else if (activeRange) {
+      // No highlight registry (older Firefox/Safari): the document selection is the only paint
+      // available. It is not registry-owned, so `clearFindMatches` leaves it — the next
+      // `showFindMatches` or the closing `selectMatch` overwrites it.
+      const sel = this.container.ownerDocument.defaultView?.getSelection();
+      sel?.removeAllRanges();
+      sel?.addRange(activeRange);
+    }
+    active.block.scrollIntoView({ block: "center", behavior: "smooth" });
+  }
+
+  /** Drop the find painting (closing the find bar, or committing a match to the caret). */
+  clearFindMatches(): void {
+    if (findPaintOwner !== this) return;
+    const registry = highlightRegistry();
+    registry?.delete(FIND_HIGHLIGHT);
+    registry?.delete(FIND_HIGHLIGHT_ACTIVE);
+    findPaintOwner = null;
+  }
+
+  /**
+   * Replace one match's text (formatting of the surrounding run is inherited). `focus: false`
+   * leaves the keyboard where it is — a Replace button pressed from the find bar must not drag
+   * the caret into the document mid-search.
+   */
+  replaceMatch(
+    match: EditorMatch,
+    replacement: string,
+    options: { focus?: boolean } = {},
+  ): boolean {
     const block = match.block;
     if (this.closed || !block.isConnected) return false;
     const unid = block.getAttribute("data-anchor");
@@ -4241,12 +4371,16 @@ export class DocxEditor {
     );
     if (!res.success) return false;
     const fresh = this.swapBlock(block, unid, res.modified?.[0]);
-    if (fresh) selectRange(fresh, span.start, replacement.length);
+    if (fresh && options.focus !== false) selectRange(fresh, span.start, replacement.length);
     return true;
   }
 
   /** Replace every occurrence; returns how many were replaced. */
-  replaceAll(query: string, replacement: string, options: { matchCase?: boolean } = {}): number {
+  replaceAll(
+    query: string,
+    replacement: string,
+    options: { matchCase?: boolean; focus?: boolean } = {},
+  ): number {
     if (this.closed || !query) return 0;
     const matches = this.find(query, options);
     let count = 0;
@@ -4262,7 +4396,9 @@ export class DocxEditor {
       for (const m of list.slice().sort((a, b) => b.start - a.start)) {
         if (!current.isConnected) break;
         const before = current;
-        if (this.replaceMatch({ block: current, start: m.start, length: m.length }, replacement)) {
+        if (this.replaceMatch(
+          { block: current, start: m.start, length: m.length }, replacement, { focus: options.focus },
+        )) {
           count++;
           // swapBlock replaced the node; keep following it.
           current = this.activeBlock && this.activeBlock !== before ? this.activeBlock : current;

--- a/npm/src/ribbon.ts
+++ b/npm/src/ribbon.ts
@@ -1378,11 +1378,20 @@ class RibbonSurface implements RibbonEditor {
       if (!this.live || !text.value) return;
       let count = 0;
       this.run("replace all", () => {
-        count = this.live!.replaceAll(text.value, replace.value, { matchCase: matchCase.checked });
+        count = this.live!.replaceAll(text.value, replace.value, {
+          matchCase: matchCase.checked,
+          focus: false,
+        });
       });
       this.setStatus(`Replaced ${count} occurrence${count === 1 ? "" : "s"}`);
       this.refreshFind(true);
     });
+    // Every find-bar button acts on the search, not on the caret: swallowing mousedown keeps the
+    // keyboard in the field that was being typed into, so a click on Next does not end the query.
+    for (const id of ["findprev", "findnext", "replaceone", "replaceall"]) {
+      const button = this.control(id);
+      if (button) this.keepSelection(button);
+    }
     bar.hidden = true;
   }
 
@@ -1394,23 +1403,40 @@ class RibbonSurface implements RibbonEditor {
     const text = this.require<HTMLInputElement>("findtext");
     text.focus();
     text.select();
-    this.refreshFind(false);
+    // Painting is focus-safe, so a reopened bar can show its hits without taking the keyboard.
+    this.refreshFind(true);
   }
 
+  /**
+   * Close the bar and hand the current hit over to the caret: the document is where the user is
+   * going next, and Word leaves the insertion point on the match it stopped at. Until this runs
+   * the match is only PAINTED (see `showFindMatches`), so the search field keeps the keyboard for
+   * as long as the bar is open.
+   */
   private closeFindBar(): void {
     const bar = this.control("findbar");
     if (bar) bar.hidden = true;
+    const match = this.findMatches[this.findIndex];
+    if (match) this.live?.selectMatch(match);
+    else this.live?.clearFindMatches();
     this.findMatches = [];
     this.findIndex = -1;
   }
 
-  private refreshFind(select: boolean): void {
+  /**
+   * Re-scan for the current query. `show` paints the hits and rides to the first one — it never
+   * focuses the document, so typing the second character of a query that already matched goes on
+   * refining the search instead of being typed into the document.
+   */
+  private refreshFind(show: boolean): void {
     const text = this.require<HTMLInputElement>("findtext");
     const matchCase = this.require<HTMLInputElement>("findcase").checked;
     this.findMatches = this.live && text.value ? this.live.find(text.value, { matchCase }) : [];
     this.findIndex = this.findMatches.length > 0 ? 0 : -1;
     this.updateFindCount();
-    if (select && this.findIndex >= 0) this.live?.selectMatch(this.findMatches[this.findIndex]);
+    if (!show) return;
+    if (this.findIndex >= 0) this.live?.showFindMatches(this.findMatches, this.findIndex);
+    else this.live?.clearFindMatches();
   }
 
   private stepFind(direction: 1 | -1): void {
@@ -1418,7 +1444,7 @@ class RibbonSurface implements RibbonEditor {
     if (this.findMatches.length === 0) this.refreshFind(false);
     if (this.findMatches.length === 0) return;
     this.findIndex = (this.findIndex + direction + this.findMatches.length) % this.findMatches.length;
-    this.live.selectMatch(this.findMatches[this.findIndex]);
+    this.live.showFindMatches(this.findMatches, this.findIndex);
     this.updateFindCount();
   }
 
@@ -1428,13 +1454,13 @@ class RibbonSurface implements RibbonEditor {
     const match = this.findMatches[this.findIndex];
     if (!match) return;
     const replacement = this.require<HTMLInputElement>("replacetext").value;
-    this.run("replace", () => this.live!.replaceMatch(match, replacement));
+    this.run("replace", () => this.live!.replaceMatch(match, replacement, { focus: false }));
     // Offsets after the replacement shifted; re-scan and continue from the same slot.
     const keep = this.findIndex;
     this.refreshFind(false);
     if (this.findMatches.length > 0) {
       this.findIndex = Math.min(keep, this.findMatches.length - 1);
-      this.live.selectMatch(this.findMatches[this.findIndex]);
+      this.live.showFindMatches(this.findMatches, this.findIndex);
       this.updateFindCount();
     }
   }

--- a/npm/tests/editor-find-focus.spec.ts
+++ b/npm/tests/editor-find-focus.spec.ts
@@ -1,0 +1,295 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Find and replace must not take the keyboard.
+ *
+ * The regression this pins: the find field re-scanned on every `input` event and then SELECTED the
+ * first hit, and selecting inside a contenteditable block focuses that block. So the moment a
+ * partial query matched, the caret jumped into the document and the REST OF THE QUERY WAS TYPED
+ * INTO THE DOCUMENT — searching for "fox" left an "ox" in the text.
+ *
+ * The fix keeps the jump-to-hit (the document still scrolls and the match is painted) but expresses
+ * it as a highlight rather than a selection, so focus never leaves the search field. The caret is
+ * handed the match only when the bar closes.
+ *
+ * Two layers, both needed:
+ *   - the DocxEditor API contract (`showFindMatches` paints, `selectMatch` commits), driven
+ *     directly against a session on the bare harness;
+ *   - the shipped find bar in `ribbon.ts`, driven with real keystrokes on the editor host.
+ */
+
+const SENTENCE = 'The quick brown fox jumps over the lazy fox.';
+
+async function waitForDocxodus(page: Page) {
+  await page.waitForFunction(() => (window as any).DocxodusReady === true, { timeout: 30000 });
+}
+
+/** Names of the registered CSS highlights, so a spec can see what was painted. */
+function paintedHighlights(): { active: number; others: number } {
+  const registry = (CSS as any).highlights;
+  return {
+    active: registry?.get('docxodus-find-active')?.size ?? 0,
+    others: registry?.get('docxodus-find')?.size ?? 0,
+  };
+}
+
+test.describe('DocxEditor — find painting does not move focus', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/test-harness.html');
+    await waitForDocxodus(page);
+  });
+
+  test('showFindMatches paints the hits and leaves the keyboard where it was', async ({ page }) => {
+    const out = await page.evaluate(async (sentence) => {
+      const D = (window as any).Docxodus;
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      // A stand-in for the find field: any control OUTSIDE the document surface will do.
+      const field = document.createElement('input');
+      field.id = 'query';
+      document.body.appendChild(field);
+
+      const editor = D.DocxEditor.open(container, D.DocxSessionBridge.CreateBlankDocx(), D, {});
+      const first = () => container.querySelector('[data-anchor][contenteditable="true"]') as HTMLElement;
+      const block = first();
+      block.focus();
+      const range = document.createRange();
+      range.selectNodeContents(block);
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+      document.execCommand('insertText', false, sentence);
+      block.dispatchEvent(new Event('blur'));
+
+      field.focus();
+      field.value = 'fox';
+      const matches = editor.find('fox');
+      editor.showFindMatches(matches, 0);
+      const registry = (CSS as any).highlights;
+      const painted = {
+        matches: matches.length,
+        focusId: (document.activeElement as HTMLElement)?.id ?? '',
+        active: registry?.get('docxodus-find-active')?.size ?? 0,
+        others: registry?.get('docxodus-find')?.size ?? 0,
+      };
+
+      // Riding to the SECOND hit is still focus-free.
+      editor.showFindMatches(matches, 1);
+      const stepped = { focusId: (document.activeElement as HTMLElement)?.id ?? '' };
+
+      editor.clearFindMatches();
+      const cleared = {
+        active: registry?.get('docxodus-find-active')?.size ?? 0,
+        others: registry?.get('docxodus-find')?.size ?? 0,
+      };
+
+      const text = (first().textContent ?? '').trim();
+      editor.close();
+      container.remove();
+      field.remove();
+      return { painted, stepped, cleared, text };
+    }, SENTENCE);
+
+    // Both hits found, one painted as active and the other as a plain match.
+    expect(out.painted.matches).toBe(2);
+    expect(out.painted.active).toBe(1);
+    expect(out.painted.others).toBe(1);
+    // The whole point: the search field still owns the keyboard.
+    expect(out.painted.focusId).toBe('query');
+    expect(out.stepped.focusId).toBe('query');
+    // Clearing takes the painting away again.
+    expect(out.cleared).toEqual({ active: 0, others: 0 });
+    // And nothing was typed into the document along the way.
+    expect(out.text).toBe(SENTENCE);
+  });
+
+  test('selectMatch still commits the caret onto the hit', async ({ page }) => {
+    const out = await page.evaluate(async (sentence) => {
+      const D = (window as any).Docxodus;
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const field = document.createElement('input');
+      field.id = 'query';
+      document.body.appendChild(field);
+
+      const editor = D.DocxEditor.open(container, D.DocxSessionBridge.CreateBlankDocx(), D, {});
+      const first = () => container.querySelector('[data-anchor][contenteditable="true"]') as HTMLElement;
+      const block = first();
+      block.focus();
+      const range = document.createRange();
+      range.selectNodeContents(block);
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+      document.execCommand('insertText', false, sentence);
+      block.dispatchEvent(new Event('blur'));
+
+      field.focus();
+      const matches = editor.find('fox');
+      editor.showFindMatches(matches, 0);
+      editor.selectMatch(matches[0]);
+      const registry = (CSS as any).highlights;
+      const after = {
+        selected: (window.getSelection()?.toString() ?? ''),
+        inDocument: first().contains(document.activeElement) || first() === document.activeElement,
+        // Committing to the caret drops the painting — one visible "current match", not two.
+        active: registry?.get('docxodus-find-active')?.size ?? 0,
+      };
+
+      editor.close();
+      container.remove();
+      field.remove();
+      return after;
+    }, SENTENCE);
+
+    expect(out.selected).toBe('fox');
+    expect(out.inDocument).toBe(true);
+    expect(out.active).toBe(0);
+  });
+
+  test('replaceMatch with focus:false edits the text without pulling the caret in', async ({ page }) => {
+    const out = await page.evaluate(async (sentence) => {
+      const D = (window as any).Docxodus;
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const field = document.createElement('input');
+      field.id = 'query';
+      document.body.appendChild(field);
+
+      const editor = D.DocxEditor.open(container, D.DocxSessionBridge.CreateBlankDocx(), D, {});
+      const first = () => container.querySelector('[data-anchor][contenteditable="true"]') as HTMLElement;
+      const block = first();
+      block.focus();
+      const range = document.createRange();
+      range.selectNodeContents(block);
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+      document.execCommand('insertText', false, sentence);
+      block.dispatchEvent(new Event('blur'));
+
+      field.focus();
+      const replaced = editor.replaceMatch(editor.find('fox')[0], 'cat', { focus: false });
+      const after = {
+        replaced,
+        focusId: (document.activeElement as HTMLElement)?.id ?? '',
+        text: (first().textContent ?? '').trim(),
+      };
+
+      editor.close();
+      container.remove();
+      field.remove();
+      return after;
+    }, SENTENCE);
+
+    expect(out.replaced).toBe(true);
+    expect(out.text).toBe('The quick brown cat jumps over the lazy fox.');
+    expect(out.focusId).toBe('query');
+  });
+});
+
+test.describe('ribbon find bar — typing a query keeps typing in the query', () => {
+  /** New blank document, one paragraph of known text, committed. */
+  async function seedDocument(page: Page) {
+    await page.goto('/editor.html');
+    await page.waitForFunction(() => !!(window as any).__demo, { timeout: 60000 });
+    await page.click('[data-dxr="new"]');
+    await page.waitForFunction(() => !!(window as any).__demo.getEditor());
+
+    const block = page.locator('[data-dxr-surface] [data-anchor][contenteditable="true"]').first();
+    await block.click();
+    await page.evaluate(() => {
+      const el = document.querySelector(
+        '[data-dxr-surface] [data-anchor][contenteditable="true"]',
+      ) as HTMLElement;
+      const range = document.createRange();
+      range.selectNodeContents(el);
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+    });
+    await page.keyboard.type(SENTENCE);
+  }
+
+  /** The document's visible text, whitespace-normalised. */
+  function surfaceText(): string {
+    const surface = document.querySelector('[data-dxr-surface]') as HTMLElement;
+    return (surface.textContent ?? '').replace(/\s+/g, ' ').trim();
+  }
+
+  test('every character of the query reaches the search field, not the document', async ({ page }) => {
+    await seedDocument(page);
+    await page.click('[data-dxr="findtoggle"]');
+    await expect(page.locator('[data-dxr="findbar"]')).toBeVisible();
+
+    const before = await page.evaluate(surfaceText);
+    expect(before).toContain(SENTENCE);
+
+    // Character by character. "f" already matches, which is exactly when the old code jumped the
+    // caret into the document and swallowed the "ox".
+    await page.keyboard.type('fox', { delay: 30 });
+
+    await expect(page.locator('[data-dxr="findtext"]')).toHaveValue('fox');
+    await expect(page.locator('[data-dxr="findcount"]')).toHaveText('1 of 2');
+    expect(await page.evaluate(surfaceText)).toBe(before);
+    expect(await page.evaluate(() => document.activeElement?.getAttribute('data-dxr'))).toBe('findtext');
+
+    // The hit is shown by painting it, which is what makes the focus-free jump possible.
+    expect(await page.evaluate(paintedHighlights)).toEqual({ active: 1, others: 1 });
+  });
+
+  test('Enter and the Next button step matches without ending the query', async ({ page }) => {
+    await seedDocument(page);
+    await page.click('[data-dxr="findtoggle"]');
+    await page.keyboard.type('fox');
+
+    await page.keyboard.press('Enter');
+    await expect(page.locator('[data-dxr="findcount"]')).toHaveText('2 of 2');
+    expect(await page.evaluate(() => document.activeElement?.getAttribute('data-dxr'))).toBe('findtext');
+
+    await page.click('[data-dxr="findnext"]');
+    await expect(page.locator('[data-dxr="findcount"]')).toHaveText('1 of 2');
+    expect(await page.evaluate(() => document.activeElement?.getAttribute('data-dxr'))).toBe('findtext');
+
+    // Typing continues to refine the same query rather than editing the document.
+    await page.keyboard.type('y');
+    await expect(page.locator('[data-dxr="findtext"]')).toHaveValue('foxy');
+    await expect(page.locator('[data-dxr="findcount"]')).toHaveText('0 of 0');
+  });
+
+  test('closing the bar hands the current match to the caret', async ({ page }) => {
+    await seedDocument(page);
+    await page.click('[data-dxr="findtoggle"]');
+    await page.keyboard.type('lazy');
+    await page.keyboard.press('Escape');
+
+    await expect(page.locator('[data-dxr="findbar"]')).toBeHidden();
+    const landed = await page.evaluate(() => {
+      const surface = document.querySelector('[data-dxr-surface]') as HTMLElement;
+      return {
+        selection: window.getSelection()?.toString() ?? '',
+        inDocument: surface.contains(document.activeElement),
+        painted: (CSS as any).highlights?.get('docxodus-find-active')?.size ?? 0,
+      };
+    });
+    // Jumped to the result, as asked — but only once the search itself is over.
+    expect(landed.selection).toBe('lazy');
+    expect(landed.inDocument).toBe(true);
+    expect(landed.painted).toBe(0);
+  });
+
+  test('Replace edits the document and leaves the keyboard in the replace field', async ({ page }) => {
+    await seedDocument(page);
+    await page.click('[data-dxr="replacetoggle"]');
+    await page.keyboard.type('quick');
+    await page.click('[data-dxr="replacetext"]');
+    await page.keyboard.type('nimble');
+    await page.click('[data-dxr="replaceone"]');
+
+    await expect
+      .poll(async () => page.evaluate(surfaceText))
+      .toContain('The nimble brown fox');
+    expect(await page.evaluate(() => document.activeElement?.getAttribute('data-dxr'))).toBe('replacetext');
+    await expect(page.locator('[data-dxr="replacetext"]')).toHaveValue('nimble');
+  });
+});


### PR DESCRIPTION
## The problem

Type into the editor's Find box and, the moment the partial query matches something, the caret jumps out of the search field and into the document. Every keystroke after that is typed **into the document text**.

Searching a paragraph reading `The quick brown fox jumps over the lazy fox.` for `quick` leaves this behind:

```
The uickuick brown fox jumps over the lazy fox.
```

The `q` matched, focus moved to the matched paragraph, and `uick` was typed into it — twice, because the second scan matched again. So this reads as a focus annoyance but is really a silent document edit, and it is why the bar was unusable for anything longer than a one-character query.

## Why it happened

The find field re-scanned on every `input` event and then called `DocxEditor.selectMatch`, which puts a DOM selection on the hit. Selecting inside a `contenteditable` block focuses that block — there is no way to place a caret there and keep the keyboard elsewhere. Jumping to the result and staying in the search box were, as written, mutually exclusive.

## The fix: paint the hit instead of selecting it

The jump-to-result is kept. What changes is how "this is the current match" is expressed while the bar is open.

* **`DocxEditor.showFindMatches(matches, activeIndex)`** registers the hits with the CSS Custom Highlight API — every match washed (`::highlight(docxodus-find)`), the current one stronger (`docxodus-find-active`) — and scrolls the active one into view. Highlights take plain `Range` objects over the live text: no DOM mutation, no selection, and therefore no focus change. Typing goes on refining the query.
* **`selectMatch` becomes the commit step.** The bar calls it when it closes: the painting is dropped and the caret is placed on the match the user stopped at, so pressing Escape leaves you editing exactly where the search landed — what Word does.
* **The rest of the bar follows the same rule.** Its buttons swallow `mousedown` (the trick the format buttons already use), so clicking Next or Replace does not end the query; `replaceMatch` and `replaceAll` take `focus: false` so a replacement does not drag the caret out of the bar mid-search.
* **Fallback.** Where the highlight registry is missing (older Firefox/Safari), the active hit is painted with the document selection instead — still without focusing the block, so the next character typed reaches the search field either way.

One implementation note: the highlight registry is per-document, so two editor surfaces on one page share it. Only the instance that last painted may clear it, which keeps one surface's find bar from wiping the other's painting when it closes.

## Validation

New spec `npm/tests/editor-find-focus.spec.ts`, seven tests at two layers:

* **`DocxEditor` API contract**, driven directly against a session on the bare harness — `showFindMatches` paints both hits and leaves `document.activeElement` on the outside input; stepping to the second hit is equally focus-free; `clearFindMatches` removes the painting; `selectMatch` still commits the caret (selection reads `fox`) and drops the painting; `replaceMatch(..., { focus: false })` edits the text without pulling the caret in.
* **The shipped find bar**, driven with real keystrokes on the editor host — every character of the query lands in the field, the document text is byte-identical afterwards, the counter reads `1 of 2`, Enter and the Next button step matches without ending the query, Escape hands the match to the caret, and Replace edits the document while the keyboard stays in the replace field.

Checked against the pre-fix bundle: all seven fail, one of them with the corrupted paragraph quoted at the top. With the fix, they pass alongside `editor.spec.ts`, `ribbon-surface.spec.ts` and `editor-comments.spec.ts` (35 tests), and the wider `editor*` Playwright suite was run on the same build.

Docs: `docs/architecture/editor_ui_surface.md` gains the paint-vs-commit contract; `CHANGELOG.md` gets a `### Fixed` entry under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019j5Vs1se3yA94yjhqQ89i2

---
_Generated by [Claude Code](https://claude.ai/code/session_019j5Vs1se3yA94yjhqQ89i2)_