### PR TITLE
feat(history): atomically publish durable request receipts

### DIFF
--- a/Docxodus.Tests/DocxVersionRequestTests.cs
+++ b/Docxodus.Tests/DocxVersionRequestTests.cs
@@ -140,6 +140,27 @@ public sealed class DocxVersionRequestTests
         Assert.Null(await history.ReadAsync("doc"));
     }
 
+    [Fact]
+    public async Task RequestIdsTooLargeToIndexAreRefusedBeforeTheyCanStrandLaterPublications()
+    {
+        var history = new DocxVersionHistory(new MemoryHistoryBlobStore(), new MemoryHistoryHeadStore());
+        var bytes = Document("bounded");
+        // Each ID is within its own limit, but the pair cannot fit the receipt index node that the
+        // NEXT publication would have to promote it into. The refusal must happen here: accepting
+        // it would publish a head no later publication of this document could ever extend.
+        var documentId = new string('\u5408', 1024);
+        Assert.Equal(PackageChangeError.ResourceLimit, (await Assert.ThrowsAsync<PackageChangeException>(async () =>
+            await history.CreateVersionAsync(documentId, new string('\u540c', 1024), null, bytes, Metadata("oversized")))).Code);
+        Assert.Null(await history.ReadAsync(documentId));
+
+        // The same document keeps working with a request ID that fits, including across the
+        // publication that promotes the first receipt and a later retry of it.
+        var first = await history.CreateVersionAsync(documentId, "matter-42", null, bytes, Metadata("first"));
+        var second = await history.CreateVersionAsync(documentId, "matter-43", first.Head, Document("changed"), Metadata("second"));
+        Assert.Equal(first.Head, (await history.CreateVersionAsync(documentId, "matter-42", null, bytes, Metadata("first"))).Head);
+        Assert.Equal(second.Head, (await history.ReadAsync(documentId))!.Head);
+    }
+
     internal static DocxVersionMetadata Metadata(string label) => new()
     { Author = "actor", CreatedAt = DateTimeOffset.Parse("2026-01-01T12:00:00Z"), Label = label };
 

