### PR TITLE
feat(history): bind decision-only publication ancestry

### DIFF
--- a/Docxodus.Tests/DocxPublicationAncestryTests.cs
+++ b/Docxodus.Tests/DocxPublicationAncestryTests.cs
@@ -1,0 +1,130 @@
+#nullable enable
+
+using System.Text;
+using System.Text.Json.Nodes;
+using Docxodus.History;
+using Docxodus.Internal;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+public sealed class DocxPublicationAncestryTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DecisionOnlyPublicationsInterleaveWithVersionsRestoresAndLegacyReceipts(bool filesystem)
+    {
+        using var store = new HistoryFaultHarness(filesystem);
+        var history = new DocxVersionHistory(store, store);
+        var bytes = DocxVersionRequestTests.Document("initial");
+        var first = await history.CreateVersionAsync("doc", null, bytes, Metadata("initial"));
+        var label = await history.CreateVersionAsync("doc", "label", first.Head, bytes, Metadata("label"));
+        var decision = await PublishDecision(store, label, "conflict");
+        var changed = await history.CreateVersionAsync("doc", "edit", decision.Head,
+            DocxVersionRequestTests.Document("changed"), Metadata("edit"));
+        var another = await PublishDecision(store, changed, "discard");
+        var restored = await history.RestoreVersionAsync("doc", "restore", another.Head, first.Version.Id, Metadata("restore"));
+        var last = await history.CreateVersionAsync("doc", restored.Head, bytes, Metadata("legacy label"));
+        history = new DocxVersionHistory(store, store);
+        foreach (var view in new[] { first, label, decision, changed, another, restored, last })
+        {
+            var updates = await history.ReadChangesSinceAsync("doc", view.Head);
+            Assert.Equal(last.Head, updates.View.Head);
+            Assert.Equal(2 - view.State.Sequence, updates.Entries.Count);
+            Assert.Equal(view.State.Epoch == 0, updates.Reset);
+            Assert.Equal(bytes, await history.ExportVersionAsync("doc", first.Version.Id));
+        }
+        Assert.Equal(5, (await history.ListVersionsAsync("doc")).Versions.Count);
+        Assert.Equal(7, last.Head.Revision);
+        Assert.Equal(2, last.State.Sequence);
+        Assert.Equal(another.State.Operation, last.State.Operation);
+        Assert.Equal(restored.Head, last.State.ParentPublication);
+        Assert.Equal(label.Head, (await history.CreateVersionAsync("doc", "label", first.Head, bytes, Metadata("label"))).Head);
+        Assert.Equal(2, (await history.ReadChangesSinceAsync("doc", first.Head, 8)).Entries.Count);
+        Assert.Equal(DocxHistoryError.TraversalLimit, (await Assert.ThrowsAsync<DocxHistoryException>(async () =>
+            await history.ReadChangesSinceAsync("doc", first.Head, 7))).Code);
+        var wire = HistoryClientJson.Write(new HistoryClientResult { View = last });
+        Assert.Contains("\"parentPublication\"", wire);
+        Assert.Equal(last.State.ParentPublication, HistoryClientJson.Read<HistoryClientResult>(wire).View!.State.ParentPublication);
+    }
+
+    [Fact]
+    public async Task AncestryRejectsSameVersionForksSkippedParentsAndForgedRevisions()
+    {
+        using var store = new HistoryFaultHarness();
+        var history = new DocxVersionHistory(store, store);
+        var first = await history.CreateVersionAsync("doc", null, DocxVersionRequestTests.Document("initial"), Metadata("initial"));
+        var a = await PublishDecision(store, first, "a");
+        var b = await PublishDecision(store, a, "b");
+        var records = new HistoryRecordStore(store);
+        async Task Invalid(DocxHistoryStateRecord state, HistoryHead after, long revision = 3)
+        {
+            var reference = await records.SaveStateAsync(state);
+            var forged = new DocxVersionHistory(store, new FixedHead(new HistoryHead(revision, reference)));
+            Assert.Equal(DocxHistoryError.InvalidHistory, (await Assert.ThrowsAsync<DocxHistoryException>(async () =>
+                await forged.ReadChangesSinceAsync("doc", after))).Code);
+        }
+        var alternateId = await records.SaveStateAsync(a.State with { Operation = first.Version.Id });
+        await Invalid(b.State with { ParentPublication = new HistoryHead(2, alternateId) }, a.Head);
+        await Invalid(b.State with { ParentPublication = first.Head }, first.Head);
+        await Invalid(b.State with { Operation = a.State.Operation }, a.Head);
+        await Invalid(b.State, a.Head, revision: 4);
+        await Invalid(b.State with { Operation = null, ParentPublication = null }, a.Head);
+        using var canceled = new CancellationTokenSource(); canceled.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await history.ReadChangesSinceAsync("doc", first.Head, cancellationToken: canceled.Token));
+        Assert.Equal(b.Head, (await history.ReadAsync("doc"))!.Head);
+    }
+
+    [Fact]
+    public async Task V3RequiresBothFieldsAndOlderCodecsCannotSilentlyDiscardThem()
+    {
+        using var store = new HistoryFaultHarness();
+        var history = new DocxVersionHistory(store, store);
+        var first = await history.CreateVersionAsync("doc", null, DocxVersionRequestTests.Document("initial"), Metadata("initial"));
+        var decision = await PublishDecision(store, first, "a");
+        var records = new HistoryRecordStore(store);
+        Assert.Equal(decision.State, await records.LoadStateAsync(decision.Head.State));
+        using var input = await store.OpenReadAsync(decision.Head.State);
+        var json = (await JsonNode.ParseAsync(input!))!;
+        Assert.Equal(3, json["schemaVersion"]!.GetValue<int>());
+        foreach (var version in new[] { 1, 2 })
+        {
+            var old = json.DeepClone(); old["schemaVersion"] = version;
+            old["schema"] = "https://docxodus.dev/schemas/history/package-state/v" + version;
+            old["record"]!["operation"] = null; old["record"]!["parentPublication"] = null;
+            await Bad(old);
+        }
+        foreach (var field in new[] { "operation", "parentPublication" })
+        {
+            var missing = json.DeepClone(); missing["record"]!.AsObject().Remove(field); await Bad(missing);
+        }
+        async Task Bad(JsonNode malformed)
+        {
+            var reference = await HistoryBlobIO.PutBytesAsync(store, Encoding.UTF8.GetBytes(malformed.ToJsonString()), default);
+            Assert.Equal(PackageChangeError.InvalidManifest, (await Assert.ThrowsAsync<PackageChangeException>(async () =>
+                await records.LoadStateAsync(reference))).Code);
+        }
+    }
+
+    // Opaque decision stubs exercise only the publication contract, not backend reconciliation.
+    private static async Task<DocxHistoryView> PublishDecision(HistoryFaultHarness store, DocxHistoryView before, string id)
+    {
+        var operation = await HistoryBlobIO.PutBytesAsync(store, Encoding.UTF8.GetBytes(id), default);
+        var requests = await new HistoryRequestJournalStore(store).AdvanceAsync("doc", before.Head, before.State.Requests,
+            new HistoryRequestIdentity(id, operation.Digest));
+        var state = before.State with { Operation = operation, ParentPublication = before.Head, Requests = requests };
+        var reference = await new HistoryRecordStore(store).SaveStateAsync(state);
+        var head = await store.TryAdvanceAsync("doc", before.Head, reference);
+        return new DocxHistoryView(head!, state, before.Version);
+    }
+
+    private static DocxVersionMetadata Metadata(string label) => DocxVersionRequestTests.Metadata(label);
+    private sealed class FixedHead(HistoryHead head) : IHistoryHeadStore
+    {
+        public ValueTask<HistoryHead?> ReadAsync(string id, CancellationToken cancellationToken = default) => new(head);
+        public ValueTask<HistoryHead?> TryAdvanceAsync(string id, HistoryHead? expected, HistoryBlobReference state,
+            CancellationToken cancellationToken = default) => throw new InvalidOperationException("Read only");
+    }
+}

