### PR TITLE
feat(history): expose durable versions to Python clients

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,12 @@ jobs:
           DOCXODUS_EVAL_ARTIFACTS: ${{ github.workspace }}/eval-artifacts
         run: dotnet test Docxodus.Tests/Docxodus.Tests.csproj -c Release --verbosity normal --logger "trx;LogFileName=test-results.trx"
 
+      - name: Run Python history binding integration tests
+        run: |
+          dotnet build tools/python-host/pyhost.csproj -c Release
+          python3 -m pip install -e './python[test]'
+          python3 -m pytest python/tests/test_history.py -q
+
       - name: Upload test results
         uses: actions/upload-artifact@v7
         if: always()

--- a/docs/history-clients.md
+++ b/docs/history-clients.md
@@ -65,8 +65,36 @@ and call the existing `docxDiffCompareProducts` API. The package-boundary WASM b
 base64 for asynchronously read/exported bytes, incurring temporary allocation overhead;
 it is not a low-latency keystroke path.
 
+## Python
+
+```python
+from docx_scalpel import open_history, DocxVersionMetadata, convert_docx_to_html
+
+with open_history('/host-owned/matter-history') as history:
+    saved = history.create_version('contract', None, docx_bytes,
+        DocxVersionMetadata('application-user-id', '2026-01-01T12:00:00Z', label='Draft'))
+    sequence = history.resolve_sequence_at_time('contract', '2026-01-02T00:00:00Z')
+    html = convert_docx_to_html(history.materialize('contract', sequence))
+```
+
+The Python client exposes `read`, `create_version`, `list_versions`, `get_version`,
+`export_version`, `materialize`, `replay`, `resolve_sequence_at_time`, and `restore_version`.
+Frozen value types use snake_case attributes and arbitrary-precision Python integers;
+Int64 bounds are enforced before positions are encoded as decimal strings. Timestamp strings
+retain their exact recorded precision. `DocxHistoryError.code` carries core domain errors;
+host/process failures remain `DocxodusTransportError`. Compare exact exports with the existing
+`docx_diff_compare_products` API, or open them with `open_session` for headless editing.
+
+The existing local stdio host owns the C# adapters. An explicit root creates/uses its `blobs`
+and `heads` directories, subject to the [filesystem adapter contract](history.md); multiple
+clients/processes may cooperate over that protected local directory. With no root,
+`open_history()` creates a private ephemeral memory history. Use the context manager or
+call `close()`; closing never removes persisted data. After a host restart, reopen the root.
+An old client fails against its original dead process rather than attaching its numeric handle
+to an unrelated newly opened history. No new transport/server has been added.
+
 This binding layer is package-boundary history, not fine-grained typing, automatic
-concurrent-edit merging, or pending-work management. Python bindings and live log followers
+concurrent-edit merging, or pending-work management. Live log followers
 are subsequent stacked layers. See [history API](history.md) for durability and retention
 responsibilities and [the architecture](architecture/collaboration_and_version_history.md)
 for the larger collaboration roadmap.

--- a/python/src/docx_scalpel/__init__.py
+++ b/python/src/docx_scalpel/__init__.py
@@ -31,6 +31,11 @@ from __future__ import annotations
 from importlib.metadata import PackageNotFoundError, version as _pkg_version
 
 from ._transport import shutdown_host
