### PR TITLE
feat(collaboration): expose validated timestamped log tails

### DIFF
--- a/Docxodus.Tests/DocxHistoryUpdateTests.cs
+++ b/Docxodus.Tests/DocxHistoryUpdateTests.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using Docxodus.History;
+using Docxodus.Internal;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+public class DocxHistoryUpdateTests
+{
+    [Fact]
+    public async Task UpdatesAreContiguousTimestampedAndDoNotFabricateLabelCommits()
+    {
+        var blobs = new TrackingBlobs(new MemoryHistoryBlobStore());
+        var heads = new MemoryHistoryHeadStore();
+        var history = new DocxVersionHistory(blobs, heads);
+        var before = DocxSession.CreateBlankDocxBytes();
+        var after = Edited(before);
+        var first = await history.CreateVersionAsync("doc", null, before, Metadata(12));
+        var joined = await history.ReadChangesSinceAsync("doc", null);
+        Assert.True(joined.Reset); Assert.Empty(joined.Entries); Assert.Equal(first.Head, joined.View.Head);
+        var named = await history.CreateVersionAsync("doc", first.Head, before, Metadata(11));
+        var label = await history.ReadChangesSinceAsync("doc", first.Head);
+        Assert.False(label.Reset); Assert.Empty(label.Entries); Assert.Equal(named.Head, label.View.Head);
+        var changed = await history.CreateVersionAsync("doc", named.Head, after, Metadata(13));
+        var restored = await history.RestoreVersionAsync("doc", changed.Head, first.Version.Id, Metadata(10));
+        blobs.Reads.Clear();
+        var tail = await history.ReadChangesSinceAsync("doc", first.Head);
+        Assert.Equal(first.Head, tail.After);
+        Assert.Equal(restored.Head, tail.View.Head);
+        Assert.True(tail.Reset);
+        Assert.Equal(new long[] { 1, 2 }, tail.Entries.Select(entry => entry.Commit.Sequence));
+        Assert.Equal(new[] { 13, 10 }, tail.Entries.Select(entry => entry.Metadata.CreatedAt.Hour));
+        Assert.Equal(changed.State.Commit, tail.Entries[0].Id);
+        Assert.Equal(restored.State.Commit, tail.Entries[1].Id);
+        Assert.Equal(tail.Entries[0].Id, tail.Entries[1].Commit.Parent);
+        Assert.DoesNotContain(first.State.Snapshot.Blob, blobs.Reads);
+        Assert.DoesNotContain(changed.State.Snapshot.Blob, blobs.Reads);
+        Assert.DoesNotContain(tail.Entries[0].Commit.Contribution!, blobs.Reads);
+        Assert.Equal(restored.Head, await heads.ReadAsync("doc"));
+        var duplicate = await history.ReadChangesSinceAsync("doc", restored.Head);
+        Assert.Empty(duplicate.Entries); Assert.False(duplicate.Reset);
+        // A join on an established history starts at its latest checkpoint, not at sequence zero.
+        Assert.Empty((await history.ReadChangesSinceAsync("doc", null)).Entries);
+    }
+
+    [Fact]
+    public async Task RewindsSameRevisionForksAndEqualContentVersionBranchesAreRejected()
+    {
+        var blobs = new MemoryHistoryBlobStore();
+        var heads = new MemoryHistoryHeadStore();
+        var history = new DocxVersionHistory(blobs, heads);
+        var bytes = DocxSession.CreateBlankDocxBytes();
+        var first = await history.CreateVersionAsync("doc", null, bytes, Metadata(12));
+        var second = await history.CreateVersionAsync("doc", first.Head, bytes, Metadata(13));
+        var rewound = new DocxVersionHistory(blobs, new FixedHead(first.Head));
+        await Invalid(async () => await rewound.ReadChangesSinceAsync("doc", second.Head));
+        var forkedRevision = new DocxVersionHistory(blobs, new FixedHead(new HistoryHead(second.Head.Revision, first.Head.State)));
+        await Invalid(async () => await forkedRevision.ReadChangesSinceAsync("doc", second.Head));
+        var branch = new DocxVersionHistory(blobs, new MemoryHistoryHeadStore());
+        var alternate = await branch.CreateVersionAsync("doc", null, bytes, Metadata(12));
+        alternate = await branch.CreateVersionAsync("doc", alternate.Head, bytes, Metadata(13));
+        Assert.Equal(first.State.InitialSnapshot, alternate.State.InitialSnapshot);
+        await Invalid(async () => await branch.ReadChangesSinceAsync("doc", first.Head));
+    }
+
+    [Fact]
+    public async Task FabricatedRevisionCannotBePairedWithAGenuineAncestorState()
+    {
+        var history = new DocxVersionHistory(new MemoryHistoryBlobStore(), new MemoryHistoryHeadStore());
+        var bytes = DocxSession.CreateBlankDocxBytes();
+        var first = await history.CreateVersionAsync("doc", null, bytes, Metadata(12));
+        var head = first.Head;
+        for (var i = 0; i < 3; i++)
+            head = (await history.CreateVersionAsync("doc", head, bytes, Metadata(13))).Head;
+        Assert.Empty((await history.ReadChangesSinceAsync("doc", first.Head)).Entries);
+        await Invalid(async () => await history.ReadChangesSinceAsync("doc", first.Head with { Revision = 2 }));
+        await Invalid(async () => await history.ReadChangesSinceAsync("doc", first.Head with { Revision = 3 }));
+    }
+
+    [Fact]
+    public async Task CommitHashNotJustContentAndSequenceMustExtendTheAcceptedTip()
+    {
+        var blobs = new MemoryHistoryBlobStore();
+        var heads = new MemoryHistoryHeadStore();
+        var history = new DocxVersionHistory(blobs, heads);
+        var bytes = DocxSession.CreateBlankDocxBytes();
+        var first = await history.CreateVersionAsync("doc", null, bytes, Metadata(12));
+        var second = await history.CreateVersionAsync("doc", first.Head, Edited(bytes), Metadata(13));
+        var third = await history.RestoreVersionAsync("doc", second.Head, first.Version.Id, Metadata(14));
+        var records = new HistoryRecordStore(blobs);
+        var original = await records.LoadCommitAsync(second.State.Commit!);
+        var fake = await records.SaveCommitAsync(original with { Version = third.Version.Id });
+        var falseState = await records.SaveStateAsync(third.State with { Commit = await records.SaveCommitAsync(
+            (await records.LoadCommitAsync(third.State.Commit!)) with { Parent = fake }) });
+        var forged = new DocxVersionHistory(blobs, new FixedHead(new HistoryHead(third.Head.Revision, falseState)));
+        await Invalid(async () => await forged.ReadChangesSinceAsync("doc", second.Head));
+    }
+
+    [Fact]
+    public async Task BudgetIncludesVersionsAndCommitsAndFailuresDoNotPublish()
+    {
+        var blobs = new MemoryHistoryBlobStore();
+        var heads = new MemoryHistoryHeadStore();
+        var history = new DocxVersionHistory(blobs, heads);
+        var bytes = DocxSession.CreateBlankDocxBytes();
+        var first = await history.CreateVersionAsync("doc", null, bytes, Metadata(12));
+        var second = await history.CreateVersionAsync("doc", first.Head, Edited(bytes), Metadata(13));
+        var limit = await Assert.ThrowsAsync<DocxHistoryException>(async () => await history.ReadChangesSinceAsync("doc", first.Head, 1));
+        Assert.Equal(DocxHistoryError.TraversalLimit, limit.Code);
+        Assert.Single((await history.ReadChangesSinceAsync("doc", first.Head, 2)).Entries);
+        using var cancellation = new CancellationTokenSource(); cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await history.ReadChangesSinceAsync("doc", first.Head,
+            cancellationToken: cancellation.Token));
+        var missing = await Assert.ThrowsAsync<DocxHistoryException>(async () => await history.ReadChangesSinceAsync("absent", null));
+        Assert.Equal(DocxHistoryError.HistoryUnavailable, missing.Code);
+        var foreign = await history.CreateVersionAsync("other", null, bytes, Metadata(12));
+        var error = await Assert.ThrowsAsync<DocxHistoryException>(async () => await history.ReadChangesSinceAsync("doc", foreign.Head));
+        Assert.Equal(DocxHistoryError.ForeignDocument, error.Code);
+        Assert.Equal(second.Head, await heads.ReadAsync("doc"));
+    }
+
+    private static async Task Invalid(Func<Task> action) =>
+        Assert.Equal(DocxHistoryError.InvalidHistory, (await Assert.ThrowsAsync<DocxHistoryException>(action)).Code);
+    private static DocxVersionMetadata Metadata(int hour) => new()
+    { Author = "actor", CreatedAt = new DateTimeOffset(2026, 1, 1, hour, 0, 0, TimeSpan.Zero) };
+    private static byte[] Edited(byte[] bytes)
+    {
+        using var session = new DocxSession(bytes);
+        var anchor = session.Project().AnchorIndex.Keys.First(key => key.StartsWith("p:", StringComparison.Ordinal));
+        Assert.True(session.ReplaceText(anchor, "updated live log").Success);
+        return session.Save();
+    }
+    private sealed class FixedHead(HistoryHead head) : IHistoryHeadStore
+    {
+        public ValueTask<HistoryHead?> ReadAsync(string documentId, CancellationToken cancellationToken = default) => new(head);
+        public ValueTask<HistoryHead?> TryAdvanceAsync(string documentId, HistoryHead? expected,
+            HistoryBlobReference state, CancellationToken cancellationToken = default) => throw new InvalidOperationException("Read only");
+    }
+    private sealed class TrackingBlobs(IHistoryBlobStore inner) : IHistoryBlobStore
+    {
+        public List<HistoryBlobReference> Reads { get; } = new();
+        public ValueTask PutAsync(HistoryBlobReference reference, Stream content, CancellationToken cancellationToken = default) =>
+            inner.PutAsync(reference, content, cancellationToken);
+        public ValueTask<Stream?> OpenReadAsync(HistoryBlobReference reference, CancellationToken cancellationToken = default)
+        { Reads.Add(reference); return inner.OpenReadAsync(reference, cancellationToken); }
+    }
+}