--- a/Docxodus.Tests/DocxVersionModelFuzzTests.cs
+++ b/Docxodus.Tests/DocxVersionModelFuzzTests.cs
@@ -1,0 +1,271 @@
+#nullable enable
+
+using System.IO.Compression;
+using Docxodus.History;
+using DocumentFormat.OpenXml.Packaging;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+using static Docxodus.Tests.DocxVersionRequestTests;
+
+namespace Docxodus.Tests;
+
+/// <summary>
+/// Stateful oracle independent of history records, package digests, and replay implementation.
+/// Override DOCXODUS_HISTORY_FUZZ_SEEDS/STEPS for the extended deterministic corpus. Every failure
+/// reports its complete seed/command trace. Each seed checks all exact exports and all sequences.
+/// </summary>
+public sealed class DocxVersionModelFuzzTests(ITestOutputHelper output)
+{
+    public static IEnumerable<object[]> Seeds => Enumerable.Range(0, Setting("SEEDS", 16, 1024))
+        .Select(index => new object[] { 60493 + index * 7919 });
+    private sealed record Command(string? Id, HistoryHead? Expected, byte[] Bytes, DocxStoredVersion? Restore,
+        DocxVersionMetadata Metadata);
+    private sealed record ExpectedVersion(DocxHistoryView View, byte[] Bytes, DateTimeOffset Time, bool ContentBoundary);
+
+    [Theory]
+    [MemberData(nameof(Seeds))]
+    public async Task VersionStreamsMatchIndependentModelUnderRetriesRacesFaultsAndRestart(int seed)
+    {
+        var steps = Setting("STEPS", 96, 10_000);
+        var random = new Random(seed);
+        var filesystem = seed % 5 == 0;
+        using var storage = new HistoryFaultHarness(filesystem);
+        var history = new DocxVersionHistory(storage, storage);
+        var trace = new List<string>();
+        var versions = new List<ExpectedVersion>();
+        var requests = new List<(Command Command, DocxHistoryView Result)>();
+        var pool = Enumerable.Range(0, 6).Select(i => Package(seed, i)).ToArray();
+        var counts = new Dictionary<string, int>();
+        void Count(string name) => counts[name] = counts.GetValueOrDefault(name) + 1;
+        ExpectedVersion? Latest() => versions.LastOrDefault();
+        DocxVersionMetadata Meta(int step) => Metadata("seed " + seed + " step " + step) with
+        {
+            Author = "actor-" + random.Next(3),
+            CreatedAt = DateTimeOffset.UnixEpoch.AddMinutes(random.Next(-50, 51)).AddTicks(random.Next(7)),
+            ApplicationMetadata = new Dictionary<string, string> { ["seed"] = seed.ToString(), ["step"] = step.ToString(), ["unicode"] = "合同 📝" },
+        };
+        try
+        {
+            for (var step = 0; step < steps; step++)
+            {
+                history = new DocxVersionHistory(storage, storage); // No producer instance survives a step.
+                var action = versions.Count == 0 ? 0 : random.Next(12);
+                trace.Add($"{step}: action={action}, head={Latest()?.View.Head.Revision ?? 0}");
+                if (action <= 5)
+                {
+                    var restore = action == 5 ? versions[random.Next(versions.Count)] : null;
+                    var bytes = restore?.Bytes ?? (action == 1 ? Latest()!.Bytes
+                        : action == 2 ? Repack(Latest()!.Bytes, step) : pool[random.Next(pool.Length)]);
+                    var requestId = action == 4 ? null : $"{seed}/{step}";
+                    var command = new Command(requestId, Latest()?.View.Head, bytes, restore?.View.Version, Meta(step));
+                    var lostAck = requestId is not null && step % 17 == 0;
+                    if (lostAck) storage.Arm(HistoryFaultHarness.Fault.AfterHead);
+                    DocxHistoryView result;
+                    if (lostAck)
+                    {
+                        await Assert.ThrowsAsync<IOException>(async () => await Invoke(history, command));
+                        storage.Arm(HistoryFaultHarness.Fault.None);
+                        result = await Invoke(new DocxVersionHistory(storage, storage), command);
+                        Assert.Equal(0, storage.Publications);
+                        Count("lost-ack-recovery");
+                    }
+                    else result = await Invoke(history, command);
+                    await Accept(command, result);
+                    Count(restore is not null ? "restore" : action == 2 ? "repack" : requestId is null ? "legacy-save" : "save");
+                }
+                else if (action == 6 && requests.Count > 0)
+                {
+                    var old = requests[random.Next(requests.Count)];
+                    var head = Latest()!.View.Head;
+                    Assert.Equal(old.Result.Head, (await Invoke(history, old.Command)).Head);
+                    Assert.Equal(head, (await history.ReadAsync("doc"))!.Head);
+                    Count("old-request-retry");
+                }
+                else if (action == 7 && requests.Count > 0)
+                {
+                    var old = requests[random.Next(requests.Count)];
+                    var collision = old.Command with { Metadata = old.Command.Metadata with { Message = "different logical request" } };
+                    Assert.Equal(DocxHistoryError.RequestConflict,
+                        (await Assert.ThrowsAsync<DocxHistoryException>(async () => await Invoke(history, collision))).Code);
+                    Count("id-reuse-refusal");
+                }
+                else if (action == 8 && versions.Count > 1)
+                {
+                    var stale = new Command($"stale/{seed}/{step}", versions[random.Next(versions.Count - 1)].View.Head,
+                        pool[random.Next(pool.Length)], null, Meta(step));
+                    Assert.Equal(DocxHistoryError.StaleHead,
+                        (await Assert.ThrowsAsync<DocxHistoryException>(async () => await Invoke(history, stale))).Code);
+                    // A request never committed/bound may be corrected and submitted intentionally.
+                    var corrected = stale with { Expected = Latest()!.View.Head };
+                    await Accept(corrected, await Invoke(history, corrected));
+                    Count("stale-then-corrected");
+                }
+                else if (action == 9)
+                {
+                    var target = versions[random.Next(versions.Count)];
+                    storage.DamagedDigest = target.View.State.Snapshot.Blob.Digest.Value;
+                    storage.Missing = random.Next(2) == 0;
+                    try
+                    {
+                        Assert.Equal(storage.Missing ? PackageChangeError.PayloadMissing : PackageChangeError.PayloadMismatch,
+                            (await Assert.ThrowsAsync<PackageChangeException>(async () => await history.ExportVersionAsync("doc", target.View.Version.Id))).Code);
+                    }
+                    finally { storage.DamagedDigest = null; }
+                    Count("damaged-storage-refusal");
+                }
+                else if (action == 10)
+                {
+                    var sameRequest = random.Next(2) == 0;
+                    var first = new Command($"race/{seed}/{step}/0", Latest()!.View.Head, pool[random.Next(pool.Length)], null, Meta(step));
+                    var second = sameRequest ? first : first with { Id = $"race/{seed}/{step}/1", Bytes = pool[random.Next(pool.Length)] };
+                    var firstWinner = random.Next(2) == 0;
+                    trace.Add($"  race: sameRequest={sameRequest}, firstWinner={firstWinner}");
+                    async Task<DocxHistoryView?> Compete(Command command)
+                    {
+                        try { return await Invoke(new DocxVersionHistory(storage, storage), command); }
+                        catch (DocxHistoryException error) when (error.Code == DocxHistoryError.StaleHead) { return null; }
+                    }
+                    var attempts = storage.Publications;
+                    storage.HoldCompetingPublications(firstWinner ? "left" : "right");
+                    DocxHistoryView?[] results;
+                    try
+                    {
+                        results = await Task.WhenAll(
+                            Task.Run(() => storage.AsContenderAsync("left", () => Compete(first))),
+                            Task.Run(() => storage.AsContenderAsync("right", () => Compete(second))));
+                    }
+                    finally { storage.ReleaseCompetingPublications(); }
+                    Assert.Equal(2, storage.Publications - attempts); // Both must reach the exact same CAS expectation.
+                    if (sameRequest)
+                    {
+                        Assert.NotNull(results[0]); Assert.NotNull(results[1]);
+                        Assert.Equal(results[0]!.Head, results[1]!.Head);
+                        await Accept(first, results[0]!);
+                    }
+                    else
+                    {
+                        Assert.Single(results.Where(x => x is not null));
+                        Assert.Equal(firstWinner, results[0] is not null);
+                        await Accept(results[0] is not null ? first : second, results[0] ?? results[1]!);
+                    }
+                    Count(sameRequest ? "identical-race" : "competing-race");
+                }
+                else
+                {
+                    var selected = versions[random.Next(versions.Count)];
+                    Assert.Equal(selected.Bytes, await history.ExportVersionAsync("doc", selected.View.Version.Id));
+                    Count("read");
+                }
+                Assert.Equal(Latest()!.View.Head, (await history.ReadAsync("doc"))!.Head);
+            }
+
+            // Immutable pagination and exact snapshots are checked against independently retained inputs.
+            var listed = new List<DocxStoredVersion>();
+            HistoryBlobReference? cursor = null;
+            do
+            {
+                var page = await history.ListVersionsAsync("doc", cursor, 7);
+                listed.AddRange(page.Versions); cursor = page.Next;
+            } while (cursor is not null);
+            Assert.Equal(versions.Select(v => v.View.Version.Id).Reverse(), listed.Select(v => v.Id));
+            foreach (var version in versions)
+                Assert.Equal(version.Bytes, await history.ExportVersionAsync("doc", version.View.Version.Id));
+
+            var boundaries = versions.Where(v => v.ContentBoundary).ToArray();
+            foreach (var boundary in boundaries)
+            {
+                var sequence = boundary.View.State.Sequence;
+                // ZIP-entry comparison does not call the production manifest/digest/replay owner.
+                SameContent(boundary.Bytes, await history.MaterializeAsync("doc", sequence));
+                SameContent(boundary.Bytes, await history.ReplayAsync("doc", sequence));
+            }
+            foreach (var cutoff in boundaries.Select(v => v.Time).Append(DateTimeOffset.UnixEpoch.AddDays(-1)))
+            {
+                var expected = boundaries.Where(v => v.Time <= cutoff).LastOrDefault();
+                if (expected is null)
+                    Assert.Equal(DocxHistoryError.HistoryUnavailable, (await Assert.ThrowsAsync<DocxHistoryException>(async () =>
+                        await history.ResolveSequenceAtTimeAsync("doc", cutoff))).Code);
+                else Assert.Equal(expected.View.State.Sequence, await history.ResolveSequenceAtTimeAsync("doc", cutoff));
+            }
+            foreach (var (command, result) in requests)
+                Assert.Equal(result.Head, (await Invoke(new DocxVersionHistory(storage, storage), command)).Head);
+            output.WriteLine($"seed={seed}; steps={steps}; filesystem={filesystem}; versions={versions.Count}; replayed-sequences={boundaries.Length}; "
+                + string.Join(", ", counts.OrderBy(p => p.Key).Select(p => p.Key + "=" + p.Value)));
+        }
+        catch (Exception error)
+        { throw new XunitException($"History fuzz failure seed={seed}, steps={steps}, filesystem={filesystem}\n{string.Join("\n", trace)}\n{error}"); }
+
+        async Task Accept(Command command, DocxHistoryView result)
+        {
+            var previous = Latest();
+            var changed = previous is not null && !Equivalent(previous.Bytes, command.Bytes);
+            var boundary = previous is null || command.Restore is not null || changed;
+            var sequence = (previous?.View.State.Sequence ?? 0) + (previous is not null && boundary ? 1 : 0);
+            var epoch = (previous?.View.State.Epoch ?? 0) + (command.Restore is not null ? 1 : 0);
+            Assert.Equal((previous?.View.Head.Revision ?? 0) + 1, result.Head.Revision);
+            Assert.Equal(sequence, result.State.Sequence); Assert.Equal(epoch, result.State.Epoch);
+            Assert.Equal(previous?.View.Version.Id, result.Version.Record.Parent);
+            Assert.Equal(command.Restore?.Id, result.Version.Record.RestoredFrom);
+            Assert.Equal(command.Metadata.Author, result.Version.Record.Metadata.Author);
+            Assert.Equal(command.Metadata.CreatedAt, result.Version.Record.Metadata.CreatedAt);
+            Assert.Equal(command.Metadata.Label, result.Version.Record.Metadata.Label);
+            Assert.Equal(command.Metadata.ApplicationMetadata, result.Version.Record.Metadata.ApplicationMetadata);
+            Assert.Equal(command.Id, result.State.Requests?.Current?.Id);
+            Assert.Equal(command.Bytes, await history.ExportVersionAsync("doc", result.Version.Id));
+            versions.Add(new ExpectedVersion(result, command.Bytes.ToArray(), command.Metadata.CreatedAt, boundary));
+            if (command.Id is not null) requests.Add((command, result));
+        }
+    }
+
+    private static ValueTask<DocxHistoryView> Invoke(DocxVersionHistory history, Command command) => command.Restore is not null
+        ? command.Id is null ? history.RestoreVersionAsync("doc", command.Expected!, command.Restore.Id, command.Metadata)
+            : history.RestoreVersionAsync("doc", command.Id, command.Expected!, command.Restore.Id, command.Metadata)
+        : command.Id is null ? history.CreateVersionAsync("doc", command.Expected, command.Bytes, command.Metadata)
+            : history.CreateVersionAsync("doc", command.Id, command.Expected, command.Bytes, command.Metadata);
+
+    private static byte[] Package(int seed, int variant)
+    {
+        using var stream = new MemoryStream(); stream.Write(Document($"seed {seed} variant {variant}: café 📝 合同"));
+        using (var document = WordprocessingDocument.Open(stream, true))
+        {
+            var part = document.MainDocumentPart!.AddCustomXmlPart("application/octet-stream");
+            var opaque = new byte[257]; new Random(seed ^ variant).NextBytes(opaque);
+            using var payload = new MemoryStream(opaque); part.FeedData(payload);
+        }
+        return stream.ToArray();
+    }
+
+    private static byte[] Repack(byte[] bytes, int step)
+    {
+        using var stream = new MemoryStream(); stream.Write(bytes);
+        using (var zip = new ZipArchive(stream, ZipArchiveMode.Update, leaveOpen: true))
+            foreach (var entry in zip.Entries) entry.LastWriteTime = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero).AddMinutes(step);
+        return stream.ToArray();
+    }
+
+    private static SortedDictionary<string, byte[]> Entries(byte[] bytes)
+    {
+        using var zip = new ZipArchive(new MemoryStream(bytes), ZipArchiveMode.Read);
+        var entries = new SortedDictionary<string, byte[]>(StringComparer.Ordinal);
+        foreach (var entry in zip.Entries.Where(e => !e.FullName.EndsWith('/')))
+        {
+            using var input = entry.Open(); using var content = new MemoryStream(); input.CopyTo(content);
+            entries.Add(entry.FullName, content.ToArray());
+        }
+        return entries;
+    }
+    private static bool Equivalent(byte[] left, byte[] right)
+    {
+        var a = Entries(left); var b = Entries(right);
+        return a.Count == b.Count && a.All(p => b.TryGetValue(p.Key, out var bytes) && p.Value.AsSpan().SequenceEqual(bytes));
+    }
+    private static void SameContent(byte[] expected, byte[] actual) => Assert.True(Equivalent(expected, actual), "Independent uncompressed ZIP-entry oracle differs.");
+    private static int Setting(string name, int fallback, int maximum)
+    {
+        var text = Environment.GetEnvironmentVariable("DOCXODUS_HISTORY_FUZZ_" + name);
+        if (text is null) return fallback;
+        return int.TryParse(text, out var value) && value > 0 && value <= maximum ? value
+            : throw new ArgumentException($"Invalid history fuzz {name}; expected 1..{maximum}.");
+    }
+}