--- a/Docxodus.Tests/DocxVersionRequestTests.cs
+++ b/Docxodus.Tests/DocxVersionRequestTests.cs
@@ -1,0 +1,172 @@
+#nullable enable
+
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json.Nodes;
+using Docxodus.History;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+public sealed class DocxVersionRequestTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CreateAndRestoreRetriesReturnOriginalHeadsAfterReopenAndLaterLegacyWrites(bool file)
+    {
+        var root = Directory.CreateTempSubdirectory("version-request-").FullName;
+        try
+        {
+            IHistoryBlobStore blobs = file ? new FileHistoryBlobStore(Path.Combine(root, "blobs")) : new MemoryHistoryBlobStore();
+            IHistoryHeadStore heads = file ? new FileHistoryHeadStore(Path.Combine(root, "heads")) : new MemoryHistoryHeadStore();
+            var history = new DocxVersionHistory(blobs, heads);
+            var firstBytes = Document("initial");
+            var secondBytes = Document("revised");
+            var first = await history.CreateVersionAsync("doc", "r1", null, firstBytes, Metadata("one"));
+            var second = await history.CreateVersionAsync("doc", "r2", first.Head, secondBytes, Metadata("two"));
+            var restored = await history.RestoreVersionAsync("doc", "r3", second.Head, first.Version.Id, Metadata("restore"));
+            var legacy = await history.CreateVersionAsync("doc", restored.Head, secondBytes, Metadata("legacy"));
+            history = file ? new DocxVersionHistory(new FileHistoryBlobStore(Path.Combine(root, "blobs")),
+                new FileHistoryHeadStore(Path.Combine(root, "heads"))) : new DocxVersionHistory(blobs, heads);
+            Assert.Equal(first.Head, (await history.CreateVersionAsync("doc", "r1", null, firstBytes, Metadata("one"))).Head);
+            Assert.Equal(second.Head, (await history.CreateVersionAsync("doc", "r2", first.Head, secondBytes, Metadata("two"))).Head);
+            Assert.Equal(restored.Head, (await history.RestoreVersionAsync("doc", "r3", second.Head, first.Version.Id, Metadata("restore"))).Head);
+            Assert.Equal(legacy.Head, (await history.ReadAsync("doc"))!.Head);
+            Assert.Equal(4, (await history.ListVersionsAsync("doc")).Versions.Count);
+            Assert.Equal(firstBytes, await history.ExportVersionAsync("doc", first.Version.Id));
+            Assert.Equal(secondBytes, await history.ExportVersionAsync("doc", second.Version.Id));
+            Assert.Equal(1, restored.State.Epoch);
+            Assert.Equal(3, (await history.ReadChangesSinceAsync("doc", first.Head)).Entries.Count);
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    [Fact]
+    public async Task IdReuseBindsExactBytesExpectedHeadOperationTargetAndNormalizedMetadata()
+    {
+        var history = new DocxVersionHistory(new MemoryHistoryBlobStore(), new MemoryHistoryHeadStore());
+        var bytes = Document("initial");
+        var metadata = Metadata("named") with { ApplicationMetadata = new Dictionary<string, string> { ["b"] = "2", ["a"] = "1" } };
+        var first = await history.CreateVersionAsync("doc", "r1", null, bytes, metadata);
+        var reordered = metadata with { ApplicationMetadata = new Dictionary<string, string> { ["a"] = "1", ["b"] = "2" } };
+        Assert.Equal(first.Head, (await history.CreateVersionAsync("doc", "r1", null, bytes, reordered)).Head);
+        async Task Conflict(Func<ValueTask<DocxHistoryView>> action) => Assert.Equal(DocxHistoryError.RequestConflict,
+            (await Assert.ThrowsAsync<DocxHistoryException>(async () => await action())).Code);
+        await Conflict(() => history.CreateVersionAsync("doc", "r1", first.Head, bytes, metadata));
+        await Conflict(() => history.CreateVersionAsync("doc", "r1", null, Document("changed"), metadata));
+        await Conflict(() => history.CreateVersionAsync("doc", "r1", null, bytes, metadata with { Author = "other" }));
+        await Conflict(() => history.CreateVersionAsync("doc", "r1", null, bytes, metadata with { CreatedAt = metadata.CreatedAt.AddTicks(1) }));
+        await Conflict(() => history.RestoreVersionAsync("doc", "r1", first.Head, first.Version.Id, metadata));
+        // Intentional second version of identical bytes is distinct; request IDs aren't blob hashes.
+        var second = await history.CreateVersionAsync("doc", "r2", first.Head, bytes, metadata);
+        Assert.NotEqual(first.Version.Id, second.Version.Id);
+        Assert.Equal(first.State.Snapshot, second.State.Snapshot);
+        Assert.Equal(0, second.State.Sequence);
+        Assert.Equal(1, (await history.CreateVersionAsync("another-document", "r1", null, bytes, metadata)).Head.Revision);
+    }
+
+    [Fact]
+    public async Task ConcurrentIdenticalRetriesHaveOnePublicationAndOneResult()
+    {
+        var blobs = new MemoryHistoryBlobStore();
+        var heads = new MemoryHistoryHeadStore();
+        var bytes = Document("shared");
+        var results = await Task.WhenAll(Enumerable.Range(0, 16).Select(_ => Task.Run(async () =>
+            await new DocxVersionHistory(blobs, heads).CreateVersionAsync("doc", "one-request", null, bytes, Metadata("one")))));
+        Assert.All(results, result => Assert.Equal(results[0].Head, result.Head));
+        Assert.Equal(1, (await heads.ReadAsync("doc"))!.Revision);
+        var view = await new DocxVersionHistory(blobs, heads).ReadAsync("doc");
+        Assert.Equal(results[0].Version.Id, view!.Version.Id);
+    }
+
+    [Fact]
+    public async Task LostAcknowledgementAfterCommittedCASIsRecoveredAfterOtherPublications()
+    {
+        var blobs = new MemoryHistoryBlobStore();
+        var backing = new MemoryHistoryHeadStore();
+        var heads = new LostAckHeads(backing) { LoseNext = true };
+        var history = new DocxVersionHistory(blobs, heads);
+        var bytes = Document("saved");
+        await Assert.ThrowsAsync<IOException>(async () => await history.CreateVersionAsync("doc", "r1", null, bytes, Metadata("one")));
+        var original = (await history.ReadAsync("doc"))!;
+        var later = await history.CreateVersionAsync("doc", original.Head, bytes, Metadata("later"));
+        var restarted = new DocxVersionHistory(blobs, backing);
+        Assert.Equal(original.Head, (await restarted.CreateVersionAsync("doc", "r1", null, bytes, Metadata("one"))).Head);
+        Assert.Equal(later.Head, (await restarted.ReadAsync("doc"))!.Head);
+        heads.LoseNext = true;
+        await Assert.ThrowsAsync<IOException>(async () => await history.RestoreVersionAsync("doc", "restore", later.Head, original.Version.Id, Metadata("restore")));
+        var reset = (await restarted.ReadAsync("doc"))!;
+        Assert.Equal(reset.Head, (await restarted.RestoreVersionAsync("doc", "restore", later.Head, original.Version.Id, Metadata("restore"))).Head);
+        Assert.Equal(1, reset.State.Epoch);
+    }
+
+    [Fact]
+    public async Task LegacyV1StateIsPreservedUntilFirstIdempotentPublicationAndV2RejectsForgedRevision()
+    {
+        var blobs = new MemoryHistoryBlobStore();
+        var heads = new MemoryHistoryHeadStore();
+        var history = new DocxVersionHistory(blobs, heads);
+        var bytes = Document("legacy");
+        var first = await history.CreateVersionAsync("doc", null, bytes, Metadata("one"));
+        using (var stream = await blobs.OpenReadAsync(first.Head.State))
+        using (var reader = new StreamReader(stream!))
+        {
+            var json = await reader.ReadToEndAsync();
+            Assert.Contains("\"schemaVersion\":1", json);
+            Assert.DoesNotContain("requests", json);
+            var malformed = JsonNode.Parse(json)!;
+            malformed["record"]!["requests"] = null;
+            var bad = await HistoryBlobIO.PutBytesAsync(blobs, Encoding.UTF8.GetBytes(malformed.ToJsonString()), default);
+            Assert.Equal(PackageChangeError.InvalidManifest, (await Assert.ThrowsAsync<PackageChangeException>(async () =>
+                await new HistoryRecordStore(blobs).LoadStateAsync(bad))).Code);
+        }
+        var second = await history.CreateVersionAsync("doc", "r2", first.Head, bytes, Metadata("two"));
+        using (var stream = await blobs.OpenReadAsync(second.Head.State))
+        using (var reader = new StreamReader(stream!)) Assert.Contains("\"schemaVersion\":2", await reader.ReadToEndAsync());
+        var invalid = await heads.TryAdvanceAsync("doc", second.Head, second.Head.State);
+        Assert.Equal(DocxHistoryError.InvalidHistory,
+            (await Assert.ThrowsAsync<DocxHistoryException>(async () => await history.ReadAsync("doc"))).Code);
+        Assert.NotNull(invalid);
+    }
+
+    [Fact]
+    public async Task InvalidRequestIdsNeverFallBackToNonIdempotentPublication()
+    {
+        var history = new DocxVersionHistory(new MemoryHistoryBlobStore(), new MemoryHistoryHeadStore());
+        var bytes = Document("unchanged");
+        foreach (var id in new[] { null, "", " ", "\ud800", new string('x', 1025) })
+            await Assert.ThrowsAnyAsync<ArgumentException>(async () => await history.CreateVersionAsync("doc", id!, null, bytes, Metadata("invalid")));
+        Assert.Null(await history.ReadAsync("doc"));
+    }
+
+    internal static DocxVersionMetadata Metadata(string label) => new()
+    { Author = "actor", CreatedAt = DateTimeOffset.Parse("2026-01-01T12:00:00Z"), Label = label };
+
+    internal static byte[] Document(string text)
+    {
+        var bytes = DocxSession.CreateBlankDocxBytes();
+        using var stream = new MemoryStream(); stream.Write(bytes);
+        using (var zip = new ZipArchive(stream, ZipArchiveMode.Update, leaveOpen: true))
+        {
+            var part = zip.GetEntry("word/document.xml")!;
+            using var content = part.Open();
+            var xml = Encoding.UTF8.GetBytes("<w:document xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\"><w:body><w:p><w:r><w:t>"
+                + System.Security.SecurityElement.Escape(text) + "</w:t></w:r></w:p></w:body></w:document>");
+            content.SetLength(0); content.Write(xml);
+        }
+        return stream.ToArray();
+    }
+
+    private sealed class LostAckHeads(IHistoryHeadStore inner) : IHistoryHeadStore
+    {
+        internal bool LoseNext;
+        public ValueTask<HistoryHead?> ReadAsync(string id, CancellationToken cancellationToken = default) => inner.ReadAsync(id, cancellationToken);
+        public async ValueTask<HistoryHead?> TryAdvanceAsync(string id, HistoryHead? expected, HistoryBlobReference state, CancellationToken cancellationToken = default)
+        {
+            var result = await inner.TryAdvanceAsync(id, expected, state, cancellationToken);
+            if (result is not null && LoseNext) { LoseNext = false; throw new IOException("Acknowledgement lost after durable publication."); }
+            return result;
+        }
+    }
+}

--- a/Docxodus.Tests/HistoryRequestJournalTests.cs
+++ b/Docxodus.Tests/HistoryRequestJournalTests.cs
@@ -1,0 +1,106 @@
+#nullable enable
+
+using System.Security.Cryptography;
+using System.Text;
+using Docxodus.History;
+using Docxodus.Verification;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+public sealed class HistoryRequestJournalTests
+{
+    [Theory]
+    [InlineData(731)]
+    [InlineData(982451653)]
+    public async Task CompressedIndexFindsEveryOriginalResultAcrossRandomInsertionAndRestart(int seed)
+    {
+        var random = new Random(seed);
+        var blobs = new CountingBlobs();
+        var store = new HistoryRequestJournalStore(blobs);
+        HistoryRequestJournal? journal = null;
+        HistoryHead? head = null;
+        var receipts = new List<(HistoryRequestIdentity Request, HistoryHead Head)>();
+        var ids = Enumerable.Range(0, 1500).OrderBy(_ => random.Next()).ToArray();
+        foreach (var id in ids)
+        {
+            var request = Identity("replica/合同/" + id);
+            Assert.Null(await store.FindAsync("doc", head, journal, request));
+            journal = await store.AdvanceAsync("doc", head, journal, request);
+            head = Head(receipts.Count + 1);
+            receipts.Add((request, head));
+            var old = receipts[random.Next(receipts.Count)];
+            Assert.Equal(old.Head, await new HistoryRequestJournalStore(blobs).FindAsync("doc", head, journal, old.Request));
+        }
+        foreach (var (request, original) in receipts.OrderBy(_ => random.Next()))
+        {
+            blobs.Reads = 0;
+            Assert.Equal(original, await store.FindAsync("doc", head, journal, request));
+            Assert.InRange(blobs.Reads, 0, 257); // Hash width is the hard bound, not history size.
+        }
+        Assert.Null(await store.FindAsync("doc", head, journal, Identity("absent")));
+        Assert.True(blobs.MaximumLength <= HistoryRequestJournalStore.MaxNodeBytes);
+        var before = blobs.Writes;
+        foreach (var receipt in receipts.Take(20))
+            await store.FindAsync("doc", head, journal, receipt.Request);
+        Assert.Equal(before, blobs.Writes); // Queries never publish/repair indexes.
+    }
+
+    [Fact]
+    public async Task LegacyPublicationsPromoteReceiptsAndConflictsDoNotBecomeMisses()
+    {
+        var store = new HistoryRequestJournalStore(new MemoryHistoryBlobStore());
+        var request = Identity("r1");
+        var first = await store.AdvanceAsync("doc", null, null, request);
+        var second = await store.AdvanceAsync("doc", Head(1), first, null);
+        Assert.Null(second!.Current);
+        Assert.Equal(Head(1), await store.FindAsync("doc", Head(2), second, request));
+        foreach (var (head, journal) in new[] { (Head(1), first), (Head(2), second) })
+        {
+            var changed = request with { Fingerprint = Digest("changed") };
+            var error = await Assert.ThrowsAsync<DocxHistoryException>(async () => await store.FindAsync("doc", head, journal, changed));
+            Assert.Equal(DocxHistoryError.RequestConflict, error.Code);
+            await Assert.ThrowsAsync<DocxHistoryException>(async () => await store.FindAsync("foreign", head, journal, request));
+            await Assert.ThrowsAsync<DocxHistoryException>(async () => await store.FindAsync("doc", Head(999), journal, request));
+        }
+    }
+
+    [Fact]
+    public async Task MissingCorruptAndCanceledIndexLookupsFailClosed()
+    {
+        var blobs = new CountingBlobs();
+        var store = new HistoryRequestJournalStore(blobs);
+        var first = await store.AdvanceAsync("doc", null, null, Identity("r1"));
+        var second = await store.AdvanceAsync("doc", Head(1), first, Identity("r2"));
+        blobs.Missing = true;
+        Assert.Equal(PackageChangeError.PayloadMissing, (await Assert.ThrowsAsync<PackageChangeException>(async () =>
+            await store.FindAsync("doc", Head(2), second, Identity("r1")))).Code);
+        blobs.Missing = false; blobs.Corrupt = true;
+        Assert.Equal(PackageChangeError.PayloadMismatch, (await Assert.ThrowsAsync<PackageChangeException>(async () =>
+            await store.FindAsync("doc", Head(2), second, Identity("r1")))).Code);
+        using var canceled = new CancellationTokenSource(); canceled.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await store.FindAsync("doc", Head(2), second, Identity("r2"), canceled.Token));
+    }
+
+    internal static HistoryRequestIdentity Identity(string id) => new(id, Digest("input:" + id));
+    internal static VerificationDigest Digest(string text) => new()
+    { Algorithm = "SHA-256", Value = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(text))).ToLowerInvariant() };
+    internal static HistoryHead Head(long revision) => new(revision, new HistoryBlobReference(Digest("state:" + revision), 100));
+
+    private sealed class CountingBlobs : IHistoryBlobStore
+    {
+        private readonly MemoryHistoryBlobStore _inner = new();
+        internal int Reads, Writes, MaximumLength;
+        internal bool Missing, Corrupt;
+        public async ValueTask PutAsync(HistoryBlobReference reference, Stream content, CancellationToken cancellationToken = default)
+        { Writes++; MaximumLength = Math.Max(MaximumLength, reference.Length); await _inner.PutAsync(reference, content, cancellationToken); }
+        public async ValueTask<Stream?> OpenReadAsync(HistoryBlobReference reference, CancellationToken cancellationToken = default)
+        {
+            Reads++;
+            if (Missing) return null;
+            if (!Corrupt) return await _inner.OpenReadAsync(reference, cancellationToken);
+            return new MemoryStream(new byte[reference.Length]);
+        }
+    }
+}

