### PR TITLE
feat(history): add shared lossless client JSON boundary

### DIFF
--- a/Docxodus.Tests/HistoryClientOpsTests.cs
+++ b/Docxodus.Tests/HistoryClientOpsTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using Docxodus.History;
+using Docxodus.Internal;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+public class HistoryClientOpsTests
+{
+    [Fact]
+    public async Task SharedClientBoundaryPublishesExportsReplaysAndRestores()
+    {
+        var client = new HistoryClientOps(new MemoryHistoryBlobStore(), new MemoryHistoryHeadStore());
+        var bytes = DocxSession.CreateBlankDocxBytes();
+        var metadata = new DocxVersionMetadata { Author = "actor", CreatedAt = DateTimeOffset.Parse("2026-01-01T12:00:00Z") };
+        var first = await Call(client, "create", bytes, metadata: metadata);
+        Assert.True(first.Success);
+        Assert.Equal(1, first.View!.Head.Revision);
+        var exported = await Call(client, "export", version: first.View.Version.Id);
+        Assert.Equal(bytes, exported.Bytes);
+        var listed = await Call(client, "list");
+        Assert.Equal(first.View.Version.Id, Assert.Single(listed.Page!.Versions).Id);
+        var got = await Call(client, "get", version: first.View.Version.Id);
+        Assert.Equal("actor", got.Version!.Record.Metadata.Author);
+        Assert.Equal(bytes, (await Call(client, "materialize", sequence: 0)).Bytes);
+        Assert.Equal(bytes, (await Call(client, "replay", sequence: 0)).Bytes);
+        Assert.Equal(0, (await Call(client, "resolveTime", cutoff: metadata.CreatedAt)).Sequence);
+        var restored = await Call(client, "restore", version: first.View.Version.Id, expected: first.View.Head, metadata: metadata);
+        Assert.True(restored.Success);
+        Assert.Equal(1, restored.View!.State.Epoch);
+        Assert.Equal(1, restored.View.State.Sequence);
+        var stale = await Call(client, "create", bytes, metadata: metadata, expected: first.View.Head);
+        Assert.False(stale.Success);
+        Assert.Equal("StaleHead", stale.ErrorCode);
+        Assert.Equal(restored.View.Head, (await Call(client, "read")).View!.Head);
+    }
+
+    [Fact]
+    public void ClientCountersAreLosslessStringsWhileBlobLengthsRemainNumbers()
+    {
+        var reference = new HistoryBlobReference(new Docxodus.Verification.VerificationDigest
+        { Algorithm = "SHA-256", Value = new string('a', 64) }, 123);
+        var head = new HistoryHead(long.MaxValue, reference);
+        var json = HistoryClientJson.Write(head);
+        Assert.Contains("\"revision\":\"9223372036854775807\"", json);
+        Assert.Contains("\"length\":123", json);
+        Assert.Equal(head, HistoryClientJson.Read<HistoryHead>(json));
+        foreach (var value in new[] { "1", "\"01\"", "\"-1\"", "\"+1\"", "\"9223372036854775808\"" })
+            Assert.Throws<System.Text.Json.JsonException>(() => HistoryClientJson.Read<HistoryHead>(
+                json.Replace("\"9223372036854775807\"", value, StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public async Task InvalidRequestsAndCancellationHaveTypedErrorsWithoutPublishing()
+    {
+        var client = new HistoryClientOps(new MemoryHistoryBlobStore(), new MemoryHistoryHeadStore());
+        foreach (var json in new[]
+        {
+            "{}", "null", "{\"schemaVersion\":1,\"operation\":\"read\",\"operation\":\"create\",\"documentId\":\"doc\"}",
+            "{\"schemaVersion\":1,\"operation\":\"read\",\"documentId\":null}",
+            "{\"schemaVersion\":1,\"operation\":\"read\",\"documentId\":\"doc\",\"unknown\":true}",
+            new string(' ', HistoryClientJson.MaxRequestChars + 1),
+        })
+        {
+            var result = HistoryClientJson.Read<HistoryClientResult>(await client.InvokeAsync(json));
+            Assert.False(result.Success);
+            Assert.Equal("InvalidRequest", result.ErrorCode);
+        }
+        Assert.Equal("InvalidRequest", (await Call(client, "create")).ErrorCode);
+        Assert.Equal("InvalidRequest", (await Call(client, "invalid")).ErrorCode);
+        var unsupported = HistoryClientJson.Write(new HistoryClientRequest { SchemaVersion = 2, DocumentId = "doc", Operation = "read" });
+        Assert.Equal("UnsupportedVersion", HistoryClientJson.Read<HistoryClientResult>(await client.InvokeAsync(unsupported)).ErrorCode);
+        using var cancel = new CancellationTokenSource(); cancel.Cancel();
+        Assert.Equal("Canceled", HistoryClientJson.Read<HistoryClientResult>(await client.InvokeAsync("{}", cancellationToken: cancel.Token)).ErrorCode);
+        Assert.Null((await Call(client, "read")).View);
+    }
+
+    private static async Task<HistoryClientResult> Call(HistoryClientOps client, string operation, byte[]? bytes = null,
+        DocxVersionMetadata? metadata = null, HistoryHead? expected = null, HistoryBlobReference? version = null,
+        long? sequence = null, DateTimeOffset? cutoff = null) => HistoryClientJson.Read<HistoryClientResult>(
+            await client.InvokeAsync(HistoryClientJson.Write(new HistoryClientRequest
+            {
+                SchemaVersion = 1, DocumentId = "doc", Operation = operation, Metadata = metadata,
+                ExpectedHead = expected, VersionId = version, Sequence = sequence, Cutoff = cutoff,
+            }), bytes));
+}

--- a/Docxodus/Internal/HistoryClientOps.cs
+++ b/Docxodus/Internal/HistoryClientOps.cs
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using Docxodus.History;
+
+namespace Docxodus.Internal;
+
+/// <summary>
+/// Shared, reflection-free client boundary for WASM and local agent bindings. Does not own a
+/// transport, storage, authorization, or a session. Binary inputs are separate from JSON; binary
+/// results use JSON base64. These are package-boundary APIs, not a keystroke recorder.
+/// </summary>
+public sealed class HistoryClientOps
+{
+    private readonly DocxVersionHistory _history;
+
+    public HistoryClientOps(IHistoryBlobStore blobs, IHistoryHeadStore heads) =>
+        _history = new DocxVersionHistory(blobs, heads);
+
+    public async Task<string> InvokeAsync(string requestJson, byte[]? docxBytes = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var request = HistoryClientJson.Read<HistoryClientRequest>(requestJson);
+            if (request.SchemaVersion != 1)
+                throw new PackageChangeException(PackageChangeError.UnsupportedVersion, "Unsupported history client version.");
+            var id = request.DocumentId;
+            var budget = request.MaxEntriesToScan;
+            var result = request.Operation switch
+            {
+                "read" => new HistoryClientResult { View = await _history.ReadAsync(id, cancellationToken).ConfigureAwait(false) },
+                "create" => new HistoryClientResult { View = await _history.CreateVersionAsync(id, request.ExpectedHead,
+                    Required(docxBytes), Required(request.Metadata), cancellationToken).ConfigureAwait(false) },
+                "list" => new HistoryClientResult { Page = await _history.ListVersionsAsync(id, request.VersionId,
+                    request.Limit, cancellationToken).ConfigureAwait(false) },
+                "get" => new HistoryClientResult { Version = await _history.GetVersionAsync(id, Required(request.VersionId),
+                    cancellationToken).ConfigureAwait(false) },
+                "export" => new HistoryClientResult { Bytes = await _history.ExportVersionAsync(id, Required(request.VersionId),
+                    cancellationToken).ConfigureAwait(false) },
+                "materialize" => new HistoryClientResult { Bytes = await _history.MaterializeAsync(id, Required(request.Sequence),
+                    budget, cancellationToken).ConfigureAwait(false) },
+                "replay" => new HistoryClientResult { Bytes = await _history.ReplayAsync(id, Required(request.Sequence),
+                    budget, cancellationToken).ConfigureAwait(false) },
+                "resolveTime" => new HistoryClientResult { Sequence = await _history.ResolveSequenceAtTimeAsync(id,
+                    Required(request.Cutoff), budget, cancellationToken).ConfigureAwait(false) },
+                "restore" => new HistoryClientResult { View = await _history.RestoreVersionAsync(id, Required(request.ExpectedHead),
+                    Required(request.VersionId), Required(request.Metadata), cancellationToken).ConfigureAwait(false) },
+                _ => throw new ArgumentException("Unknown history operation."),
+            };
+            return HistoryClientJson.Write(result);
+        }
+        catch (Exception error) when (error is DocxHistoryException or PackageChangeException or JsonException
+            or ArgumentException or OperationCanceledException or FormatException)
+        {
+            var code = error switch
+            {
+                DocxHistoryException history => history.Code.ToString(),
+                PackageChangeException package => package.Code.ToString(),
+                OperationCanceledException => "Canceled",
+                _ => "InvalidRequest",
+            };
+            return HistoryClientJson.Write(new HistoryClientResult { Success = false, ErrorCode = code, Message = error.Message });
+        }
+    }
+
+    private static T Required<T>(T? value) where T : class => value ?? throw new ArgumentException("Required history argument is missing.");
+    private static T Required<T>(T? value) where T : struct => value ?? throw new ArgumentException("Required history argument is missing.");
+}
+
+public sealed record HistoryClientRequest
+{
+    public required int SchemaVersion { get; init; }
+    public required string Operation { get; init; }
+    public required string DocumentId { get; init; }
+    public HistoryHead? ExpectedHead { get; init; }
+    public HistoryBlobReference? VersionId { get; init; }
+    public DocxVersionMetadata? Metadata { get; init; }
+    public long? Sequence { get; init; }
+    public DateTimeOffset? Cutoff { get; init; }
+    public int Limit { get; init; } = 25;
+    public int MaxEntriesToScan { get; init; } = 10_000;
+}
+
+public sealed record HistoryClientResult
+{
+    public bool Success { get; init; } = true;
+    public string? ErrorCode { get; init; }
+    public string? Message { get; init; }
+    public DocxHistoryView? View { get; init; }
+    public DocxStoredVersion? Version { get; init; }
+    public DocxVersionPage? Page { get; init; }
+    public long? Sequence { get; init; }
+    public byte[]? Bytes { get; init; }
+}
+
+/// <summary>Client JSON only: 64-bit positions are decimal strings, preserving precision in JS.</summary>
+public static class HistoryClientJson
+{
+    public const int MaxRequestChars = 512 * 1024;
+    private static readonly HistoryClientJsonContext Context = new(new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+        AllowDuplicateProperties = false, RespectNullableAnnotations = true,
+        RespectRequiredConstructorParameters = true, MaxDepth = 16,
+        Converters = { new HistoryInt64JsonConverter() },
+    });
+
+    public static string Write<T>(T value) => JsonSerializer.Serialize(value, Info<T>());
+    public static T Read<T>(string json)
+    {
+        ArgumentNullException.ThrowIfNull(json);
+        if (json.Length > MaxRequestChars) throw new ArgumentException("History client metadata exceeds its limit.");
+        return JsonSerializer.Deserialize(json, Info<T>()) ?? throw new JsonException("History metadata is null.");
+    }
+    private static JsonTypeInfo<T> Info<T>() => (JsonTypeInfo<T>)(Context.GetTypeInfo(typeof(T))
+        ?? throw new ArgumentException("Unsupported history client JSON type."));
+}
+
+internal sealed class HistoryInt64JsonConverter : JsonConverter<long>
+{
+    public override long Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String && long.TryParse(reader.GetString(), NumberStyles.None,
+            CultureInfo.InvariantCulture, out var value) && value.ToString(CultureInfo.InvariantCulture) == reader.GetString()) return value;
+        throw new JsonException("History positions must be canonical nonnegative decimal strings.");
+    }
+    public override void Write(Utf8JsonWriter writer, long value, JsonSerializerOptions options) =>
+        writer.WriteStringValue(value.ToString(CultureInfo.InvariantCulture));
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow, AllowDuplicateProperties = false,
+    RespectNullableAnnotations = true, RespectRequiredConstructorParameters = true, MaxDepth = 16)]
+[JsonSerializable(typeof(HistoryClientRequest))]
+[JsonSerializable(typeof(HistoryClientResult))]
+[JsonSerializable(typeof(HistoryHead))]
+[JsonSerializable(typeof(HistoryBlobReference))]
+internal partial class HistoryClientJsonContext : JsonSerializerContext { }