--- a/Docxodus.Tests/DocxVersionRequestFaultTests.cs
+++ b/Docxodus.Tests/DocxVersionRequestFaultTests.cs
@@ -1,0 +1,77 @@
+#nullable enable
+
+using Docxodus.History;
+using Xunit;
+using static Docxodus.Tests.DocxVersionRequestTests;
+
+namespace Docxodus.Tests;
+
+public sealed class DocxVersionRequestFaultTests
+{
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task EveryImmutableWriteAndHeadBoundaryIsRetryableWithoutDuplicatePublication(bool restore, bool filesystem)
+    {
+        var initial = Document("initial");
+        var candidate = Document("new contents");
+        async Task<(DocxVersionHistory History, DocxHistoryView First, DocxHistoryView Current)> Setup(HistoryFaultHarness storage)
+        {
+            var history = new DocxVersionHistory(storage, storage);
+            var first = await history.CreateVersionAsync("doc", "first", null, initial, Metadata("first"));
+            var current = first;
+            for (var i = 0; i < 6; i++) current = await history.CreateVersionAsync("doc", "label-" + i, current.Head, initial, Metadata("label"));
+            return (history, first, current);
+        }
+        ValueTask<DocxHistoryView> Publish(DocxVersionHistory history, DocxHistoryView first, DocxHistoryView current, CancellationToken cancellationToken = default) => restore
+            ? history.RestoreVersionAsync("doc", "tested", current.Head, first.Version.Id, Metadata("tested"), cancellationToken)
+            : history.CreateVersionAsync("doc", "tested", current.Head, candidate, Metadata("tested"), cancellationToken);
+
+        int writeCount;
+        using (var storage = new HistoryFaultHarness(filesystem))
+        {
+            var setup = await Setup(storage);
+            storage.Arm(HistoryFaultHarness.Fault.None);
+            await Publish(setup.History, setup.First, setup.Current);
+            writeCount = storage.Writes;
+            Assert.True(writeCount >= 5); // Includes index promotion and application state.
+        }
+        var cases = Enumerable.Range(1, writeCount).SelectMany(at => new[]
+        {
+            (HistoryFaultHarness.Fault.BeforeBlob, at), (HistoryFaultHarness.Fault.AfterBlob, at),
+        }).Concat(new[]
+        {
+            (HistoryFaultHarness.Fault.BeforeHead, 1), (HistoryFaultHarness.Fault.AfterHead, 1),
+            (HistoryFaultHarness.Fault.CancelBeforeHead, 1), (HistoryFaultHarness.Fault.CancelAfterHead, 1),
+        });
+        foreach (var (fault, at) in cases)
+        {
+            using var storage = new HistoryFaultHarness(filesystem);
+            var (history, first, current) = await Setup(storage);
+            storage.Cancellation = new CancellationTokenSource();
+            storage.Arm(fault, at);
+            if (fault is HistoryFaultHarness.Fault.CancelAfterHead)
+                await Publish(history, first, current, storage.Cancellation.Token);
+            else if (fault is HistoryFaultHarness.Fault.CancelBeforeHead)
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await Publish(history, first, current, storage.Cancellation.Token));
+            else
+                await Assert.ThrowsAsync<IOException>(async () => await Publish(history, first, current));
+            var committed = fault is HistoryFaultHarness.Fault.AfterHead or HistoryFaultHarness.Fault.CancelAfterHead;
+            storage.Arm(HistoryFaultHarness.Fault.None);
+            history = new DocxVersionHistory(storage, storage); // Discard the producer; no cache may be needed.
+            var observed = (await history.ReadAsync("doc"))!;
+            Assert.Equal(current.Head.Revision + (committed ? 1 : 0), observed.Head.Revision);
+            if (!committed) Assert.Equal(current.Head, observed.Head);
+            var retried = await Publish(history, first, current);
+            Assert.Equal(current.Head.Revision + 1, retried.Head.Revision);
+            Assert.Equal(committed ? 0 : 1, storage.Publications);
+            Assert.Equal(retried.Head, (await Publish(history, first, current)).Head);
+            Assert.Equal(restore ? initial : candidate, await history.ExportVersionAsync("doc", retried.Version.Id));
+            Assert.Equal(first.Head, (await history.CreateVersionAsync("doc", "first", null, initial, Metadata("first"))).Head);
+            Assert.Equal(8, (await history.ListVersionsAsync("doc")).Versions.Count);
+            Assert.Equal(restore ? 1 : 0, retried.State.Epoch);
+        }
+    }
+}