--- a/Docxodus.Tests/HistoryRequestJournalTests.cs
+++ b/Docxodus.Tests/HistoryRequestJournalTests.cs
@@ -66,6 +66,29 @@ public sealed class HistoryRequestJournalTests
     }
 
     [Fact]
+    public async Task IdentitiesTooLargeToIndexAreRefusedWhenSuppliedAndLeaveTheDocumentPublishable()
+    {
+        var blobs = new CountingBlobs();
+        var store = new HistoryRequestJournalStore(blobs);
+        // Both IDs sit exactly on their own documented character limits, but JSON escapes each of
+        // these characters to six bytes, so the receipt cannot fit one 16 KiB index node.
+        var documentId = new string('\u5408', 1024);
+        var oversized = Identity(new string('\u540c', 1024));
+        Assert.Equal(PackageChangeError.ResourceLimit, (await Assert.ThrowsAsync<PackageChangeException>(async () =>
+            await store.AdvanceAsync(documentId, null, null, oversized))).Code);
+        Assert.Equal(0, blobs.Writes); // Refused before any blob is written, so nothing is abandoned.
+
+        // The refusal is about the pair, not the character set: an ID that fits still publishes,
+        // and the NEXT publication promotes it into the index rather than failing to.
+        var accepted = Identity("\u5408\u540c/matter-42");
+        var first = await store.AdvanceAsync(documentId, null, null, accepted);
+        var second = await store.AdvanceAsync(documentId, Head(1), first, null);
+        Assert.Null(second!.Current);
+        Assert.Equal(Head(1), await store.FindAsync(documentId, Head(2), second, accepted));
+        Assert.True(blobs.MaximumLength <= HistoryRequestJournalStore.MaxNodeBytes);
+    }
+
+    [Fact]
     public async Task MissingCorruptAndCanceledIndexLookupsFailClosed()
     {
         var blobs = new CountingBlobs();

--- a/Docxodus/History/DocxVersionHistory.Requests.cs
+++ b/Docxodus/History/DocxVersionHistory.Requests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Security.Cryptography;
+using System.Text.Json;
+using Docxodus.Verification;
+
+namespace Docxodus.History;
+
+public sealed partial class DocxVersionHistory
+{
+    private async ValueTask<DocxHistoryView?> FindRequestAsync(string documentId, DocxHistoryView? current,
+        HistoryRequestIdentity? request, CancellationToken cancellationToken)
+    {
+        if (request is null) return null;
+        var original = await _requests.FindAsync(documentId, current?.Head, current?.State.Requests,
+            request, cancellationToken).ConfigureAwait(false);
+        if (original is null) return null;
+        var view = original == current!.Head ? current
+            : await ReadHeadViewAsync(documentId, original, cancellationToken).ConfigureAwait(false);
+        Consistent(original.Revision <= current.Head.Revision && view.State.Requests?.Current == request,
+            "Request receipt does not match its original publication.");
+        return view;
+    }
+
+    // Explicit, versioned, length-delimited canonical input. Metadata has already been copied and
+    // sorted before any await. Exact raw bytes distinguish repacks; timestamps retain their offset
+    // and precision. Nonces/generated results are intentionally NOT part of caller input identity.
+    private static HistoryRequestIdentity VersionRequest(string operation, string documentId, HistoryHead? expected,
+        DocxVersionMetadata metadata, string requestId, byte[]? docx, HistoryBlobReference? target)
+    {
+        HistoryRequestJournalStore.ValidateId(requestId);
+        if (expected is not null)
+        {
+            if (expected.Revision <= 0) throw new ArgumentOutOfRangeException(nameof(expected));
+            HistoryBlobIO.Validate(expected.State, int.MaxValue);
+        }
+        if (target is not null) HistoryBlobIO.Validate(target, int.MaxValue);
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("schema", "docxodus.version-request/v1");
+            writer.WriteString("operation", operation);
+            writer.WriteString("documentId", documentId);
+            writer.WritePropertyName("expectedHead");
+            if (expected is null) writer.WriteNullValue();
+            else
+            {
+                writer.WriteStartObject(); writer.WriteNumber("revision", expected.Revision);
+                Reference("state", expected.State); writer.WriteEndObject();
+            }
+            Reference("target", target);
+            if (docx is null) writer.WriteNull("snapshot");
+            else Reference("snapshot", new HistoryBlobReference(new VerificationDigest
+            { Algorithm = "SHA-256", Value = Convert.ToHexString(SHA256.HashData(docx)).ToLowerInvariant() }, docx.Length));
+            writer.WriteString("author", metadata.Author);
+            writer.WriteString("createdAt", metadata.CreatedAt.ToString("O", System.Globalization.CultureInfo.InvariantCulture));
+            writer.WriteString("label", metadata.Label); writer.WriteString("message", metadata.Message);
+            writer.WriteStartObject("applicationMetadata");
+            foreach (var pair in metadata.ApplicationMetadata) writer.WriteString(pair.Key, pair.Value);
+            writer.WriteEndObject(); writer.WriteEndObject();
+
+            void Reference(string name, HistoryBlobReference? reference)
+            {
+                writer.WritePropertyName(name);
+                if (reference is null) { writer.WriteNullValue(); return; }
+                writer.WriteStartObject(); writer.WriteString("sha256", reference.Digest.Value);
+                writer.WriteNumber("length", reference.Length); writer.WriteEndObject();
+            }
+        }
+        return new HistoryRequestIdentity(requestId, new VerificationDigest
+        { Algorithm = "SHA-256", Value = Convert.ToHexString(SHA256.HashData(buffer.ToArray())).ToLowerInvariant() });
+    }
+}

--- a/Docxodus/History/DocxVersionHistory.Restore.cs
+++ b/Docxodus/History/DocxVersionHistory.Restore.cs
@@ -14,16 +14,31 @@ public sealed partial class DocxVersionHistory
     /// when target content is already current. Does not silently replace any live DocxSession.
     /// Hosts must preserve pre-reset pending work as a recoverable branch when notifying clients.
     /// </summary>
-    public async ValueTask<DocxHistoryView> RestoreVersionAsync(string documentId, HistoryHead expected,
-        HistoryBlobReference targetVersion, DocxVersionMetadata metadata, CancellationToken cancellationToken = default)
+    public ValueTask<DocxHistoryView> RestoreVersionAsync(string documentId, HistoryHead expected,
+        HistoryBlobReference targetVersion, DocxVersionMetadata metadata, CancellationToken cancellationToken = default) =>
+        RestoreVersionCoreAsync(documentId, expected, targetVersion, metadata, null, cancellationToken);
+
+    /// <summary>Restore with a durable caller-owned retry identity, without repeating the reset.</summary>
+    public ValueTask<DocxHistoryView> RestoreVersionAsync(string documentId, string requestId, HistoryHead expected,
+        HistoryBlobReference targetVersion, DocxVersionMetadata metadata, CancellationToken cancellationToken = default) =>
+        RestoreVersionCoreAsync(documentId, expected, targetVersion, metadata,
+            requestId ?? throw new ArgumentNullException(nameof(requestId)), cancellationToken);
+
+    private async ValueTask<DocxHistoryView> RestoreVersionCoreAsync(string documentId, HistoryHead expected,
+        HistoryBlobReference targetVersion, DocxVersionMetadata metadata, string? requestId, CancellationToken cancellationToken)
     {
         HistoryHeadCodec.Key(documentId);
         ArgumentNullException.ThrowIfNull(expected);
         ArgumentNullException.ThrowIfNull(targetVersion);
         cancellationToken.ThrowIfCancellationRequested();
         var capturedMetadata = HistoryRecordStore.PrepareMetadata(metadata);
+        var request = requestId is null ? null : VersionRequest("restore", documentId, expected,
+            capturedMetadata, requestId, null, targetVersion);
         var nonce = Guid.NewGuid();
-        var current = await ReadExpectedAsync(documentId, expected, cancellationToken).ConfigureAwait(false);
+        var current = await ReadAsync(documentId, cancellationToken).ConfigureAwait(false);
+        var repeated = await FindRequestAsync(documentId, current, request, cancellationToken).ConfigureAwait(false);
+        if (repeated is not null) return repeated;
+        if (current?.Head != expected) throw Stale();
         var target = await GetVersionAsync(documentId, targetVersion, cancellationToken).ConfigureAwait(false);
         // Verify exact target bytes and package identity before publishing a reset. Reuse its
         // immutable snapshot reference; restore never reserializes or rewrites the target blob.
@@ -46,6 +61,7 @@ public sealed partial class DocxVersionHistory
         {
             Commit = commitId, Epoch = epoch, Sequence = sequence, Snapshot = target.Record.Snapshot, Version = versionId,
         };
-        return await PublishAsync(documentId, expected, state, new DocxStoredVersion(versionId, version), cancellationToken).ConfigureAwait(false);
+        return await PublishAsync(documentId, expected, state, new DocxStoredVersion(versionId, version),
+            cancellationToken, request, current.State.Requests).ConfigureAwait(false);
     }
 }