--- a/Docxodus.Tests/HistoryClientOpsTests.cs
+++ b/Docxodus.Tests/HistoryClientOpsTests.cs
@@ -55,6 +55,10 @@ public class HistoryClientOpsTests
         Assert.True(restored.Success);
         Assert.Equal(1, restored.View!.State.Epoch);
         Assert.Equal(1, restored.View.State.Sequence);
+        var updates = (await Call(client, "updates", expected: first.View.Head)).Update!;
+        Assert.True(updates.Reset);
+        Assert.Equal(1, Assert.Single(updates.Entries).Commit.Sequence);
+        Assert.Equal(restored.View.Head, updates.View.Head);
         var stale = await Call(client, "create", bytes, metadata: metadata, expected: first.View.Head);
         Assert.False(stale.Success);
         Assert.Equal("StaleHead", stale.ErrorCode);

--- a/Docxodus/History/DocxVersionHistory.Reconstruction.cs
+++ b/Docxodus/History/DocxVersionHistory.Reconstruction.cs
@@ -86,7 +86,7 @@ public sealed partial class DocxVersionHistory
         return current;
     }
 
-    private sealed record TraversedCommit(PackageHistoryCommitRecord Commit, DocxVersionRecord Version);
+    private sealed record TraversedCommit(HistoryBlobReference Id, PackageHistoryCommitRecord Commit, DocxVersionRecord Version);
 
     private async IAsyncEnumerable<TraversedCommit> ReadBackwardsAsync(string documentId,
         DocxHistoryView current, int maximum, [EnumeratorCancellation] CancellationToken cancellationToken)