--- a/Docxodus.Tests/HistoryFaultHarness.cs
+++ b/Docxodus.Tests/HistoryFaultHarness.cs
@@ -1,0 +1,105 @@
+#nullable enable
+
+using Docxodus.History;
+
+namespace Docxodus.Tests;
+
+/// <summary>Real reference adapters beneath deterministic faults; shared by history/backend fuzzers.</summary>
+internal sealed class HistoryFaultHarness : IHistoryBlobStore, IHistoryHeadStore, IDisposable
+{
+    internal enum Fault { None, BeforeBlob, AfterBlob, BeforeHead, AfterHead, CancelBeforeHead, CancelAfterHead }
+    private readonly IHistoryBlobStore _blobs;
+    private readonly IHistoryHeadStore _heads;
+    private readonly string? _directory;
+    private Fault _fault;
+    private int _at;
+    internal int Writes, Publications;
+    internal string? DamagedDigest;
+    internal bool Missing;
+    internal CancellationTokenSource? Cancellation;
+    private readonly AsyncLocal<string?> _contender = new();
+    private PublicationGate? _publicationGate;
+
+    internal void HoldCompetingPublications(string firstTag) => _publicationGate = new PublicationGate(firstTag);
+    internal void ReleaseCompetingPublications() => _publicationGate = null;
+    internal async Task<T> AsContenderAsync<T>(string tag, Func<Task<T>> action)
+    {
+        var previous = _contender.Value; _contender.Value = tag;
+        try { return await action(); }
+        finally { _contender.Value = previous; }
+    }
+
+    private sealed class PublicationGate(string firstTag)
+    {
+        private readonly TaskCompletionSource _bothArrived = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _firstFinished = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _arrived;
+        internal async Task EnterAsync(string? tag, CancellationToken cancellationToken)
+        {
+            if (tag is null) throw new InvalidOperationException("A gated publication must identify its contender.");
+            if (Interlocked.Increment(ref _arrived) == 2) _bothArrived.TrySetResult();
+            await _bothArrived.Task.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);
+            if (tag != firstTag) await _firstFinished.Task.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);
+        }
+        internal void Exit(string? tag) { if (tag == firstTag) _firstFinished.TrySetResult(); }
+    }
+
+    internal HistoryFaultHarness(bool filesystem = false)
+    {
+        if (filesystem)
+        {
+            _directory = Directory.CreateTempSubdirectory("history-fault-fuzz-").FullName;
+            _blobs = new FileHistoryBlobStore(Path.Combine(_directory, "blobs"));
+            _heads = new FileHistoryHeadStore(Path.Combine(_directory, "heads"));
+        }
+        else { _blobs = new MemoryHistoryBlobStore(); _heads = new MemoryHistoryHeadStore(); }
+    }
+
+    internal void Arm(Fault fault, int at = 1)
+    { _fault = fault; _at = at; Writes = 0; Publications = 0; }
+
+    public async ValueTask PutAsync(HistoryBlobReference reference, Stream content, CancellationToken cancellationToken = default)
+    {
+        var at = Interlocked.Increment(ref Writes);
+        if (_fault == Fault.BeforeBlob && at == _at) throw new IOException("Injected pre-blob fault " + at);
+        await _blobs.PutAsync(reference, content, cancellationToken);
+        if (_fault == Fault.AfterBlob && at == _at) throw new IOException("Injected post-blob fault " + at);
+    }
+
+    public async ValueTask<Stream?> OpenReadAsync(HistoryBlobReference reference, CancellationToken cancellationToken = default)
+    {
+        if (reference.Digest.Value != DamagedDigest) return await _blobs.OpenReadAsync(reference, cancellationToken);
+        if (Missing) return null;
+        using var input = await _blobs.OpenReadAsync(reference, cancellationToken);
+        using var buffer = new MemoryStream(); await input!.CopyToAsync(buffer, cancellationToken);
+        var bytes = buffer.ToArray(); bytes[bytes.Length / 2] ^= 1;
+        return new MemoryStream(bytes, writable: false);
+    }
+
+    public ValueTask<HistoryHead?> ReadAsync(string documentId, CancellationToken cancellationToken = default) =>
+        _heads.ReadAsync(documentId, cancellationToken);
+
+    public async ValueTask<HistoryHead?> TryAdvanceAsync(string documentId, HistoryHead? expected,
+        HistoryBlobReference state, CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref Publications);
+        var gate = _publicationGate;
+        if (gate is not null) await gate.EnterAsync(_contender.Value, cancellationToken);
+        try
+        {
+            if (_fault == Fault.BeforeHead) throw new IOException("Injected failure before head CAS.");
+            if (_fault == Fault.CancelBeforeHead) Cancellation!.Cancel();
+            var result = await _heads.TryAdvanceAsync(documentId, expected, state, cancellationToken);
+            if (result is not null && _fault == Fault.AfterHead) throw new IOException("Injected lost head acknowledgement.");
+            if (result is not null && _fault == Fault.CancelAfterHead) Cancellation!.Cancel();
+            return result;
+        }
+        finally { gate?.Exit(_contender.Value); }
+    }
+
+    public void Dispose()
+    {
+        Cancellation?.Dispose();
+        if (_directory is not null) Directory.Delete(_directory, recursive: true);
+    }
+}

