### PR TITLE
test(history): fuzz versions and force publication races

### DIFF
--- a/Docxodus.Tests/DocxVersionModelFuzzTests.cs
+++ b/Docxodus.Tests/DocxVersionModelFuzzTests.cs
@@ -1,0 +1,271 @@
+#nullable enable
+
+using System.IO.Compression;
+using Docxodus.History;
+using DocumentFormat.OpenXml.Packaging;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+using static Docxodus.Tests.DocxVersionRequestTests;
+
+namespace Docxodus.Tests;
+
+/// <summary>
+/// Stateful oracle independent of history records, package digests, and replay implementation.
+/// Override DOCXODUS_HISTORY_FUZZ_SEEDS/STEPS for the extended deterministic corpus. Every failure
+/// reports its complete seed/command trace. Each seed checks all exact exports and all sequences.
+/// </summary>
+public sealed class DocxVersionModelFuzzTests(ITestOutputHelper output)
+{
+    public static IEnumerable<object[]> Seeds => Enumerable.Range(0, Setting("SEEDS", 16, 1024))
+        .Select(index => new object[] { 60493 + index * 7919 });
+    private sealed record Command(string? Id, HistoryHead? Expected, byte[] Bytes, DocxStoredVersion? Restore,
+        DocxVersionMetadata Metadata);
+    private sealed record ExpectedVersion(DocxHistoryView View, byte[] Bytes, DateTimeOffset Time, bool ContentBoundary);
+
+    [Theory]
+    [MemberData(nameof(Seeds))]
+    public async Task VersionStreamsMatchIndependentModelUnderRetriesRacesFaultsAndRestart(int seed)
+    {
+        var steps = Setting("STEPS", 96, 10_000);
+        var random = new Random(seed);
+        var filesystem = seed % 5 == 0;
+        using var storage = new HistoryFaultHarness(filesystem);
+        var history = new DocxVersionHistory(storage, storage);
+        var trace = new List<string>();
+        var versions = new List<ExpectedVersion>();
+        var requests = new List<(Command Command, DocxHistoryView Result)>();
+        var pool = Enumerable.Range(0, 6).Select(i => Package(seed, i)).ToArray();
+        var counts = new Dictionary<string, int>();
+        void Count(string name) => counts[name] = counts.GetValueOrDefault(name) + 1;
+        ExpectedVersion? Latest() => versions.LastOrDefault();
+        DocxVersionMetadata Meta(int step) => Metadata("seed " + seed + " step " + step) with
+        {
+            Author = "actor-" + random.Next(3),
+            CreatedAt = DateTimeOffset.UnixEpoch.AddMinutes(random.Next(-50, 51)).AddTicks(random.Next(7)),
+            ApplicationMetadata = new Dictionary<string, string> { ["seed"] = seed.ToString(), ["step"] = step.ToString(), ["unicode"] = "合同 📝" },
+        };
+        try
+        {
+            for (var step = 0; step < steps; step++)
+            {
+                history = new DocxVersionHistory(storage, storage); // No producer instance survives a step.
+                var action = versions.Count == 0 ? 0 : random.Next(12);
+                trace.Add($"{step}: action={action}, head={Latest()?.View.Head.Revision ?? 0}");
+                if (action <= 5)
+                {
+                    var restore = action == 5 ? versions[random.Next(versions.Count)] : null;
+                    var bytes = restore?.Bytes ?? (action == 1 ? Latest()!.Bytes
+                        : action == 2 ? Repack(Latest()!.Bytes, step) : pool[random.Next(pool.Length)]);
+                    var requestId = action == 4 ? null : $"{seed}/{step}";
+                    var command = new Command(requestId, Latest()?.View.Head, bytes, restore?.View.Version, Meta(step));
+                    var lostAck = requestId is not null && step % 17 == 0;
+                    if (lostAck) storage.Arm(HistoryFaultHarness.Fault.AfterHead);
+                    DocxHistoryView result;
+                    if (lostAck)
+                    {
+                        await Assert.ThrowsAsync<IOException>(async () => await Invoke(history, command));
+                        storage.Arm(HistoryFaultHarness.Fault.None);
+                        result = await Invoke(new DocxVersionHistory(storage, storage), command);
+                        Assert.Equal(0, storage.Publications);
+                        Count("lost-ack-recovery");
+                    }
+                    else result = await Invoke(history, command);
+                    await Accept(command, result);
+                    Count(restore is not null ? "restore" : action == 2 ? "repack" : requestId is null ? "legacy-save" : "save");
+                }
+                else if (action == 6 && requests.Count > 0)
+                {
+                    var old = requests[random.Next(requests.Count)];
+                    var head = Latest()!.View.Head;
+                    Assert.Equal(old.Result.Head, (await Invoke(history, old.Command)).Head);
+                    Assert.Equal(head, (await history.ReadAsync("doc"))!.Head);
+                    Count("old-request-retry");
+                }
+                else if (action == 7 && requests.Count > 0)
+                {
+                    var old = requests[random.Next(requests.Count)];
+                    var collision = old.Command with { Metadata = old.Command.Metadata with { Message = "different logical request" } };
+                    Assert.Equal(DocxHistoryError.RequestConflict,
+                        (await Assert.ThrowsAsync<DocxHistoryException>(async () => await Invoke(history, collision))).Code);
+                    Count("id-reuse-refusal");
+                }
+                else if (action == 8 && versions.Count > 1)
+                {
+                    var stale = new Command($"stale/{seed}/{step}", versions[random.Next(versions.Count - 1)].View.Head,
+                        pool[random.Next(pool.Length)], null, Meta(step));
+                    Assert.Equal(DocxHistoryError.StaleHead,
+                        (await Assert.ThrowsAsync<DocxHistoryException>(async () => await Invoke(history, stale))).Code);
+                    // A request never committed/bound may be corrected and submitted intentionally.
+                    var corrected = stale with { Expected = Latest()!.View.Head };
+                    await Accept(corrected, await Invoke(history, corrected));
+                    Count("stale-then-corrected");
+                }
+                else if (action == 9)
+                {
+                    var target = versions[random.Next(versions.Count)];
+                    storage.DamagedDigest = target.View.State.Snapshot.Blob.Digest.Value;
+                    storage.Missing = random.Next(2) == 0;
+                    try
+                    {
+                        Assert.Equal(storage.Missing ? PackageChangeError.PayloadMissing : PackageChangeError.PayloadMismatch,
+                            (await Assert.ThrowsAsync<PackageChangeException>(async () => await history.ExportVersionAsync("doc", target.View.Version.Id))).Code);
+                    }
+                    finally { storage.DamagedDigest = null; }
+                    Count("damaged-storage-refusal");
+                }
+                else if (action == 10)
+                {
+                    var sameRequest = random.Next(2) == 0;
+                    var first = new Command($"race/{seed}/{step}/0", Latest()!.View.Head, pool[random.Next(pool.Length)], null, Meta(step));
+                    var second = sameRequest ? first : first with { Id = $"race/{seed}/{step}/1", Bytes = pool[random.Next(pool.Length)] };
+                    var firstWinner = random.Next(2) == 0;
+                    trace.Add($"  race: sameRequest={sameRequest}, firstWinner={firstWinner}");
+                    async Task<DocxHistoryView?> Compete(Command command)
+                    {
+                        try { return await Invoke(new DocxVersionHistory(storage, storage), command); }
+                        catch (DocxHistoryException error) when (error.Code == DocxHistoryError.StaleHead) { return null; }
+                    }
+                    var attempts = storage.Publications;
+                    storage.HoldCompetingPublications(firstWinner ? "left" : "right");
+                    DocxHistoryView?[] results;
+                    try
+                    {
+                        results = await Task.WhenAll(
+                            Task.Run(() => storage.AsContenderAsync("left", () => Compete(first))),
+                            Task.Run(() => storage.AsContenderAsync("right", () => Compete(second))));
+                    }
+                    finally { storage.ReleaseCompetingPublications(); }
+                    Assert.Equal(2, storage.Publications - attempts); // Both must reach the exact same CAS expectation.
+                    if (sameRequest)
+                    {
+                        Assert.NotNull(results[0]); Assert.NotNull(results[1]);
+                        Assert.Equal(results[0]!.Head, results[1]!.Head);
+                        await Accept(first, results[0]!);
+                    }
+                    else
+                    {
+                        Assert.Single(results.Where(x => x is not null));
+                        Assert.Equal(firstWinner, results[0] is not null);
+                        await Accept(results[0] is not null ? first : second, results[0] ?? results[1]!);
+                    }
+                    Count(sameRequest ? "identical-race" : "competing-race");
+                }
+                else
+                {
+                    var selected = versions[random.Next(versions.Count)];
+                    Assert.Equal(selected.Bytes, await history.ExportVersionAsync("doc", selected.View.Version.Id));
+                    Count("read");
+                }
+                Assert.Equal(Latest()!.View.Head, (await history.ReadAsync("doc"))!.Head);
+            }
+
+            // Immutable pagination and exact snapshots are checked against independently retained inputs.
+            var listed = new List<DocxStoredVersion>();
+            HistoryBlobReference? cursor = null;
+            do
+            {
+                var page = await history.ListVersionsAsync("doc", cursor, 7);
+                listed.AddRange(page.Versions); cursor = page.Next;
+            } while (cursor is not null);
+            Assert.Equal(versions.Select(v => v.View.Version.Id).Reverse(), listed.Select(v => v.Id));
+            foreach (var version in versions)
+                Assert.Equal(version.Bytes, await history.ExportVersionAsync("doc", version.View.Version.Id));
+
+            var boundaries = versions.Where(v => v.ContentBoundary).ToArray();
+            foreach (var boundary in boundaries)
+            {
+                var sequence = boundary.View.State.Sequence;
+                // ZIP-entry comparison does not call the production manifest/digest/replay owner.
+                SameContent(boundary.Bytes, await history.MaterializeAsync("doc", sequence));
+                SameContent(boundary.Bytes, await history.ReplayAsync("doc", sequence));
+            }
+            foreach (var cutoff in boundaries.Select(v => v.Time).Append(DateTimeOffset.UnixEpoch.AddDays(-1)))
+            {
+                var expected = boundaries.Where(v => v.Time <= cutoff).LastOrDefault();
+                if (expected is null)
+                    Assert.Equal(DocxHistoryError.HistoryUnavailable, (await Assert.ThrowsAsync<DocxHistoryException>(async () =>
+                        await history.ResolveSequenceAtTimeAsync("doc", cutoff))).Code);
+                else Assert.Equal(expected.View.State.Sequence, await history.ResolveSequenceAtTimeAsync("doc", cutoff));
+            }
+            foreach (var (command, result) in requests)
+                Assert.Equal(result.Head, (await Invoke(new DocxVersionHistory(storage, storage), command)).Head);
+            output.WriteLine($"seed={seed}; steps={steps}; filesystem={filesystem}; versions={versions.Count}; replayed-sequences={boundaries.Length}; "
+                + string.Join(", ", counts.OrderBy(p => p.Key).Select(p => p.Key + "=" + p.Value)));
+        }
+        catch (Exception error)
+        { throw new XunitException($"History fuzz failure seed={seed}, steps={steps}, filesystem={filesystem}\n{string.Join("\n", trace)}\n{error}"); }
+
+        async Task Accept(Command command, DocxHistoryView result)
+        {
+            var previous = Latest();
+            var changed = previous is not null && !Equivalent(previous.Bytes, command.Bytes);
+            var boundary = previous is null || command.Restore is not null || changed;
+            var sequence = (previous?.View.State.Sequence ?? 0) + (previous is not null && boundary ? 1 : 0);
+            var epoch = (previous?.View.State.Epoch ?? 0) + (command.Restore is not null ? 1 : 0);
+            Assert.Equal((previous?.View.Head.Revision ?? 0) + 1, result.Head.Revision);
+            Assert.Equal(sequence, result.State.Sequence); Assert.Equal(epoch, result.State.Epoch);
+            Assert.Equal(previous?.View.Version.Id, result.Version.Record.Parent);
+            Assert.Equal(command.Restore?.Id, result.Version.Record.RestoredFrom);
+            Assert.Equal(command.Metadata.Author, result.Version.Record.Metadata.Author);
+            Assert.Equal(command.Metadata.CreatedAt, result.Version.Record.Metadata.CreatedAt);
+            Assert.Equal(command.Metadata.Label, result.Version.Record.Metadata.Label);
+            Assert.Equal(command.Metadata.ApplicationMetadata, result.Version.Record.Metadata.ApplicationMetadata);
+            Assert.Equal(command.Id, result.State.Requests?.Current?.Id);
+            Assert.Equal(command.Bytes, await history.ExportVersionAsync("doc", result.Version.Id));
+            versions.Add(new ExpectedVersion(result, command.Bytes.ToArray(), command.Metadata.CreatedAt, boundary));
+            if (command.Id is not null) requests.Add((command, result));
+        }
+    }
+
+    private static ValueTask<DocxHistoryView> Invoke(DocxVersionHistory history, Command command) => command.Restore is not null
+        ? command.Id is null ? history.RestoreVersionAsync("doc", command.Expected!, command.Restore.Id, command.Metadata)
+            : history.RestoreVersionAsync("doc", command.Id, command.Expected!, command.Restore.Id, command.Metadata)
+        : command.Id is null ? history.CreateVersionAsync("doc", command.Expected, command.Bytes, command.Metadata)
+            : history.CreateVersionAsync("doc", command.Id, command.Expected, command.Bytes, command.Metadata);
+
+    private static byte[] Package(int seed, int variant)
+    {
+        using var stream = new MemoryStream(); stream.Write(Document($"seed {seed} variant {variant}: café 📝 合同"));
+        using (var document = WordprocessingDocument.Open(stream, true))
+        {
+            var part = document.MainDocumentPart!.AddCustomXmlPart("application/octet-stream");
+            var opaque = new byte[257]; new Random(seed ^ variant).NextBytes(opaque);
+            using var payload = new MemoryStream(opaque); part.FeedData(payload);
+        }
+        return stream.ToArray();
+    }
+
+    private static byte[] Repack(byte[] bytes, int step)
+    {
+        using var stream = new MemoryStream(); stream.Write(bytes);
+        using (var zip = new ZipArchive(stream, ZipArchiveMode.Update, leaveOpen: true))
+            foreach (var entry in zip.Entries) entry.LastWriteTime = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero).AddMinutes(step);
+        return stream.ToArray();
+    }
+
+    private static SortedDictionary<string, byte[]> Entries(byte[] bytes)
+    {
+        using var zip = new ZipArchive(new MemoryStream(bytes), ZipArchiveMode.Read);
+        var entries = new SortedDictionary<string, byte[]>(StringComparer.Ordinal);
+        foreach (var entry in zip.Entries.Where(e => !e.FullName.EndsWith('/')))
+        {
+            using var input = entry.Open(); using var content = new MemoryStream(); input.CopyTo(content);
+            entries.Add(entry.FullName, content.ToArray());
+        }
+        return entries;
+    }
+    private static bool Equivalent(byte[] left, byte[] right)
+    {
+        var a = Entries(left); var b = Entries(right);
+        return a.Count == b.Count && a.All(p => b.TryGetValue(p.Key, out var bytes) && p.Value.AsSpan().SequenceEqual(bytes));
+    }
+    private static void SameContent(byte[] expected, byte[] actual) => Assert.True(Equivalent(expected, actual), "Independent uncompressed ZIP-entry oracle differs.");
+    private static int Setting(string name, int fallback, int maximum)
+    {
+        var text = Environment.GetEnvironmentVariable("DOCXODUS_HISTORY_FUZZ_" + name);
+        if (text is null) return fallback;
+        return int.TryParse(text, out var value) && value > 0 && value <= maximum ? value
+            : throw new ArgumentException($"Invalid history fuzz {name}; expected 1..{maximum}.");
+    }
+}