--- a/Docxodus/History/DocxVersionHistory.cs
+++ b/Docxodus/History/DocxVersionHistory.cs
@@ -7,7 +7,7 @@ using Docxodus.Verification;
 
 namespace Docxodus.History;
 
-public enum DocxHistoryError { StaleHead, ForeignDocument, InvalidHistory, HistoryUnavailable, TraversalLimit }
+public enum DocxHistoryError { StaleHead, ForeignDocument, InvalidHistory, HistoryUnavailable, TraversalLimit, RequestConflict }
 
 /// <summary>A publication precondition or cross-record history invariant failed.</summary>
 public sealed class DocxHistoryException : Exception
@@ -30,6 +30,7 @@ public sealed partial class DocxVersionHistory
     private readonly IHistoryBlobStore _blobs;
     private readonly IHistoryHeadStore _heads;
     private readonly HistoryRecordStore _records;
+    private readonly HistoryRequestJournalStore _requests;
     private readonly DocxSnapshotStore _snapshots;
     private readonly int _maxSnapshotBytes;
     private readonly PackageManifestOptions? _packageOptions;
@@ -43,6 +44,7 @@ public sealed partial class DocxVersionHistory
         _blobs = blobs;
         _heads = heads;
         _records = new HistoryRecordStore(blobs, maxRecordBytes);
+        _requests = new HistoryRequestJournalStore(blobs);
         _snapshots = new DocxSnapshotStore(blobs, maxSnapshotBytes, packageOptions);
         _maxSnapshotBytes = maxSnapshotBytes;
         _packageOptions = packageOptions;
@@ -63,6 +65,7 @@ public sealed partial class DocxVersionHistory
     {
         var state = await _records.LoadStateAsync(head.State, cancellationToken).ConfigureAwait(false);
         SameDocument(documentId, state.DocumentId);
+        HistoryRequestJournalStore.ValidatePublication(documentId, head, state.Requests);
         Consistent(state.Sequence < head.Revision && state.Epoch <= state.Sequence, "Invalid head publication position.");
         var version = await GetVersionAsync(documentId, state.Version, cancellationToken).ConfigureAwait(false);
         Consistent(version.Record.Sequence == state.Sequence && version.Record.Snapshot == state.Snapshot,
@@ -88,8 +91,21 @@ public sealed partial class DocxVersionHistory
     /// Changed OPC content appends an import commit with lossless effects; unchanged content adds
     /// metadata only, even when ZIP serialization differs. All blobs precede the one CAS commit point.
     /// </summary>
-    public async ValueTask<DocxHistoryView> CreateVersionAsync(string documentId, HistoryHead? expected,
-        byte[] docxBytes, DocxVersionMetadata metadata, CancellationToken cancellationToken = default)
+    public ValueTask<DocxHistoryView> CreateVersionAsync(string documentId, HistoryHead? expected,
+        byte[] docxBytes, DocxVersionMetadata metadata, CancellationToken cancellationToken = default) =>
+        CreateVersionCoreAsync(documentId, expected, docxBytes, metadata, null, cancellationToken);
+
+    /// <summary>
+    /// Idempotent publication. Persist requestId with the original input before submission. An
+    /// identical retry returns the original view, even after later writes; changed input fails.
+    /// </summary>
+    public ValueTask<DocxHistoryView> CreateVersionAsync(string documentId, string requestId, HistoryHead? expected,
+        byte[] docxBytes, DocxVersionMetadata metadata, CancellationToken cancellationToken = default) =>
+        CreateVersionCoreAsync(documentId, expected, docxBytes, metadata,
+            requestId ?? throw new ArgumentNullException(nameof(requestId)), cancellationToken);
+
+    private async ValueTask<DocxHistoryView> CreateVersionCoreAsync(string documentId, HistoryHead? expected,
+        byte[] docxBytes, DocxVersionMetadata metadata, string? requestId, CancellationToken cancellationToken)
     {
         HistoryHeadCodec.Key(documentId);
         ArgumentNullException.ThrowIfNull(docxBytes);
@@ -98,8 +114,13 @@ public sealed partial class DocxVersionHistory
             throw new PackageChangeException(PackageChangeError.ResourceLimit, "Snapshot exceeds the byte limit.");
         var captured = docxBytes.ToArray();
         var capturedMetadata = HistoryRecordStore.PrepareMetadata(metadata);
+        var request = requestId is null ? null : VersionRequest("create", documentId, expected,
+            capturedMetadata, requestId, captured, null);
         var nonce = Guid.NewGuid();
-        var current = await ReadExpectedAsync(documentId, expected, cancellationToken).ConfigureAwait(false);
+        var current = await ReadAsync(documentId, cancellationToken).ConfigureAwait(false);
+        var repeated = await FindRequestAsync(documentId, current, request, cancellationToken).ConfigureAwait(false);
+        if (repeated is not null) return repeated;
+        if (current?.Head != expected) throw Stale();
         var snapshot = await _snapshots.CaptureAsync(captured, cancellationToken).ConfigureAwait(false);
         var changed = current is not null && current.State.Snapshot.ContentDigest != snapshot.ContentDigest;
         var sequence = checked((current?.State.Sequence ?? 0) + (changed ? 1 : 0));
@@ -133,7 +154,8 @@ public sealed partial class DocxVersionHistory
             InitialSnapshot = current?.State.InitialSnapshot ?? snapshot, Sequence = sequence,
             Snapshot = snapshot, Version = versionId,
         };
-        return await PublishAsync(documentId, expected, state, new DocxStoredVersion(versionId, version), cancellationToken).ConfigureAwait(false);
+        return await PublishAsync(documentId, expected, state, new DocxStoredVersion(versionId, version),
+            cancellationToken, request, current?.State.Requests).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -186,20 +208,22 @@ public sealed partial class DocxVersionHistory
         return await _snapshots.CompareAsync(left.Record.Snapshot, right.Record.Snapshot, settings, cancellationToken).ConfigureAwait(false);
     }
 
-    private async ValueTask<DocxHistoryView?> ReadExpectedAsync(string documentId, HistoryHead? expected, CancellationToken cancellationToken)
-    {
-        var current = await ReadAsync(documentId, cancellationToken).ConfigureAwait(false);
-        if (current?.Head != expected) throw Stale();
-        return current;
-    }
-
     private async ValueTask<DocxHistoryView> PublishAsync(string documentId, HistoryHead? expected,
-        DocxHistoryStateRecord state, DocxStoredVersion version, CancellationToken cancellationToken)
+        DocxHistoryStateRecord state, DocxStoredVersion version, CancellationToken cancellationToken,
+        HistoryRequestIdentity? request = null, HistoryRequestJournal? previousRequests = null)
     {
+        state = state with { Requests = await _requests.AdvanceAsync(documentId, expected, previousRequests,
+            request, cancellationToken).ConfigureAwait(false) };
         var stateId = await _records.SaveStateAsync(state, cancellationToken).ConfigureAwait(false);
         var head = await _heads.TryAdvanceAsync(documentId, expected, stateId, cancellationToken).ConfigureAwait(false);
         // Do not throw cancellation after publication: the CAS is the definitive commit point.
-        return head is null ? throw Stale() : new DocxHistoryView(head, state, version);
+        if (head is not null) return new DocxHistoryView(head, state, version);
+        // A concurrent identical retry may have won the CAS. Resolve its durable receipt rather
+        // than reporting that successfully published request stale. Unknown storage exceptions
+        // propagate: the caller retries the same identity to resolve a possibly lost acknowledgement.
+        var repeated = await FindRequestAsync(documentId,
+            await ReadAsync(documentId, cancellationToken).ConfigureAwait(false), request, cancellationToken).ConfigureAwait(false);
+        return repeated ?? throw Stale();
     }
 
     private static DocxHistoryException Stale() => new(DocxHistoryError.StaleHead, "History head changed; recapture the expected head before publishing.");