--- a/Docxodus/History/DocxVersionHistory.Updates.cs
+++ b/Docxodus/History/DocxVersionHistory.Updates.cs
@@ -31,6 +31,12 @@ public sealed partial class DocxVersionHistory
         if (maxEntriesToScan <= 0) throw new ArgumentOutOfRangeException(nameof(maxEntriesToScan));
         var current = await ReadAsync(documentId, cancellationToken).ConfigureAwait(false)
             ?? throw new DocxHistoryException(DocxHistoryError.HistoryUnavailable, "Document history is unavailable.");
+        return await ReadChangesBetweenAsync(documentId, current, after, maxEntriesToScan, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask<DocxHistoryUpdate> ReadChangesBetweenAsync(string documentId, DocxHistoryView current,
+        HistoryHead? after, int maxEntriesToScan, CancellationToken cancellationToken)
+    {
         if (after is null) return new DocxHistoryUpdate(null, current, Array.Empty<DocxHistoryLogEntry>(), true);
         if (current.Head == after) return new DocxHistoryUpdate(after, current, Array.Empty<DocxHistoryLogEntry>(), false);
         Consistent(current.Head.Revision > after.Revision, "The supplied history head rewinds or forks the accepted publication.");
@@ -46,9 +52,24 @@ public sealed partial class DocxVersionHistory
                 "History update scan budget reached; increase it explicitly to continue.");
         }
 