--- a/Docxodus.Tests/DocxVersionRequestFaultTests.cs
+++ b/Docxodus.Tests/DocxVersionRequestFaultTests.cs
@@ -1,0 +1,77 @@
+#nullable enable
+
+using Docxodus.History;
+using Xunit;
+using static Docxodus.Tests.DocxVersionRequestTests;
+
+namespace Docxodus.Tests;
+
+public sealed class DocxVersionRequestFaultTests
+{
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task EveryImmutableWriteAndHeadBoundaryIsRetryableWithoutDuplicatePublication(bool restore, bool filesystem)
+    {
+        var initial = Document("initial");
+        var candidate = Document("new contents");
+        async Task<(DocxVersionHistory History, DocxHistoryView First, DocxHistoryView Current)> Setup(HistoryFaultHarness storage)
+        {
+            var history = new DocxVersionHistory(storage, storage);
+            var first = await history.CreateVersionAsync("doc", "first", null, initial, Metadata("first"));
+            var current = first;
+            for (var i = 0; i < 6; i++) current = await history.CreateVersionAsync("doc", "label-" + i, current.Head, initial, Metadata("label"));
+            return (history, first, current);
+        }
+        ValueTask<DocxHistoryView> Publish(DocxVersionHistory history, DocxHistoryView first, DocxHistoryView current, CancellationToken cancellationToken = default) => restore
+            ? history.RestoreVersionAsync("doc", "tested", current.Head, first.Version.Id, Metadata("tested"), cancellationToken)
+            : history.CreateVersionAsync("doc", "tested", current.Head, candidate, Metadata("tested"), cancellationToken);
+
+        int writeCount;
+        using (var storage = new HistoryFaultHarness(filesystem))
+        {
+            var setup = await Setup(storage);
+            storage.Arm(HistoryFaultHarness.Fault.None);
+            await Publish(setup.History, setup.First, setup.Current);
+            writeCount = storage.Writes;
+            Assert.True(writeCount >= 5); // Includes index promotion and application state.
+        }
+        var cases = Enumerable.Range(1, writeCount).SelectMany(at => new[]
+        {
+            (HistoryFaultHarness.Fault.BeforeBlob, at), (HistoryFaultHarness.Fault.AfterBlob, at),
+        }).Concat(new[]
+        {
+            (HistoryFaultHarness.Fault.BeforeHead, 1), (HistoryFaultHarness.Fault.AfterHead, 1),
+            (HistoryFaultHarness.Fault.CancelBeforeHead, 1), (HistoryFaultHarness.Fault.CancelAfterHead, 1),
+        });
+        foreach (var (fault, at) in cases)
+        {
+            using var storage = new HistoryFaultHarness(filesystem);
+            var (history, first, current) = await Setup(storage);
+            storage.Cancellation = new CancellationTokenSource();
+            storage.Arm(fault, at);
+            if (fault is HistoryFaultHarness.Fault.CancelAfterHead)
+                await Publish(history, first, current, storage.Cancellation.Token);
+            else if (fault is HistoryFaultHarness.Fault.CancelBeforeHead)
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await Publish(history, first, current, storage.Cancellation.Token));
+            else
+                await Assert.ThrowsAsync<IOException>(async () => await Publish(history, first, current));
+            var committed = fault is HistoryFaultHarness.Fault.AfterHead or HistoryFaultHarness.Fault.CancelAfterHead;
+            storage.Arm(HistoryFaultHarness.Fault.None);
+            history = new DocxVersionHistory(storage, storage); // Discard the producer; no cache may be needed.
+            var observed = (await history.ReadAsync("doc"))!;
+            Assert.Equal(current.Head.Revision + (committed ? 1 : 0), observed.Head.Revision);
+            if (!committed) Assert.Equal(current.Head, observed.Head);
+            var retried = await Publish(history, first, current);
+            Assert.Equal(current.Head.Revision + 1, retried.Head.Revision);
+            Assert.Equal(committed ? 0 : 1, storage.Publications);
+            Assert.Equal(retried.Head, (await Publish(history, first, current)).Head);
+            Assert.Equal(restore ? initial : candidate, await history.ExportVersionAsync("doc", retried.Version.Id));
+            Assert.Equal(first.Head, (await history.CreateVersionAsync("doc", "first", null, initial, Metadata("first"))).Head);
+            Assert.Equal(8, (await history.ListVersionsAsync("doc")).Versions.Count);
+            Assert.Equal(restore ? 1 : 0, retried.State.Epoch);
+        }
+    }
+}