+from .history import (
+    DocxHistoryClient, DocxHistoryError, DocxHistoryState, DocxHistoryView,
+    DocxSnapshotReference, DocxStoredVersion, DocxVersionMetadata, DocxVersionPage,
+    DocxVersionRecord, HistoryBlobReference, HistoryHead, open_history,
+)
 from .enums import (
     AnchorIdRendering,
     AnchorRenderMode,
@@ -260,6 +265,9 @@ except PackageNotFoundError:
     __version__ = "0.0.0+source"
 
 __all__ = [
+    "DocxHistoryClient", "DocxHistoryError", "DocxHistoryState", "DocxHistoryView",
+    "DocxSnapshotReference", "DocxStoredVersion", "DocxVersionMetadata", "DocxVersionPage",
+    "DocxVersionRecord", "HistoryBlobReference", "HistoryHead", "open_history",
     "__version__",
     # entry points
     "DocxSession",

--- a/python/src/docx_scalpel/history.py
+++ b/python/src/docx_scalpel/history.py
@@ -1,0 +1,237 @@
+"""Host-owned exact version history through the existing local .NET process.
+
+No new network/transit layer. File-backed histories survive client and process restarts;
+memory histories are private to their open handle. Accepted sequence, not wall time,
+orders content. Package-boundary calls are not a fine-grained typing recorder.
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import MappingProxyType, TracebackType
+from typing import Any, Mapping
+
+from ._transport import _Transport
+from .errors import DocxScalpelError
+from .types import VerificationDigest
+
+
+class DocxHistoryError(DocxScalpelError):
+    """A typed history-domain failure (for example StaleHead or PayloadMismatch)."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def _position(value: int) -> str:
+    if isinstance(value, bool) or not isinstance(value, int) or not 0 <= value <= 9223372036854775807:
+        raise ValueError("History positions must be nonnegative Int64 integers")
+    return str(value)
+
+
+@dataclass(frozen=True, slots=True)
+class HistoryBlobReference:
+    digest: VerificationDigest
+    length: int
+
+    @classmethod
+    def _from_wire(cls, data: Mapping[str, Any]) -> HistoryBlobReference:
+        return cls(VerificationDigest._from_wire(data["digest"]), data["length"])
+
+    def to_wire(self) -> dict[str, Any]:
+        return {"digest": {"algorithm": self.digest.algorithm, "value": self.digest.value}, "length": self.length}
+
+
+def _reference(data: Mapping[str, Any] | None) -> HistoryBlobReference | None:
+    return None if data is None else HistoryBlobReference._from_wire(data)
+
+
+@dataclass(frozen=True, slots=True)
+class HistoryHead:
+    revision: int
+    state: HistoryBlobReference
+
+    @classmethod
+    def _from_wire(cls, data: Mapping[str, Any]) -> HistoryHead:
+        return cls(int(data["revision"]), HistoryBlobReference._from_wire(data["state"]))
+
+    def to_wire(self) -> dict[str, Any]:
+        return {"revision": _position(self.revision), "state": self.state.to_wire()}
+
+
+@dataclass(frozen=True, slots=True)
+class DocxSnapshotReference:
+    blob: HistoryBlobReference
+    content_digest: VerificationDigest
+
+    @classmethod
+    def _from_wire(cls, data: Mapping[str, Any]) -> DocxSnapshotReference:
+        return cls(HistoryBlobReference._from_wire(data["blob"]), VerificationDigest._from_wire(data["contentDigest"]))
+
+
+@dataclass(frozen=True, slots=True)
+class DocxVersionMetadata:
+    author: str
+    created_at: str
+    label: str | None = None
+    message: str | None = None
+    application_metadata: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "application_metadata", MappingProxyType(dict(self.application_metadata)))
+
+    @classmethod
+    def _from_wire(cls, data: Mapping[str, Any]) -> DocxVersionMetadata:
+        return cls(data["author"], data["createdAt"], data.get("label"), data.get("message"), data["applicationMetadata"])
+
+    def to_wire(self) -> dict[str, Any]:
+        return {"author": self.author, "createdAt": self.created_at, "label": self.label,
+                "message": self.message, "applicationMetadata": dict(self.application_metadata)}
+
+
+@dataclass(frozen=True, slots=True)
+class DocxVersionRecord:
+    document_id: str
+    metadata: DocxVersionMetadata
+    nonce: str
+    parent: HistoryBlobReference | None
+    restored_from: HistoryBlobReference | None
+    sequence: int
+    snapshot: DocxSnapshotReference
+
+    @classmethod
+    def _from_wire(cls, data: Mapping[str, Any]) -> DocxVersionRecord:
+        return cls(data["documentId"], DocxVersionMetadata._from_wire(data["metadata"]), data["nonce"],
+                   _reference(data["parent"]), _reference(data["restoredFrom"]), int(data["sequence"]),
+                   DocxSnapshotReference._from_wire(data["snapshot"]))
+
+
+@dataclass(frozen=True, slots=True)
+class DocxStoredVersion:
+    id: HistoryBlobReference
+    record: DocxVersionRecord
+
+    @classmethod
+    def _from_wire(cls, data: Mapping[str, Any]) -> DocxStoredVersion:
+        return cls(HistoryBlobReference._from_wire(data["id"]), DocxVersionRecord._from_wire(data["record"]))
+
+
+@dataclass(frozen=True, slots=True)
+class DocxHistoryState:
+    commit: HistoryBlobReference | None
+    document_id: str
+    epoch: int
+    initial_snapshot: DocxSnapshotReference
+    sequence: int
+    snapshot: DocxSnapshotReference
+    version: HistoryBlobReference
+
+    @classmethod
+    def _from_wire(cls, data: Mapping[str, Any]) -> DocxHistoryState:
+        return cls(_reference(data["commit"]), data["documentId"], int(data["epoch"]),
+                   DocxSnapshotReference._from_wire(data["initialSnapshot"]), int(data["sequence"]),
+                   DocxSnapshotReference._from_wire(data["snapshot"]), HistoryBlobReference._from_wire(data["version"]))
+
+
+@dataclass(frozen=True, slots=True)
+class DocxHistoryView:
+    head: HistoryHead
+    state: DocxHistoryState
+    version: DocxStoredVersion
+
+    @classmethod
+    def _from_wire(cls, data: Mapping[str, Any]) -> DocxHistoryView:
+        return cls(HistoryHead._from_wire(data["head"]), DocxHistoryState._from_wire(data["state"]),
+                   DocxStoredVersion._from_wire(data["version"]))
+
+
+@dataclass(frozen=True, slots=True)
+class DocxVersionPage:
+    versions: tuple[DocxStoredVersion, ...]
+    next: HistoryBlobReference | None
+
+
+class DocxHistoryClient:
+    """Use open_history(); a client is bound to its original subprocess, never a reused handle."""
+
+    def __init__(self, transport: _Transport, handle: int) -> None:
+        self._transport = transport
+        self._handle = handle
+        self._closed = False
+
+    def __enter__(self) -> DocxHistoryClient:
+        if self._closed:
+            raise DocxHistoryError("Closed", "History client is closed")
+        return self
+
+    def __exit__(self, exc_type: type[BaseException] | None, exc: BaseException | None,
+                 tb: TracebackType | None) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if not self._closed:
+            self._transport.call("close_history", {"handle": self._handle})
+            self._closed = True
+
+    def _call(self, operation: str, document_id: str, *, docx_bytes: bytes | None = None, **fields: Any) -> dict[str, Any]:
+        if self._closed:
+            raise DocxHistoryError("Closed", "History client is closed")
+        args: dict[str, Any] = {"handle": self._handle,
+                               "request": {"schemaVersion": 1, "operation": operation, "documentId": document_id, **fields}}
+        if docx_bytes is not None:
+            if len(docx_bytes) > 256 * 1024 * 1024:
+                raise ValueError("DOCX input exceeds the byte limit")
+            args["docxB64"] = base64.b64encode(docx_bytes).decode("ascii")
+        result = self._transport.call("history", args)
+        if not result["success"]:
+            raise DocxHistoryError(result["errorCode"], result["message"])
+        return result
+
+    def read(self, document_id: str) -> DocxHistoryView | None:
+        value = self._call("read", document_id)["view"]
+        return None if value is None else DocxHistoryView._from_wire(value)
+
+    def create_version(self, document_id: str, expected_head: HistoryHead | None, docx_bytes: bytes,
+                       metadata: DocxVersionMetadata) -> DocxHistoryView:
+        return DocxHistoryView._from_wire(self._call("create", document_id, docx_bytes=docx_bytes,
+            expectedHead=None if expected_head is None else expected_head.to_wire(), metadata=metadata.to_wire())["view"])
+
+    def list_versions(self, document_id: str, cursor: HistoryBlobReference | None = None, limit: int = 25) -> DocxVersionPage:
+        page = self._call("list", document_id, versionId=None if cursor is None else cursor.to_wire(), limit=limit)["page"]
+        return DocxVersionPage(tuple(DocxStoredVersion._from_wire(version) for version in page["versions"]), _reference(page["next"]))
+
+    def get_version(self, document_id: str, version_id: HistoryBlobReference) -> DocxStoredVersion:
+        return DocxStoredVersion._from_wire(self._call("get", document_id, versionId=version_id.to_wire())["version"])
+
+    def export_version(self, document_id: str, version_id: HistoryBlobReference) -> bytes:
+        return base64.b64decode(self._call("export", document_id, versionId=version_id.to_wire())["bytes"], validate=True)
+
+    def materialize(self, document_id: str, sequence: int, max_entries_to_scan: int = 10_000) -> bytes:
+        return base64.b64decode(self._call("materialize", document_id, sequence=_position(sequence),
+                                         maxEntriesToScan=max_entries_to_scan)["bytes"], validate=True)
+
+    def replay(self, document_id: str, sequence: int, max_entries_to_scan: int = 10_000) -> bytes:
+        return base64.b64decode(self._call("replay", document_id, sequence=_position(sequence),
+                                         maxEntriesToScan=max_entries_to_scan)["bytes"], validate=True)
+
+    def resolve_sequence_at_time(self, document_id: str, cutoff: str, max_entries_to_scan: int = 10_000) -> int:
+        return int(self._call("resolveTime", document_id, cutoff=cutoff, maxEntriesToScan=max_entries_to_scan)["sequence"])
+
+    def restore_version(self, document_id: str, expected_head: HistoryHead, version_id: HistoryBlobReference,
+                        metadata: DocxVersionMetadata) -> DocxHistoryView:
+        return DocxHistoryView._from_wire(self._call("restore", document_id, expectedHead=expected_head.to_wire(),
+                                                   versionId=version_id.to_wire(), metadata=metadata.to_wire())["view"])
+
+
+def open_history(root: str | Path | None = None) -> DocxHistoryClient:
+    """Open a host-owned filesystem history, or an isolated ephemeral memory history when None.
+
+    The caller controls permissions/retention of root/blobs and root/heads. Closing never
+    deletes storage. Reopen after a process restart to obtain a new valid client handle.
+    """
+    transport = _Transport.get()
+    handle = transport.call("open_history", {"root": None if root is None else str(Path(root).resolve())})
+    return DocxHistoryClient(transport, handle)

--- a/python/tests/test_history.py
+++ b/python/tests/test_history.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from docx_scalpel import (
+    DocxHistoryError, DocxVersionMetadata, HistoryBlobReference, HistoryHead,
+    VerificationDigest, convert_docx_to_html, docx_diff_compare_products,
+    generate_package_manifest, open_history, open_session, shutdown_host,
+)
+from docx_scalpel.errors import DocxodusTransportError
+
+
+def metadata(hour: int = 12) -> DocxVersionMetadata:
+    return DocxVersionMetadata("python-actor", f"2026-01-01T{hour:02}:00:00Z", application_metadata={"matter": "123"})
+
+
+def test_file_history_exact_reopen_time_render_restore_and_compare(tmp_path, tour_plan_bytes):
+    root = tmp_path / "history"
+    with open_history(root) as a, open_history(root) as b:
+        first = a.create_version("doc", None, tour_plan_bytes, metadata())
+        assert first.state.sequence == 0
+        assert isinstance(first.head.revision, int)
+        with open_session(tour_plan_bytes) as session:
+            anchor = next(key for key in session.project().anchor_index if key.startswith("p:body:"))
+            assert session.replace_text(anchor, "Shared Python historical content.").success
+            edited = session.save()
+        second = b.create_version("doc", first.head, edited, metadata(13))
+        sequence = a.resolve_sequence_at_time("doc", "2026-01-01T13:00:00Z")
+        assert sequence == 1
+        replay = a.replay("doc", sequence)
+        assert generate_package_manifest(replay).ordered_opc_content_digest == generate_package_manifest(edited).ordered_opc_content_digest
+        assert "Shared Python historical content." in convert_docx_to_html(a.materialize("doc", sequence))
+        comparison = docx_diff_compare_products(a.export_version("doc", first.version.id), a.export_version("doc", second.version.id))
+        assert comparison.revisions
+        first_page = a.list_versions("doc", limit=1)
+        assert first_page.versions[0].id == second.version.id
+        assert a.list_versions("doc", first_page.next).versions[0].id == first.version.id
+        assert a.get_version("doc", first.version.id).record.metadata.application_metadata["matter"] == "123"
+        with pytest.raises(DocxHistoryError) as stale:
+            a.create_version("doc", first.head, tour_plan_bytes, metadata())
+        assert stale.value.code == "StaleHead"
+        restored = b.restore_version("doc", second.head, first.version.id, metadata(14))
+        assert restored.state.sequence == 2 and restored.state.epoch == 1
+        assert restored.version.record.restored_from == first.version.id
+        assert a.export_version("doc", second.version.id) == edited
+
+    shutdown_host()
+    with open_history(root) as reopened:
+        assert reopened.read("doc").head == restored.head
+        assert reopened.export_version("doc", restored.version.id) == tour_plan_bytes
+        assert reopened.export_version("doc", first.version.id) == tour_plan_bytes
+
+
+def test_memory_history_lifecycle_and_handles_do_not_attach_to_restarted_host(tour_plan_bytes):
+    old = open_history()
+    old.create_version("doc", None, tour_plan_bytes, metadata())
+    shutdown_host()
+    with open_history() as new:
+        assert new.read("doc") is None
+        with pytest.raises(DocxodusTransportError):
+            old.read("doc")
+    new.close()
+    with pytest.raises(DocxHistoryError) as closed:
+        new.read("doc")
+    assert closed.value.code == "Closed"
+
+
+def test_two_file_clients_cannot_overwrite_same_expected_head(tmp_path, tour_plan_bytes):
+    with open_history(tmp_path) as a, open_history(tmp_path) as b:
+        first = a.create_version("doc", None, tour_plan_bytes, metadata())
+
+        def publish(client):
+            try:
+                return client.create_version("doc", first.head, tour_plan_bytes, metadata(13))
+            except DocxHistoryError as error:
+                assert error.code == "StaleHead"
+                return None
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = list(pool.map(publish, [a, b]))
+        assert sum(result is not None for result in results) == 1
+        assert a.read("doc").head.revision == 2
+
+
+def test_value_types_copy_metadata_and_keep_exact_int64_positions():
+    values = {"key": "before"}
+    record = DocxVersionMetadata("author", "2026-01-01T00:00:00Z", application_metadata=values)
+    values["key"] = "after"
+    assert record.application_metadata["key"] == "before"
+    with pytest.raises(TypeError):
+        record.application_metadata["key"] = "mutation"
+    with pytest.raises(FrozenInstanceError):
+        record.author = "mutation"
+    reference = HistoryBlobReference(VerificationDigest("SHA-256", "a" * 64), 3)
+    head = HistoryHead(9223372036854775807, reference)
+    assert head.to_wire()["revision"] == "9223372036854775807"
+    assert HistoryHead._from_wire(head.to_wire()) == head
+    for invalid in [-1, 9223372036854775808, True, 1.5]:
+        with pytest.raises(ValueError):
+            HistoryHead(invalid, reference).to_wire()

--- a/tools/python-host/Dispatcher.cs
+++ b/tools/python-host/Dispatcher.cs
@@ -44,6 +44,9 @@ internal static class Dispatcher
     private static string DispatchCore(string op, JsonElement args) => op switch
     {
         "ping" => Ping(),
+        "open_history" => HistoryBindings.Open(args),
+        "close_history" => HistoryBindings.Close(args),
+        "history" => HistoryBindings.Invoke(args),
         "open_session" => OpenSession(args),
         "close_session" => CloseSession(args),
         "save" => Save(args),

--- a/tools/python-host/HistoryBindings.cs
+++ b/tools/python-host/HistoryBindings.cs
@@ -1,0 +1,58 @@
+#nullable enable
+
+using System.Text.Json;
+using Docxodus.History;
+using Docxodus.Internal;
+
+namespace Docxodus.PyHost;
+
+/// <summary>History over existing local stdio dispatch; no new transit or network layer.</summary>
+internal static class HistoryBindings
+{
+    private static readonly Dictionary<int, HistoryClientOps> Clients = new();
+    private static int _nextHandle;
+
+    public static string Open(JsonElement args)
+    {
+        var root = args.TryGetProperty("root", out var value) && value.ValueKind != JsonValueKind.Null
+            ? value.GetString() : null;
+        IHistoryBlobStore blobs;
+        IHistoryHeadStore heads;
+        if (root is null)
+        {
+            blobs = new MemoryHistoryBlobStore(); heads = new MemoryHistoryHeadStore();
+        }
+        else
+        {
+            if (!Path.IsPathFullyQualified(root)) throw new ArgumentException("History storage root must be an absolute host-owned path.");
+            blobs = new FileHistoryBlobStore(Path.Combine(root, "blobs"));
+            heads = new FileHistoryHeadStore(Path.Combine(root, "heads"));
+        }
+        var handle = checked(++_nextHandle);
+        Clients.Add(handle, new HistoryClientOps(blobs, heads));
+        return handle.ToString(System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    public static string Close(JsonElement args)
+    {
+        Clients.Remove(args.GetProperty("handle").GetInt32());
+        return "null";
+    }
+
+    public static string Invoke(JsonElement args)
+    {
+        if (!Clients.TryGetValue(args.GetProperty("handle").GetInt32(), out var client))
+            throw new ArgumentException("Unknown history client handle.");
+        byte[]? bytes = null;
+        if (args.TryGetProperty("docxB64", out var data))
+        {
+            var encoded = data.GetString() ?? throw new ArgumentException("DOCX base64 must not be null.");
+            if ((long)encoded.Length > ((256L * 1024 * 1024 + 2) / 3) * 4)
+                throw new ArgumentException("DOCX input exceeds the byte limit.");
+            bytes = Convert.FromBase64String(encoded);
+        }
+        return client.InvokeAsync(args.GetProperty("request").GetRawText(), bytes).GetAwaiter().GetResult();
+    }
+
+    public static void CloseAll() => Clients.Clear();
+}

--- a/tools/python-host/Program.cs
+++ b/tools/python-host/Program.cs
@@ -68,6 +68,7 @@ internal static class Program
                     WriteOk(stdout, requestId, "null");
                     stdout.Flush();
                     SessionRegistry.DisposeAll();
+                    HistoryBindings.CloseAll();
                     return 0;
                 }
 
@@ -102,6 +103,7 @@ internal static class Program
         }
 
         SessionRegistry.DisposeAll();
+        HistoryBindings.CloseAll();
         return 0;
     }
 


### PR DESCRIPTION
Stack layer 13 for #671/#672, based on #716. Adds Python history bindings over the existing local stdio host, with filesystem or isolated-memory C# adapters, frozen snake_case value types, copied immutable application metadata, lossless Int64 counters, and typed domain errors. Clients retain their original host-process connection so stale numeric handles cannot attach to unrelated histories after restart. No new transit/network layer.

Supports read/create/list/get/export/materialize/replay/time lookup/restore. Existing Python session, HTML and DocxDiff APIs consume reconstructed/exported bytes. Closing releases only handles; file storage survives client and process restarts. Adds a CI real-host history smoke.

Validation: all 168 Python tests pass, including 4 new full-host integration tests for exact file reopen/restart, replay/render/compare/restore, stale and competing saves, dead-host handle safety, metadata immutability, and Int64 extremes. Host Release build and git diff --check pass.

Self-review: GPT-5.6-sol reviewed the complete layer read-only; no actionable findings. Next layer supplies validated ordered log updates for live rendering.