+        // V3 binds every publication, including a conflict/no-op decision that creates no version.
+        // Follow exact parent heads before falling back to V1/V2's one-version-per-publication chain.
+        var publication = current;
+        while (publication.Head != after && publication.State.ParentPublication is { } parentHead)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Spend();
+            Consistent(parentHead.Revision >= after.Revision, "Accepted publication is not an ancestor of the new head.");
+            var parent = await ReadHeadViewAsync(documentId, parentHead, cancellationToken).ConfigureAwait(false);
+            ValidatePublicationEdge(publication, parent);
+            publication = parent;
+        }
+        Consistent(publication.Head == after || (publication.Head.Revision > after.Revision && previous.State.Operation is null),
+            "Accepted publication is not an ancestor of the new head.");
+
         // Content sequence alone cannot prove ancestry: competing labels and same-content forks
-        // also have distinct immutable version chains. Check the previously accepted version ID.
-        var version = current.Version;
+        // also have distinct immutable version chains. Check the accepted legacy version ID.
+        var version = publication.Version;
         long versionEdges = 0;
         while (version.Id != previous.Version.Id)
         {
@@ -65,7 +86,7 @@ public sealed partial class DocxVersionHistory
                     && version.Record.RestoredFrom is null, "A metadata-only version cannot change content or restore.");
             version = parent;
         }
-        Consistent(versionEdges == current.Head.Revision - after.Revision,
+        Consistent(versionEdges == publication.Head.Revision - after.Revision,
             "Publication revision does not match the accepted version ancestry.");
 
         var entries = new List<DocxHistoryLogEntry>();
@@ -96,5 +117,28 @@ public sealed partial class DocxVersionHistory
         }
         cancellationToken.ThrowIfCancellationRequested();
         return new DocxHistoryUpdate(after, current, entries.AsReadOnly(), current.State.Epoch != previous.State.Epoch);
+    }
+
+    private static void ValidatePublicationEdge(DocxHistoryView child, DocxHistoryView parent)
+    {
+        Consistent(child.State.InitialSnapshot == parent.State.InitialSnapshot
+            && child.State.Sequence >= parent.State.Sequence && child.State.Sequence - parent.State.Sequence <= 1
+            && child.State.Epoch >= parent.State.Epoch && child.State.Epoch - parent.State.Epoch <= 1,
+            "Publication ancestry is discontinuous.");
+        if (child.Version.Id == parent.Version.Id)
+        {
+            Consistent(child.State.Snapshot == parent.State.Snapshot && child.State.Sequence == parent.State.Sequence
+                && child.State.Commit == parent.State.Commit && child.State.Epoch == parent.State.Epoch
+                && child.State.Operation != parent.State.Operation && child.State.Requests?.Current is not null,
+                "A version-free publication must record a new identified decision without changing content.");
+        }
+        else
+        {
+            Consistent(child.Version.Record.Parent == parent.Version.Id, "Publication skipped its parent version.");
+            if (child.State.Sequence == parent.State.Sequence)
+                Consistent(child.State.Commit == parent.State.Commit && child.State.Epoch == parent.State.Epoch
+                    && child.State.Snapshot.ContentDigest == parent.State.Snapshot.ContentDigest
+                    && child.Version.Record.RestoredFrom is null, "A metadata-only publication cannot change content or restore.");
+        }
     }
 }

--- a/Docxodus/History/DocxVersionHistory.cs
+++ b/Docxodus/History/DocxVersionHistory.cs
@@ -66,6 +66,8 @@ public sealed partial class DocxVersionHistory
         var state = await _records.LoadStateAsync(head.State, cancellationToken).ConfigureAwait(false);
         SameDocument(documentId, state.DocumentId);
         HistoryRequestJournalStore.ValidatePublication(documentId, head, state.Requests);
+        Consistent(state.ParentPublication is null || state.ParentPublication.Revision == head.Revision - 1,
+            "Publication parent must immediately precede this head.");
         Consistent(state.Sequence < head.Revision && state.Epoch <= state.Sequence, "Invalid head publication position.");
         var version = await GetVersionAsync(documentId, state.Version, cancellationToken).ConfigureAwait(false);
         Consistent(version.Record.Sequence == state.Sequence && version.Record.Snapshot == state.Snapshot,
@@ -116,11 +118,21 @@ public sealed partial class DocxVersionHistory
         var capturedMetadata = HistoryRecordStore.PrepareMetadata(metadata);
         var request = requestId is null ? null : VersionRequest("create", documentId, expected,
             capturedMetadata, requestId, captured, null);
-        var nonce = Guid.NewGuid();
         var current = await ReadAsync(documentId, cancellationToken).ConfigureAwait(false);
         var repeated = await FindRequestAsync(documentId, current, request, cancellationToken).ConfigureAwait(false);
         if (repeated is not null) return repeated;
         if (current?.Head != expected) throw Stale();
+        var prepared = await PrepareCandidateAsync(documentId, current, captured, capturedMetadata, cancellationToken).ConfigureAwait(false);
+        return await PublishAsync(documentId, expected, prepared.State, prepared.Version,
+            cancellationToken, request, current?.State.Requests).ConfigureAwait(false);
+    }
+
+    // Shared immutable preparation for version imports and accepted backend effects. Only the
+    // caller publishes; a losing backend writer may reconcile its original intent and try again.
+    private async ValueTask<(DocxHistoryStateRecord State, DocxStoredVersion Version)> PrepareCandidateAsync(
+        string documentId, DocxHistoryView? current, byte[] captured, DocxVersionMetadata capturedMetadata,
+        CancellationToken cancellationToken)
+    {
         var snapshot = await _snapshots.CaptureAsync(captured, cancellationToken).ConfigureAwait(false);
         var changed = current is not null && current.State.Snapshot.ContentDigest != snapshot.ContentDigest;
         var sequence = checked((current?.State.Sequence ?? 0) + (changed ? 1 : 0));
@@ -134,7 +146,7 @@ public sealed partial class DocxVersionHistory
         }
         var version = new DocxVersionRecord
         {
-            DocumentId = documentId, Metadata = capturedMetadata, Nonce = nonce,
+            DocumentId = documentId, Metadata = capturedMetadata, Nonce = Guid.NewGuid(),
             Parent = current?.State.Version, RestoredFrom = null, Sequence = sequence, Snapshot = snapshot,
         };
         var versionId = await _records.SaveVersionAsync(version, cancellationToken).ConfigureAwait(false);