--- a/Docxodus.Tests/HistoryFaultHarness.cs
+++ b/Docxodus.Tests/HistoryFaultHarness.cs
@@ -1,0 +1,105 @@
+#nullable enable
+
+using Docxodus.History;
+
+namespace Docxodus.Tests;
+
+/// <summary>Real reference adapters beneath deterministic faults; shared by history/backend fuzzers.</summary>
+internal sealed class HistoryFaultHarness : IHistoryBlobStore, IHistoryHeadStore, IDisposable
+{
+    internal enum Fault { None, BeforeBlob, AfterBlob, BeforeHead, AfterHead, CancelBeforeHead, CancelAfterHead }
+    private readonly IHistoryBlobStore _blobs;
+    private readonly IHistoryHeadStore _heads;
+    private readonly string? _directory;
+    private Fault _fault;
+    private int _at;
+    internal int Writes, Publications;
+    internal string? DamagedDigest;
+    internal bool Missing;
+    internal CancellationTokenSource? Cancellation;
+    private readonly AsyncLocal<string?> _contender = new();
+    private PublicationGate? _publicationGate;
+
+    internal void HoldCompetingPublications(string firstTag) => _publicationGate = new PublicationGate(firstTag);
+    internal void ReleaseCompetingPublications() => _publicationGate = null;
+    internal async Task<T> AsContenderAsync<T>(string tag, Func<Task<T>> action)
+    {
+        var previous = _contender.Value; _contender.Value = tag;
+        try { return await action(); }
+        finally { _contender.Value = previous; }
+    }
+
+    private sealed class PublicationGate(string firstTag)
+    {
+        private readonly TaskCompletionSource _bothArrived = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _firstFinished = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _arrived;
+        internal async Task EnterAsync(string? tag, CancellationToken cancellationToken)
+        {
+            if (tag is null) throw new InvalidOperationException("A gated publication must identify its contender.");
+            if (Interlocked.Increment(ref _arrived) == 2) _bothArrived.TrySetResult();
+            await _bothArrived.Task.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);
+            if (tag != firstTag) await _firstFinished.Task.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);
+        }
+        internal void Exit(string? tag) { if (tag == firstTag) _firstFinished.TrySetResult(); }
+    }
+
+    internal HistoryFaultHarness(bool filesystem = false)
+    {
+        if (filesystem)
+        {
+            _directory = Directory.CreateTempSubdirectory("history-fault-fuzz-").FullName;
+            _blobs = new FileHistoryBlobStore(Path.Combine(_directory, "blobs"));
+            _heads = new FileHistoryHeadStore(Path.Combine(_directory, "heads"));
+        }
+        else { _blobs = new MemoryHistoryBlobStore(); _heads = new MemoryHistoryHeadStore(); }
+    }
+
+    internal void Arm(Fault fault, int at = 1)
+    { _fault = fault; _at = at; Writes = 0; Publications = 0; }
+
+    public async ValueTask PutAsync(HistoryBlobReference reference, Stream content, CancellationToken cancellationToken = default)
+    {
+        var at = Interlocked.Increment(ref Writes);
+        if (_fault == Fault.BeforeBlob && at == _at) throw new IOException("Injected pre-blob fault " + at);
+        await _blobs.PutAsync(reference, content, cancellationToken);
+        if (_fault == Fault.AfterBlob && at == _at) throw new IOException("Injected post-blob fault " + at);
+    }
+
+    public async ValueTask<Stream?> OpenReadAsync(HistoryBlobReference reference, CancellationToken cancellationToken = default)
+    {
+        if (reference.Digest.Value != DamagedDigest) return await _blobs.OpenReadAsync(reference, cancellationToken);
+        if (Missing) return null;
+        using var input = await _blobs.OpenReadAsync(reference, cancellationToken);
+        using var buffer = new MemoryStream(); await input!.CopyToAsync(buffer, cancellationToken);
+        var bytes = buffer.ToArray(); bytes[bytes.Length / 2] ^= 1;
+        return new MemoryStream(bytes, writable: false);
+    }
+
+    public ValueTask<HistoryHead?> ReadAsync(string documentId, CancellationToken cancellationToken = default) =>
+        _heads.ReadAsync(documentId, cancellationToken);
+
+    public async ValueTask<HistoryHead?> TryAdvanceAsync(string documentId, HistoryHead? expected,
+        HistoryBlobReference state, CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref Publications);
+        var gate = _publicationGate;
+        if (gate is not null) await gate.EnterAsync(_contender.Value, cancellationToken);
+        try
+        {
+            if (_fault == Fault.BeforeHead) throw new IOException("Injected failure before head CAS.");
+            if (_fault == Fault.CancelBeforeHead) Cancellation!.Cancel();
+            var result = await _heads.TryAdvanceAsync(documentId, expected, state, cancellationToken);
+            if (result is not null && _fault == Fault.AfterHead) throw new IOException("Injected lost head acknowledgement.");
+            if (result is not null && _fault == Fault.CancelAfterHead) Cancellation!.Cancel();
+            return result;
+        }
+        finally { gate?.Exit(_contender.Value); }
+    }
+
+    public void Dispose()
+    {
+        Cancellation?.Dispose();
+        if (_directory is not null) Directory.Delete(_directory, recursive: true);
+    }
+}

