### PR TITLE
feat(history): bind browser clients to host-owned async storage

### DIFF
--- a/Docxodus.Tests/HistoryClientOpsTests.cs
+++ b/Docxodus.Tests/HistoryClientOpsTests.cs
@@ -12,6 +12,28 @@ namespace Docxodus.Tests;
 public class HistoryClientOpsTests
 {
     [Fact]
+    public async Task OmittedOptionalFieldsUseWireDefaultsWithGeneratedMetadata()
+    {
+        const string request = """
+            {"schemaVersion":1,"documentId":"doc","operation":"create",
+             "metadata":{"author":"actor","createdAt":"2026-01-01T00:00:00Z"}}
+            """;
+        var client = new HistoryClientOps(new MemoryHistoryBlobStore(), new MemoryHistoryHeadStore());
+        var parsed = HistoryClientJson.Read<HistoryClientRequest>(request);
+        Assert.Equal(25, parsed.Limit);
+        Assert.Equal(10_000, parsed.MaxEntriesToScan);
+        Assert.Empty(parsed.Metadata!.ApplicationMetadata);
+        var created = HistoryClientJson.Read<HistoryClientResult>(await client.InvokeAsync(request, DocxSession.CreateBlankDocxBytes()));
+        Assert.True(created.Success, created.Message);
+        var listed = HistoryClientJson.Read<HistoryClientResult>(await client.InvokeAsync(
+            """{"schemaVersion":1,"documentId":"doc","operation":"list"}"""));
+        Assert.Single(listed.Page!.Versions);
+        var invalid = HistoryClientJson.Read<HistoryClientResult>(await client.InvokeAsync(
+            """{"schemaVersion":1,"documentId":"doc","operation":"list","limit":0}"""));
+        Assert.Equal("InvalidRequest", invalid.ErrorCode);
+    }
+
+    [Fact]
     public async Task SharedClientBoundaryPublishesExportsReplaysAndRestores()
     {
         var client = new HistoryClientOps(new MemoryHistoryBlobStore(), new MemoryHistoryHeadStore());

--- a/Docxodus/Internal/HistoryClientOps.cs
+++ b/Docxodus/Internal/HistoryClientOps.cs
@@ -119,7 +119,25 @@ public static class HistoryClientJson
     {
         ArgumentNullException.ThrowIfNull(json);
         if (json.Length > MaxRequestChars) throw new ArgumentException("History client metadata exceeds its limit.");
-        return JsonSerializer.Deserialize(json, Info<T>()) ?? throw new JsonException("History metadata is null.");
+        var value = JsonSerializer.Deserialize(json, Info<T>()) ?? throw new JsonException("History metadata is null.");
+        if (value is HistoryClientRequest request)
+        {
+            // Generated init-only construction can supply default(T) for omitted optional
+            // properties instead of preserving their C# initializer. Apply wire defaults by
+            // presence, never by value, so explicit null/zero remains invalid downstream.
+            using var document = JsonDocument.Parse(json);
+            var root = document.RootElement;
+            var metadata = request.Metadata;
+            if (metadata is not null && !root.GetProperty("metadata").TryGetProperty("applicationMetadata", out _))
+                metadata = metadata with { ApplicationMetadata = new Dictionary<string, string>() };
+            value = (T)(object)(request with
+            {
+                Metadata = metadata,
+                Limit = root.TryGetProperty("limit", out _) ? request.Limit : 25,
+                MaxEntriesToScan = root.TryGetProperty("maxEntriesToScan", out _) ? request.MaxEntriesToScan : 10_000,
+            });
+        }
+        return value;
     }
     private static JsonTypeInfo<T> Info<T>() => (JsonTypeInfo<T>)(Context.GetTypeInfo(typeof(T))
         ?? throw new ArgumentException("Unsupported history client JSON type."));

--- a/docs/history-clients.md
+++ b/docs/history-clients.md
@@ -28,8 +28,45 @@ changes. `resolveTime` finds a content sequence; `materialize` or `replay` retur
 for the existing rendering/session APIs. Opening a historical view never changes a shared
 head. Comparison composes two exact exports with the existing DocxDiff client API.
 
-This first binding layer is package-boundary history, not fine-grained typing, automatic
-concurrent-edit merging, or pending-work management. Language bindings and live log followers
+## Browser and npm
+
+```ts
+import { initialize, openDocxHistory, createMemoryHistoryStorage, openDocxSession } from 'docxodus';
+await initialize();
+const storage = createMemoryHistoryStorage(); // or implement HistoryStorage for your host
+const history = openDocxHistory(storage);
+const saved = await history.createVersion('contract', null, docxBytes, {
+  author: 'application-user-id', createdAt: '2026-01-01T12:00:00Z', label: 'Draft',
+});
+const sequence = await history.resolveSequenceAtTime('contract', '2026-01-02T00:00:00Z');
+const session = openDocxSession(await history.materialize('contract', sequence));
+console.log(session.project().markdown);
+session.close();
+history.close(); // closes the binding, not the host's retained data
+```
+
+`HistoryStorage` supplies asynchronous `readBlob`, `putBlob`, `readHead`, and atomic
+`advanceHead(documentId, expectedHead, stateReference)` callbacks. Missing blobs/heads and
+failed compare-and-swap return `null`. Successful CAS returns its incremented revision plus
+the published state reference, just like `IHistoryHeadStore`. Storage callbacks must settle;
+this binding does not impose a timeout or network-cancellation policy. Host exceptions propagate.
+`DocxHistoryError.code` preserves domain error codes such as `StaleHead` and `PayloadMismatch`.
+
+The memory reference adapter verifies SHA-256 and copies inputs/outputs. Multiple clients may
+share it, but a page/process restart loses it. Supply durable storage for restart recovery.
+`close()` rejects while calls are active; await outstanding calls, then close. A custom WASM
+loader calls `installHistoryStorageImports(runtime.setModuleImports)` before opening a
+`DocxHistoryClient` over `exports.DocxodusWasm.HistoryBridge`. Normal npm `initialize()` does
+this automatically. The existing worker RPC does not yet expose these host callbacks.
+
+Methods are `read`, `createVersion`, `listVersions`, `getVersion`, `exportVersion`, `materialize`,
+`replay`, `resolveSequenceAtTime`, and `restoreVersion`. For comparisons, export both versions
+and call the existing `docxDiffCompareProducts` API. The package-boundary WASM bridge uses
+base64 for asynchronously read/exported bytes, incurring temporary allocation overhead;
+it is not a low-latency keystroke path.
+
+This binding layer is package-boundary history, not fine-grained typing, automatic
+concurrent-edit merging, or pending-work management. Python bindings and live log followers
 are subsequent stacked layers. See [history API](history.md) for durability and retention
 responsibilities and [the architecture](architecture/collaboration_and_version_history.md)
 for the larger collaboration roadmap.

--- a/npm/src/history.ts
+++ b/npm/src/history.ts
@@ -1,0 +1,208 @@
+import type { VerificationDigest } from './types.js';
+
+/** Nonnegative Int64 decimal string, never a JS number. Sequence orders content; time does not. */
+export type HistoryPosition = string;
+export interface HistoryBlobReference { digest: VerificationDigest; length: number }
+export interface HistoryHead { revision: HistoryPosition; state: HistoryBlobReference }
+export interface DocxSnapshotReference { blob: HistoryBlobReference; contentDigest: VerificationDigest }
+export interface DocxVersionMetadata {
+  author: string;
+  createdAt: string;
+  label?: string | null;
+  message?: string | null;
+  applicationMetadata?: Readonly<Record<string, string>>;
+}
+export interface DocxVersionRecord {
+  documentId: string;
+  metadata: DocxVersionMetadata;
+  nonce: string;
+  parent: HistoryBlobReference | null;
+  restoredFrom: HistoryBlobReference | null;
+  sequence: HistoryPosition;
+  snapshot: DocxSnapshotReference;
+}
+export interface DocxStoredVersion { id: HistoryBlobReference; record: DocxVersionRecord }
+export interface DocxHistoryState {
+  commit: HistoryBlobReference | null;
+  documentId: string;
+  epoch: HistoryPosition;
+  initialSnapshot: DocxSnapshotReference;
+  sequence: HistoryPosition;
+  snapshot: DocxSnapshotReference;
+  version: HistoryBlobReference;
+}
+export interface DocxHistoryView { head: HistoryHead; state: DocxHistoryState; version: DocxStoredVersion }
+export interface DocxVersionPage { versions: DocxStoredVersion[]; next: HistoryBlobReference | null }
+
+/** Host-owned storage. Persist blobs before returning; advanceHead must be an atomic CAS.
+ * References and returned bytes are verified in the core. Methods must settle their promises.
+ * No fetching, subscription, timer, authorization or retention policy is supplied by this API. */
+export interface HistoryStorage {
+  readBlob(reference: HistoryBlobReference): Promise<Uint8Array | null>;
+  putBlob(reference: HistoryBlobReference, bytes: Uint8Array): Promise<void>;
+  readHead(documentId: string): Promise<HistoryHead | null>;
+  advanceHead(documentId: string, expected: HistoryHead | null, state: HistoryBlobReference): Promise<HistoryHead | null>;
+}
+
+export interface HistoryBridge {
+  Open(adapterId: number): number;
+  Close(handle: number): void;
+  Invoke(handle: number, requestJson: string, bytes: Uint8Array): Promise<string>;
+}
+
+export class DocxHistoryError extends Error {
+  constructor(public readonly code: string, message: string) { super(message); this.name = 'DocxHistoryError'; }
+}
+
+interface Result {
+  success: boolean;
+  errorCode: string | null;
+  message: string | null;
+  view: DocxHistoryView | null;
+  version: DocxStoredVersion | null;
+  page: DocxVersionPage | null;
+  sequence: HistoryPosition | null;
+  bytes: string | null;
+}
+
+const adapters = new Map<number, HistoryStorage>();
+let nextAdapter = 0;
+function adapter(id: number): HistoryStorage {
+  const store = adapters.get(id);
+  if (!store) throw new DocxHistoryError('Closed', 'History storage adapter is closed.');
+  return store;
+}
+
+function toBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (let offset = 0; offset < bytes.length; offset += 0x8000)
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000));
+  return btoa(binary);
+}
+function fromBase64(encoded: string): Uint8Array {
+  const binary = atob(encoded);
+  return Uint8Array.from(binary, c => c.charCodeAt(0));
+}
+
+/** For custom WASM loaders. initialize() installs these automatically. */
+export function installHistoryStorageImports(setModuleImports: (name: string, imports: object) => void): void {
+  setModuleImports('docxodus.history', {
+    readBlob: async (id: number, json: string): Promise<string> => {
+      const reference: HistoryBlobReference = JSON.parse(json);
+      const bytes = await adapter(id).readBlob(reference);
+      if (bytes === null) return '';
+      if (bytes.length !== reference.length) throw new DocxHistoryError('PayloadMismatch', 'Stored blob length differs from its reference.');
+      return bytes.length === 0 ? '=' : toBase64(bytes);
+    },
+    putBlob: async (id: number, json: string, bytes: Uint8Array): Promise<void> =>
+      adapter(id).putBlob(JSON.parse(json), bytes.slice()),
+    readHead: async (id: number, documentId: string): Promise<string> =>
+      JSON.stringify(await adapter(id).readHead(documentId)),
+    advanceHead: async (id: number, documentId: string, expected: string, state: string): Promise<string> =>
+      JSON.stringify(await adapter(id).advanceHead(documentId, JSON.parse(expected), JSON.parse(state))),
+  });
+}
+
+/** Durable package-history client. Reopening over the same adapters preserves history.
+ * Await active calls before close(); it releases handles but never deletes host data. */
+export class DocxHistoryClient {
+  private readonly adapterId: number;
+  private readonly handle: number;
+  private closed = false;
+
+  constructor(private readonly bridge: HistoryBridge, storage: HistoryStorage) {
+    if (nextAdapter >= 0x7fffffff) throw new Error('History adapter identifiers exhausted.');
+    this.adapterId = ++nextAdapter;
+    adapters.set(this.adapterId, storage);
+    try { this.handle = bridge.Open(this.adapterId); }
+    catch (error) { adapters.delete(this.adapterId); throw error; }
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.bridge.Close(this.handle);
+    adapters.delete(this.adapterId);
+    this.closed = true;
+  }
+
+  async read(documentId: string): Promise<DocxHistoryView | null> {
+    return (await this.call('read', documentId)).view;
+  }
+  async createVersion(documentId: string, expectedHead: HistoryHead | null, bytes: Uint8Array,
+    metadata: DocxVersionMetadata): Promise<DocxHistoryView> {
+    return (await this.call('create', documentId, { expectedHead, metadata }, bytes)).view!;
+  }
+  async listVersions(documentId: string, cursor: HistoryBlobReference | null = null, limit = 25): Promise<DocxVersionPage> {
+    return (await this.call('list', documentId, { versionId: cursor, limit })).page!;
+  }
+  async getVersion(documentId: string, versionId: HistoryBlobReference): Promise<DocxStoredVersion> {
+    return (await this.call('get', documentId, { versionId })).version!;
+  }
+  async exportVersion(documentId: string, versionId: HistoryBlobReference): Promise<Uint8Array> {
+    return fromBase64((await this.call('export', documentId, { versionId })).bytes!);
+  }
+  async materialize(documentId: string, sequence: HistoryPosition, maxEntriesToScan = 10_000): Promise<Uint8Array> {
+    return fromBase64((await this.call('materialize', documentId, { sequence, maxEntriesToScan })).bytes!);
+  }
+  async replay(documentId: string, sequence: HistoryPosition, maxEntriesToScan = 10_000): Promise<Uint8Array> {
+    return fromBase64((await this.call('replay', documentId, { sequence, maxEntriesToScan })).bytes!);
+  }
+  async resolveSequenceAtTime(documentId: string, cutoff: string, maxEntriesToScan = 10_000): Promise<HistoryPosition> {
+    return (await this.call('resolveTime', documentId, { cutoff, maxEntriesToScan })).sequence!;
+  }
+  async restoreVersion(documentId: string, expectedHead: HistoryHead, versionId: HistoryBlobReference,
+    metadata: DocxVersionMetadata): Promise<DocxHistoryView> {
+    return (await this.call('restore', documentId, { expectedHead, versionId, metadata })).view!;
+  }
+
+  private async call(operation: string, documentId: string, fields: object = {}, bytes: Uint8Array = new Uint8Array()): Promise<Result> {
+    if (this.closed) throw new DocxHistoryError('Closed', 'History client is closed.');
+    const result: Result = JSON.parse(await this.bridge.Invoke(this.handle,
+      JSON.stringify({ schemaVersion: 1, operation, documentId, ...fields }), bytes));
+    if (!result.success) throw new DocxHistoryError(result.errorCode!, result.message!);
+    return result;
+  }
+}
+
+/** Reference process-local storage. Share one instance among local clients; it is not durable
+ * across a page/process restart. Every incoming blob is copied and SHA-256 verified. */
+export function createMemoryHistoryStorage(maxBlobBytes = 256 * 1024 * 1024): HistoryStorage {
+  if (!Number.isSafeInteger(maxBlobBytes) || maxBlobBytes <= 0) throw new RangeError('Invalid blob byte limit.');
+  const blobs = new Map<string, Uint8Array>();
+  const heads = new Map<string, HistoryHead>();
+  const copy = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+  const key = (reference: HistoryBlobReference): string => {
+    if (reference.digest.algorithm !== 'SHA-256' || !/^[a-f0-9]{64}$/.test(reference.digest.value)
+      || !Number.isSafeInteger(reference.length) || reference.length < 0 || reference.length > maxBlobBytes)
+      throw new DocxHistoryError('InvalidRequest', 'Invalid blob reference or byte limit.');
+    return `${reference.digest.value}:${reference.length}`;
+  };
+  const equalReference = (a: HistoryBlobReference, b: HistoryBlobReference): boolean =>
+    a.length === b.length && a.digest.algorithm === b.digest.algorithm && a.digest.value === b.digest.value;
+  const equalHead = (a: HistoryHead | null, b: HistoryHead | null): boolean => a === null || b === null
+    ? a === b : a.revision === b.revision && equalReference(a.state, b.state);
+  return {
+    async readBlob(reference) { return blobs.get(key(reference))?.slice() ?? null; },
+    async putBlob(reference, bytes) {
+      const blobKey = key(reference);
+      const captured = bytes.slice();
+      if (captured.length !== reference.length) throw new DocxHistoryError('PayloadMismatch', 'Blob length mismatch.');
+      const digest = Array.from(new Uint8Array(await crypto.subtle.digest('SHA-256', captured)),
+        n => n.toString(16).padStart(2, '0')).join('');
+      if (digest !== blobKey.split(':')[0]) throw new DocxHistoryError('PayloadMismatch', 'Blob digest mismatch.');
+      if (!blobs.has(blobKey)) blobs.set(blobKey, captured);
+    },
+    async readHead(documentId) { return copy(heads.get(documentId) ?? null); },
+    async advanceHead(documentId, expected, state) {
+      key(state);
+      const current = heads.get(documentId) ?? null;
+      if (!equalHead(current, expected)) return null;
+      const revision = BigInt(current?.revision ?? '0') + 1n;
+      if (revision > 9223372036854775807n) throw new RangeError('History revision exhausted.');
+      const head = { revision: String(revision), state: copy(state) };
+      // No awaits inside the compare/publication critical section, even under concurrent callers.
+      heads.set(documentId, head);
+      return copy(head);
+    },
+  };
+}

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -68,6 +68,16 @@ import type {
 } from "./types.js";
 
 import { DocxSession, openDocxSession as openDocxSessionImpl } from "./session.js";