--- a/Docxodus/History/HistoryRecordStore.cs
+++ b/Docxodus/History/HistoryRecordStore.cs
@@ -58,9 +58,10 @@ public sealed class HistoryRecordStore
     {
         cancellationToken.ThrowIfCancellationRequested();
         var normalized = Validate(record);
+        var schemaVersion = normalized is DocxHistoryStateRecord { Requests: not null } ? 2 : 1;
         var bytes = JsonSerializer.SerializeToUtf8Bytes(new HistoryRecordEnvelope<T>
         {
-            Record = normalized, Schema = Schema(kind), SchemaVersion = 1,
+            Record = normalized, Schema = Schema(kind, schemaVersion), SchemaVersion = schemaVersion,
         }, TypeInfo<T>());
         Budget(bytes.Length <= _maxRecordBytes);
         var reference = new HistoryBlobReference(new VerificationDigest
@@ -85,12 +86,19 @@ public sealed class HistoryRecordStore
             using var header = JsonDocument.Parse(bytes, new JsonDocumentOptions { MaxDepth = 12, AllowDuplicateProperties = false });
             var fields = header.RootElement.EnumerateObject().Select(p => p.Name).ToHashSet(StringComparer.Ordinal);
             Require(fields.SetEquals(["record", "schema", "schemaVersion"]), "Malformed history envelope.");
-            if (header.RootElement.GetProperty("schemaVersion").GetInt32() != 1)
+            var schemaVersion = header.RootElement.GetProperty("schemaVersion").GetInt32();
+            if (schemaVersion != 1 && !(schemaVersion == 2 && kind == "package-state"))
                 throw new PackageChangeException(PackageChangeError.UnsupportedVersion, "Unsupported history record version.");
-            Require(header.RootElement.GetProperty("schema").GetString() == Schema(kind), "Unexpected history record schema.");
+            Require(header.RootElement.GetProperty("schema").GetString() == Schema(kind, schemaVersion), "Unexpected history record schema.");
             var envelope = JsonSerializer.Deserialize(bytes, TypeInfo<T>());
             Require(envelope is not null, "History envelope is required.");
             var record = Validate(envelope!.Record);
+            if (record is DocxHistoryStateRecord state)
+            {
+                Require((state.Requests is not null) == (schemaVersion == 2), "Request journals require state schema V2.");
+                Require(schemaVersion != 1 || !header.RootElement.GetProperty("record").TryGetProperty("requests", out _),
+                    "V1 states cannot declare request journals, including null.");
+            }
             cancellationToken.ThrowIfCancellationRequested();
             return record;
         }
@@ -128,6 +136,8 @@ public sealed class HistoryRecordStore
                 break;
             case DocxHistoryStateRecord state:
                 HistoryHeadCodec.Key(state.DocumentId);
+                HistoryRequestJournalStore.ValidateJournal(state.Requests);
+                Require(state.Requests is null || state.Requests.DocumentId == state.DocumentId, "Foreign request journal.");
                 Require(state.Sequence >= 0 && state.Epoch >= 0
                     && (state.Commit is null) == (state.Sequence == 0), "Invalid history state position.");
                 Reference(state.Commit); RequiredReference(state.Version);
@@ -179,7 +189,7 @@ public sealed class HistoryRecordStore
         Budget(value.Length <= maximumLength);
         _ = new UTF8Encoding(false, true).GetByteCount(value);
     }
-    private static string Schema(string kind) => $"https://docxodus.dev/schemas/history/{kind}/v1";
+    private static string Schema(string kind, int version) => $"https://docxodus.dev/schemas/history/{kind}/v{version}";
     private static JsonTypeInfo<HistoryRecordEnvelope<T>> TypeInfo<T>() =>
         (JsonTypeInfo<HistoryRecordEnvelope<T>>)JsonContext.GetTypeInfo(typeof(HistoryRecordEnvelope<T>))!;
     private static void Require(bool condition, string message)