@@ -150,12 +162,12 @@ public sealed partial class DocxVersionHistory
         }
         var state = new DocxHistoryStateRecord
         {
+            Operation = current?.State.Operation, ParentPublication = current?.State.ParentPublication,
             Commit = commitId, DocumentId = documentId, Epoch = current?.State.Epoch ?? 0,
             InitialSnapshot = current?.State.InitialSnapshot ?? snapshot, Sequence = sequence,
             Snapshot = snapshot, Version = versionId,
         };
-        return await PublishAsync(documentId, expected, state, new DocxStoredVersion(versionId, version),
-            cancellationToken, request, current?.State.Requests).ConfigureAwait(false);
+        return (state, new DocxStoredVersion(versionId, version));
     }
 
     /// <summary>
@@ -212,8 +224,12 @@ public sealed partial class DocxVersionHistory
         DocxHistoryStateRecord state, DocxStoredVersion version, CancellationToken cancellationToken,
         HistoryRequestIdentity? request = null, HistoryRequestJournal? previousRequests = null)
     {
-        state = state with { Requests = await _requests.AdvanceAsync(documentId, expected, previousRequests,
-            request, cancellationToken).ConfigureAwait(false) };
+        state = state with
+        {
+            ParentPublication = state.Operation is null ? null : expected,
+            Requests = await _requests.AdvanceAsync(documentId, expected, previousRequests,
+                request, cancellationToken).ConfigureAwait(false),
+        };
         var stateId = await _records.SaveStateAsync(state, cancellationToken).ConfigureAwait(false);
         var head = await _heads.TryAdvanceAsync(documentId, expected, stateId, cancellationToken).ConfigureAwait(false);
         // Do not throw cancellation after publication: the CAS is the definitive commit point.

--- a/Docxodus/History/HistoryRecordStore.cs
+++ b/Docxodus/History/HistoryRecordStore.cs
@@ -58,7 +58,8 @@ public sealed class HistoryRecordStore
     {
         cancellationToken.ThrowIfCancellationRequested();
         var normalized = Validate(record);
-        var schemaVersion = normalized is DocxHistoryStateRecord { Requests: not null } ? 2 : 1;
+        var schemaVersion = normalized is DocxHistoryStateRecord { Operation: not null } ? 3
+            : normalized is DocxHistoryStateRecord { Requests: not null } ? 2 : 1;
         var bytes = JsonSerializer.SerializeToUtf8Bytes(new HistoryRecordEnvelope<T>
         {
             Record = normalized, Schema = Schema(kind, schemaVersion), SchemaVersion = schemaVersion,
@@ -87,7 +88,7 @@ public sealed class HistoryRecordStore
             var fields = header.RootElement.EnumerateObject().Select(p => p.Name).ToHashSet(StringComparer.Ordinal);
             Require(fields.SetEquals(["record", "schema", "schemaVersion"]), "Malformed history envelope.");
             var schemaVersion = header.RootElement.GetProperty("schemaVersion").GetInt32();
-            if (schemaVersion != 1 && !(schemaVersion == 2 && kind == "package-state"))
+            if (schemaVersion != 1 && !(schemaVersion is 2 or 3 && kind == "package-state"))
                 throw new PackageChangeException(PackageChangeError.UnsupportedVersion, "Unsupported history record version.");
             Require(header.RootElement.GetProperty("schema").GetString() == Schema(kind, schemaVersion), "Unexpected history record schema.");
             var envelope = JsonSerializer.Deserialize(bytes, TypeInfo<T>());
@@ -95,9 +96,13 @@ public sealed class HistoryRecordStore
             var record = Validate(envelope!.Record);
             if (record is DocxHistoryStateRecord state)
             {
-                Require((state.Requests is not null) == (schemaVersion == 2), "Request journals require state schema V2.");
+                Require(schemaVersion != 2 || state.Requests is not null, "V2 states require request journals.");
                 Require(schemaVersion != 1 || !header.RootElement.GetProperty("record").TryGetProperty("requests", out _),
                     "V1 states cannot declare request journals, including null.");
+                Require((state.Operation is not null) == (schemaVersion == 3), "Backend tips require state schema V3.");
+                Require(schemaVersion == 3 || (!header.RootElement.GetProperty("record").TryGetProperty("operation", out _)
+                    && !header.RootElement.GetProperty("record").TryGetProperty("parentPublication", out _)),
+                    "Older states cannot declare V3 publication fields, including null.");
             }
             cancellationToken.ThrowIfCancellationRequested();
             return record;
@@ -138,6 +143,13 @@ public sealed class HistoryRecordStore
                 HistoryHeadCodec.Key(state.DocumentId);
                 HistoryRequestJournalStore.ValidateJournal(state.Requests);
                 Require(state.Requests is null || state.Requests.DocumentId == state.DocumentId, "Foreign request journal.");
+                Require((state.Operation is null) == (state.ParentPublication is null), "Backend tip and publication parent must occur together.");
+                Reference(state.Operation);
+                if (state.ParentPublication is not null)
+                {
+                    Require(state.ParentPublication.Revision > 0, "Invalid parent publication revision.");
+                    RequiredReference(state.ParentPublication.State);
+                }
                 Require(state.Sequence >= 0 && state.Epoch >= 0
                     && (state.Commit is null) == (state.Sequence == 0), "Invalid history state position.");
                 Reference(state.Commit); RequiredReference(state.Version);

--- a/Docxodus/History/HistoryRecords.cs
+++ b/Docxodus/History/HistoryRecords.cs
@@ -56,6 +56,12 @@ public sealed record PackageHistoryCommitRecord
 /// </summary>
 public sealed record DocxHistoryStateRecord
 {
+    /// <summary>V3 explicit publication ancestry, including decisions that create no version.</summary>
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    public HistoryHead? ParentPublication { get; init; }
+    /// <summary>V3 immutable backend decision-log tip, carried through later saves and restores.</summary>
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    public HistoryBlobReference? Operation { get; init; }
     /// <summary>V2 publication metadata. Absent in legacy V1 states; older records remain readable.</summary>
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
     public HistoryRequestJournal? Requests { get; init; }

--- a/docs/history-validation.md
+++ b/docs/history-validation.md
@@ -1,0 +1,49 @@
+# Shared history infrastructure validation
+
+## Version model/fault fuzzing
+
+Run `bash scripts/history-fuzz.sh` for the extended corpus. Default ordinary test discovery runs
+16 seeds × 96 steps; the script runs 64 × 128. Override `DOCXODUS_HISTORY_FUZZ_SEEDS` (1–1024) and
+`DOCXODUS_HISTORY_FUZZ_STEPS` (1–10000) explicitly for larger campaigns. A failure reports seed,
+step count, storage kind, and command trace. TRX output is in `Docxodus.Tests/TestResults`.
+
+The recorded run below passed on 2026-09-06 (.NET 10.0.301 SDK / 10.0.9 runtime, Linux).
+Generated race cases rendezvous both contenders at the actual head CAS, release them in seeded
+order, and assert two attempts. Counts come from `history-model-fuzz-gated-64x128.trx`.
+
+| Observed coverage | Count |
+|---|---:|
+| Passing seeds | 64 |
+| Seeds using real filesystem adapters | 13 |
+| Scheduled steps | 8,192 |
+| Accepted versions, each checked by exact exported bytes | 5,409 |
+| Content sequences, each materialized and effect-replayed | 3,548 |
+| Restore operations | 640 |
+| Metadata/byte-preserving repacks | 667 |
+| Legacy saves carrying earlier receipts forward | 644 |
+| Old request retries during generated streams | 712 |
+| Same-ID/different-input refusals | 689 |
+| Stale writes refused, then intentionally corrected | 679 |
+| Corrupt/missing snapshot refusals | 690 |
+| Competing different-request races | 327 |
+| Concurrent identical-request races | 349 |
+| Recoveries from lost post-commit acknowledgements | 245 |
+
+All 64 cases passed in 3.57 minutes. Each seed also retries every accepted identified request at
+the end, checks immutable pagination against its independent version list, and resolves every
+content-boundary timestamp against its own recorded-time model. The oracle compares retained
+input bytes and uncompressed ZIP entry bytes; it does not use the production package digest or
+replay implementation to calculate expected content. Fixtures include Unicode and opaque binary
+custom parts. Timestamps move backwards and can tie; labels do not fabricate content sequences.
+
+Separate fault-matrix tests enumerate every immutable write before/after its durable store call,
+plus failures/cancellation before and after head CAS, for create AND restore on memory AND real
+filesystem adapters. Before-commit failures retain the old head; after-commit acknowledgement
+loss returns the original result on retry; cancellation after successful CAS cannot erase it.
+Producers are discarded before recovery. All four matrix cases passed. The receipt-index tests
+also insert/read 3,000 randomly ordered IDs, enforce the 257-node lookup bound, and check that
+lookup writes nothing and corruption is not treated as an absent request.
+
+These are deterministic model/fault campaigns, not a claim of exhaustive state-space coverage,
+power-loss certification, or a distributed-filesystem guarantee. Actual process-kill and backend
+reconciliation evidence are separate gates; in-process service recreation is not a process kill.

--- a/docs/history.md
+++ b/docs/history.md
@@ -83,6 +83,19 @@ retirement/fencing, not a best-effort TTL. No retention deletion or transport is
 
 ## Reading and comparison
 
+Backend-enabled histories use state schema V3: `ParentPublication` binds the immediately prior
+head, while `Operation` references the latest immutable backend decision. This permits an
+identified conflict/no-op decision to advance publication revision without creating a version
+or content commit. Ordinary creates/restores carry the decision tip forward. V1/V2 history stays
+readable and retains its original wire format until enabled; older codecs reject V3 explicitly.
+The storage layer treats the decision reference as opaque; the backend owner must validate its
+record, outcome, and effects. A stored reference alone is not proof of acceptance.
+
+Ordered updates validate exact V3 publication parents, then legacy version ancestry if the tail
+crosses the schema boundary. The traversal budget includes publication edges as well as legacy
+version edges and content commits. Decision-only updates have an empty content tail, not a fake
+document edit; history consumers can still advance their accepted head.
+
 `ReadAsync` validates the current document and the state/version/commit tip relationships. `ListVersionsAsync` starts at that published head and returns newest-first pages (1–100 records); pass a non-null `Next` to continue the same immutable chain while newer versions publish. A null `Next` means the page reached the end.
 
 `GetVersionAsync`, `ExportVersionAsync`, and explicit list cursors also accept retained branch references belonging to the same document. A reference is neither authorization nor proof that a version is on the current published branch. The host must authorize access before invoking these APIs. Cross-document references are rejected.

--- a/docs/schemas/history-state-v3.schema.json
+++ b/docs/schemas/history-state-v3.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docxodus.dev/schemas/history/package-state/v3",
+  "title": "Package-history state with explicit publication ancestry and backend decision tip",
+  "$comment": "Register adjacent state-v2 schema to resolve shared definitions. Runtime validation proves exact parent publication ancestry. Operation is an opaque immutable decision reference at this storage layer; its owner validates its record and graph.",
+  "type": "object", "additionalProperties": false,
+  "required": ["schema", "schemaVersion", "record"],
+  "properties": {
+    "schema": { "const": "https://docxodus.dev/schemas/history/package-state/v3" },
+    "schemaVersion": { "const": 3 },
+    "record": {
+      "type": "object", "additionalProperties": false,
+      "required": ["parentPublication", "operation", "commit", "documentId", "epoch", "initialSnapshot", "sequence", "snapshot", "version"],
+      "properties": {
+        "parentPublication": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/head" },
+        "operation": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/blob" },
+        "requests": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/journal" },
+        "commit": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/optionalBlob" },
+        "documentId": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/id" },
+        "epoch": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/position" },
+        "initialSnapshot": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/snapshot" },
+        "sequence": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/position" },
+        "snapshot": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/snapshot" },
+        "version": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/blob" }
+      }
+    }
+  }
+}

--- a/scripts/history-fuzz.sh
+++ b/scripts/history-fuzz.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Deterministic extended version-history corpus. Every failing case prints its seed and trace.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export DOCXODUS_HISTORY_FUZZ_SEEDS="${DOCXODUS_HISTORY_FUZZ_SEEDS:-64}"
+export DOCXODUS_HISTORY_FUZZ_STEPS="${DOCXODUS_HISTORY_FUZZ_STEPS:-128}"
+dotnet test Docxodus.Tests/Docxodus.Tests.csproj -c Release -m:1 /p:UseSharedCompilation=false \
+  --filter 'FullyQualifiedName~DocxVersionModelFuzz|FullyQualifiedName~DocxVersionRequestFault|FullyQualifiedName~HistoryRequestJournal' \
+  --logger 'console;verbosity=normal' --logger 'trx;LogFileName=history-fuzz.trx' "$@"


### PR DESCRIPTION
Stacked on #723. State V3 adds exact parent-publication links plus an opaque backend decision tip, allowing identified conflict/no-op outcomes without fabricating versions or content commits. Normal creates/restores preserve the tip. Ordered updates prove V3 publication ancestry, then legacy version ancestry across the schema boundary; scan budgets cover both. Shared immutable version preparation is separated from publication for the upcoming backend reconciler.

V1/V2 formats remain readable and unchanged until backend-enabled; old schemas reject V3 fields even when null. The decision reference remains opaque at this layer: backend codec/outcome validation follows next, and test stubs explicitly do not claim reconciliation.

Validation: 30 focused ancestry/codec/version-request tests passed, including memory/filesystem mixed chains, forks, revision forgery, budget boundaries and client JSON round-trip. GPT-5.6-sol review clean. No GUI, transport or live editor.