@@ -118,7 +118,7 @@ public sealed partial class DocxVersionHistory
                 var target = await GetVersionAsync(documentId, version.Record.RestoredFrom!, cancellationToken).ConfigureAwait(false);
                 Consistent(target.Record.Snapshot == commit.After, "Restore target disagrees with its recorded snapshot.");
             }
-            yield return new TraversedCommit(commit, version.Record);
+            yield return new TraversedCommit(cursor, commit, version.Record);
             cursor = commit.Parent;
             sequence--;
             if (commit.Kind == "restore") epoch--;

--- a/Docxodus/History/DocxVersionHistory.Updates.cs
+++ b/Docxodus/History/DocxVersionHistory.Updates.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+namespace Docxodus.History;
+
+/// <summary>An accepted content commit with its recorded host timestamp and author metadata.</summary>
+public sealed record DocxHistoryLogEntry(HistoryBlobReference Id, PackageHistoryCommitRecord Commit, DocxVersionMetadata Metadata);
+
+/// <summary>
+/// An immutable captured head and its ascending, contiguous accepted content tail. A first join
+/// (After=null) supplies the latest checkpoint with no historical tail. Reset marks first join
+/// or an epoch transition; clients must preserve pending work before installing that checkpoint.
+/// </summary>
+public sealed record DocxHistoryUpdate(HistoryHead? After, DocxHistoryView View,
+    IReadOnlyList<DocxHistoryLogEntry> Entries, bool Reset);
+
+public sealed partial class DocxVersionHistory
+{
+    /// <summary>
+    /// Read host-triggered live updates since an exact previously accepted head. Validates both
+    /// version and commit ancestry, rejecting forks/rewinds even when package content matches.
+    /// Reads bounded metadata only; hosts retain blobs and provide their own notifications.
+    /// Duplicate reads are empty, labels do not fabricate content entries, and timestamps never
+    /// replace sequence order. No transport, timer, subscription, or polling loop is installed.
+    /// </summary>
+    public async ValueTask<DocxHistoryUpdate> ReadChangesSinceAsync(string documentId, HistoryHead? after,
+        int maxEntriesToScan = 10_000, CancellationToken cancellationToken = default)
+    {
+        if (maxEntriesToScan <= 0) throw new ArgumentOutOfRangeException(nameof(maxEntriesToScan));
+        var current = await ReadAsync(documentId, cancellationToken).ConfigureAwait(false)
+            ?? throw new DocxHistoryException(DocxHistoryError.HistoryUnavailable, "Document history is unavailable.");
+        if (after is null) return new DocxHistoryUpdate(null, current, Array.Empty<DocxHistoryLogEntry>(), true);
+        if (current.Head == after) return new DocxHistoryUpdate(after, current, Array.Empty<DocxHistoryLogEntry>(), false);
+        Consistent(current.Head.Revision > after.Revision, "The supplied history head rewinds or forks the accepted publication.");
+        var previous = await ReadHeadViewAsync(documentId, after, cancellationToken).ConfigureAwait(false);
+        Consistent(current.State.InitialSnapshot == previous.State.InitialSnapshot
+            && current.State.Sequence >= previous.State.Sequence && current.State.Epoch >= previous.State.Epoch,
+            "History updates do not extend the accepted checkpoint.");
+
+        var remaining = maxEntriesToScan;
+        void Spend()
+        {
+            if (remaining-- <= 0) throw new DocxHistoryException(DocxHistoryError.TraversalLimit,
+                "History update scan budget reached; increase it explicitly to continue.");
+        }
+
+        // Content sequence alone cannot prove ancestry: competing labels and same-content forks
+        // also have distinct immutable version chains. Check the previously accepted version ID.
+        var version = current.Version;
+        long versionEdges = 0;
+        while (version.Id != previous.Version.Id)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Spend();
+            versionEdges++;
+            Consistent(version.Record.Parent is not null, "Accepted version is not an ancestor of the new head.");
+            var parent = await GetVersionAsync(documentId, version.Record.Parent!, cancellationToken).ConfigureAwait(false);
+            Consistent(parent.Record.Sequence >= previous.State.Sequence && parent.Record.Sequence <= version.Record.Sequence
+                && version.Record.Sequence - parent.Record.Sequence <= 1,
+                "Version ancestry is discontinuous.");
+            if (parent.Record.Sequence == version.Record.Sequence)
+                Consistent(parent.Record.Snapshot.ContentDigest == version.Record.Snapshot.ContentDigest
+                    && version.Record.RestoredFrom is null, "A metadata-only version cannot change content or restore.");
+            version = parent;
+        }
+        Consistent(versionEdges == current.Head.Revision - after.Revision,
+            "Publication revision does not match the accepted version ancestry.");
+
+        var entries = new List<DocxHistoryLogEntry>();
+        if (current.State.Sequence == previous.State.Sequence)
+        {
+            Consistent(current.State.Commit == previous.State.Commit && current.State.Epoch == previous.State.Epoch
+                && current.State.Snapshot.ContentDigest == previous.State.Snapshot.ContentDigest,
+                "Metadata-only updates disagree with the accepted content tip.");
+        }
+        else
+        {
+            Spend(); // Reserve the first commit; the iterator checks its own remaining budget.
+            await foreach (var entry in ReadBackwardsAsync(documentId, current, remaining + 1, cancellationToken).ConfigureAwait(false))
+            {
+                entries.Add(new DocxHistoryLogEntry(entry.Id, entry.Commit, entry.Version.Metadata));
+                if (entry.Commit.Sequence == previous.State.Sequence + 1)
+                {
+                    Consistent(entry.Commit.Parent == previous.State.Commit
+                        && entry.Commit.Before.ContentDigest == previous.State.Snapshot.ContentDigest
+                        && entry.Commit.Epoch - (entry.Commit.Kind == "restore" ? 1 : 0) == previous.State.Epoch,
+                        "Commit tail does not extend the accepted content tip.");
+                    break;
+                }
+            }
+            Consistent(entries.Count == current.State.Sequence - previous.State.Sequence,
+                "The accepted content tail has a gap.");
+            entries.Reverse();
+        }
+        cancellationToken.ThrowIfCancellationRequested();
+        return new DocxHistoryUpdate(after, current, entries.AsReadOnly(), current.State.Epoch != previous.State.Epoch);
+    }
+}