--- a/Docxodus/History/HistoryRecords.cs
+++ b/Docxodus/History/HistoryRecords.cs
@@ -56,6 +56,9 @@ public sealed record PackageHistoryCommitRecord
 /// </summary>
 public sealed record DocxHistoryStateRecord
 {
+    /// <summary>V2 publication metadata. Absent in legacy V1 states; older records remain readable.</summary>
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    public HistoryRequestJournal? Requests { get; init; }
     public required HistoryBlobReference? Commit { get; init; }
     public required string DocumentId { get; init; }
     public required long Epoch { get; init; }

--- a/Docxodus/History/HistoryRequestJournal.cs
+++ b/Docxodus/History/HistoryRequestJournal.cs
@@ -88,7 +88,7 @@ public sealed class HistoryRequestJournalStore
     {
         HistoryHeadCodec.Key(documentId);
         ValidatePublication(documentId, currentHead, journal);
-        if (request is not null) ValidateIdentity(request);
+        if (request is not null) { ValidateIdentity(request); ValidateIndexable(documentId, request); }
         cancellationToken.ThrowIfCancellationRequested();
         var index = journal?.Index;
         if (journal?.Current is not null)
@@ -193,11 +193,39 @@ public sealed class HistoryRequestJournalStore
 
     private async ValueTask<HistoryBlobReference> SaveAsync(HistoryRequestIndexNode node, CancellationToken cancellationToken)
     {
-        ValidateNode(node);
-        var bytes = JsonSerializer.SerializeToUtf8Bytes(new HistoryRequestIndexEnvelope
-        { SchemaVersion = 1, Schema = "https://docxodus.dev/schemas/history/request-index/v1", Node = node }, Json.HistoryRequestIndexEnvelope);
+        var bytes = Serialize(node);
         if (bytes.Length > MaxNodeBytes) throw new PackageChangeException(PackageChangeError.ResourceLimit, "Request-index node exceeds its limit.");
         return await HistoryBlobIO.PutBytesAsync(_blobs, bytes, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static byte[] Serialize(HistoryRequestIndexNode node)
+    {
+        ValidateNode(node);
+        return JsonSerializer.SerializeToUtf8Bytes(new HistoryRequestIndexEnvelope
+        { SchemaVersion = 1, Schema = "https://docxodus.dev/schemas/history/request-index/v1", Node = node }, Json.HistoryRequestIndexEnvelope);
+    }
+
+    /// <summary>
+    /// A receipt published inline must also fit the ONE index node that the next publication
+    /// promotes it into. Both IDs are bounded in characters, but JSON escapes each non-ASCII or
+    /// reserved character to six bytes, so legal IDs can still exceed a node. Rejecting that here
+    /// fails the call supplying the ID instead of the next unrelated publication, which could
+    /// otherwise never promote the receipt and would leave the document permanently unpublishable.
+    /// The probe uses the largest head a publication can carry, so it never accepts a receipt the
+    /// promotion would refuse.
+    /// </summary>
+    private static void ValidateIndexable(string documentId, HistoryRequestIdentity request)
+    {
+        var widest = new HistoryHead(long.MaxValue, new HistoryBlobReference(new VerificationDigest
+        { Algorithm = "SHA-256", Value = new string('f', 64) }, int.MaxValue));
+        var probe = new HistoryRequestIndexNode
+        {
+            DocumentId = documentId, Bit = 256, Key = Key(request.Id), Zero = null, One = null,
+            Receipt = new HistoryRequestReceipt(documentId, request, widest),
+        };
+        if (Serialize(probe).Length > MaxNodeBytes)
+            throw new PackageChangeException(PackageChangeError.ResourceLimit,
+                "Document and request ID exceed the request-index node limit.");
     }
 
     private static void ValidateNode(HistoryRequestIndexNode node)

--- a/Docxodus/History/HistoryRequestJournal.cs
+++ b/Docxodus/History/HistoryRequestJournal.cs
@@ -1,0 +1,284 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Docxodus.Verification;
+
+namespace Docxodus.History;
+
+/// <summary>An opaque, document-scoped logical request ID bound to its canonical input digest.</summary>
+public sealed record HistoryRequestIdentity(string Id, VerificationDigest Fingerprint);
+
+/// <summary>
+/// Atomically publish this value with application state. Current's result is that publication's
+/// own head; Index contains earlier receipts. The next publication indexes the now-known head,
+/// avoiding a content-hash cycle. Retain the reachable index and original result states.
+/// </summary>
+public sealed record HistoryRequestJournal(string DocumentId, long Revision,
+    HistoryBlobReference? Index, HistoryRequestIdentity? Current);
+
+/// <summary>A durable binding from a logical request to its exact original publication.</summary>
+public sealed record HistoryRequestReceipt(string DocumentId, HistoryRequestIdentity Request, HistoryHead Head);
+
+/// <summary>
+/// Storage-neutral durable retry lookup. The caller publishes AdvanceAsync's result in the SAME
+/// head CAS as its application state. This class writes immutable blobs only; it never publishes
+/// independently. No authoritative in-memory cache, transport, clocks, or actor allocator.
+/// </summary>
+public sealed class HistoryRequestJournalStore
+{
+    public const int MaxRequestIdChars = 1024;
+    public const int MaxNodeBytes = 16 * 1024;
+    private static readonly UTF8Encoding Utf8 = new(false, true);
+    private static readonly HistoryRequestJsonContext Json = new(new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase, AllowDuplicateProperties = false,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow, RespectNullableAnnotations = true,
+        RespectRequiredConstructorParameters = true, MaxDepth = 12,
+    });
+    private readonly IHistoryBlobStore _blobs;
+
+    public HistoryRequestJournalStore(IHistoryBlobStore blobs) =>
+        _blobs = blobs ?? throw new ArgumentNullException(nameof(blobs));
+
+    /// <summary>Resolve a retry before checking its old expected head. ID reuse fails explicitly.</summary>
+    public async ValueTask<HistoryHead?> FindAsync(string documentId, HistoryHead? currentHead,
+        HistoryRequestJournal? journal, HistoryRequestIdentity request, CancellationToken cancellationToken = default)
+    {
+        HistoryHeadCodec.Key(documentId);
+        ValidateIdentity(request); ValidatePublication(documentId, currentHead, journal);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (journal?.Current?.Id == request.Id)
+        {
+            Match(journal.Current, request);
+            return currentHead;
+        }
+        var key = Key(request.Id);
+        var cursor = journal?.Index;
+        HistoryRequestIndexNode? parent = null;
+        while (cursor is not null)
+        {
+            var node = await LoadAsync(documentId, cursor, cancellationToken).ConfigureAwait(false);
+            ValidateChild(parent, node, key);
+            if (!PrefixMatches(key, node.Key, node.Bit)) return null;
+            if (node.Bit == 256)
+            {
+                Require(node.Receipt!.Request.Id == request.Id, "Request key collision.");
+                Match(node.Receipt.Request, request);
+                Require(node.Receipt.Head.Revision < currentHead!.Revision, "Indexed receipt does not precede this publication.");
+                return node.Receipt.Head;
+            }
+            parent = node;
+            cursor = Bit(key, node.Bit) ? node.One : node.Zero;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Prepare the next journal. Promote the preceding inline receipt, including when the next
+    /// publication is legacy/non-idempotent. Abandoned prepared nodes are safe unreferenced blobs.
+    /// </summary>
+    public async ValueTask<HistoryRequestJournal?> AdvanceAsync(string documentId, HistoryHead? currentHead,
+        HistoryRequestJournal? journal, HistoryRequestIdentity? request, CancellationToken cancellationToken = default)
+    {
+        HistoryHeadCodec.Key(documentId);
+        ValidatePublication(documentId, currentHead, journal);
+        if (request is not null) ValidateIdentity(request);
+        cancellationToken.ThrowIfCancellationRequested();
+        var index = journal?.Index;
+        if (journal?.Current is not null)
+            index = await InsertAsync(documentId, index,
+                new HistoryRequestReceipt(documentId, journal.Current, currentHead!), cancellationToken).ConfigureAwait(false);
+        return index is null && request is null ? null : new HistoryRequestJournal(documentId,
+            checked((currentHead?.Revision ?? 0) + 1), index, request);
+    }
+
+    internal static void ValidateJournal(HistoryRequestJournal? journal)
+    {
+        if (journal is null) return;
+        HistoryHeadCodec.Key(journal.DocumentId);
+        Require(journal.Revision > 0, "Invalid request-journal revision.");
+        Require(journal.Index is not null || journal.Current is not null, "Empty request journal.");
+        if (journal.Index is not null) HistoryBlobIO.Validate(journal.Index, MaxNodeBytes);
+        if (journal.Current is not null) ValidateIdentity(journal.Current);
+    }
+
+    internal static void ValidateIdentity(HistoryRequestIdentity request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ValidateId(request.Id);
+        HistoryBlobIO.Validate(new HistoryBlobReference(request.Fingerprint, 0), 0);
+    }
+
+    internal static void ValidateId(string id)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        if (id.Length > MaxRequestIdChars) throw new ArgumentException("Request ID exceeds its limit.", nameof(id));
+        _ = Utf8.GetByteCount(id);
+    }
+
+    internal static void ValidatePublication(string documentId, HistoryHead? head, HistoryRequestJournal? journal)
+    {
+        ValidateJournal(journal);
+        Require(journal is null || (journal.DocumentId == documentId && journal.Revision == head?.Revision),
+            "Request journal does not belong to this document publication.");
+        if (head is null) return;
+        Require(head.Revision > 0, "Invalid request publication revision.");
+        HistoryBlobIO.Validate(head.State, int.MaxValue);
+    }
+
+    private async ValueTask<HistoryBlobReference> InsertAsync(string documentId, HistoryBlobReference? root,
+        HistoryRequestReceipt receipt, CancellationToken cancellationToken)
+    {
+        var key = Key(receipt.Request.Id);
+        var leaf = new HistoryRequestIndexNode
+        { DocumentId = documentId, Bit = 256, Key = key, Receipt = receipt, Zero = null, One = null };
+        if (root is null) return await SaveAsync(leaf, cancellationToken).ConfigureAwait(false);
+        return await InsertAtAsync(root, null).ConfigureAwait(false);
+
+        async ValueTask<HistoryBlobReference> InsertAtAsync(HistoryBlobReference reference, HistoryRequestIndexNode? parent)
+        {
+            var node = await LoadAsync(documentId, reference, cancellationToken).ConfigureAwait(false);
+            ValidateChild(parent, node, key);
+            var divergence = FirstDifference(key, node.Key);
+            if (divergence < node.Bit)
+            {
+                var added = await SaveAsync(leaf, cancellationToken).ConfigureAwait(false);
+                return await SaveAsync(new HistoryRequestIndexNode
+                {
+                    DocumentId = documentId, Bit = divergence, Key = Prefix(key, divergence), Receipt = null,
+                    Zero = Bit(key, divergence) ? reference : added,
+                    One = Bit(key, divergence) ? added : reference,
+                }, cancellationToken).ConfigureAwait(false);
+            }
+            if (node.Bit == 256)
+            {
+                Require(node.Receipt == receipt, "A request was published more than once or its key collided.");
+                return reference;
+            }
+            var one = Bit(key, node.Bit);
+            var child = await InsertAtAsync((one ? node.One : node.Zero)!, node).ConfigureAwait(false);
+            return await SaveAsync(one ? node with { One = child } : node with { Zero = child }, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask<HistoryRequestIndexNode> LoadAsync(string documentId, HistoryBlobReference reference,
+        CancellationToken cancellationToken)
+    {
+        HistoryBlobIO.Validate(reference, MaxNodeBytes);
+        cancellationToken.ThrowIfCancellationRequested();
+        using var stream = await _blobs.OpenReadAsync(reference, cancellationToken).ConfigureAwait(false);
+        if (stream is null) throw new PackageChangeException(PackageChangeError.PayloadMissing, "Request-index node is missing.");
+        var bytes = await PackageChangeSetCodec.ReadPayloadAsync(reference, stream, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            using var header = JsonDocument.Parse(bytes);
+            if (header.RootElement.GetProperty("schemaVersion").GetInt32() != 1)
+                throw new PackageChangeException(PackageChangeError.UnsupportedVersion, "Unsupported request-index version.");
+            var envelope = JsonSerializer.Deserialize(bytes, Json.HistoryRequestIndexEnvelope)
+                ?? throw new JsonException("Missing request-index envelope.");
+            Require(envelope.Schema == "https://docxodus.dev/schemas/history/request-index/v1", "Unexpected request-index schema.");
+            ValidateNode(envelope.Node);
+            Require(envelope.Node.DocumentId == documentId, "Foreign request-index node.");
+            return envelope.Node;
+        }
+        catch (Exception error) when (error is JsonException or ArgumentException or InvalidOperationException or FormatException or KeyNotFoundException)
+        { throw new PackageChangeException(PackageChangeError.InvalidManifest, "Malformed request-index node."); }
+    }
+
+    private async ValueTask<HistoryBlobReference> SaveAsync(HistoryRequestIndexNode node, CancellationToken cancellationToken)
+    {
+        ValidateNode(node);
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(new HistoryRequestIndexEnvelope
+        { SchemaVersion = 1, Schema = "https://docxodus.dev/schemas/history/request-index/v1", Node = node }, Json.HistoryRequestIndexEnvelope);
+        if (bytes.Length > MaxNodeBytes) throw new PackageChangeException(PackageChangeError.ResourceLimit, "Request-index node exceeds its limit.");
+        return await HistoryBlobIO.PutBytesAsync(_blobs, bytes, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static void ValidateNode(HistoryRequestIndexNode node)
+    {
+        ArgumentNullException.ThrowIfNull(node);
+        HistoryHeadCodec.Key(node.DocumentId);
+        Require(node.Bit is >= 0 and <= 256, "Invalid request-index bit position.");
+        Require(node.Key is { Length: 64 } && node.Key.All(c => c is >= '0' and <= '9' or >= 'a' and <= 'f'), "Invalid request-index key.");
+        if (node.Bit == 256)
+        {
+            Require(node.Receipt is not null && node.Zero is null && node.One is null, "Invalid request-index leaf.");
+            var receipt = node.Receipt!;
+            Require(receipt.DocumentId == node.DocumentId, "Foreign request receipt.");
+            ValidateIdentity(receipt.Request);
+            ArgumentNullException.ThrowIfNull(receipt.Head);
+            Require(receipt.Head.Revision > 0 && node.Key == Key(receipt.Request.Id), "Invalid request receipt identity.");
+            HistoryBlobIO.Validate(receipt.Head.State, int.MaxValue);
+        }
+        else
+        {
+            Require(node.Receipt is null && node.Zero is not null && node.One is not null && node.Zero != node.One
+                && node.Key == Prefix(node.Key, node.Bit), "Invalid request-index branch.");
+            HistoryBlobIO.Validate(node.Zero!, MaxNodeBytes); HistoryBlobIO.Validate(node.One!, MaxNodeBytes);
+        }
+    }
+
+    private static void ValidateChild(HistoryRequestIndexNode? parent, HistoryRequestIndexNode child, string key)
+    {
+        if (parent is null) return;
+        Require(child.Bit > parent.Bit && PrefixMatches(child.Key, parent.Key, parent.Bit)
+            && Bit(child.Key, parent.Bit) == Bit(key, parent.Bit), "Request-index path is inconsistent or cyclic.");
+    }
+
+    private static void Match(HistoryRequestIdentity stored, HistoryRequestIdentity requested)
+    {
+        if (stored.Fingerprint != requested.Fingerprint)
+            throw new DocxHistoryException(DocxHistoryError.RequestConflict, "Request ID is already bound to different input.");
+    }
+
+    private static string Key(string id) => Convert.ToHexString(SHA256.HashData(Utf8.GetBytes(id))).ToLowerInvariant();
+    private static bool Bit(string hex, int bit) => (Nibble(hex[bit / 4]) & (8 >> (bit % 4))) != 0;
+    private static int Nibble(char c) => c <= '9' ? c - '0' : c - 'a' + 10;
+    private static int FirstDifference(string left, string right)
+    {
+        for (var i = 0; i < 256; i++) if (Bit(left, i) != Bit(right, i)) return i;
+        return 256;
+    }
+    private static bool PrefixMatches(string key, string prefix, int bits) => FirstDifference(key, prefix) >= bits;
+    private static string Prefix(string key, int bits)
+    {
+        var chars = key.ToCharArray();
+        for (var i = bits / 4; i < chars.Length; i++)
+        {
+            var keep = i == bits / 4 ? bits % 4 : 0;
+            chars[i] = "0123456789abcdef"[Nibble(chars[i]) & (15 << (4 - keep))];
+        }
+        return new string(chars);
+    }
+    private static void Require(bool condition, string message)
+    { if (!condition) throw new DocxHistoryException(DocxHistoryError.InvalidHistory, message); }
+}
+
+internal sealed record HistoryRequestIndexNode
+{
+    public required string DocumentId { get; init; }
+    public required int Bit { get; init; }
+    public required string Key { get; init; }
+    public required HistoryRequestReceipt? Receipt { get; init; }
+    public required HistoryBlobReference? Zero { get; init; }
+    public required HistoryBlobReference? One { get; init; }
+}
+
+internal sealed record HistoryRequestIndexEnvelope
+{
+    public required string Schema { get; init; }
+    public required int SchemaVersion { get; init; }
+    public required HistoryRequestIndexNode Node { get; init; }
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow, AllowDuplicateProperties = false,
+    RespectNullableAnnotations = true, RespectRequiredConstructorParameters = true, MaxDepth = 12)]
+[JsonSerializable(typeof(HistoryRequestIndexEnvelope))]
+internal partial class HistoryRequestJsonContext : JsonSerializerContext { }

--- a/docs/architecture/shared_history_infrastructure.md
+++ b/docs/architecture/shared_history_infrastructure.md
@@ -1,0 +1,39 @@
+# Shared publication and backend reconciliation infrastructure
+
+Scope: storage-neutral durable publication, version-history fault/model fuzzing, and a backend
+operation-stream reconciler. No GUI, transport, subscriptions, presence, or real-time editor.
+
+## Completion gates
+
+1. Durable request identity: the same document/request ID and canonical input returns the original
+   committed result after restart, later writes, concurrent retries, or a lost acknowledgement.
+   Reusing an ID with different input fails. Byte deduplication is independent of request identity.
+2. One atomic publication exposes state and its request receipt together. Failures before it
+   leave the old state; failures after it are recoverable by retry. No process-local dedup cache
+   is authoritative. Existing immutable version records remain readable.
+3. Version creation/restoration use that machinery, preserving exact bytes, lineage, metadata,
+   content sequence/epoch, stale-write guards, and current host-owned storage contracts.
+4. A backend acceptance log records operation IDs, original bases, accepted order, resolved
+   effects/outcomes, and recoverable conflicts. Reconciliation combines compatible work and
+   preserves incompatible contenders for explicit resolution. Replay never reruns clocks or
+   allocators. Multiple instances/restarts and delayed/repeated/reordered submissions are tested.
+5. Reproducible model/fault fuzzing covers version create/label/repack/restore/list/export/replay,
+   retries and ID collisions, competing writers, cancellation, corrupt/missing storage, and
+   failures at publication boundaries. Backend conflict streams are checked against independent
+   expected content/outcomes, including cross-part dependencies and preservation of opaque data.
+6. Document the adapter requirements, retry/retention semantics, conflict policy, limits, and
+   executed seed/operation counts. Run existing history and binding regressions. Review each PR.
+
+## Atomic receipts without circular content references
+
+Each publication stores the latest request identity inline, plus an immutable index of earlier
+receipts. The latest result is the publication's own head. The next publication promotes that
+receipt into the index, now that its exact head is known, and writes its own request inline.
+Thus a receipt can identify the exact original result without a hash cycle between the head,
+index, and receipt. An immutable compressed radix index bounds lookup by request-key hash width,
+not total history length. Legacy publications carry the index forward even without a request ID.
+
+Version request fingerprints cover the operation, document, exact expected head, input snapshot
+bytes or restore target, and normalized metadata. Caller IDs are bounded opaque strings scoped
+to a document; hosts authenticate callers and allocate replica/request namespaces. Timestamps
+are recorded metadata, not deduplication keys or ordering authority.

--- a/docs/history.md
+++ b/docs/history.md
@@ -31,13 +31,55 @@ Use `MemoryHistoryBlobStore` and `MemoryHistoryHeadStore` for process-local use 
 
 ## Publication and identity
 
-`CreateVersionAsync` requires the exact previously read `HistoryHead`; null initializes an absent document. A stale expectation raises `DocxHistoryException` with `StaleHead`. Do not silently retry with a new expectation: a host should decide whether the submitted document still represents the desired next version. Every successful create produces a distinct version ID. After an uncertain storage response, inspect the head/list before deciding whether to issue a new create; operation-level retry deduplication is not yet implemented.
+`CreateVersionAsync` requires the exact previously read `HistoryHead`; null initializes an absent document. A stale expectation raises `DocxHistoryException` with `StaleHead`. Do not silently retry with a new expectation: a host should decide whether the submitted document still represents the desired next version. Every successful new create produces a distinct version ID. Use the request-ID overload described below for safe retries after uncertain storage responses; the legacy overload remains non-idempotent.
 
 A version ID is its immutable manifest's `HistoryBlobReference` (SHA-256 plus byte length), not a mutable filename or array index. It retains a parent link, exact snapshot, creation nonce, host metadata, and content-log sequence. Raw snapshot SHA-256 binds the downloadable bytes; the independent ordered OPC digest identifies package content. No provenance is inserted into the DOCX.
 
 Initial capture establishes sequence 0. Naming unchanged content increments only `HistoryHead.Revision`, even if ZIP timestamps/compression differ. Changed content appends one import commit, its reversible package contribution, and its named version; one head CAS publishes them together. A failed blob write or CAS leaves the prior history visible. Unreferenced blobs may remain and belong to the host's retention/cleanup policy.
 
 Inputs are captured before awaiting host storage. The service does not mutate a `DocxSession` or the supplied byte array. These full-package captures and inspections belong at version/import boundaries, not on the typing path.
+
+## Durable request identity
+
+```csharp
+// Allocate/persist once with the original bytes, metadata, and expected head before submission.
+var saved = await history.CreateVersionAsync(documentId, requestId, expectedHead,
+    capturedBytes, capturedMetadata, cancellationToken);
+var restored = await history.RestoreVersionAsync(documentId, restoreRequestId, previewedHead,
+    selectedVersionId, restoreMetadata, cancellationToken);
+```
+
+IDs are opaque, document-scoped strings of 1–1024 UTF-16 characters (nonblank, valid Unicode).
+The host owns authentication and ID allocation; a persisted replica UUID plus monotonic counter,
+or a persisted unique request UUID, can distinguish independent intents. Never infer identity
+from timestamps or snapshot hashes. Two intentional saves of identical bytes use different IDs.
+
+The same ID and canonical input returns the exact original `DocxHistoryView`, even after later
+saves/restores, concurrent retries, or a restart. Its head is the original publication, NOT the
+latest head: read current history separately before making a new edit. Changed input raises
+`RequestConflict`, including a changed expected head, metadata, operation, restore target, or
+exact snapshot bytes. Metadata dictionary insertion order is normalized; timestamps include
+their stored offset/precision. Repacked ZIP bytes are different input even if OPC content agrees.
+Keep the original captured bytes; do not re-save/re-capture a live session for a retry.
+
+One head CAS publishes state plus `HistoryRequestJournal`. The current receipt is inline; the
+next publication promotes it into an immutable compressed SHA-256 radix index with its now-known
+head. This avoids circular hashes and binds the original result durably. Legacy calls carry the
+index forward too. Lookup verifies only its selected path (at most 257 bounded 16 KiB nodes), not
+the entire unvisited tree. Missing/corrupt index data fails; it is never treated as a new request.
+
+Failures before CAS do not bind the request. A concurrent identical winner is resolved through
+its receipt. An I/O exception may have occurred after a successful CAS; retry the same request
+to resolve that uncertainty. Cancellation after this call's successful CAS cannot change its
+success into cancellation. Receipts are not a separate process-local cache or mutable table.
+State schema V2 carries journals; V1 records remain readable and are still written for histories
+that never opted in. Old readers must fail on V2 rather than discard the journal.
+
+Retention must keep reachable receipt-index nodes AND the original result state/version records.
+Deleting the request index would reopen old IDs to duplicate publication and is not permitted as
+routine compaction. Snapshot retention is separate: a receipt identifies a version but does not
+make deleted snapshot bytes recoverable. A future bounded dedup policy needs explicit namespace
+retirement/fencing, not a best-effort TTL. No retention deletion or transport is supplied here.
 
 ## Reading and comparison
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -50,6 +50,10 @@ var restored = await history.RestoreVersionAsync(documentId, restoreRequestId, p
 ```
 
 IDs are opaque, document-scoped strings of 1–1024 UTF-16 characters (nonblank, valid Unicode).
+The document ID and the request ID must also fit together in one 16 KiB index node once escaped
+(JSON escapes each non-ASCII or reserved character to six bytes), so a pair of long IDs made
+entirely of such characters is refused with `ResourceLimit` by the call that supplies it rather
+than by the next publication. Plain identifiers are nowhere near that bound.
 The host owns authentication and ID allocation; a persisted replica UUID plus monotonic counter,
 or a persisted unique request UUID, can distinguish independent intents. Never infer identity
 from timestamps or snapshot hashes. Two intentional saves of identical bytes use different IDs.

--- a/docs/schemas/history-request-index-v1.schema.json
+++ b/docs/schemas/history-request-index-v1.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docxodus.dev/schemas/history/request-index/v1",
+  "title": "Immutable compressed binary request-receipt index",
+  "$comment": "Resolve shared definitions from the adjacent history-state-v2.schema.json. Runtime also enforces a 16 KiB blob limit, SHA-256/length integrity, document identity, canonical zero-padded branch prefixes, leaf key = SHA-256(UTF-8 request ID), strictly increasing child bit positions, and parent/child path agreement. Reads are bounded by 257 nodes.",
+  "type": "object", "additionalProperties": false,
+  "required": ["schema", "schemaVersion", "node"],
+  "properties": {
+    "schema": { "const": "https://docxodus.dev/schemas/history/request-index/v1" },
+    "schemaVersion": { "const": 1 },
+    "node": {
+      "type": "object", "additionalProperties": false,
+      "required": ["documentId", "bit", "key", "receipt", "zero", "one"],
+      "properties": {
+        "documentId": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/id" },
+        "bit": { "type": "integer", "minimum": 0, "maximum": 256 },
+        "key": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "receipt": { "anyOf": [{ "$ref": "#/$defs/receipt" }, { "type": "null" }] },
+        "zero": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/optionalBlob" },
+        "one": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/optionalBlob" }
+      },
+      "if": { "properties": { "bit": { "const": 256 } } },
+      "then": { "properties": { "receipt": { "$ref": "#/$defs/receipt" }, "zero": { "type": "null" }, "one": { "type": "null" } } },
+      "else": { "properties": { "receipt": { "type": "null" }, "zero": { "$ref": "#/$defs/nodeRef" }, "one": { "$ref": "#/$defs/nodeRef" } } }
+    }
+  },
+  "$defs": {
+    "nodeRef": { "allOf": [{ "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/blob" }, { "properties": { "length": { "maximum": 16384 } } }] },
+    "receipt": {
+      "type": "object", "additionalProperties": false, "required": ["documentId", "request", "head"],
+      "properties": {
+        "documentId": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/id" },
+        "request": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/request" },
+        "head": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/head" }
+      }
+    }
+  }
+}

--- a/docs/schemas/history-state-v2.schema.json
+++ b/docs/schemas/history-state-v2.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docxodus.dev/schemas/history/package-state/v2",
+  "title": "Package-history state with atomic durable request receipts",
+  "$comment": "Runtime validation also binds document ID/publication revision to the journal and validates the content/version/commit graph. Counters here are durable Int64 numbers, not client-wire decimal strings.",
+  "type": "object", "additionalProperties": false,
+  "required": ["schema", "schemaVersion", "record"],
+  "properties": {
+    "schema": { "const": "https://docxodus.dev/schemas/history/package-state/v2" },
+    "schemaVersion": { "const": 2 },
+    "record": {
+      "type": "object", "additionalProperties": false,
+      "required": ["requests", "commit", "documentId", "epoch", "initialSnapshot", "sequence", "snapshot", "version"],
+      "properties": {
+        "requests": { "$ref": "#/$defs/journal" },
+        "commit": { "$ref": "#/$defs/optionalBlob" },
+        "documentId": { "$ref": "#/$defs/id" },
+        "epoch": { "$ref": "#/$defs/position" },
+        "initialSnapshot": { "$ref": "#/$defs/snapshot" },
+        "sequence": { "$ref": "#/$defs/position" },
+        "snapshot": { "$ref": "#/$defs/snapshot" },
+        "version": { "$ref": "#/$defs/blob" }
+      }
+    }
+  },
+  "$defs": {
+    "id": { "type": "string", "minLength": 1, "maxLength": 1024, "pattern": "\\S" },
+    "position": { "type": "integer", "minimum": 0, "maximum": 9223372036854775807 },
+    "digest": {
+      "type": "object", "additionalProperties": false, "required": ["algorithm", "value"],
+      "properties": { "algorithm": { "const": "SHA-256" }, "value": { "type": "string", "pattern": "^[0-9a-f]{64}$" } }
+    },
+    "blob": {
+      "type": "object", "additionalProperties": false, "required": ["digest", "length"],
+      "properties": { "digest": { "$ref": "#/$defs/digest" }, "length": { "type": "integer", "minimum": 0, "maximum": 2147483647 } }
+    },
+    "optionalBlob": { "anyOf": [{ "$ref": "#/$defs/blob" }, { "type": "null" }] },
+    "snapshot": {
+      "type": "object", "additionalProperties": false, "required": ["blob", "contentDigest"],
+      "properties": { "blob": { "$ref": "#/$defs/blob" }, "contentDigest": { "$ref": "#/$defs/digest" } }
+    },
+    "request": {
+      "type": "object", "additionalProperties": false, "required": ["id", "fingerprint"],
+      "properties": { "id": { "$ref": "#/$defs/id" }, "fingerprint": { "$ref": "#/$defs/digest" } }
+    },
+    "head": {
+      "type": "object", "additionalProperties": false, "required": ["revision", "state"],
+      "properties": { "revision": { "allOf": [{ "$ref": "#/$defs/position" }, { "minimum": 1 }] }, "state": { "$ref": "#/$defs/blob" } }
+    },
+    "journal": {
+      "type": "object", "additionalProperties": false, "required": ["documentId", "revision", "index", "current"],
+      "properties": {
+        "documentId": { "$ref": "#/$defs/id" },
+        "revision": { "allOf": [{ "$ref": "#/$defs/position" }, { "minimum": 1 }] },
+        "index": { "anyOf": [{ "allOf": [{ "$ref": "#/$defs/blob" }, { "properties": { "length": { "maximum": 16384 } } }] }, { "type": "null" }] },
+        "current": { "anyOf": [{ "$ref": "#/$defs/request" }, { "type": "null" }] }
+      },
+      "not": { "properties": { "index": { "type": "null" }, "current": { "type": "null" } } }
+    }
+  }
+}


### PR DESCRIPTION
First shared-infrastructure layer for #671/#672 and the requested backend-only work. Adds document-scoped request IDs/fingerprints, an immutable compressed receipt index, and idempotent .NET version create/restore overloads. The current receipt is inline; the next publication indexes its known head, avoiding content-hash cycles. One existing head CAS publishes state and receipt together. Legacy calls preserve earlier receipts; V1 records remain readable, V2 states explicitly carry journals.

Identical retries return the exact original head/version after later publications or lost acknowledgements; changed input under an existing ID returns RequestConflict. Fingerprints bind exact snapshot bytes/restore targets, expected heads and normalized metadata. Lookup is bounded by 257 verified 16 KiB nodes. No transport, GUI, timers or real-time editor integration.

Validation: focused history/storage/client regressions pass (119 tests in this layer); 3,000 randomized receipt-index insertions/lookups; memory/filesystem reopen, old retries, input conflicts, concurrent identical callers, lost acknowledgements, legacy carryforward, forged revisions and strict V1/V2 validation. Separate reflection-disabled process round-trips receipt/index/state/client graphs. git diff --check clean.

GPT-5.6-sol reviewed and re-reviewed the complete layer; no remaining findings. Extensive fault/model fuzzing and backend conflict-stream reconciliation follow as separate layers; this PR does not claim completion of that full objective.