--- a/docs/history-clients.md
+++ b/docs/history-clients.md
@@ -1,0 +1,35 @@
+# History clients and log-driven rendering
+
+The core history service remains the sole replay/publication implementation. Client bindings
+use `Docxodus.Internal.HistoryClientOps` with host-supplied `IHistoryBlobStore` and
+`IHistoryHeadStore` adapters. No networking, server, subscription, timer, or transit layer is
+provided. Hosts decide when to deliver a new head or ask a client to refresh.
+
+The version-1 client request includes `schemaVersion: 1`, `operation`, and `documentId`.
+Operations are `read`, `create`, `list`, `get`, `export`, `materialize`, `replay`,
+`resolveTime`, and `restore`. Additional fields are `expectedHead`, `versionId` (also
+the list cursor), `metadata`, `sequence`, `cutoff`, `limit`, and `maxEntriesToScan`.
+Create receives DOCX bytes separately from its JSON request. Export/materialize/replay
+return base64 bytes in their JSON result, which the language wrapper decodes.
+
+Publication revision, content sequence, and epoch are **decimal strings** at this client
+boundary, so JavaScript never rounds a 64-bit position. Blob lengths, schema versions,
+and limits are numbers. The existing durable record codecs are unchanged. Requests are
+bounded to 512 Ki UTF-16 characters and reject missing required, unknown, duplicate,
+null-required, and malformed fields. Generated JSON metadata supports trimmed WASM.
+
+Responses contain `success` and the relevant `view`, `version`, `page`, `sequence`, or
+`bytes` field. Expected domain/argument failures return `success: false`, `errorCode`, and
+`message`; unexpected host-storage failures propagate. Cancellation before publication
+returns `Canceled`; a successful atomic head publication is not later reported canceled.
+
+Timestamps are recorded metadata, not ordering authority: sequence orders accepted content
+changes. `resolveTime` finds a content sequence; `materialize` or `replay` returns its DOCX
+for the existing rendering/session APIs. Opening a historical view never changes a shared
+head. Comparison composes two exact exports with the existing DocxDiff client API.
+
+This first binding layer is package-boundary history, not fine-grained typing, automatic
+concurrent-edit merging, or pending-work management. Language bindings and live log followers
+are subsequent stacked layers. See [history API](history.md) for durability and retention
+responsibilities and [the architecture](architecture/collaboration_and_version_history.md)
+for the larger collaboration roadmap.


### PR DESCRIPTION
Stack layer 11 for #671/#672, based on #714. Continues the requested client bindings and log-driven live rendering; no new transit/network layer.

Adds a shared reflection-free HistoryClientOps facade for WASM/local-agent clients, delegating create/read/list/get/export/materialize/replay/timestamp lookup/restore to the existing core. Versioned bounded strict request JSON uses canonical decimal strings for 64-bit positions, retaining integer precision in JavaScript without changing durable record codecs. DOCX input is separate; exported bytes use base64 in the result. Expected domain errors are typed; unexpected storage failures propagate. No session ownership, server, network, timer, or storage policy is introduced.

Validation: 97 focused history/client tests pass; separate reflection-disabled process round-trips the new request/response graphs; git diff --check clean.

Self-review: GPT-5.6-sol reviewed the entire layer read-only; no actionable findings. Browser/Python bindings and log followers follow as separate stacked PRs.