+import { DocxHistoryClient, installHistoryStorageImports } from './history.js';
+import type { HistoryStorage } from './history.js';
+export * from './history.js';
+
+/** Open history over host-owned storage after initialize(). No network layer is installed. */
+export function openDocxHistory(storage: HistoryStorage): DocxHistoryClient {
+  const bridge = ensureInitialized().HistoryBridge;
+  if (!bridge) throw new Error('This WASM build does not include history bindings.');
+  return new DocxHistoryClient(bridge, storage);
+}
 
 export { DocxSession } from "./session.js";
 export type {
@@ -566,10 +576,11 @@ async function tryLoadFromPath(basePath: string): Promise<boolean> {
     const dotnetPath = basePath + "_framework/dotnet.js";
     const { dotnet } = await import(/* webpackIgnore: true */ /* @vite-ignore */ dotnetPath);
 
-    const { getAssemblyExports, getConfig } = await dotnet
+    const { getAssemblyExports, getConfig, setModuleImports } = await dotnet
       .withDiagnosticTracing(false)
       .create();
 
+    installHistoryStorageImports(setModuleImports);
     const config = getConfig();
     const exports = await getAssemblyExports(config.mainAssemblyName);
 
@@ -578,6 +589,7 @@ async function tryLoadFromPath(basePath: string): Promise<boolean> {
       DocumentComparer: exports.DocxodusWasm.DocumentComparer,
       DocxDiffBridge: exports.DocxodusWasm.DocxDiffBridge,
       DocxSessionBridge: exports.DocxodusWasm.DocxSessionBridge,
+      HistoryBridge: exports.DocxodusWasm.HistoryBridge,
     };
     return true;
   } catch {

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -1279,6 +1279,8 @@ export interface PackageManifestInspectionLimits {
  * Internal WASM exports structure
  */
 export interface DocxodusWasmExports {
+  /** Available in builds with durable history bindings. */
+  HistoryBridge?: import('./history.js').HistoryBridge;
   DocumentConverter: {
     GeneratePackageManifest: (bytes: Uint8Array) => string;
     VerifyDeliverable: (bytes: Uint8Array) => string;

--- a/npm/tests/history-client.spec.ts
+++ b/npm/tests/history-client.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect } from '@playwright/test';
+import { build } from 'esbuild';
+
+let bundle: string;
+test.beforeAll(async () => {
+  const result = await build({ entryPoints: ['dist/index.js'], bundle: true, format: 'esm', write: false });
+  bundle = result.outputFiles[0].text;
+});
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/history-test.html', route => route.fulfill({ contentType: 'text/html', body: '<!doctype html><title>History test</title>' }));
+  await page.route('**/history-api.js', route => route.fulfill({ contentType: 'text/javascript', body: bundle }));
+  await page.goto('http://localhost:8083/history-test.html');
+  await page.evaluate(async () => {
+    const moduleUrl = '/history-api.js';
+    const api = await import(moduleUrl);
+    await api.initialize('http://localhost:8083/wasm/');
+    (window as any).historyApi = api;
+  });
+});
+
+test('two host-backed clients reopen, replay, render at time, and restore exact versions', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const api = (window as any).historyApi;
+    const storage = api.createMemoryHistoryStorage();
+    const a = api.openDocxHistory(storage);
+    const b = api.openDocxHistory(storage);
+    const original = api.createBlankDocx();
+    const metadata = { author: 'alice', createdAt: '2026-01-01T12:00:00Z' };
+    const first = await a.createVersion('doc', null, original, metadata);
+    const session = api.openDocxSession(original);
+    const anchor = Object.keys(session.project().anchorIndex).find(id => id.startsWith('p:'));
+    const edit = session.replaceText(anchor, 'shared historical text');
+    if (!edit.success) throw new Error(JSON.stringify(edit));
+    const edited = session.save(); session.close();
+    const second = await b.createVersion('doc', first.head, edited, { ...metadata, createdAt: '2026-01-01T13:00:00Z' });
+    const sequence = await a.resolveSequenceAtTime('doc', '2026-01-01T13:00:00Z');
+    const replay = await a.replay('doc', sequence);
+    const rendered = api.openDocxSession(replay);
+    const markdown = rendered.project().markdown; rendered.close();
+    const bytes = await a.exportVersion('doc', first.version.id);
+    const page = await a.listVersions('doc', null, 1);
+    const rest = await a.listVersions('doc', page.next);
+    let stale = '';
+    try { await a.createVersion('doc', first.head, original, metadata); }
+    catch (error: any) { stale = error.code; }
+    const restored = await b.restoreVersion('doc', second.head, first.version.id, metadata);
+    a.close(); b.close();
+    const reopened = api.openDocxHistory(storage);
+    const latest = await reopened.read('doc');
+    const materialized = await reopened.materialize('doc', restored.state.sequence);
+    reopened.close();
+    let closed = '';
+    try { await reopened.read('doc'); } catch (error: any) { closed = error.code; }
+    return {
+      sequence, markdown, stale, closed, epoch: latest.state.epoch, revisionType: typeof latest.head.revision,
+      exact: bytes.every((n: number, i: number) => n === original[i]) && bytes.length === original.length,
+      restored: materialized.every((n: number, i: number) => n === original[i]) && materialized.length === original.length,
+      firstId: first.version.id.digest.value, listedId: rest.versions[0].id.digest.value,
+    };
+  });
+  expect(result.sequence).toBe('1');
+  expect(result.markdown).toContain('shared historical text');
+  expect(result.stale).toBe('StaleHead');
+  expect(result.closed).toBe('Closed');
+  expect(result.epoch).toBe('1');
+  expect(result.revisionType).toBe('string');
+  expect(result.exact).toBe(true);
+  expect(result.restored).toBe(true);
+  expect(result.listedId).toBe(result.firstId);
+});
+
+test('async storage retains captured inputs, rejects close while active, and detects corrupted payloads', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const api = (window as any).historyApi;
+    const backing = api.createMemoryHistoryStorage();
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    let paused = true;
+    let corrupt = false;
+    const storage = {
+      ...backing,
+      async readHead(id: string) { if (paused) { paused = false; await gate; } return backing.readHead(id); },
+      async readBlob(ref: any) {
+        const bytes = await backing.readBlob(ref);
+        if (corrupt && bytes) bytes[0] ^= 1;
+        return bytes;
+      },
+    };
+    const client = api.openDocxHistory(storage);
+    const original = api.createBlankDocx();
+    const bytes = original.slice();
+    const metadata = { author: 'original', createdAt: '2026-01-01T00:00:00Z' };
+    const pending = client.createVersion('doc', null, bytes, metadata);
+    bytes.fill(0); metadata.author = 'mutated';
+    let activeClose = false;
+    try { client.close(); } catch { activeClose = true; }
+    release();
+    const created = await pending;
+    const exported = await client.exportVersion('doc', created.version.id);
+    corrupt = true;
+    let corruption = '';
+    try { await client.read('doc'); } catch (error: any) { corruption = error.code; }
+    client.close();
+    return { activeClose, author: created.version.record.metadata.author, corruption,
+      exact: original.length === exported.length && original.every((n: number, i: number) => n === exported[i]) };
+  });
+  expect(result).toEqual({ activeClose: true, author: 'original', corruption: 'PayloadMismatch', exact: true });
+});
+
+test('memory adapter makes one concurrent CAS winner and owns its blobs and heads', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const api = (window as any).historyApi;
+    const storage = api.createMemoryHistoryStorage();
+    const bytes = new Uint8Array([1, 2, 3]);
+    const digest = Array.from(new Uint8Array(await crypto.subtle.digest('SHA-256', bytes)), n => n.toString(16).padStart(2, '0')).join('');
+    const reference = { digest: { algorithm: 'SHA-256', value: digest }, length: 3 };
+    const put = storage.putBlob(reference, bytes); bytes.fill(9); await put;
+    const firstRead = await storage.readBlob(reference); firstRead.fill(7);
+    const retained = Array.from(await storage.readBlob(reference));
+    const winners = await Promise.all(Array.from({ length: 8 }, () => storage.advanceHead('doc', null, reference)));
+    const winner = winners.find(Boolean); winner.revision = '99'; winner.state.digest.value = 'bad';
+    const actual = await storage.readHead('doc');
+    let mismatch = '';
+    try { await storage.putBlob(reference, new Uint8Array([3, 2, 1])); } catch (error: any) { mismatch = error.code; }
+    return { retained, count: winners.filter(Boolean).length, revision: actual.revision, digest: actual.state.digest.value, expectedDigest: digest, mismatch };
+  });
+  expect(result.retained).toEqual([1, 2, 3]);
+  expect(result.count).toBe(1);
+  expect(result.revision).toBe('1');
+  expect(result.digest).toBe(result.expectedDigest);
+  expect(result.mismatch).toBe('PayloadMismatch');
+});