--- a/Docxodus/History/DocxVersionHistory.cs
+++ b/Docxodus/History/DocxVersionHistory.cs
@@ -55,6 +55,12 @@ public sealed partial class DocxVersionHistory
         cancellationToken.ThrowIfCancellationRequested();
         var head = await _heads.ReadAsync(documentId, cancellationToken).ConfigureAwait(false);
         if (head is null) return null;
+        return await ReadHeadViewAsync(documentId, head, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask<DocxHistoryView> ReadHeadViewAsync(string documentId, HistoryHead head,
+        CancellationToken cancellationToken)
+    {
         var state = await _records.LoadStateAsync(head.State, cancellationToken).ConfigureAwait(false);
         SameDocument(documentId, state.DocumentId);
         Consistent(state.Sequence < head.Revision && state.Epoch <= state.Sequence, "Invalid head publication position.");

--- a/Docxodus/Internal/HistoryClientOps.cs
+++ b/Docxodus/Internal/HistoryClientOps.cs
@@ -37,6 +37,8 @@ public sealed class HistoryClientOps
             var result = request.Operation switch
             {
                 "read" => new HistoryClientResult { View = await _history.ReadAsync(id, cancellationToken).ConfigureAwait(false) },
+                "updates" => new HistoryClientResult { Update = await _history.ReadChangesSinceAsync(id, request.ExpectedHead,
+                    budget, cancellationToken).ConfigureAwait(false) },
                 "create" => new HistoryClientResult { View = await _history.CreateVersionAsync(id, request.ExpectedHead,
                     Required(docxBytes), Required(request.Metadata), cancellationToken).ConfigureAwait(false) },
                 "list" => new HistoryClientResult { Page = await _history.ListVersionsAsync(id, request.VersionId,
@@ -99,6 +101,7 @@ public sealed record HistoryClientResult
     public DocxVersionPage? Page { get; init; }
     public long? Sequence { get; init; }
     public byte[]? Bytes { get; init; }
+    public DocxHistoryUpdate? Update { get; init; }
 }
 
 /// <summary>Client JSON only: 64-bit positions are decimal strings, preserving precision in JS.</summary>

--- a/docs/history-clients.md
+++ b/docs/history-clients.md
@@ -98,3 +98,28 @@ concurrent-edit merging, or pending-work management. Live log followers
 are subsequent stacked layers. See [history API](history.md) for durability and retention
 responsibilities and [the architecture](architecture/collaboration_and_version_history.md)
 for the larger collaboration roadmap.
+
+## Ordered live log updates
+
+`ReadChangesSinceAsync` (.NET), `readChangesSince` (npm), and `read_changes_since` (Python)
+accept the exact last accepted `HistoryHead` and return one captured `DocxHistoryUpdate`.
+Each update contains that `after` head, its new `view`, an ascending contiguous list of
+`entries` (immutable commit reference, commit record, and recorded author/time metadata),
+and `reset`. Sequence determines order even when timestamps move backwards. Metadata-only
+labels advance the publication head without creating content entries. A repeated accepted
+head returns an empty tail. First join passes `null`/`None` and starts at the latest checkpoint
+with an empty historical tail and `reset: true`.
+
+Both immutable version ancestry and content-commit ancestry must extend the accepted head.
+Rewinds, same-revision forks, same-content version branches, broken commit links, and absent
+history fail explicitly. The scan budget covers traversed version ancestors plus content
+commits; each can require several bounded metadata reads. The update call reads no snapshot
+or effect bytes. Hosts must retain all metadata needed to establish ancestry.
+
+Hosts invoke refresh when their own notification/log delivery mechanism says there is new
+work. No library timer, subscribe loop, socket, transport, or service is created. A reset means
+the epoch changed (for example a restore); a client must preserve local pending work separately
+before installing that checkpoint. This API does not authorize dropping local edits, rebase
+stale intents, or implement last-writer-wins. Exact-head publication failures keep the caller's
+candidate untouched. Use the returned view's exact version reference to load its snapshot for
+rendering; that reference remains stable even if newer versions publish during the load.

--- a/npm/src/history.ts
+++ b/npm/src/history.ts
@@ -33,6 +33,24 @@ export interface DocxHistoryState {
 }
 export interface DocxHistoryView { head: HistoryHead; state: DocxHistoryState; version: DocxStoredVersion }
 export interface DocxVersionPage { versions: DocxStoredVersion[]; next: HistoryBlobReference | null }
+export interface PackageHistoryCommit {
+  after: DocxSnapshotReference;
+  before: DocxSnapshotReference;
+  contribution: HistoryBlobReference | null;
+  documentId: string;
+  epoch: HistoryPosition;
+  kind: 'import' | 'restore';
+  parent: HistoryBlobReference | null;
+  sequence: HistoryPosition;
+  version: HistoryBlobReference;
+}
+export interface DocxHistoryLogEntry { id: HistoryBlobReference; commit: PackageHistoryCommit; metadata: DocxVersionMetadata }
+export interface DocxHistoryUpdate {
+  after: HistoryHead | null;
+  view: DocxHistoryView;
+  entries: DocxHistoryLogEntry[];
+  reset: boolean;
+}
 
 /** Host-owned storage. Persist blobs before returning; advanceHead must be an atomic CAS.
  * References and returned bytes are verified in the core. Methods must settle their promises.
@@ -63,6 +81,7 @@ interface Result {
   page: DocxVersionPage | null;
   sequence: HistoryPosition | null;
   bytes: string | null;
+  update: DocxHistoryUpdate | null;
 }
 
 const adapters = new Map<number, HistoryStorage>();
@@ -127,6 +146,10 @@ export class DocxHistoryClient {
 
   async read(documentId: string): Promise<DocxHistoryView | null> {
     return (await this.call('read', documentId)).view;
+  }
+  /** Host-triggered validated metadata tail; first join starts at the latest checkpoint. */
+  async readChangesSince(documentId: string, after: HistoryHead | null, maxEntriesToScan = 10_000): Promise<DocxHistoryUpdate> {
+    return (await this.call('updates', documentId, { expectedHead: after, maxEntriesToScan })).update!;
   }
   async createVersion(documentId: string, expectedHead: HistoryHead | null, bytes: Uint8Array,
     metadata: DocxVersionMetadata): Promise<DocxHistoryView> {

--- a/npm/tests/history-client.spec.ts
+++ b/npm/tests/history-client.spec.ts
@@ -45,6 +45,8 @@ test('two host-backed clients reopen, replay, render at time, and restore exact 
     try { await a.createVersion('doc', first.head, original, metadata); }
     catch (error: any) { stale = error.code; }
     const restored = await b.restoreVersion('doc', second.head, first.version.id, metadata);
+    const updates = await a.readChangesSince('doc', first.head);
+    const duplicate = await b.readChangesSince('doc', restored.head);
     a.close(); b.close();
     const reopened = api.openDocxHistory(storage);
     const latest = await reopened.read('doc');
@@ -57,6 +59,7 @@ test('two host-backed clients reopen, replay, render at time, and restore exact 
       exact: bytes.every((n: number, i: number) => n === original[i]) && bytes.length === original.length,
       restored: materialized.every((n: number, i: number) => n === original[i]) && materialized.length === original.length,
       firstId: first.version.id.digest.value, listedId: rest.versions[0].id.digest.value,
+      updates: updates.entries.map((entry: any) => entry.commit.sequence), reset: updates.reset, duplicates: duplicate.entries.length,
     };
   });
   expect(result.sequence).toBe('1');
@@ -68,6 +71,9 @@ test('two host-backed clients reopen, replay, render at time, and restore exact 
   expect(result.exact).toBe(true);
   expect(result.restored).toBe(true);
   expect(result.listedId).toBe(result.firstId);
+  expect(result.updates).toEqual(['1', '2']);
+  expect(result.reset).toBe(true);
+  expect(result.duplicates).toBe(0);
 });
 
 test('async storage retains captured inputs, rejects close while active, and detects corrupted payloads', async ({ page }) => {

--- a/python/src/docx_scalpel/__init__.py
+++ b/python/src/docx_scalpel/__init__.py
@@ -32,6 +32,7 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 
 from ._transport import shutdown_host
 from .history import (
+    DocxHistoryLogEntry, DocxHistoryUpdate, PackageHistoryCommit,
     DocxHistoryClient, DocxHistoryError, DocxHistoryState, DocxHistoryView,
     DocxSnapshotReference, DocxStoredVersion, DocxVersionMetadata, DocxVersionPage,
     DocxVersionRecord, HistoryBlobReference, HistoryHead, open_history,
@@ -265,6 +266,7 @@ except PackageNotFoundError:
     __version__ = "0.0.0+source"
 
 __all__ = [
+    "DocxHistoryLogEntry", "DocxHistoryUpdate", "PackageHistoryCommit",
     "DocxHistoryClient", "DocxHistoryError", "DocxHistoryState", "DocxHistoryView",
     "DocxSnapshotReference", "DocxStoredVersion", "DocxVersionMetadata", "DocxVersionPage",
     "DocxVersionRecord", "HistoryBlobReference", "HistoryHead", "open_history",

--- a/python/src/docx_scalpel/history.py
+++ b/python/src/docx_scalpel/history.py
@@ -154,6 +154,40 @@ class DocxVersionPage:
     next: HistoryBlobReference | None
 
 
+@dataclass(frozen=True, slots=True)
+class PackageHistoryCommit:
+    after: DocxSnapshotReference
+    before: DocxSnapshotReference
+    contribution: HistoryBlobReference | None
+    document_id: str
+    epoch: int
+    kind: str
+    parent: HistoryBlobReference | None
+    sequence: int
+    version: HistoryBlobReference
+
+    @classmethod
+    def _from_wire(cls, data: Mapping[str, Any]) -> PackageHistoryCommit:
+        return cls(DocxSnapshotReference._from_wire(data["after"]), DocxSnapshotReference._from_wire(data["before"]),
+                   _reference(data["contribution"]), data["documentId"], int(data["epoch"]), data["kind"],
+                   _reference(data["parent"]), int(data["sequence"]), HistoryBlobReference._from_wire(data["version"]))
+
+
+@dataclass(frozen=True, slots=True)
+class DocxHistoryLogEntry:
+    id: HistoryBlobReference
+    commit: PackageHistoryCommit
+    metadata: DocxVersionMetadata
+
+
+@dataclass(frozen=True, slots=True)
+class DocxHistoryUpdate:
+    after: HistoryHead | None
+    view: DocxHistoryView
+    entries: tuple[DocxHistoryLogEntry, ...]
+    reset: bool
+
+
 class DocxHistoryClient:
     """Use open_history(); a client is bound to its original subprocess, never a reused handle."""
 
@@ -193,6 +227,15 @@ class DocxHistoryClient:
     def read(self, document_id: str) -> DocxHistoryView | None:
         value = self._call("read", document_id)["view"]
         return None if value is None else DocxHistoryView._from_wire(value)
+
+    def read_changes_since(self, document_id: str, after: HistoryHead | None, max_entries_to_scan: int = 10_000) -> DocxHistoryUpdate:
+        """Host-triggered validated tail; first join starts at the latest checkpoint."""
+        update = self._call("updates", document_id, expectedHead=None if after is None else after.to_wire(),
+                            maxEntriesToScan=max_entries_to_scan)["update"]
+        return DocxHistoryUpdate(None if update["after"] is None else HistoryHead._from_wire(update["after"]),
+            DocxHistoryView._from_wire(update["view"]), tuple(DocxHistoryLogEntry(
+                HistoryBlobReference._from_wire(entry["id"]), PackageHistoryCommit._from_wire(entry["commit"]),
+                DocxVersionMetadata._from_wire(entry["metadata"])) for entry in update["entries"]), update["reset"])
 
     def create_version(self, document_id: str, expected_head: HistoryHead | None, docx_bytes: bytes,
                        metadata: DocxVersionMetadata) -> DocxHistoryView:

--- a/python/tests/test_history.py
+++ b/python/tests/test_history.py
@@ -46,6 +46,12 @@ def test_file_history_exact_reopen_time_render_restore_and_compare(tmp_path, tou
         assert restored.state.sequence == 2 and restored.state.epoch == 1
         assert restored.version.record.restored_from == first.version.id
         assert a.export_version("doc", second.version.id) == edited
+        updates = a.read_changes_since("doc", first.head)
+        assert [entry.commit.sequence for entry in updates.entries] == [1, 2]
+        assert updates.entries[0].id == second.state.commit
+        assert updates.entries[1].metadata.author == "python-actor"
+        assert updates.reset and updates.view.head == restored.head
+        assert a.read_changes_since("doc", restored.head).entries == ()
 
     shutdown_host()
     with open_history(root) as reopened:


### PR DESCRIPTION
Stack layer 14 for #671/#672, based on #717. Adds host-triggered ReadChangesSinceAsync plus npm/Python bindings. Updates carry a captured head and ascending contiguous accepted commit records with their recorded author/timestamp metadata. First join starts at the latest checkpoint; duplicate heads return empty tails; labels do not fabricate content commits; epoch transitions mark resets. No timer, subscription, socket, or transit/network layer.

Validates immutable version AND commit ancestry, sequence/epoch/content continuity, exact commit references, and one version-parent edge per publication-revision increment. Rejects rewinds, forks, same-content branches, forged revision/state pairs and bounded-scan exhaustion. Reads metadata only; rendering loads the returned immutable snapshot separately. Pending local work is not overwritten or automatically rebased.

Validation: 103 focused .NET tests; all 168 Python tests; full npm typecheck; trimmed WASM publish; 3 real Chromium tests including the new log-tail binding. Tests cover non-monotonic timestamps, metadata labels, resets, duplicates, exact ancestry, forged revisions, budgets, cancellation, read-only behavior and no snapshot/effect payload reads during log lookup.

Self-review: GPT-5.6-sol found the forged ancestor revision/state issue; fixed with version-edge/revision-delta binding and regression tests. Final re-review clean. A host-driven live viewer follows.