--- a/docs/history-validation.md
+++ b/docs/history-validation.md
@@ -1,0 +1,49 @@
+# Shared history infrastructure validation
+
+## Version model/fault fuzzing
+
+Run `bash scripts/history-fuzz.sh` for the extended corpus. Default ordinary test discovery runs
+16 seeds × 96 steps; the script runs 64 × 128. Override `DOCXODUS_HISTORY_FUZZ_SEEDS` (1–1024) and
+`DOCXODUS_HISTORY_FUZZ_STEPS` (1–10000) explicitly for larger campaigns. A failure reports seed,
+step count, storage kind, and command trace. TRX output is in `Docxodus.Tests/TestResults`.
+
+The recorded run below passed on 2026-09-06 (.NET 10.0.301 SDK / 10.0.9 runtime, Linux).
+Generated race cases rendezvous both contenders at the actual head CAS, release them in seeded
+order, and assert two attempts. Counts come from `history-model-fuzz-gated-64x128.trx`.
+
+| Observed coverage | Count |
+|---|---:|
+| Passing seeds | 64 |
+| Seeds using real filesystem adapters | 13 |
+| Scheduled steps | 8,192 |
+| Accepted versions, each checked by exact exported bytes | 5,409 |
+| Content sequences, each materialized and effect-replayed | 3,548 |
+| Restore operations | 640 |
+| Metadata/byte-preserving repacks | 667 |
+| Legacy saves carrying earlier receipts forward | 644 |
+| Old request retries during generated streams | 712 |
+| Same-ID/different-input refusals | 689 |
+| Stale writes refused, then intentionally corrected | 679 |
+| Corrupt/missing snapshot refusals | 690 |
+| Competing different-request races | 327 |
+| Concurrent identical-request races | 349 |
+| Recoveries from lost post-commit acknowledgements | 245 |
+
+All 64 cases passed in 3.57 minutes. Each seed also retries every accepted identified request at
+the end, checks immutable pagination against its independent version list, and resolves every
+content-boundary timestamp against its own recorded-time model. The oracle compares retained
+input bytes and uncompressed ZIP entry bytes; it does not use the production package digest or
+replay implementation to calculate expected content. Fixtures include Unicode and opaque binary
+custom parts. Timestamps move backwards and can tie; labels do not fabricate content sequences.
+
+Separate fault-matrix tests enumerate every immutable write before/after its durable store call,
+plus failures/cancellation before and after head CAS, for create AND restore on memory AND real
+filesystem adapters. Before-commit failures retain the old head; after-commit acknowledgement
+loss returns the original result on retry; cancellation after successful CAS cannot erase it.
+Producers are discarded before recovery. All four matrix cases passed. The receipt-index tests
+also insert/read 3,000 randomly ordered IDs, enforce the 257-node lookup bound, and check that
+lookup writes nothing and corruption is not treated as an absent request.
+
+These are deterministic model/fault campaigns, not a claim of exhaustive state-space coverage,
+power-loss certification, or a distributed-filesystem guarantee. Actual process-kill and backend
+reconciliation evidence are separate gates; in-process service recreation is not a process kill.