--- a/wasm/DocxodusWasm/HistoryBridge.cs
+++ b/wasm/DocxodusWasm/HistoryBridge.cs
@@ -1,0 +1,95 @@
+#nullable enable
+
+using System.Runtime.InteropServices.JavaScript;
+using System.Runtime.Versioning;
+using Docxodus.History;
+using Docxodus.Internal;
+
+namespace DocxodusWasm;
+
+/// <summary>WASM history binding; the host supplies storage, never a network transport here.</summary>
+[SupportedOSPlatform("browser")]
+public static partial class HistoryBridge
+{
+    private sealed class Client(HistoryClientOps ops)
+    {
+        public HistoryClientOps Ops { get; } = ops;
+        public int Active { get; set; }
+    }
+    private static readonly Dictionary<int, Client> Clients = new();
+    private static int _nextHandle;
+
+    [JSExport]
+    public static int Open(int adapterId)
+    {
+        var storage = new JsStorage(adapterId);
+        var handle = checked(++_nextHandle);
+        Clients.Add(handle, new Client(new HistoryClientOps(storage, storage)));
+        return handle;
+    }
+
+    [JSExport]
+    public static void Close(int handle)
+    {
+        if (!Clients.TryGetValue(handle, out var client)) return;
+        if (client.Active != 0) throw new InvalidOperationException("History client has pending calls; await them before closing.");
+        Clients.Remove(handle);
+    }
+
+    [JSExport]
+    public static async Task<string> Invoke(int handle, string requestJson, byte[] bytes)
+    {
+        if (!Clients.TryGetValue(handle, out var client)) throw new ArgumentException("Unknown history client handle.");
+        client.Active++;
+        try { return await client.Ops.InvokeAsync(requestJson, bytes); }
+        finally { client.Active--; }
+    }
+
+    [JSImport("readBlob", "docxodus.history")]
+    private static partial Task<string> ReadBlob(int adapterId, string referenceJson);
+    [JSImport("putBlob", "docxodus.history")]
+    private static partial Task PutBlob(int adapterId, string referenceJson, byte[] bytes);
+    [JSImport("readHead", "docxodus.history")]
+    private static partial Task<string> ReadHead(int adapterId, string documentId);
+    [JSImport("advanceHead", "docxodus.history")]
+    private static partial Task<string> AdvanceHead(int adapterId, string documentId, string expectedJson, string stateJson);
+
+    private sealed class JsStorage(int adapterId) : IHistoryBlobStore, IHistoryHeadStore
+    {
+        public async ValueTask<Stream?> OpenReadAsync(HistoryBlobReference reference, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var encoded = await ReadBlob(adapterId, HistoryClientJson.Write(reference));
+            if (encoded == "") return null;
+            // Reject an oversized adapter reply before allocating its decoded bytes. Core verifies
+            // the exact length and hash before trusting any payload. Empty blobs encode as "=".
+            if (encoded == "=") return new MemoryStream(Array.Empty<byte>(), writable: false);
+            if ((long)encoded.Length > ((long)reference.Length + 2) / 3 * 4)
+                throw new IOException("History adapter returned an oversized blob.");
+            return new MemoryStream(Convert.FromBase64String(encoded), writable: false);
+        }
+
+        public async ValueTask PutAsync(HistoryBlobReference reference, Stream content, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            using var buffer = new MemoryStream(reference.Length);
+            await content.CopyToAsync(buffer, cancellationToken);
+            await PutBlob(adapterId, HistoryClientJson.Write(reference), buffer.ToArray());
+        }
+
+        public async ValueTask<HistoryHead?> ReadAsync(string documentId, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var json = await ReadHead(adapterId, documentId);
+            return json == "null" ? null : HistoryClientJson.Read<HistoryHead>(json);
+        }
+
+        public async ValueTask<HistoryHead?> TryAdvanceAsync(string documentId, HistoryHead? expected,
+            HistoryBlobReference state, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var json = await AdvanceHead(adapterId, documentId, HistoryClientJson.Write(expected), HistoryClientJson.Write(state));
+            return json == "null" ? null : HistoryClientJson.Read<HistoryHead>(json);
+        }
+    }
+}


### PR DESCRIPTION
Stack layer 12 for #671/#672, based on #715. Adds npm/browser history bindings with host-owned async blob/head callbacks, a verified copy-owning process-local reference adapter, typed client methods/errors, and automatic standard WASM-loader wiring. Close rejects while calls are active and never deletes retained storage. No network service, fetching, subscription, or transit layer is introduced.

Real trimmed-WASM tests found generated init-only deserialization loses omitted optional C# defaults. The shared boundary now applies documented wire defaults by property presence (not value), preserving explicit invalid null/zero values. Added a native regression and reran self-review.

Validation: 98 focused .NET tests; complete npm typecheck; trimmed WASM publish (interpreter build); 3 real Chromium integration tests covering two-client shared storage, exact reopen/export/restore, effect replay and time-selected rendering, stale writes, delayed storage/caller mutation, active close, corruption, blob ownership and concurrent CAS. git diff --check clean. Existing worker RPC remains explicitly outside this binding.

Self-review: GPT-5.6-sol reviewed the entire layer and re-reviewed the runtime-discovered defaults fix; no remaining findings. Python bindings and live log-following follow in the stack.

Additional verification: the standard profile-guided AOT build also passes (4.85 MiB Brotli, below the 5 MiB gate), and all three Chromium history tests pass against that standard build.