--- a/scripts/history-fuzz.sh
+++ b/scripts/history-fuzz.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Deterministic extended version-history corpus. Every failing case prints its seed and trace.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export DOCXODUS_HISTORY_FUZZ_SEEDS="${DOCXODUS_HISTORY_FUZZ_SEEDS:-64}"
+export DOCXODUS_HISTORY_FUZZ_STEPS="${DOCXODUS_HISTORY_FUZZ_STEPS:-128}"
+dotnet test Docxodus.Tests/Docxodus.Tests.csproj -c Release -m:1 /p:UseSharedCompilation=false \
+  --filter 'FullyQualifiedName~DocxVersionModelFuzz|FullyQualifiedName~DocxVersionRequestFault|FullyQualifiedName~HistoryRequestJournal' \
+  --logger 'console;verbosity=normal' --logger 'trx;LogFileName=history-fuzz.trx' "$@"


### PR DESCRIPTION
Stacked on #722. Adds a deterministic independent version model, real memory/filesystem fault harness, exhaustive per-write/head-boundary fault matrix, and extended fuzz runner/documented measurements.

Validation: 64 seeded cases × 128 scheduled steps passed (8,192 steps; 5,409 exact version exports; 3,548 independently checked materializations/replays). Includes 327 different-request and 349 identical-request races, forced at the actual CAS with seeded winner ordering, plus retries, restores, repacks, metadata, legacy calls, corruption/missing storage, timestamps and 245 lost acknowledgements. Separate 8 fault-matrix/index tests passed; index corpus contains 3,000 randomized IDs.

GPT-5.6-sol reviewed/re-reviewed; its initial concurrency coverage finding is fixed and no findings remain. Backend reconciliation and actual process-crash recovery remain separate follow-up gates. No GUI or transport.