### PR TITLE
feat(history): reconcile backend intents and preserve conflicts

### DIFF
--- a/Docxodus.Tests/DocxBackendFaultTests.cs
+++ b/Docxodus.Tests/DocxBackendFaultTests.cs
@@ -1,0 +1,107 @@
+#nullable enable
+
+using Docxodus.History;
+using Xunit;
+using static Docxodus.Tests.DocxBackendReconciliationTests;
+
+namespace Docxodus.Tests;
+
+public sealed class DocxBackendFaultTests
+{
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task EveryDurableWriteAndCASBoundaryRecoversAcceptedAndConflictingOperations(bool filesystem, bool conflicting)
+    {
+        var bytes = Package("abcd");
+        int writes;
+        using (var probe = new HistoryFaultHarness(filesystem))
+        {
+            var prepared = await Setup(probe);
+            probe.Arm(HistoryFaultHarness.Fault.None);
+            _ = await new DocxVersionHistory(probe, probe).SubmitOperationAsync("doc", prepared.Request);
+            writes = probe.Writes;
+        }
+        Assert.True(writes >= 3);
+        var cases = Enumerable.Range(1, writes).SelectMany(at => new[]
+        {
+            (Fault: HistoryFaultHarness.Fault.BeforeBlob, At: at), (Fault: HistoryFaultHarness.Fault.AfterBlob, At: at),
+        }).Concat(new[] { HistoryFaultHarness.Fault.BeforeHead, HistoryFaultHarness.Fault.AfterHead,
+            HistoryFaultHarness.Fault.CancelBeforeHead, HistoryFaultHarness.Fault.CancelAfterHead }.Select(f => (Fault: f, At: 1)));
+        foreach (var fault in cases)
+        {
+            using var store = new HistoryFaultHarness(filesystem);
+            var prepared = await Setup(store);
+            store.Cancellation = new CancellationTokenSource(); store.Arm(fault.Fault, fault.At);
+            var action = new DocxVersionHistory(store, store).SubmitOperationAsync("doc", prepared.Request,
+                cancellationToken: store.Cancellation.Token).AsTask();
+            if (fault.Fault == HistoryFaultHarness.Fault.CancelAfterHead) Assert.NotNull(await action);
+            else if (fault.Fault == HistoryFaultHarness.Fault.CancelBeforeHead) await Assert.ThrowsAnyAsync<OperationCanceledException>(() => action);
+            else await Assert.ThrowsAsync<IOException>(() => action);
+            var committed = fault.Fault is HistoryFaultHarness.Fault.AfterHead or HistoryFaultHarness.Fault.CancelAfterHead;
+            var recovered = new DocxVersionHistory(store, store);
+            var observed = (await recovered.ReadAsync("doc"))!;
+            Assert.Equal(prepared.Before.Head.Revision + (committed ? 1 : 0), observed.Head.Revision);
+            if (!committed) Assert.Equal(prepared.Before.Head, observed.Head);
+            store.Arm(HistoryFaultHarness.Fault.None);
+            var result = await recovered.SubmitOperationAsync("doc", prepared.Request);
+            Assert.Equal(committed ? 0 : 1, store.Publications);
+            Assert.Equal(prepared.Before.Head.Revision + 1, result.View.Head.Revision);
+            Assert.Equal(conflicting ? "conflict" : "accepted", result.Operation.Record.Status);
+            Assert.Equal(conflicting ? "aXd" : "aXd!", BodyText(await recovered.ExportVersionAsync("doc", result.View.Version.Id)));
+            Assert.Equal(conflicting ? "ab?d" : "abcd!", BodyText(await recovered.ExportOperationProposalAsync("doc", result.Operation.Id)));
+            Assert.Equal(2, (await recovered.ReadOperationsSinceAsync("doc", null)).Operations.Count);
+            Assert.Equal(conflicting ? 2 : 3, (await recovered.ListVersionsAsync("doc")).Versions.Count);
+            var again = await new DocxVersionHistory(store, store).SubmitOperationAsync("doc", prepared.Request);
+            Assert.Equal(result.View.Head, again.View.Head); Assert.Equal(result.Operation.Id, again.Operation.Id);
+            SameEntries(await recovered.ExportVersionAsync("doc", result.View.Version.Id), await recovered.ReplayAsync("doc", result.View.State.Sequence));
+        }
+
+        async Task<(DocxHistoryView Before, DocxOperationRequest Request)> Setup(HistoryFaultHarness store)
+        {
+            var history = new DocxVersionHistory(store, store);
+            var initial = await history.CreateVersionAsync("doc", "initial", null, bytes, Metadata("initial"));
+            var winner = await history.SubmitOperationAsync("doc", Text("winner", initial.Head, 1, 2, "X"));
+            var request = conflicting ? Text("request", initial.Head, 2, 1, "?") : Text("request", initial.Head, 4, 0, "!");
+            return (winner.View, request);
+        }
+    }
+
+    [Fact]
+    public async Task DecisionAuditReadsNoRadixIndexAndBudgetCountsInterveningVersionPublications()
+    {
+        var blobs = new MemoryHistoryBlobStore(); var heads = new MemoryHistoryHeadStore();
+        var history = new DocxVersionHistory(blobs, heads);
+        var current = await history.CreateVersionAsync("doc", "initial", null, Package("abcd"), Metadata("initial"));
+        var roots = new HashSet<HistoryBlobReference>();
+        for (var i = 0; i < 8; i++)
+        {
+            current = (await history.SubmitOperationAsync("doc", Text("operation-" + i, current.Head, 0, 0, "!"))).View;
+            if (current.State.Requests!.Index is { } root) roots.Add(root);
+        }
+        // A forbidden root catches even ONE restarted receipt lookup, regardless of index depth.
+        var audited = new DocxVersionHistory(new ForbiddenIndexReads(blobs, roots), heads);
+        Assert.Equal(8, (await audited.ReadOperationsSinceAsync("doc", null, 8)).Operations.Count);
+        Assert.Equal(DocxHistoryError.TraversalLimit, (await Assert.ThrowsAsync<DocxHistoryException>(async () =>
+            await audited.ReadOperationsSinceAsync("doc", null, 7))).Code);
+        var snapshot = await history.ExportVersionAsync("doc", current.Version.Id);
+        for (var i = 0; i < 4; i++)
+            current = await history.CreateVersionAsync("doc", current.Head, snapshot, Metadata("label"));
+        Assert.Equal(DocxHistoryError.TraversalLimit, (await Assert.ThrowsAsync<DocxHistoryException>(async () =>
+            await history.ReadOperationsSinceAsync("doc", null, 8))).Code);
+        Assert.Equal(8, (await history.ReadOperationsSinceAsync("doc", null, 12)).Operations.Count);
+    }
+
+    private sealed class ForbiddenIndexReads(IHistoryBlobStore inner, HashSet<HistoryBlobReference> roots) : IHistoryBlobStore
+    {
+        public ValueTask PutAsync(HistoryBlobReference reference, Stream stream, CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("Read-only audit.");
+        public ValueTask<Stream?> OpenReadAsync(HistoryBlobReference reference, CancellationToken cancellationToken = default)
+        {
+            Assert.DoesNotContain(reference, roots);
+            return inner.OpenReadAsync(reference, cancellationToken);
+        }
+    }
+}

--- a/Docxodus.Tests/DocxBackendReconciliationTests.cs
+++ b/Docxodus.Tests/DocxBackendReconciliationTests.cs
@@ -1,0 +1,257 @@
+#nullable enable
+
+using System.IO.Compression;
+using System.Text;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
+using DocumentFormat.OpenXml.Wordprocessing;
+using Docxodus.History;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+public sealed class DocxBackendReconciliationTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DelayedConflictingStreamPreservesBothCompatibleEditsAndRecoverableContenders(bool filesystem)
+    {
+        using var store = new HistoryFaultHarness(filesystem);
+        var history = new DocxVersionHistory(store, store);
+        var original = Package("abcdefghij café 📝");
+        var first = await history.CreateVersionAsync("doc", "initial", null, original, Metadata("initial"));
+        var a = Text("a", first.Head, 2, 0, "A");
+        var b = Text("b", first.Head, 2, 0, "B");
+        var c = Text("c", first.Head, 6, 2, "");
+        var d = Text("d", first.Head, 7, 1, "X");
+        var ra = await history.SubmitOperationAsync("doc", a);
+        var rb = await history.SubmitOperationAsync("doc", b);
+        var rc = await history.SubmitOperationAsync("doc", c);
+        var rd = await history.SubmitOperationAsync("doc", d);
+        Assert.Equal("accepted", rb.Operation.Record.Status);
+        Assert.Equal(3, rb.Operation.Record.AppliedText!.Offset);
+        Assert.Equal("OverlappingText", rd.Operation.Record.Conflict);
+        Assert.Equal(rc.View.Version.Id, rd.View.Version.Id);
+        Assert.Equal(rc.View.State.Sequence, rd.View.State.Sequence);
+        Assert.Equal(rc.View.Head.Revision + 1, rd.View.Head.Revision);
+        Assert.Equal("abABcdefij café 📝", BodyText(await history.ExportVersionAsync("doc", rd.View.Version.Id)));
+        Assert.Equal("abcdefgXij café 📝", BodyText(await history.ExportOperationProposalAsync("doc", rd.Operation.Id)));
+        var resolution = Text("resolve-d", rd.View.Head, 8, 0, "R") with { Resolves = rd.Operation.Id };
+        var resolved = await history.SubmitOperationAsync("doc", resolution);
+        Assert.Equal("accepted", resolved.Operation.Record.Status);
+        Assert.Equal("abABcdefRij café 📝", BodyText(await history.ExportVersionAsync("doc", resolved.View.Version.Id)));
+        // Reopen, delayed duplicate, and a competing new resolution do not apply the same work twice.
+        history = new DocxVersionHistory(store, store);
+        Assert.Equal(ra.View.Head, (await history.SubmitOperationAsync("doc", a)).View.Head);
+        Assert.Equal(rd.View.Head, (await history.SubmitOperationAsync("doc", d)).View.Head);
+        var repeatedResolution = await history.SubmitOperationAsync("doc", resolution with { RequestId = "other-resolution" });
+        Assert.Equal("AlreadyResolved", repeatedResolution.Operation.Record.Conflict);
+        var outcomes = await history.ReadOperationsSinceAsync("doc", first.Head);
+        Assert.Equal(new[] { "a", "b", "c", "d", "resolve-d", "other-resolution" }, outcomes.Operations.Select(o => o.Input.Request.RequestId));
+        Assert.Equal(new long[] { 2, 3, 4, 5, 6, 7 }, outcomes.Operations.Select(o => o.Record.Revision));
+        Assert.Empty((await history.ReadOperationsSinceAsync("doc", repeatedResolution.View.Head)).Operations);
+        Assert.Equal(5, (await history.ListVersionsAsync("doc")).Versions.Count);
+        var snapshots = new[] { first, ra.View, rb.View, rc.View, resolved.View };
+        foreach (var view in snapshots)
+        {
+            var exact = await history.ExportVersionAsync("doc", view.Version.Id);
+            SameEntries(exact, await history.ReplayAsync("doc", view.State.Sequence));
+            Untouched(original, exact, "word/document.xml");
+            NoNewValidationErrors(original, exact);
+        }
+        Assert.Equal(original, await history.ExportVersionAsync("doc", first.Version.Id));
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task RealCASLoserReconcilesDifferentIntentAndIdenticalRetriesReturnOneOutcome(bool filesystem, bool rightFirst)
+    {
+        using var store = new HistoryFaultHarness(filesystem);
+        var history = new DocxVersionHistory(store, store);
+        var first = await history.CreateVersionAsync("doc", null, Package("abcd"), Metadata("initial"));
+        var a = Text("a", first.Head, 2, 0, "A");
+        var b = Text("b", first.Head, 2, 0, "B");
+        store.Arm(HistoryFaultHarness.Fault.None);
+        store.HoldCompetingPublications(rightFirst ? "right" : "left");
+        DocxOperationResult[] results;
+        try
+        {
+            results = await Task.WhenAll(
+                Task.Run(() => store.AsContenderAsync("left", async () => await new DocxVersionHistory(store, store).SubmitOperationAsync("doc", a))),
+                Task.Run(() => store.AsContenderAsync("right", async () => await new DocxVersionHistory(store, store).SubmitOperationAsync("doc", b))));
+        }
+        finally { store.ReleaseCompetingPublications(); }
+        Assert.All(results, r => Assert.Equal("accepted", r.Operation.Record.Status));
+        Assert.Equal(3, store.Publications); // Both attempt the old CAS; the loser then reconciles and commits.
+        var current = (await history.ReadAsync("doc"))!;
+        Assert.Equal(rightFirst ? "abBAcd" : "abABcd", BodyText(await history.ExportVersionAsync("doc", current.Version.Id)));
+        var shared = Text("shared", current.Head, 0, 0, "!");
+        store.Arm(HistoryFaultHarness.Fault.None); store.HoldCompetingPublications(rightFirst ? "right" : "left");
+        try
+        {
+            results = await Task.WhenAll(
+                Task.Run(() => store.AsContenderAsync("left", async () => await new DocxVersionHistory(store, store).SubmitOperationAsync("doc", shared))),
+                Task.Run(() => store.AsContenderAsync("right", async () => await new DocxVersionHistory(store, store).SubmitOperationAsync("doc", shared))));
+        }
+        finally { store.ReleaseCompetingPublications(); }
+        Assert.Equal(2, store.Publications);
+        Assert.Equal(results[0].View.Head, results[1].View.Head);
+        Assert.Equal(results[0].Operation.Id, results[1].Operation.Id);
+        Assert.Equal(3, (await history.ReadOperationsSinceAsync("doc", null)).Operations.Count);
+    }
+
+    [Fact]
+    public async Task DisjointPackagePartsMergeReadDependenciesConflictAndDiscardIsAuditable()
+    {
+        using var store = new HistoryFaultHarness();
+        var history = new DocxVersionHistory(store, store);
+        var original = Package("body");
+        var first = await history.CreateVersionAsync("doc", null, original, Metadata("initial"));
+        var header = ReplacePartText(original, "word/header1.xml", "header", "new header");
+        var footnote = ReplacePartText(original, "word/footnotes.xml", "note", "new note");
+        var headerResult = await history.SubmitOperationAsync("doc", PackageRequest("header", first.Head), header);
+        var noteResult = await history.SubmitOperationAsync("doc", PackageRequest("note", first.Head), footnote);
+        Assert.Equal("accepted", noteResult.Operation.Record.Status);
+        var merged = await history.ExportVersionAsync("doc", noteResult.View.Version.Id);
+        Assert.Contains("new header", Encoding.UTF8.GetString(Entries(merged)["word/header1.xml"]));
+        Assert.Contains("new note", Encoding.UTF8.GetString(Entries(merged)["word/footnotes.xml"]));
+        Untouched(original, merged, "word/header1.xml", "word/footnotes.xml");
+        NoNewValidationErrors(original, merged);
+        var dependency = PackageRequest("dependency", first.Head) with { ReadParts = new[] { "/word/header1.xml" } };
+        var conflict = await history.SubmitOperationAsync("doc", dependency, footnote);
+        Assert.Equal("ReadDependencyChanged", conflict.Operation.Record.Conflict);
+        Assert.Equal(footnote, await history.ExportOperationProposalAsync("doc", conflict.Operation.Id));
+        var discard = new DocxOperationRequest
+        {
+            RequestId = "discard", Base = conflict.View.Head, Kind = "discard", Metadata = Metadata("discard"), Resolves = conflict.Operation.Id,
+        };
+        var discarded = await history.SubmitOperationAsync("doc", discard);
+        Assert.Equal("accepted", discarded.Operation.Record.Status);
+        Assert.Null(discarded.Operation.Record.ContentCommit);
+        Assert.Equal(noteResult.View.Version.Id, discarded.View.Version.Id);
+        Assert.Empty((await history.ReadChangesSinceAsync("doc", noteResult.View.Head)).Entries);
+        // Same desired package content is accepted without manufacturing a version or content edit.
+        var noOp = await history.SubmitOperationAsync("doc", PackageRequest("same-header", first.Head), header);
+        Assert.Equal("accepted", noOp.Operation.Record.Status); Assert.Null(noOp.Operation.Record.ContentCommit);
+        Assert.Equal(discarded.View.Version.Id, noOp.View.Version.Id);
+        Assert.Equal(headerResult.View.Head, (await history.SubmitOperationAsync("doc", PackageRequest("header", first.Head), header)).View.Head);
+    }
+
+    [Fact]
+    public async Task EpochAndUnknownStructuralChangesAreExplicitBoundariesAndIdsBindOriginalInput()
+    {
+        using var store = new HistoryFaultHarness();
+        var history = new DocxVersionHistory(store, store);
+        var original = Package("abcd");
+        var first = await history.CreateVersionAsync("doc", null, original, Metadata("initial"));
+        var stale = Text("stale", first.Head, 1, 0, "X");
+        var imported = await history.CreateVersionAsync("doc", first.Head,
+            ReplacePartText(original, "word/document.xml", "abcd", "new paragraph"), Metadata("external edit"));
+        var unknown = await history.SubmitOperationAsync("doc", stale);
+        Assert.Equal("UnknownTextChange", unknown.Operation.Record.Conflict);
+        var reset = await history.RestoreVersionAsync("doc", unknown.View.Head, first.Version.Id, Metadata("restore"));
+        var epoch = await history.SubmitOperationAsync("doc", stale with { RequestId = "across-reset" });
+        Assert.Equal("EpochChanged", epoch.Operation.Record.Conflict);
+        Assert.Equal(reset.Version.Id, epoch.View.Version.Id);
+        Assert.Equal(DocxHistoryError.RequestConflict, (await Assert.ThrowsAsync<DocxHistoryException>(async () =>
+            await history.SubmitOperationAsync("doc", stale with { Base = epoch.View.Head }))).Code);
+        Assert.Equal(unknown.View.Head, (await history.SubmitOperationAsync("doc", stale)).View.Head);
+        Assert.Equal(imported.Version.Id, unknown.View.Version.Id);
+    }
+
+    [Fact]
+    public async Task InvalidUnicodeOrBaseInputsNeverPublishAndCancellationAfterCASDoesNotEraseSuccess()
+    {
+        using var store = new HistoryFaultHarness();
+        var history = new DocxVersionHistory(store, store);
+        var first = await history.CreateVersionAsync("doc", null, Package("a📝b"), Metadata("initial"));
+        foreach (var invalid in new[] { Text("split", first.Head, 2, 0, "x"), Text("range", first.Head, 100, 0, "x") })
+            await Assert.ThrowsAsync<PackageChangeException>(async () => await history.SubmitOperationAsync("doc", invalid));
+        Assert.Equal(first.Head, (await history.ReadAsync("doc"))!.Head);
+        store.Cancellation = new CancellationTokenSource(); store.Arm(HistoryFaultHarness.Fault.CancelAfterHead);
+        var request = Text("committed", first.Head, 3, 0, "!");
+        var result = await history.SubmitOperationAsync("doc", request, cancellationToken: store.Cancellation.Token);
+        Assert.True(store.Cancellation.IsCancellationRequested);
+        store.Arm(HistoryFaultHarness.Fault.None);
+        Assert.Equal(result.View.Head, (await history.SubmitOperationAsync("doc", request)).View.Head);
+        Assert.Equal("a📝!b", BodyText(await history.ExportVersionAsync("doc", result.View.Version.Id)));
+    }
+
+    internal static DocxVersionMetadata Metadata(string label) => DocxVersionRequestTests.Metadata(label);
+    internal static DocxOperationRequest Text(string id, HistoryHead baseline, int offset, int delete, string insert) => new()
+    { RequestId = id, Base = baseline, Kind = "text", Metadata = Metadata(id), Text = new DocxTextSplice("/word/document.xml", 0, offset, delete, insert) };
+    internal static DocxOperationRequest PackageRequest(string id, HistoryHead baseline) => new()
+    { RequestId = id, Base = baseline, Kind = "package", Metadata = Metadata(id) };
+
+    internal static byte[] Package(string text)
+    {
+        using var stream = new MemoryStream(); stream.Write(DocxSession.CreateBlankDocxBytes());
+        using (var doc = WordprocessingDocument.Open(stream, true))
+        {
+            var main = doc.MainDocumentPart!;
+            var header = main.AddNewPart<HeaderPart>(); header.Header = new Header(new Paragraph(new Run(new Text("header"))));
+            var notes = main.AddNewPart<FootnotesPart>();
+            notes.Footnotes = new Footnotes(new Footnote(new Paragraph(new Run(new Text("note")))) { Id = 1 });
+            var comments = main.AddNewPart<WordprocessingCommentsPart>();
+            comments.Comments = new Comments(new Comment(new Paragraph(new Run(new Text("review"))))
+            { Id = "0", Author = "Reviewer", Date = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc) });
+            main.Document.Body = new Body(new Paragraph(new Run(new Text(text)), new Run(new FootnoteReference { Id = 1 })),
+                new Paragraph(new CommentRangeStart { Id = "0" }, new Run(new Text("commented")), new CommentRangeEnd { Id = "0" },
+                    new Run(new CommentReference { Id = "0" })),
+                new SectionProperties(new HeaderReference { Type = HeaderFooterValues.Default, Id = main.GetIdOfPart(header) }));
+            var opaque = main.AddCustomXmlPart("application/octet-stream");
+            using var payload = new MemoryStream(Enumerable.Range(0, 257).Select(i => (byte)(i * 37)).ToArray()); opaque.FeedData(payload);
+        }
+        return stream.ToArray();
+    }
+    internal static string BodyText(byte[] package) => XDocument.Parse(Encoding.UTF8.GetString(Entries(package)["word/document.xml"]))
+        .Descendants(XName.Get("t", "http://schemas.openxmlformats.org/wordprocessingml/2006/main")).First().Value;
+    internal static byte[] ReplacePartText(byte[] package, string name, string before, string after)
+    {
+        using var stream = new MemoryStream(); stream.Write(package);
+        using (var zip = new ZipArchive(stream, ZipArchiveMode.Update, leaveOpen: true))
+        {
+            var entry = zip.GetEntry(name)!;
+            using var content = entry.Open(); using var reader = new StreamReader(content, leaveOpen: true);
+            var xml = XDocument.Parse(reader.ReadToEnd(), LoadOptions.PreserveWhitespace);
+            foreach (var text in xml.DescendantNodes().OfType<XText>().Where(t => t.Value == before)) text.Value = after;
+            content.Position = 0; content.SetLength(0); content.Write(Encoding.UTF8.GetBytes(xml.ToString(SaveOptions.DisableFormatting)));
+        }
+        return stream.ToArray();
+    }
+    internal static SortedDictionary<string, byte[]> Entries(byte[] package)
+    {
+        using var zip = new ZipArchive(new MemoryStream(package), ZipArchiveMode.Read);
+        var entries = new SortedDictionary<string, byte[]>(StringComparer.Ordinal);
+        foreach (var entry in zip.Entries)
+        { using var input = entry.Open(); using var output = new MemoryStream(); input.CopyTo(output); entries.Add(entry.FullName, output.ToArray()); }
+        return entries;
+    }
+    internal static void SameEntries(byte[] expected, byte[] actual)
+    {
+        var a = Entries(expected); var b = Entries(actual); Assert.Equal(a.Keys, b.Keys);
+        foreach (var pair in a) Assert.Equal(pair.Value, b[pair.Key]);
+    }
+    internal static void Untouched(byte[] before, byte[] after, params string[] changed)
+    {
+        var a = Entries(before); var b = Entries(after); Assert.Equal(a.Keys, b.Keys);
+        foreach (var pair in a.Where(p => !changed.Contains(p.Key))) Assert.Equal(pair.Value, b[pair.Key]);
+    }
+    internal static void NoNewValidationErrors(byte[] before, byte[] after)
+    {
+        static HashSet<string> Errors(byte[] bytes)
+        {
+            using var doc = WordprocessingDocument.Open(new MemoryStream(bytes), false);
+            return new OpenXmlValidator(FileFormatVersions.Office2019).Validate(doc)
+                .Select(e => e.Id + "|" + e.Part?.Uri + "|" + e.Path?.XPath).ToHashSet();
+        }
+        var baseline = Errors(before);
+        Assert.Empty(Errors(after).Except(baseline));
+    }
+}

--- a/Docxodus.Tests/DocxBackendRecordTests.cs
+++ b/Docxodus.Tests/DocxBackendRecordTests.cs
@@ -1,0 +1,118 @@
+#nullable enable
+
+using System.Text;
+using System.Text.Json.Nodes;
+using Docxodus.History;
+using Xunit;
+using static Docxodus.Tests.DocxBackendReconciliationTests;
+
+namespace Docxodus.Tests;
+
+public sealed class DocxBackendRecordTests
+{
+    [Fact]
+    public async Task StrictDecisionCodecRejectsUnknownDuplicateMissingAndUnsupportedFields()
+    {
+        using var store = new HistoryFaultHarness();
+        var history = new DocxVersionHistory(store, store);
+        var first = await history.CreateVersionAsync("doc", null, Package("abcd"), Metadata("initial"));
+        var result = await history.SubmitOperationAsync("doc", Text("a", first.Head, 1, 0, "X"));
+        var recordStore = new DocxOperationStore(store);
+        var record = await recordStore.LoadDecisionAsync(result.Operation.Id, default);
+        Assert.Equal(result.Operation.Record, record);
+        Assert.Equal(result.Operation.Id, await recordStore.SaveDecisionAsync(record, default));
+        using var stream = await store.OpenReadAsync(result.Operation.Id);
+        using var reader = new StreamReader(stream!);
+        var original = await reader.ReadToEndAsync();
+        await Bad(original.Replace("\"status\":\"accepted\"", "\"status\":\"accepted\",\"status\":\"accepted\"", StringComparison.Ordinal));
+        var unknown = JsonNode.Parse(original)!; unknown["record"]!["extra"] = true; await Bad(unknown.ToJsonString());
+        foreach (var property in new[] { "appliedText", "contentCommit", "conflict", "proposedSnapshot", "input" })
+        {
+            var missing = JsonNode.Parse(original)!; missing["record"]!.AsObject().Remove(property); await Bad(missing.ToJsonString());
+        }
+        var future = JsonNode.Parse(original)!; future["schemaVersion"] = 2;
+        await Bad(future.ToJsonString(), PackageChangeError.UnsupportedVersion);
+        var badStatus = JsonNode.Parse(original)!; badStatus["record"]!["status"] = "conflict"; await Bad(badStatus.ToJsonString());
+        var foreign = await Assert.ThrowsAsync<DocxHistoryException>(async () => await history.GetOperationAsync("other", result.Operation.Id));
+        Assert.Equal(DocxHistoryError.ForeignDocument, foreign.Code);
+
+        async Task Bad(string json, PackageChangeError code = PackageChangeError.InvalidManifest)
+        {
+            var reference = await HistoryBlobIO.PutBytesAsync(store, Encoding.UTF8.GetBytes(json), default);
+            Assert.Equal(code, (await Assert.ThrowsAsync<PackageChangeException>(async () =>
+                await recordStore.LoadDecisionAsync(reference, default))).Code);
+        }
+    }
+
+    [Fact]
+    public async Task CorruptMissingDecisionInputAndProposalAreNotEmptyHistoryOrSuccessfulRetry()
+    {
+        using var store = new HistoryFaultHarness();
+        var history = new DocxVersionHistory(store, store);
+        var first = await history.CreateVersionAsync("doc", null, Package("abcd"), Metadata("initial"));
+        var request = Text("a", first.Head, 1, 0, "X");
+        var result = await history.SubmitOperationAsync("doc", request);
+        foreach (var reference in new[] { result.Operation.Id, result.Operation.Record.Input })
+        foreach (var missing in new[] { false, true })
+        {
+            store.DamagedDigest = reference.Digest.Value; store.Missing = missing;
+            Assert.Equal(missing ? PackageChangeError.PayloadMissing : PackageChangeError.PayloadMismatch,
+                (await Assert.ThrowsAsync<PackageChangeException>(async () => await history.ReadOperationsSinceAsync("doc", null))).Code);
+            await Assert.ThrowsAsync<PackageChangeException>(async () => await history.SubmitOperationAsync("doc", request));
+        }
+        store.DamagedDigest = result.Operation.Record.ProposedSnapshot.Blob.Digest.Value; store.Missing = true;
+        await Assert.ThrowsAsync<PackageChangeException>(async () => await history.ExportOperationProposalAsync("doc", result.Operation.Id));
+        store.DamagedDigest = null;
+        Assert.Equal(result.View.Head, (await history.ReadAsync("doc"))!.Head);
+        Assert.Equal(result.Operation.Id, (await history.SubmitOperationAsync("doc", request)).Operation.Id);
+    }
+
+    [Fact]
+    public async Task AClaimedPositionMapMustReproduceActualAcceptedEffectsBeforeRebasing()
+    {
+        var blobs = new MemoryHistoryBlobStore(); var heads = new MemoryHistoryHeadStore();
+        var history = new DocxVersionHistory(blobs, heads);
+        var first = await history.CreateVersionAsync("doc", null, Package("abcd"), Metadata("initial"));
+        var accepted = await history.SubmitOperationAsync("doc", Text("accepted", first.Head, 1, 0, "X"));
+        var falseDecision = await new DocxOperationStore(blobs).SaveDecisionAsync(accepted.Operation.Record with
+        { AppliedText = accepted.Operation.Record.AppliedText! with { Offset = 2 } }, default);
+        var falseState = await new HistoryRecordStore(blobs).SaveStateAsync(accepted.View.State with { Operation = falseDecision });
+        var forged = new DocxVersionHistory(blobs, new FixedHead(accepted.View.Head with { State = falseState }));
+        Assert.Equal(DocxHistoryError.InvalidHistory, (await Assert.ThrowsAsync<DocxHistoryException>(async () =>
+            await forged.SubmitOperationAsync("doc", Text("pending", first.Head, 3, 0, "Y")))).Code);
+        Assert.Equal(accepted.View.Head, (await history.ReadAsync("doc"))!.Head);
+    }
+
+    [Fact]
+    public async Task ReadSetsAndMetadataNormalizeButChangedCandidateOrResolutionNeverReuseAnId()
+    {
+        using var store = new HistoryFaultHarness();
+        var history = new DocxVersionHistory(store, store);
+        var bytes = Package("abcd");
+        var first = await history.CreateVersionAsync("doc", null, bytes, Metadata("initial"));
+        var a = PackageRequest("package", first.Head) with
+        {
+            ReadParts = new[] { "/word/footnotes.xml", "/word/header1.xml", "/word/header1.xml" },
+            Metadata = Metadata("package") with { ApplicationMetadata = new Dictionary<string, string> { ["b"] = "2", ["a"] = "1" } },
+        };
+        var result = await history.SubmitOperationAsync("doc", a, bytes);
+        var reordered = a with
+        {
+            ReadParts = new[] { "/word/header1.xml", "/word/footnotes.xml" },
+            Metadata = a.Metadata with { ApplicationMetadata = new Dictionary<string, string> { ["a"] = "1", ["b"] = "2" } },
+        };
+        Assert.Equal(result.View.Head, (await history.SubmitOperationAsync("doc", reordered, bytes)).View.Head);
+        foreach (var changed in new[] { a with { ReadParts = Array.Empty<string>() }, a with { Resolves = result.Operation.Id } })
+            Assert.Equal(DocxHistoryError.RequestConflict, (await Assert.ThrowsAsync<DocxHistoryException>(async () =>
+                await history.SubmitOperationAsync("doc", changed, bytes))).Code);
+        Assert.Equal(DocxHistoryError.RequestConflict, (await Assert.ThrowsAsync<DocxHistoryException>(async () =>
+            await history.SubmitOperationAsync("doc", a, ReplacePartText(bytes, "word/document.xml", "abcd", "new")))).Code);
+    }
+
+    private sealed class FixedHead(HistoryHead head) : IHistoryHeadStore
+    {
+        public ValueTask<HistoryHead?> ReadAsync(string id, CancellationToken cancellationToken = default) => new(head);
+        public ValueTask<HistoryHead?> TryAdvanceAsync(string id, HistoryHead? expected, HistoryBlobReference state,
+            CancellationToken cancellationToken = default) => throw new InvalidOperationException("Must not publish an unverified text map.");
+    }
+}

--- a/Docxodus.Tests/DocxPublicationAncestryTests.cs
+++ b/Docxodus.Tests/DocxPublicationAncestryTests.cs
@@ -1,0 +1,130 @@
+#nullable enable
+
+using System.Text;
+using System.Text.Json.Nodes;
+using Docxodus.History;
+using Docxodus.Internal;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+public sealed class DocxPublicationAncestryTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task DecisionOnlyPublicationsInterleaveWithVersionsRestoresAndLegacyReceipts(bool filesystem)
+    {
+        using var store = new HistoryFaultHarness(filesystem);
+        var history = new DocxVersionHistory(store, store);
+        var bytes = DocxVersionRequestTests.Document("initial");
+        var first = await history.CreateVersionAsync("doc", null, bytes, Metadata("initial"));
+        var label = await history.CreateVersionAsync("doc", "label", first.Head, bytes, Metadata("label"));
+        var decision = await PublishDecision(store, label, "conflict");
+        var changed = await history.CreateVersionAsync("doc", "edit", decision.Head,
+            DocxVersionRequestTests.Document("changed"), Metadata("edit"));
+        var another = await PublishDecision(store, changed, "discard");
+        var restored = await history.RestoreVersionAsync("doc", "restore", another.Head, first.Version.Id, Metadata("restore"));
+        var last = await history.CreateVersionAsync("doc", restored.Head, bytes, Metadata("legacy label"));
+        history = new DocxVersionHistory(store, store);
+        foreach (var view in new[] { first, label, decision, changed, another, restored, last })
+        {
+            var updates = await history.ReadChangesSinceAsync("doc", view.Head);
+            Assert.Equal(last.Head, updates.View.Head);
+            Assert.Equal(2 - view.State.Sequence, updates.Entries.Count);
+            Assert.Equal(view.State.Epoch == 0, updates.Reset);
+            Assert.Equal(bytes, await history.ExportVersionAsync("doc", first.Version.Id));
+        }
+        Assert.Equal(5, (await history.ListVersionsAsync("doc")).Versions.Count);
+        Assert.Equal(7, last.Head.Revision);
+        Assert.Equal(2, last.State.Sequence);
+        Assert.Equal(another.State.Operation, last.State.Operation);
+        Assert.Equal(restored.Head, last.State.ParentPublication);
+        Assert.Equal(label.Head, (await history.CreateVersionAsync("doc", "label", first.Head, bytes, Metadata("label"))).Head);
+        Assert.Equal(2, (await history.ReadChangesSinceAsync("doc", first.Head, 8)).Entries.Count);
+        Assert.Equal(DocxHistoryError.TraversalLimit, (await Assert.ThrowsAsync<DocxHistoryException>(async () =>
+            await history.ReadChangesSinceAsync("doc", first.Head, 7))).Code);
+        var wire = HistoryClientJson.Write(new HistoryClientResult { View = last });
+        Assert.Contains("\"parentPublication\"", wire);
+        Assert.Equal(last.State.ParentPublication, HistoryClientJson.Read<HistoryClientResult>(wire).View!.State.ParentPublication);
+    }
+
+    [Fact]
+    public async Task AncestryRejectsSameVersionForksSkippedParentsAndForgedRevisions()
+    {
+        using var store = new HistoryFaultHarness();
+        var history = new DocxVersionHistory(store, store);
+        var first = await history.CreateVersionAsync("doc", null, DocxVersionRequestTests.Document("initial"), Metadata("initial"));
+        var a = await PublishDecision(store, first, "a");
+        var b = await PublishDecision(store, a, "b");
+        var records = new HistoryRecordStore(store);
+        async Task Invalid(DocxHistoryStateRecord state, HistoryHead after, long revision = 3)
+        {
+            var reference = await records.SaveStateAsync(state);
+            var forged = new DocxVersionHistory(store, new FixedHead(new HistoryHead(revision, reference)));
+            Assert.Equal(DocxHistoryError.InvalidHistory, (await Assert.ThrowsAsync<DocxHistoryException>(async () =>
+                await forged.ReadChangesSinceAsync("doc", after))).Code);
+        }
+        var alternateId = await records.SaveStateAsync(a.State with { Operation = first.Version.Id });
+        await Invalid(b.State with { ParentPublication = new HistoryHead(2, alternateId) }, a.Head);
+        await Invalid(b.State with { ParentPublication = first.Head }, first.Head);
+        await Invalid(b.State with { Operation = a.State.Operation }, a.Head);
+        await Invalid(b.State, a.Head, revision: 4);
+        await Invalid(b.State with { Operation = null, ParentPublication = null }, a.Head);
+        using var canceled = new CancellationTokenSource(); canceled.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await history.ReadChangesSinceAsync("doc", first.Head, cancellationToken: canceled.Token));
+        Assert.Equal(b.Head, (await history.ReadAsync("doc"))!.Head);
+    }
+
+    [Fact]
+    public async Task V3RequiresBothFieldsAndOlderCodecsCannotSilentlyDiscardThem()
+    {
+        using var store = new HistoryFaultHarness();
+        var history = new DocxVersionHistory(store, store);
+        var first = await history.CreateVersionAsync("doc", null, DocxVersionRequestTests.Document("initial"), Metadata("initial"));
+        var decision = await PublishDecision(store, first, "a");
+        var records = new HistoryRecordStore(store);
+        Assert.Equal(decision.State, await records.LoadStateAsync(decision.Head.State));
+        using var input = await store.OpenReadAsync(decision.Head.State);
+        var json = (await JsonNode.ParseAsync(input!))!;
+        Assert.Equal(3, json["schemaVersion"]!.GetValue<int>());
+        foreach (var version in new[] { 1, 2 })
+        {
+            var old = json.DeepClone(); old["schemaVersion"] = version;
+            old["schema"] = "https://docxodus.dev/schemas/history/package-state/v" + version;
+            old["record"]!["operation"] = null; old["record"]!["parentPublication"] = null;
+            await Bad(old);
+        }
+        foreach (var field in new[] { "operation", "parentPublication" })
+        {
+            var missing = json.DeepClone(); missing["record"]!.AsObject().Remove(field); await Bad(missing);
+        }
+        async Task Bad(JsonNode malformed)
+        {
+            var reference = await HistoryBlobIO.PutBytesAsync(store, Encoding.UTF8.GetBytes(malformed.ToJsonString()), default);
+            Assert.Equal(PackageChangeError.InvalidManifest, (await Assert.ThrowsAsync<PackageChangeException>(async () =>
+                await records.LoadStateAsync(reference))).Code);
+        }
+    }
+
+    // Opaque decision stubs exercise only the publication contract, not backend reconciliation.
+    private static async Task<DocxHistoryView> PublishDecision(HistoryFaultHarness store, DocxHistoryView before, string id)
+    {
+        var operation = await HistoryBlobIO.PutBytesAsync(store, Encoding.UTF8.GetBytes(id), default);
+        var requests = await new HistoryRequestJournalStore(store).AdvanceAsync("doc", before.Head, before.State.Requests,
+            new HistoryRequestIdentity(id, operation.Digest));
+        var state = before.State with { Operation = operation, ParentPublication = before.Head, Requests = requests };
+        var reference = await new HistoryRecordStore(store).SaveStateAsync(state);
+        var head = await store.TryAdvanceAsync("doc", before.Head, reference);
+        return new DocxHistoryView(head!, state, before.Version);
+    }
+
+    private static DocxVersionMetadata Metadata(string label) => DocxVersionRequestTests.Metadata(label);
+    private sealed class FixedHead(HistoryHead head) : IHistoryHeadStore
+    {
+        public ValueTask<HistoryHead?> ReadAsync(string id, CancellationToken cancellationToken = default) => new(head);
+        public ValueTask<HistoryHead?> TryAdvanceAsync(string id, HistoryHead? expected, HistoryBlobReference state,
+            CancellationToken cancellationToken = default) => throw new InvalidOperationException("Read only");
+    }
+}

--- a/Docxodus.Tests/DocxVersionModelFuzzTests.cs
+++ b/Docxodus.Tests/DocxVersionModelFuzzTests.cs
@@ -1,0 +1,271 @@
+#nullable enable
+
+using System.IO.Compression;
+using Docxodus.History;
+using DocumentFormat.OpenXml.Packaging;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+using static Docxodus.Tests.DocxVersionRequestTests;
+
+namespace Docxodus.Tests;
+
+/// <summary>
+/// Stateful oracle independent of history records, package digests, and replay implementation.
+/// Override DOCXODUS_HISTORY_FUZZ_SEEDS/STEPS for the extended deterministic corpus. Every failure
+/// reports its complete seed/command trace. Each seed checks all exact exports and all sequences.
+/// </summary>
+public sealed class DocxVersionModelFuzzTests(ITestOutputHelper output)
+{
+    public static IEnumerable<object[]> Seeds => Enumerable.Range(0, Setting("SEEDS", 16, 1024))
+        .Select(index => new object[] { 60493 + index * 7919 });
+    private sealed record Command(string? Id, HistoryHead? Expected, byte[] Bytes, DocxStoredVersion? Restore,
+        DocxVersionMetadata Metadata);
+    private sealed record ExpectedVersion(DocxHistoryView View, byte[] Bytes, DateTimeOffset Time, bool ContentBoundary);
+
+    [Theory]
+    [MemberData(nameof(Seeds))]
+    public async Task VersionStreamsMatchIndependentModelUnderRetriesRacesFaultsAndRestart(int seed)
+    {
+        var steps = Setting("STEPS", 96, 10_000);
+        var random = new Random(seed);
+        var filesystem = seed % 5 == 0;
+        using var storage = new HistoryFaultHarness(filesystem);
+        var history = new DocxVersionHistory(storage, storage);
+        var trace = new List<string>();
+        var versions = new List<ExpectedVersion>();
+        var requests = new List<(Command Command, DocxHistoryView Result)>();
+        var pool = Enumerable.Range(0, 6).Select(i => Package(seed, i)).ToArray();
+        var counts = new Dictionary<string, int>();
+        void Count(string name) => counts[name] = counts.GetValueOrDefault(name) + 1;
+        ExpectedVersion? Latest() => versions.LastOrDefault();
+        DocxVersionMetadata Meta(int step) => Metadata("seed " + seed + " step " + step) with
+        {
+            Author = "actor-" + random.Next(3),
+            CreatedAt = DateTimeOffset.UnixEpoch.AddMinutes(random.Next(-50, 51)).AddTicks(random.Next(7)),
+            ApplicationMetadata = new Dictionary<string, string> { ["seed"] = seed.ToString(), ["step"] = step.ToString(), ["unicode"] = "合同 📝" },
+        };
+        try
+        {
+            for (var step = 0; step < steps; step++)
+            {
+                history = new DocxVersionHistory(storage, storage); // No producer instance survives a step.
+                var action = versions.Count == 0 ? 0 : random.Next(12);
+                trace.Add($"{step}: action={action}, head={Latest()?.View.Head.Revision ?? 0}");
+                if (action <= 5)
+                {
+                    var restore = action == 5 ? versions[random.Next(versions.Count)] : null;
+                    var bytes = restore?.Bytes ?? (action == 1 ? Latest()!.Bytes
+                        : action == 2 ? Repack(Latest()!.Bytes, step) : pool[random.Next(pool.Length)]);
+                    var requestId = action == 4 ? null : $"{seed}/{step}";
+                    var command = new Command(requestId, Latest()?.View.Head, bytes, restore?.View.Version, Meta(step));
+                    var lostAck = requestId is not null && step % 17 == 0;
+                    if (lostAck) storage.Arm(HistoryFaultHarness.Fault.AfterHead);
+                    DocxHistoryView result;
+                    if (lostAck)
+                    {
+                        await Assert.ThrowsAsync<IOException>(async () => await Invoke(history, command));
+                        storage.Arm(HistoryFaultHarness.Fault.None);
+                        result = await Invoke(new DocxVersionHistory(storage, storage), command);
+                        Assert.Equal(0, storage.Publications);
+                        Count("lost-ack-recovery");
+                    }
+                    else result = await Invoke(history, command);
+                    await Accept(command, result);
+                    Count(restore is not null ? "restore" : action == 2 ? "repack" : requestId is null ? "legacy-save" : "save");
+                }
+                else if (action == 6 && requests.Count > 0)
+                {
+                    var old = requests[random.Next(requests.Count)];
+                    var head = Latest()!.View.Head;
+                    Assert.Equal(old.Result.Head, (await Invoke(history, old.Command)).Head);
+                    Assert.Equal(head, (await history.ReadAsync("doc"))!.Head);
+                    Count("old-request-retry");
+                }
+                else if (action == 7 && requests.Count > 0)
+                {
+                    var old = requests[random.Next(requests.Count)];
+                    var collision = old.Command with { Metadata = old.Command.Metadata with { Message = "different logical request" } };
+                    Assert.Equal(DocxHistoryError.RequestConflict,
+                        (await Assert.ThrowsAsync<DocxHistoryException>(async () => await Invoke(history, collision))).Code);
+                    Count("id-reuse-refusal");
+                }
+                else if (action == 8 && versions.Count > 1)
+                {
+                    var stale = new Command($"stale/{seed}/{step}", versions[random.Next(versions.Count - 1)].View.Head,
+                        pool[random.Next(pool.Length)], null, Meta(step));
+                    Assert.Equal(DocxHistoryError.StaleHead,
+                        (await Assert.ThrowsAsync<DocxHistoryException>(async () => await Invoke(history, stale))).Code);
+                    // A request never committed/bound may be corrected and submitted intentionally.
+                    var corrected = stale with { Expected = Latest()!.View.Head };
+                    await Accept(corrected, await Invoke(history, corrected));
+                    Count("stale-then-corrected");
+                }
+                else if (action == 9)
+                {
+                    var target = versions[random.Next(versions.Count)];
+                    storage.DamagedDigest = target.View.State.Snapshot.Blob.Digest.Value;
+                    storage.Missing = random.Next(2) == 0;
+                    try
+                    {
+                        Assert.Equal(storage.Missing ? PackageChangeError.PayloadMissing : PackageChangeError.PayloadMismatch,
+                            (await Assert.ThrowsAsync<PackageChangeException>(async () => await history.ExportVersionAsync("doc", target.View.Version.Id))).Code);
+                    }
+                    finally { storage.DamagedDigest = null; }
+                    Count("damaged-storage-refusal");
+                }
+                else if (action == 10)
+                {
+                    var sameRequest = random.Next(2) == 0;
+                    var first = new Command($"race/{seed}/{step}/0", Latest()!.View.Head, pool[random.Next(pool.Length)], null, Meta(step));
+                    var second = sameRequest ? first : first with { Id = $"race/{seed}/{step}/1", Bytes = pool[random.Next(pool.Length)] };
+                    var firstWinner = random.Next(2) == 0;
+                    trace.Add($"  race: sameRequest={sameRequest}, firstWinner={firstWinner}");
+                    async Task<DocxHistoryView?> Compete(Command command)
+                    {
+                        try { return await Invoke(new DocxVersionHistory(storage, storage), command); }
+                        catch (DocxHistoryException error) when (error.Code == DocxHistoryError.StaleHead) { return null; }
+                    }
+                    var attempts = storage.Publications;
+                    storage.HoldCompetingPublications(firstWinner ? "left" : "right");
+                    DocxHistoryView?[] results;
+                    try
+                    {
+                        results = await Task.WhenAll(
+                            Task.Run(() => storage.AsContenderAsync("left", () => Compete(first))),
+                            Task.Run(() => storage.AsContenderAsync("right", () => Compete(second))));
+                    }
+                    finally { storage.ReleaseCompetingPublications(); }
+                    Assert.Equal(2, storage.Publications - attempts); // Both must reach the exact same CAS expectation.
+                    if (sameRequest)
+                    {
+                        Assert.NotNull(results[0]); Assert.NotNull(results[1]);
+                        Assert.Equal(results[0]!.Head, results[1]!.Head);
+                        await Accept(first, results[0]!);
+                    }
+                    else
+                    {
+                        Assert.Single(results.Where(x => x is not null));
+                        Assert.Equal(firstWinner, results[0] is not null);
+                        await Accept(results[0] is not null ? first : second, results[0] ?? results[1]!);
+                    }
+                    Count(sameRequest ? "identical-race" : "competing-race");
+                }
+                else
+                {
+                    var selected = versions[random.Next(versions.Count)];
+                    Assert.Equal(selected.Bytes, await history.ExportVersionAsync("doc", selected.View.Version.Id));
+                    Count("read");
+                }
+                Assert.Equal(Latest()!.View.Head, (await history.ReadAsync("doc"))!.Head);
+            }
+
+            // Immutable pagination and exact snapshots are checked against independently retained inputs.
+            var listed = new List<DocxStoredVersion>();
+            HistoryBlobReference? cursor = null;
+            do
+            {
+                var page = await history.ListVersionsAsync("doc", cursor, 7);
+                listed.AddRange(page.Versions); cursor = page.Next;
+            } while (cursor is not null);
+            Assert.Equal(versions.Select(v => v.View.Version.Id).Reverse(), listed.Select(v => v.Id));
+            foreach (var version in versions)
+                Assert.Equal(version.Bytes, await history.ExportVersionAsync("doc", version.View.Version.Id));
+
+            var boundaries = versions.Where(v => v.ContentBoundary).ToArray();
+            foreach (var boundary in boundaries)
+            {
+                var sequence = boundary.View.State.Sequence;
+                // ZIP-entry comparison does not call the production manifest/digest/replay owner.
+                SameContent(boundary.Bytes, await history.MaterializeAsync("doc", sequence));
+                SameContent(boundary.Bytes, await history.ReplayAsync("doc", sequence));
+            }
+            foreach (var cutoff in boundaries.Select(v => v.Time).Append(DateTimeOffset.UnixEpoch.AddDays(-1)))
+            {
+                var expected = boundaries.Where(v => v.Time <= cutoff).LastOrDefault();
+                if (expected is null)
+                    Assert.Equal(DocxHistoryError.HistoryUnavailable, (await Assert.ThrowsAsync<DocxHistoryException>(async () =>
+                        await history.ResolveSequenceAtTimeAsync("doc", cutoff))).Code);
+                else Assert.Equal(expected.View.State.Sequence, await history.ResolveSequenceAtTimeAsync("doc", cutoff));
+            }
+            foreach (var (command, result) in requests)
+                Assert.Equal(result.Head, (await Invoke(new DocxVersionHistory(storage, storage), command)).Head);
+            output.WriteLine($"seed={seed}; steps={steps}; filesystem={filesystem}; versions={versions.Count}; replayed-sequences={boundaries.Length}; "
+                + string.Join(", ", counts.OrderBy(p => p.Key).Select(p => p.Key + "=" + p.Value)));
+        }
+        catch (Exception error)
+        { throw new XunitException($"History fuzz failure seed={seed}, steps={steps}, filesystem={filesystem}\n{string.Join("\n", trace)}\n{error}"); }
+
+        async Task Accept(Command command, DocxHistoryView result)
+        {
+            var previous = Latest();
+            var changed = previous is not null && !Equivalent(previous.Bytes, command.Bytes);
+            var boundary = previous is null || command.Restore is not null || changed;
+            var sequence = (previous?.View.State.Sequence ?? 0) + (previous is not null && boundary ? 1 : 0);
+            var epoch = (previous?.View.State.Epoch ?? 0) + (command.Restore is not null ? 1 : 0);
+            Assert.Equal((previous?.View.Head.Revision ?? 0) + 1, result.Head.Revision);
+            Assert.Equal(sequence, result.State.Sequence); Assert.Equal(epoch, result.State.Epoch);
+            Assert.Equal(previous?.View.Version.Id, result.Version.Record.Parent);
+            Assert.Equal(command.Restore?.Id, result.Version.Record.RestoredFrom);
+            Assert.Equal(command.Metadata.Author, result.Version.Record.Metadata.Author);
+            Assert.Equal(command.Metadata.CreatedAt, result.Version.Record.Metadata.CreatedAt);
+            Assert.Equal(command.Metadata.Label, result.Version.Record.Metadata.Label);
+            Assert.Equal(command.Metadata.ApplicationMetadata, result.Version.Record.Metadata.ApplicationMetadata);
+            Assert.Equal(command.Id, result.State.Requests?.Current?.Id);
+            Assert.Equal(command.Bytes, await history.ExportVersionAsync("doc", result.Version.Id));
+            versions.Add(new ExpectedVersion(result, command.Bytes.ToArray(), command.Metadata.CreatedAt, boundary));
+            if (command.Id is not null) requests.Add((command, result));
+        }
+    }
+
+    private static ValueTask<DocxHistoryView> Invoke(DocxVersionHistory history, Command command) => command.Restore is not null
+        ? command.Id is null ? history.RestoreVersionAsync("doc", command.Expected!, command.Restore.Id, command.Metadata)
+            : history.RestoreVersionAsync("doc", command.Id, command.Expected!, command.Restore.Id, command.Metadata)
+        : command.Id is null ? history.CreateVersionAsync("doc", command.Expected, command.Bytes, command.Metadata)
+            : history.CreateVersionAsync("doc", command.Id, command.Expected, command.Bytes, command.Metadata);
+
+    private static byte[] Package(int seed, int variant)
+    {
+        using var stream = new MemoryStream(); stream.Write(Document($"seed {seed} variant {variant}: café 📝 合同"));
+        using (var document = WordprocessingDocument.Open(stream, true))
+        {
+            var part = document.MainDocumentPart!.AddCustomXmlPart("application/octet-stream");
+            var opaque = new byte[257]; new Random(seed ^ variant).NextBytes(opaque);
+            using var payload = new MemoryStream(opaque); part.FeedData(payload);
+        }
+        return stream.ToArray();
+    }
+
+    private static byte[] Repack(byte[] bytes, int step)
+    {
+        using var stream = new MemoryStream(); stream.Write(bytes);
+        using (var zip = new ZipArchive(stream, ZipArchiveMode.Update, leaveOpen: true))
+            foreach (var entry in zip.Entries) entry.LastWriteTime = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero).AddMinutes(step);
+        return stream.ToArray();
+    }
+
+    private static SortedDictionary<string, byte[]> Entries(byte[] bytes)
+    {
+        using var zip = new ZipArchive(new MemoryStream(bytes), ZipArchiveMode.Read);
+        var entries = new SortedDictionary<string, byte[]>(StringComparer.Ordinal);
+        foreach (var entry in zip.Entries.Where(e => !e.FullName.EndsWith('/')))
+        {
+            using var input = entry.Open(); using var content = new MemoryStream(); input.CopyTo(content);
+            entries.Add(entry.FullName, content.ToArray());
+        }
+        return entries;
+    }
+    private static bool Equivalent(byte[] left, byte[] right)
+    {
+        var a = Entries(left); var b = Entries(right);
+        return a.Count == b.Count && a.All(p => b.TryGetValue(p.Key, out var bytes) && p.Value.AsSpan().SequenceEqual(bytes));
+    }
+    private static void SameContent(byte[] expected, byte[] actual) => Assert.True(Equivalent(expected, actual), "Independent uncompressed ZIP-entry oracle differs.");
+    private static int Setting(string name, int fallback, int maximum)
+    {
+        var text = Environment.GetEnvironmentVariable("DOCXODUS_HISTORY_FUZZ_" + name);
+        if (text is null) return fallback;
+        return int.TryParse(text, out var value) && value > 0 && value <= maximum ? value
+            : throw new ArgumentException($"Invalid history fuzz {name}; expected 1..{maximum}.");
+    }
+}

--- a/Docxodus.Tests/DocxVersionRequestFaultTests.cs
+++ b/Docxodus.Tests/DocxVersionRequestFaultTests.cs
@@ -1,0 +1,77 @@
+#nullable enable
+
+using Docxodus.History;
+using Xunit;
+using static Docxodus.Tests.DocxVersionRequestTests;
+
+namespace Docxodus.Tests;
+
+public sealed class DocxVersionRequestFaultTests
+{
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task EveryImmutableWriteAndHeadBoundaryIsRetryableWithoutDuplicatePublication(bool restore, bool filesystem)
+    {
+        var initial = Document("initial");
+        var candidate = Document("new contents");
+        async Task<(DocxVersionHistory History, DocxHistoryView First, DocxHistoryView Current)> Setup(HistoryFaultHarness storage)
+        {
+            var history = new DocxVersionHistory(storage, storage);
+            var first = await history.CreateVersionAsync("doc", "first", null, initial, Metadata("first"));
+            var current = first;
+            for (var i = 0; i < 6; i++) current = await history.CreateVersionAsync("doc", "label-" + i, current.Head, initial, Metadata("label"));
+            return (history, first, current);
+        }
+        ValueTask<DocxHistoryView> Publish(DocxVersionHistory history, DocxHistoryView first, DocxHistoryView current, CancellationToken cancellationToken = default) => restore
+            ? history.RestoreVersionAsync("doc", "tested", current.Head, first.Version.Id, Metadata("tested"), cancellationToken)
+            : history.CreateVersionAsync("doc", "tested", current.Head, candidate, Metadata("tested"), cancellationToken);
+
+        int writeCount;
+        using (var storage = new HistoryFaultHarness(filesystem))
+        {
+            var setup = await Setup(storage);
+            storage.Arm(HistoryFaultHarness.Fault.None);
+            await Publish(setup.History, setup.First, setup.Current);
+            writeCount = storage.Writes;
+            Assert.True(writeCount >= 5); // Includes index promotion and application state.
+        }
+        var cases = Enumerable.Range(1, writeCount).SelectMany(at => new[]
+        {
+            (HistoryFaultHarness.Fault.BeforeBlob, at), (HistoryFaultHarness.Fault.AfterBlob, at),
+        }).Concat(new[]
+        {
+            (HistoryFaultHarness.Fault.BeforeHead, 1), (HistoryFaultHarness.Fault.AfterHead, 1),
+            (HistoryFaultHarness.Fault.CancelBeforeHead, 1), (HistoryFaultHarness.Fault.CancelAfterHead, 1),
+        });
+        foreach (var (fault, at) in cases)
+        {
+            using var storage = new HistoryFaultHarness(filesystem);
+            var (history, first, current) = await Setup(storage);
+            storage.Cancellation = new CancellationTokenSource();
+            storage.Arm(fault, at);
+            if (fault is HistoryFaultHarness.Fault.CancelAfterHead)
+                await Publish(history, first, current, storage.Cancellation.Token);
+            else if (fault is HistoryFaultHarness.Fault.CancelBeforeHead)
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await Publish(history, first, current, storage.Cancellation.Token));
+            else
+                await Assert.ThrowsAsync<IOException>(async () => await Publish(history, first, current));
+            var committed = fault is HistoryFaultHarness.Fault.AfterHead or HistoryFaultHarness.Fault.CancelAfterHead;
+            storage.Arm(HistoryFaultHarness.Fault.None);
+            history = new DocxVersionHistory(storage, storage); // Discard the producer; no cache may be needed.
+            var observed = (await history.ReadAsync("doc"))!;
+            Assert.Equal(current.Head.Revision + (committed ? 1 : 0), observed.Head.Revision);
+            if (!committed) Assert.Equal(current.Head, observed.Head);
+            var retried = await Publish(history, first, current);
+            Assert.Equal(current.Head.Revision + 1, retried.Head.Revision);
+            Assert.Equal(committed ? 0 : 1, storage.Publications);
+            Assert.Equal(retried.Head, (await Publish(history, first, current)).Head);
+            Assert.Equal(restore ? initial : candidate, await history.ExportVersionAsync("doc", retried.Version.Id));
+            Assert.Equal(first.Head, (await history.CreateVersionAsync("doc", "first", null, initial, Metadata("first"))).Head);
+            Assert.Equal(8, (await history.ListVersionsAsync("doc")).Versions.Count);
+            Assert.Equal(restore ? 1 : 0, retried.State.Epoch);
+        }
+    }
+}

--- a/Docxodus.Tests/HistoryFaultHarness.cs
+++ b/Docxodus.Tests/HistoryFaultHarness.cs
@@ -1,0 +1,105 @@
+#nullable enable
+
+using Docxodus.History;
+
+namespace Docxodus.Tests;
+
+/// <summary>Real reference adapters beneath deterministic faults; shared by history/backend fuzzers.</summary>
+internal sealed class HistoryFaultHarness : IHistoryBlobStore, IHistoryHeadStore, IDisposable
+{
+    internal enum Fault { None, BeforeBlob, AfterBlob, BeforeHead, AfterHead, CancelBeforeHead, CancelAfterHead }
+    private readonly IHistoryBlobStore _blobs;
+    private readonly IHistoryHeadStore _heads;
+    private readonly string? _directory;
+    private Fault _fault;
+    private int _at;
+    internal int Writes, Publications;
+    internal string? DamagedDigest;
+    internal bool Missing;
+    internal CancellationTokenSource? Cancellation;
+    private readonly AsyncLocal<string?> _contender = new();
+    private PublicationGate? _publicationGate;
+
+    internal void HoldCompetingPublications(string firstTag) => _publicationGate = new PublicationGate(firstTag);
+    internal void ReleaseCompetingPublications() => _publicationGate = null;
+    internal async Task<T> AsContenderAsync<T>(string tag, Func<Task<T>> action)
+    {
+        var previous = _contender.Value; _contender.Value = tag;
+        try { return await action(); }
+        finally { _contender.Value = previous; }
+    }
+
+    private sealed class PublicationGate(string firstTag)
+    {
+        private readonly TaskCompletionSource _bothArrived = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _firstFinished = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _arrived;
+        internal async Task EnterAsync(string? tag, CancellationToken cancellationToken)
+        {
+            if (tag is null) throw new InvalidOperationException("A gated publication must identify its contender.");
+            if (Interlocked.Increment(ref _arrived) == 2) _bothArrived.TrySetResult();
+            await _bothArrived.Task.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);
+            if (tag != firstTag) await _firstFinished.Task.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);
+        }
+        internal void Exit(string? tag) { if (tag == firstTag) _firstFinished.TrySetResult(); }
+    }
+
+    internal HistoryFaultHarness(bool filesystem = false)
+    {
+        if (filesystem)
+        {
+            _directory = Directory.CreateTempSubdirectory("history-fault-fuzz-").FullName;
+            _blobs = new FileHistoryBlobStore(Path.Combine(_directory, "blobs"));
+            _heads = new FileHistoryHeadStore(Path.Combine(_directory, "heads"));
+        }
+        else { _blobs = new MemoryHistoryBlobStore(); _heads = new MemoryHistoryHeadStore(); }
+    }
+
+    internal void Arm(Fault fault, int at = 1)
+    { _fault = fault; _at = at; Writes = 0; Publications = 0; }
+
+    public async ValueTask PutAsync(HistoryBlobReference reference, Stream content, CancellationToken cancellationToken = default)
+    {
+        var at = Interlocked.Increment(ref Writes);
+        if (_fault == Fault.BeforeBlob && at == _at) throw new IOException("Injected pre-blob fault " + at);
+        await _blobs.PutAsync(reference, content, cancellationToken);
+        if (_fault == Fault.AfterBlob && at == _at) throw new IOException("Injected post-blob fault " + at);
+    }
+
+    public async ValueTask<Stream?> OpenReadAsync(HistoryBlobReference reference, CancellationToken cancellationToken = default)
+    {
+        if (reference.Digest.Value != DamagedDigest) return await _blobs.OpenReadAsync(reference, cancellationToken);
+        if (Missing) return null;
+        using var input = await _blobs.OpenReadAsync(reference, cancellationToken);
+        using var buffer = new MemoryStream(); await input!.CopyToAsync(buffer, cancellationToken);
+        var bytes = buffer.ToArray(); bytes[bytes.Length / 2] ^= 1;
+        return new MemoryStream(bytes, writable: false);
+    }
+
+    public ValueTask<HistoryHead?> ReadAsync(string documentId, CancellationToken cancellationToken = default) =>
+        _heads.ReadAsync(documentId, cancellationToken);
+
+    public async ValueTask<HistoryHead?> TryAdvanceAsync(string documentId, HistoryHead? expected,
+        HistoryBlobReference state, CancellationToken cancellationToken = default)
+    {
+        Interlocked.Increment(ref Publications);
+        var gate = _publicationGate;
+        if (gate is not null) await gate.EnterAsync(_contender.Value, cancellationToken);
+        try
+        {
+            if (_fault == Fault.BeforeHead) throw new IOException("Injected failure before head CAS.");
+            if (_fault == Fault.CancelBeforeHead) Cancellation!.Cancel();
+            var result = await _heads.TryAdvanceAsync(documentId, expected, state, cancellationToken);
+            if (result is not null && _fault == Fault.AfterHead) throw new IOException("Injected lost head acknowledgement.");
+            if (result is not null && _fault == Fault.CancelAfterHead) Cancellation!.Cancel();
+            return result;
+        }
+        finally { gate?.Exit(_contender.Value); }
+    }
+
+    public void Dispose()
+    {
+        Cancellation?.Dispose();
+        if (_directory is not null) Directory.Delete(_directory, recursive: true);
+    }
+}

--- a/Docxodus/History/DocxOperationPackage.cs
+++ b/Docxodus/History/DocxOperationPackage.cs
@@ -1,0 +1,137 @@
+#nullable enable
+
+using System.IO.Compression;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+using Docxodus.Verification;
+
+namespace Docxodus.History;
+
+/// <summary>Conservative package/text reconciliation, not a live-session mutation recorder.</summary>
+internal static class DocxOperationPackage
+{
+    private sealed record Entry(string Name, byte[] Bytes);
+    private static readonly XNamespace Word = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+
+    internal static byte[] ApplyText(byte[] package, DocxTextSplice splice, PackageManifestOptions? options)
+    {
+        DocxOperationStore.Text(splice);
+        var entries = Read(package, options);
+        if (!entries.TryGetValue(splice.PartUri, out var entry)) throw Invalid("Text part is absent at the supplied base.");
+        using var input = new MemoryStream(entry.Bytes, writable: false);
+        using var reader = XmlReader.Create(input, new XmlReaderSettings
+        { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null, MaxCharactersInDocument = entry.Bytes.Length + 1L });
+        var document = XDocument.Load(reader, LoadOptions.PreserveWhitespace);
+        var node = document.Descendants(Word + "t").Skip(splice.TextNode).FirstOrDefault();
+        if (node is null || node.Nodes().Any(n => n is not XText)) throw Invalid("Text node is absent or has unsupported children.");
+        var text = node.Value;
+        var end = (long)splice.Offset + splice.DeleteCount;
+        if (end > text.Length || !Boundary(text, splice.Offset) || !Boundary(text, (int)end))
+            throw Invalid("Splice must address valid UTF-16 boundaries in the base text.");
+        var replacement = text[..splice.Offset] + splice.Insert + text[(int)end..];
+        if (text == replacement) return package.ToArray();
+        node.Value = replacement;
+        node.SetAttributeValue(XNamespace.Xml + "space", "preserve");
+        using var output = new MemoryStream();
+        using (var writer = XmlWriter.Create(output, new XmlWriterSettings
+        { Encoding = new UTF8Encoding(false, true), Indent = false, CloseOutput = false, NewLineHandling = NewLineHandling.Entitize }))
+            document.Save(writer);
+        entries[splice.PartUri] = entry with { Bytes = output.ToArray() };
+        return Write(entries);
+    }
+
+    // Preserve accepted order for same-gap inserts. Never extend a stale deletion into text
+    // inserted concurrently inside its observed range; contested overlaps remain explicit.
+    internal static DocxTextSplice? Map(DocxTextSplice incoming, DocxTextSplice accepted)
+    {
+        if (incoming.PartUri != accepted.PartUri || incoming.TextNode != accepted.TextNode) return incoming;
+        var p = incoming.Offset; var q = (long)p + incoming.DeleteCount;
+        var a = accepted.Offset; var b = (long)a + accepted.DeleteCount;
+        if (accepted.DeleteCount == 0)
+        {
+            if (q <= a && p < a) return incoming;
+            if (p >= a) return incoming with { Offset = checked(p + accepted.Insert.Length) };
+            return null;
+        }
+        if (q <= a) return incoming;
+        if (p >= b) return incoming with { Offset = checked(p + accepted.Insert.Length - accepted.DeleteCount) };
+        return null;
+    }
+
+    internal static bool IsTopology(string uri) => uri == "/[Content_Types].xml" || uri.EndsWith(".rels", StringComparison.Ordinal);
+
+    internal static string? CheckReads(byte[] baseline, byte[] current, IReadOnlyList<string> readParts,
+        PackageManifestOptions? options)
+    {
+        var left = Manifest(baseline, options).Entries.ToDictionary(e => e.Uri, e => e.RawBytesDigest, StringComparer.Ordinal);
+        var right = Manifest(current, options).Entries.ToDictionary(e => e.Uri, e => e.RawBytesDigest, StringComparer.Ordinal);
+        foreach (var uri in readParts.Concat(left.Keys.Concat(right.Keys).Where(IsTopology)).Distinct(StringComparer.Ordinal))
+        {
+            left.TryGetValue(uri, out var before); right.TryGetValue(uri, out var after);
+            if (before != after) return "ReadDependencyChanged";
+        }
+        return null;
+    }
+
+    internal static (byte[]? Bytes, string? Conflict) Merge(byte[] current, PackageChangeSet proposed,
+        PackageManifestOptions? options)
+    {
+        var identities = Manifest(current, options).Entries.ToDictionary(e => e.Uri, e => e.RawBytesDigest, StringComparer.Ordinal);
+        foreach (var change in proposed.Changes)
+        {
+            identities.TryGetValue(change.Uri, out var actual);
+            if (actual != change.BeforeDigest && actual != change.AfterDigest) return (null, "ChangedPart");
+        }
+        var entries = Read(current, options);
+        var changed = false;
+        foreach (var change in proposed.Changes)
+        {
+            identities.TryGetValue(change.Uri, out var actual);
+            if (actual == change.AfterDigest) continue;
+            changed = true;
+            if (change.AfterDigest is null) entries.Remove(change.Uri);
+            else entries[change.Uri] = new Entry(change.AfterEntryName!, proposed.GetPayload(change.AfterDigest));
+        }
+        return (changed ? Write(entries) : current.ToArray(), null);
+    }
+
+    private static Dictionary<string, Entry> Read(byte[] package, PackageManifestOptions? options)
+    {
+        _ = Manifest(package, options); // Bound expansion and validate OPC names before allocating entries.
+        using var zip = new ZipArchive(new MemoryStream(package, writable: false), ZipArchiveMode.Read);
+        var result = new Dictionary<string, Entry>(StringComparer.Ordinal);
+        foreach (var entry in zip.Entries)
+        {
+            if (!PackageManifestGenerator.TryCanonicalizeEntryName(entry.FullName, out var uri)) throw Invalid("Invalid OPC part URI.");
+            using var stream = entry.Open();
+            var bytes = new byte[checked((int)entry.Length)]; stream.ReadExactly(bytes);
+            result.Add(uri, new Entry(entry.FullName, bytes));
+        }
+        return result;
+    }
+
+    private static byte[] Write(Dictionary<string, Entry> entries)
+    {
+        using var output = new MemoryStream();
+        using (var zip = new ZipArchive(output, ZipArchiveMode.Create, leaveOpen: true))
+            foreach (var pair in entries.OrderBy(e => e.Key, StringComparer.Ordinal))
+            {
+                var entry = zip.CreateEntry(pair.Value.Name, CompressionLevel.NoCompression);
+                entry.LastWriteTime = new DateTimeOffset(1980, 1, 1, 0, 0, 0, TimeSpan.Zero);
+                using var stream = entry.Open(); stream.Write(pair.Value.Bytes);
+            }
+        return output.ToArray();
+    }
+
+    private static PackageManifest Manifest(byte[] package, PackageManifestOptions? options)
+    {
+        var manifest = PackageManifestGenerator.Generate(package, options);
+        if (!manifest.IsValid || manifest.PackageKind != "opc" || manifest.OrderedOpcContentDigest is null)
+            throw Invalid("A valid bounded OPC package is required.");
+        return manifest;
+    }
+    private static bool Boundary(string text, int at) => at >= 0 && at <= text.Length
+        && (at == 0 || at == text.Length || !char.IsHighSurrogate(text[at - 1]) || !char.IsLowSurrogate(text[at]));
+    private static PackageChangeException Invalid(string message) => new(PackageChangeError.InvalidPackage, message);
+}

--- a/Docxodus/History/DocxOperationRecords.cs
+++ b/Docxodus/History/DocxOperationRecords.cs
@@ -1,0 +1,54 @@
+#nullable enable
+
+namespace Docxodus.History;
+
+/// <summary>
+/// A splice in a w:t element addressed relative to an immutable base publication. TextNode is
+/// the zero-based document-order w:t ordinal in PartUri; offsets/counts are UTF-16 boundaries.
+/// Known splices preserve that topology. Unmodeled edits of the part form a conflict boundary.
+/// </summary>
+public sealed record DocxTextSplice(string PartUri, int TextNode, int Offset, int DeleteCount, string Insert);
+
+/// <summary>Host-owned durable intent. Capture/persist once before submitting or retrying.</summary>
+public sealed record DocxOperationRequest
+{
+    public required string RequestId { get; init; }
+    public required HistoryHead Base { get; init; }
+    /// <summary>Exactly text, package, or discard. Package takes candidate DOCX bytes separately.</summary>
+    public required string Kind { get; init; }
+    public required DocxVersionMetadata Metadata { get; init; }
+    public DocxTextSplice? Text { get; init; }
+    /// <summary>Additional whole-part read dependencies, including expected absence at the base.</summary>
+    public IReadOnlyList<string> ReadParts { get; init; } = Array.Empty<string>();
+    /// <summary>An earlier published conflict explicitly resolved by this NEW request.</summary>
+    public HistoryBlobReference? Resolves { get; init; }
+}
+
+/// <summary>Canonical immutable input; its manifest digest is the request fingerprint.</summary>
+public sealed record DocxOperationInput(string DocumentId, DocxOperationRequest Request, HistoryBlobReference? Candidate);
+
+/// <summary>
+/// Durable acceptance/conflict outcome. Revision orders decisions and ordinary publications;
+/// ContentCommit is non-null only for actual accepted effects. Conflict preserves ProposedSnapshot
+/// without changing the visible document. Parent links only decisions, Before links publications.
+/// </summary>
+public sealed record DocxOperationRecord
+{
+    public required string DocumentId { get; init; }
+    public required HistoryBlobReference Input { get; init; }
+    public required HistoryBlobReference? Parent { get; init; }
+    public required long Revision { get; init; }
+    public required HistoryHead Before { get; init; }
+    public required DocxSnapshotReference ProposedSnapshot { get; init; }
+    public required DocxSnapshotReference AfterSnapshot { get; init; }
+    public required HistoryBlobReference Version { get; init; }
+    public required HistoryBlobReference? ContentCommit { get; init; }
+    /// <summary>Exactly accepted or conflict.</summary>
+    public required string Status { get; init; }
+    public required string? Conflict { get; init; }
+    public required DocxTextSplice? AppliedText { get; init; }
+}
+
+public sealed record DocxStoredOperation(HistoryBlobReference Id, DocxOperationRecord Record, DocxOperationInput Input);
+public sealed record DocxOperationResult(DocxHistoryView View, DocxStoredOperation Operation);
+public sealed record DocxOperationUpdate(HistoryHead? After, DocxHistoryView View, IReadOnlyList<DocxStoredOperation> Operations);

--- a/Docxodus/History/DocxOperationStore.cs
+++ b/Docxodus/History/DocxOperationStore.cs
@@ -1,0 +1,160 @@
+#nullable enable
+
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using System.Xml;
+using Docxodus.Verification;
+
+namespace Docxodus.History;
+
+/// <summary>Bounded, strict, generated codecs for the backend intent/decision vocabulary.</summary>
+internal sealed class DocxOperationStore(IHistoryBlobStore blobs)
+{
+    internal const int MaxBytes = 512 * 1024;
+    private static readonly DocxOperationJsonContext Json = new(new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase, AllowDuplicateProperties = false,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow, RespectNullableAnnotations = true,
+        RespectRequiredConstructorParameters = true, MaxDepth = 16,
+    });
+
+    internal static DocxOperationInput Capture(string documentId, DocxOperationRequest request, byte[]? candidate)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return Validate(new DocxOperationInput(documentId, request with
+        {
+            Metadata = HistoryRecordStore.PrepareMetadata(request.Metadata),
+            ReadParts = Array.AsReadOnly((request.ReadParts ?? throw new ArgumentNullException(nameof(request.ReadParts)))
+                .OrderBy(x => x, StringComparer.Ordinal).Distinct(StringComparer.Ordinal).ToArray()),
+        }, candidate is null ? null : Reference(candidate)));
+    }
+
+    internal static byte[] EncodeInput(DocxOperationInput input) => Encode(Validate(input), "operation-input");
+    internal ValueTask<HistoryBlobReference> SaveDecisionAsync(DocxOperationRecord record, CancellationToken cancellationToken) =>
+        HistoryBlobIO.PutBytesAsync(blobs, Encode(Validate(record), "operation-decision"), cancellationToken);
+    internal ValueTask<DocxOperationInput> LoadInputAsync(HistoryBlobReference reference, CancellationToken cancellationToken) =>
+        LoadAsync<DocxOperationInput>(reference, "operation-input", cancellationToken);
+    internal ValueTask<DocxOperationRecord> LoadDecisionAsync(HistoryBlobReference reference, CancellationToken cancellationToken) =>
+        LoadAsync<DocxOperationRecord>(reference, "operation-decision", cancellationToken);
+
+    internal static HistoryBlobReference Reference(byte[] bytes) => new(new VerificationDigest
+    { Algorithm = "SHA-256", Value = Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant() }, bytes.Length);
+
+    private static byte[] Encode<T>(T value, string kind)
+    {
+        var result = JsonSerializer.SerializeToUtf8Bytes(new HistoryRecordEnvelope<T>
+        { Record = value, SchemaVersion = 1, Schema = Schema(kind) }, TypeInfo<T>());
+        Require(result.Length <= MaxBytes, "Operation metadata exceeds its byte limit.");
+        return result;
+    }
+
+    private async ValueTask<T> LoadAsync<T>(HistoryBlobReference reference, string kind, CancellationToken cancellationToken)
+    {
+        var bytes = await HistoryBlobIO.ReadBytesAsync(blobs, reference, MaxBytes, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var envelope = JsonSerializer.Deserialize(bytes, TypeInfo<T>())
+                ?? throw new JsonException("Missing operation envelope.");
+            if (envelope.SchemaVersion != 1)
+                throw new PackageChangeException(PackageChangeError.UnsupportedVersion, "Unsupported operation codec version.");
+            Require(envelope.Schema == Schema(kind), "Unexpected operation schema.");
+            var validated = envelope.Record switch
+            {
+                DocxOperationInput input => (T)(object)Validate(input),
+                DocxOperationRecord decision => (T)(object)Validate(decision),
+                _ => throw new JsonException("Unexpected operation record."),
+            };
+            cancellationToken.ThrowIfCancellationRequested();
+            return validated;
+        }
+        catch (Exception error) when (error is JsonException or ArgumentException or XmlException or OverflowException)
+        { throw new PackageChangeException(PackageChangeError.InvalidManifest, "Malformed operation record."); }
+    }
+
+    private static DocxOperationInput Validate(DocxOperationInput input)
+    {
+        HistoryHeadCodec.Key(input.DocumentId);
+        var request = input.Request ?? throw new ArgumentNullException(nameof(input.Request));
+        HistoryRequestJournalStore.ValidateId(request.RequestId);
+        Head(request.Base);
+        Require(request.Kind is "text" or "package" or "discard", "Unknown operation kind.");
+        Require((request.Kind == "text") == (request.Text is not null), "Text payload disagrees with operation kind.");
+        Require((request.Kind == "package") == (input.Candidate is not null), "Candidate bytes disagree with operation kind.");
+        Require(request.Kind != "discard" || request.Resolves is not null, "Discard must resolve a published conflict.");
+        if (request.Text is not null) Text(request.Text);
+        if (input.Candidate is not null) HistoryBlobIO.Validate(input.Candidate, int.MaxValue);
+        if (request.Resolves is not null) HistoryBlobIO.Validate(request.Resolves, MaxBytes);
+        Require(request.ReadParts is not null && request.ReadParts.Count <= 256, "Too many read dependencies.");
+        string? previous = null;
+        foreach (var uri in request.ReadParts!)
+        {
+            Part(uri);
+            Require(previous is null || StringComparer.Ordinal.Compare(previous, uri) < 0,
+                "Read dependencies must be unique and ordinally sorted.");
+            previous = uri;
+        }
+        return input with { Request = request with
+        {
+            Metadata = HistoryRecordStore.PrepareMetadata(request.Metadata),
+            ReadParts = Array.AsReadOnly(request.ReadParts.ToArray()),
+        } };
+    }
+
+    private static DocxOperationRecord Validate(DocxOperationRecord record)
+    {
+        HistoryHeadCodec.Key(record.DocumentId); Head(record.Before);
+        Require(record.Revision > 1 && record.Revision - 1 == record.Before.Revision, "Invalid decision revision.");
+        HistoryBlobIO.Validate(record.Input, MaxBytes); HistoryBlobIO.Validate(record.Version, int.MaxValue);
+        if (record.Parent is not null) HistoryBlobIO.Validate(record.Parent, MaxBytes);
+        if (record.ContentCommit is not null) HistoryBlobIO.Validate(record.ContentCommit, int.MaxValue);
+        Snapshot(record.ProposedSnapshot); Snapshot(record.AfterSnapshot);
+        Require(record.Status is "accepted" or "conflict", "Unknown decision status.");
+        Require((record.Status == "conflict") == (record.Conflict is not null), "Conflict reason disagrees with status.");
+        Require(record.Conflict is null or "OverlappingText" or "ChangedPart" or "ReadDependencyChanged"
+            or "EpochChanged" or "AlreadyResolved" or "UnknownTextChange", "Unknown conflict reason.");
+        Require(record.Status != "conflict" || (record.ContentCommit is null && record.AppliedText is null),
+            "Conflicting decisions cannot have applied effects.");
+        Require(record.AppliedText is null || record.ContentCommit is not null, "Mapped text requires a content commit.");
+        if (record.AppliedText is not null) Text(record.AppliedText);
+        return record;
+    }
+
+    internal static void Part(string uri)
+    {
+        Require(uri is not null && uri.Length is > 1 and <= 4096 && uri[0] == '/'
+            && PackageManifestGenerator.TryCanonicalizeEntryName(uri[1..], out var canonical) && canonical == uri,
+            "Expected a canonical absolute OPC part URI.");
+    }
+    internal static void Text(DocxTextSplice text)
+    {
+        Part(text.PartUri);
+        Require(text.TextNode >= 0 && text.Offset >= 0 && text.DeleteCount >= 0
+            && (long)text.Offset + text.DeleteCount <= int.MaxValue && text.Insert is not null
+            && text.Insert.Length <= 64 * 1024, "Invalid text splice or payload limit.");
+        XmlConvert.VerifyXmlChars(text.Insert!);
+    }
+    private static void Head(HistoryHead head)
+    {
+        ArgumentNullException.ThrowIfNull(head); Require(head.Revision > 0, "Invalid base head.");
+        HistoryBlobIO.Validate(head.State, int.MaxValue);
+    }
+    private static void Snapshot(DocxSnapshotReference snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot); HistoryBlobIO.Validate(snapshot.Blob, int.MaxValue);
+        HistoryBlobIO.Validate(new HistoryBlobReference(snapshot.ContentDigest, 0), 0);
+    }
+    private static void Require(bool condition, string message)
+    { if (!condition) throw new PackageChangeException(PackageChangeError.InvalidManifest, message); }
+    private static string Schema(string kind) => $"https://docxodus.dev/schemas/history/{kind}/v1";
+    private static JsonTypeInfo<HistoryRecordEnvelope<T>> TypeInfo<T>() =>
+        (JsonTypeInfo<HistoryRecordEnvelope<T>>)Json.GetTypeInfo(typeof(HistoryRecordEnvelope<T>))!;
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow, AllowDuplicateProperties = false,
+    RespectNullableAnnotations = true, RespectRequiredConstructorParameters = true, MaxDepth = 16)]
+[JsonSerializable(typeof(HistoryRecordEnvelope<DocxOperationInput>))]
+[JsonSerializable(typeof(HistoryRecordEnvelope<DocxOperationRecord>))]
+internal partial class DocxOperationJsonContext : JsonSerializerContext { }

--- a/Docxodus/History/DocxVersionHistory.Operations.cs
+++ b/Docxodus/History/DocxVersionHistory.Operations.cs
@@ -1,0 +1,246 @@
+#nullable enable
+
+namespace Docxodus.History;
+
+public sealed partial class DocxVersionHistory
+{
+    /// <summary>
+    /// Reconcile a durable backend intent against accepted history and atomically publish effects
+    /// OR a recoverable conflict. Concurrent CAS losers re-evaluate the ORIGINAL input. No GUI,
+    /// transport, outbox, subscription, or optimistic live session is installed. Initialize with
+    /// CreateVersionAsync first. Each bounded ancestry/decision scan is limited independently.
+    /// </summary>
+    public async ValueTask<DocxOperationResult> SubmitOperationAsync(string documentId, DocxOperationRequest request,
+        byte[]? candidateDocx = null, int maxAttempts = 16, int maxEntriesToScan = 10_000,
+        CancellationToken cancellationToken = default)
+    {
+        if (maxAttempts is < 1 or > 1024) throw new ArgumentOutOfRangeException(nameof(maxAttempts));
+        if (maxEntriesToScan <= 0) throw new ArgumentOutOfRangeException(nameof(maxEntriesToScan));
+        cancellationToken.ThrowIfCancellationRequested();
+        if (candidateDocx?.Length > _maxSnapshotBytes)
+            throw new PackageChangeException(PackageChangeError.ResourceLimit, "Candidate exceeds the snapshot byte limit.");
+        var captured = candidateDocx?.ToArray();
+        var input = DocxOperationStore.Capture(documentId, request, captured);
+        var inputBytes = DocxOperationStore.EncodeInput(input);
+        var inputId = DocxOperationStore.Reference(inputBytes);
+        var identity = new HistoryRequestIdentity(input.Request.RequestId, inputId.Digest);
+        var store = new DocxOperationStore(_blobs);
+        var current = await ReadAsync(documentId, cancellationToken).ConfigureAwait(false)
+            ?? throw new DocxHistoryException(DocxHistoryError.HistoryUnavailable, "Initialize document history before submitting operations.");
+        var duplicate = await FindRequestAsync(documentId, current, identity, cancellationToken).ConfigureAwait(false);
+        if (duplicate is not null) return await OperationResultAsync(documentId, duplicate, inputId, cancellationToken).ConfigureAwait(false);
+
+        var baseline = await ReadHeadViewAsync(documentId, input.Request.Base, cancellationToken).ConfigureAwait(false);
+        // Prove the submitted base belongs to this publication chain before preserving new input.
+        _ = await ReadChangesBetweenAsync(documentId, current, baseline.Head, maxEntriesToScan, cancellationToken).ConfigureAwait(false);
+        var baseBytes = await _snapshots.ExportAsync(baseline.State.Snapshot, cancellationToken).ConfigureAwait(false);
+        var proposedBytes = input.Request.Kind switch
+        {
+            "text" => DocxOperationPackage.ApplyText(baseBytes, input.Request.Text!, _packageOptions),
+            "package" => captured!,
+            _ => baseBytes,
+        };
+        var proposed = await _snapshots.CaptureAsync(proposedBytes, cancellationToken).ConfigureAwait(false);
+        Consistent(input.Candidate is null || input.Candidate == proposed.Blob, "Captured candidate disagrees with its input fingerprint.");
+        _ = await HistoryBlobIO.PutBytesAsync(_blobs, inputBytes, cancellationToken).ConfigureAwait(false);
+        var contribution = input.Request.Kind == "package" ? PackageChangeSet.Create(baseBytes, proposedBytes, _packageOptions) : null;
+
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (attempt > 0)
+            {
+                current = await ReadAsync(documentId, cancellationToken).ConfigureAwait(false)
+                    ?? throw new DocxHistoryException(DocxHistoryError.InvalidHistory, "Published document history disappeared.");
+                duplicate = await FindRequestAsync(documentId, current, identity, cancellationToken).ConfigureAwait(false);
+                if (duplicate is not null) return await OperationResultAsync(documentId, duplicate, inputId, cancellationToken).ConfigureAwait(false);
+            }
+            var updates = await ReadChangesBetweenAsync(documentId, current, baseline.Head, maxEntriesToScan, cancellationToken).ConfigureAwait(false);
+            var decisions = await ReadOperationChainAsync(documentId, current,
+                input.Request.Resolves is null ? baseline.State.Operation : null, maxEntriesToScan, cancellationToken).ConfigureAwait(false);
+            string? conflict = null;
+            if (input.Request.Resolves is { } resolves)
+            {
+                var target = decisions.SingleOrDefault(d => d.Id == resolves);
+                Consistent(target is not null && target.Record.Status == "conflict" && target.Record.Revision <= baseline.Head.Revision,
+                    "Resolution must name an earlier conflict observed at the submitted base.");
+                if (decisions.Any(d => d.Record.Status == "accepted" && d.Input.Request.Resolves == resolves)) conflict = "AlreadyResolved";
+            }
+            if (current.State.Epoch != baseline.State.Epoch) conflict ??= "EpochChanged";
+            var currentBytes = await _snapshots.ExportAsync(current.State.Snapshot, cancellationToken).ConfigureAwait(false);
+            conflict ??= DocxOperationPackage.CheckReads(baseBytes, currentBytes, input.Request.ReadParts, _packageOptions);
+            byte[]? accepted = null;
+            var mapped = input.Request.Text;
+            if (conflict is null && mapped is not null)
+            {
+                var byCommit = decisions.Where(d => d.Record.ContentCommit is not null)
+                    .ToDictionary(d => d.Record.ContentCommit!);
+                foreach (var entry in updates.Entries)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    Consistent(entry.Commit.Contribution is not null, "A same-epoch text tail cannot contain a reset.");
+                    var manifest = await HistoryBlobIO.ReadBytesAsync(_blobs, entry.Commit.Contribution!,
+                        new PackageChangeLimits().MaxManifestBytes, cancellationToken).ConfigureAwait(false);
+                    var changes = await PackageChangeSetCodec.LoadAsync(manifest, _blobs, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    Consistent(changes.BeforeDigest == entry.Commit.Before.ContentDigest && changes.AfterDigest == entry.Commit.After.ContentDigest,
+                        "Contribution endpoints disagree with their accepted commit.");
+                    var beforeBytes = await _snapshots.ExportAsync(entry.Commit.Before, cancellationToken).ConfigureAwait(false);
+                    _ = changes.Apply(beforeBytes, _packageOptions); // Verify the footprint, not just a claimed list of changed URIs.
+                    if (changes.Changes.Any(c => DocxOperationPackage.IsTopology(c.Uri) || input.Request.ReadParts.Contains(c.Uri)))
+                    { conflict = "ReadDependencyChanged"; break; }
+                    if (!changes.Changes.Any(c => c.Uri == mapped.PartUri)) continue;
+                    if (!byCommit.TryGetValue(entry.Id, out var decision) || decision.Record.AppliedText is null)
+                    { conflict = "UnknownTextChange"; break; }
+                    VerifyRecordedText(decision, entry.Commit, beforeBytes);
+                    mapped = DocxOperationPackage.Map(mapped, decision.Record.AppliedText);
+                    if (mapped is null) { conflict = "OverlappingText"; break; }
+                }
+                if (conflict is null) accepted = DocxOperationPackage.ApplyText(currentBytes, mapped!, _packageOptions);
+            }
+            else if (conflict is null && contribution is not null)
+            {
+                (accepted, conflict) = DocxOperationPackage.Merge(currentBytes, contribution, _packageOptions);
+            }
+
+            var state = current.State;
+            var version = current.Version;
+            var changed = conflict is null && accepted is not null
+                && PackageChangeSet.Create(currentBytes, accepted, _packageOptions).Changes.Count != 0;
+            if (changed)
+                (state, version) = await PrepareCandidateAsync(documentId, current, accepted!, input.Request.Metadata, cancellationToken).ConfigureAwait(false);
+            var record = new DocxOperationRecord
+            {
+                DocumentId = documentId, Input = inputId, Parent = current.State.Operation,
+                Revision = checked(current.Head.Revision + 1), Before = current.Head,
+                ProposedSnapshot = proposed, AfterSnapshot = state.Snapshot, Version = version.Id,
+                ContentCommit = changed ? state.Commit : null, Status = conflict is null ? "accepted" : "conflict",
+                Conflict = conflict, AppliedText = changed && input.Request.Kind == "text" ? mapped : null,
+            };
+            var decisionId = await store.SaveDecisionAsync(record, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                var published = await PublishAsync(documentId, current.Head, state with { Operation = decisionId }, version,
+                    cancellationToken, identity, current.State.Requests).ConfigureAwait(false);
+                // No reads/cancellation after OUR successful commit. Another identical winner's
+                // original result is separately verified instead of returning this abandoned draft.
+                if (published.State.Operation == decisionId)
+                    return new DocxOperationResult(published, new DocxStoredOperation(decisionId, record, input));
+                return await OperationResultAsync(documentId, published, inputId, cancellationToken).ConfigureAwait(false);
+            }
+            catch (DocxHistoryException error) when (error.Code == DocxHistoryError.StaleHead) { }
+        }
+        throw new DocxHistoryException(DocxHistoryError.Contention, "Publication contention limit reached; retry the same captured request.");
+    }
+
+    /// <summary>Ascending durable outcomes since an accepted head; null scans all retained decisions.</summary>
+    public async ValueTask<DocxOperationUpdate> ReadOperationsSinceAsync(string documentId, HistoryHead? after,
+        int maxEntriesToScan = 10_000, CancellationToken cancellationToken = default)
+    {
+        if (maxEntriesToScan <= 0) throw new ArgumentOutOfRangeException(nameof(maxEntriesToScan));
+        var current = await ReadAsync(documentId, cancellationToken).ConfigureAwait(false)
+            ?? throw new DocxHistoryException(DocxHistoryError.HistoryUnavailable, "Document history is unavailable.");
+        _ = await ReadChangesBetweenAsync(documentId, current, after, maxEntriesToScan, cancellationToken).ConfigureAwait(false);
+        var stop = after is null ? null : (await ReadHeadViewAsync(documentId, after, cancellationToken).ConfigureAwait(false)).State.Operation;
+        var entries = await ReadOperationChainAsync(documentId, current, stop, maxEntriesToScan, cancellationToken).ConfigureAwait(false);
+        entries.Reverse();
+        return new DocxOperationUpdate(after, current, entries.AsReadOnly());
+    }
+
+    /// <summary>Read a retained immutable outcome. Reference access is host-authorized, not publication proof.</summary>
+    public async ValueTask<DocxStoredOperation> GetOperationAsync(string documentId, HistoryBlobReference operationId,
+        CancellationToken cancellationToken = default)
+    {
+        HistoryHeadCodec.Key(documentId);
+        var store = new DocxOperationStore(_blobs);
+        var record = await store.LoadDecisionAsync(operationId, cancellationToken).ConfigureAwait(false);
+        SameDocument(documentId, record.DocumentId);
+        var input = await store.LoadInputAsync(record.Input, cancellationToken).ConfigureAwait(false);
+        SameDocument(documentId, input.DocumentId);
+        Consistent(input.Request.Base.Revision <= record.Before.Revision, "Operation base is newer than its before publication.");
+        Consistent(DocxOperationStore.Reference(DocxOperationStore.EncodeInput(input)) == record.Input,
+            "Operation input is not its canonical fingerprint.");
+        Consistent(input.Candidate is null || input.Candidate == record.ProposedSnapshot.Blob,
+            "Preserved package proposal does not match original input.");
+        if (record.AppliedText is { } applied)
+            Consistent(input.Request.Kind == "text" && input.Request.Text is { } original
+                && applied == original with { Offset = applied.Offset }, "Mapped text changed the original intent.");
+        return new DocxStoredOperation(operationId, record, input);
+    }
+
+    /// <summary>Exact preserved proposal, including work that conflicted; does not change current history.</summary>
+    public async ValueTask<byte[]> ExportOperationProposalAsync(string documentId, HistoryBlobReference operationId,
+        CancellationToken cancellationToken = default) => await _snapshots.ExportAsync(
+            (await GetOperationAsync(documentId, operationId, cancellationToken).ConfigureAwait(false)).Record.ProposedSnapshot,
+            cancellationToken).ConfigureAwait(false);
+
+    private async ValueTask<DocxOperationResult> OperationResultAsync(string documentId, DocxHistoryView publication,
+        HistoryBlobReference inputId, CancellationToken cancellationToken)
+    {
+        Consistent(publication.State.Operation is not null, "Request receipt does not identify an operation publication.");
+        var operation = await GetOperationAsync(documentId, publication.State.Operation!, cancellationToken).ConfigureAwait(false);
+        Consistent(operation.Record.Input == inputId, "Request receipt identifies a different operation input.");
+        await ValidateOperationPublicationAsync(documentId, publication, operation, cancellationToken).ConfigureAwait(false);
+        return new DocxOperationResult(publication, operation);
+    }
+
+    private async ValueTask<List<DocxStoredOperation>> ReadOperationChainAsync(string documentId, DocxHistoryView current,
+        HistoryBlobReference? stop, int maximum, CancellationToken cancellationToken)
+    {
+        var entries = new List<DocxStoredOperation>();
+        var publication = current;
+        var scanned = 0;
+        // Correlate decisions with exact publication ancestry in one bounded walk. Restarting
+        // a radix receipt lookup per decision would multiply this budget by up to 257 reads.
+        while (publication.State.Operation != stop)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Consistent(publication.State.Operation is not null && publication.State.ParentPublication is not null,
+                "Accepted operation log is not an ancestor of the new head.");
+            if (scanned++ >= maximum) throw new DocxHistoryException(DocxHistoryError.TraversalLimit, "Operation publication scan budget reached.");
+            var parent = await ReadHeadViewAsync(documentId, publication.State.ParentPublication!, cancellationToken).ConfigureAwait(false);
+            ValidatePublicationEdge(publication, parent);
+            if (publication.State.Operation != parent.State.Operation)
+            {
+                var operation = await GetOperationAsync(documentId, publication.State.Operation!, cancellationToken).ConfigureAwait(false);
+                await ValidateOperationPublicationAsync(documentId, publication, operation, cancellationToken, parent).ConfigureAwait(false);
+                entries.Add(operation);
+            }
+            publication = parent;
+        }
+        return entries;
+    }
+
+    private async ValueTask ValidateOperationPublicationAsync(string documentId, DocxHistoryView publication,
+        DocxStoredOperation operation, CancellationToken cancellationToken, DocxHistoryView? before = null)
+    {
+        var record = operation.Record;
+        Consistent(publication.Head.Revision == record.Revision && publication.State.ParentPublication == record.Before
+            && publication.State.Operation == operation.Id && publication.State.Snapshot == record.AfterSnapshot
+            && publication.State.Version == record.Version, "Decision disagrees with its original publication.");
+        Consistent(publication.State.Requests?.Current == new HistoryRequestIdentity(operation.Input.Request.RequestId, record.Input.Digest),
+            "Decision is not bound to its original inline request receipt.");
+        before ??= await ReadHeadViewAsync(documentId, record.Before, cancellationToken).ConfigureAwait(false);
+        ValidatePublicationEdge(publication, before);
+        Consistent(record.Parent == before.State.Operation, "Decision does not extend the preceding operation tip.");
+        if (record.ContentCommit is null)
+            Consistent(publication.State.Version == before.State.Version && publication.State.Snapshot == before.State.Snapshot,
+                "Decision without effects changed the document.");
+        else
+        {
+            Consistent(record.Status == "accepted" && publication.State.Commit == record.ContentCommit
+                && publication.State.Sequence == before.State.Sequence + 1 && publication.State.Epoch == before.State.Epoch,
+                "Accepted effects disagree with the document commit.");
+            var commit = await _records.LoadCommitAsync(record.ContentCommit, cancellationToken).ConfigureAwait(false);
+            Consistent(commit.Kind == "import" && commit.Parent == before.State.Commit && commit.Before == before.State.Snapshot
+                && commit.After == publication.State.Snapshot && commit.Version == publication.Version.Id,
+                "Accepted content commit does not extend its before publication.");
+        }
+    }
+
+    private void VerifyRecordedText(DocxStoredOperation operation, PackageHistoryCommitRecord commit, byte[] before)
+    {
+        var applied = DocxOperationPackage.ApplyText(before, operation.Record.AppliedText!, _packageOptions);
+        Consistent(PackageChangeSet.Create(before, applied, _packageOptions).AfterDigest == commit.After.ContentDigest,
+            "Recorded text map does not describe the accepted package effects.");
+    }
+}

--- a/Docxodus/History/DocxVersionHistory.Updates.cs
+++ b/Docxodus/History/DocxVersionHistory.Updates.cs
@@ -31,6 +31,12 @@ public sealed partial class DocxVersionHistory
         if (maxEntriesToScan <= 0) throw new ArgumentOutOfRangeException(nameof(maxEntriesToScan));
         var current = await ReadAsync(documentId, cancellationToken).ConfigureAwait(false)
             ?? throw new DocxHistoryException(DocxHistoryError.HistoryUnavailable, "Document history is unavailable.");
+        return await ReadChangesBetweenAsync(documentId, current, after, maxEntriesToScan, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask<DocxHistoryUpdate> ReadChangesBetweenAsync(string documentId, DocxHistoryView current,
+        HistoryHead? after, int maxEntriesToScan, CancellationToken cancellationToken)
+    {
         if (after is null) return new DocxHistoryUpdate(null, current, Array.Empty<DocxHistoryLogEntry>(), true);
         if (current.Head == after) return new DocxHistoryUpdate(after, current, Array.Empty<DocxHistoryLogEntry>(), false);
         Consistent(current.Head.Revision > after.Revision, "The supplied history head rewinds or forks the accepted publication.");
@@ -46,9 +52,24 @@ public sealed partial class DocxVersionHistory
                 "History update scan budget reached; increase it explicitly to continue.");
         }
 
+        // V3 binds every publication, including a conflict/no-op decision that creates no version.
+        // Follow exact parent heads before falling back to V1/V2's one-version-per-publication chain.
+        var publication = current;
+        while (publication.Head != after && publication.State.ParentPublication is { } parentHead)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Spend();
+            Consistent(parentHead.Revision >= after.Revision, "Accepted publication is not an ancestor of the new head.");
+            var parent = await ReadHeadViewAsync(documentId, parentHead, cancellationToken).ConfigureAwait(false);
+            ValidatePublicationEdge(publication, parent);
+            publication = parent;
+        }
+        Consistent(publication.Head == after || (publication.Head.Revision > after.Revision && previous.State.Operation is null),
+            "Accepted publication is not an ancestor of the new head.");
+
         // Content sequence alone cannot prove ancestry: competing labels and same-content forks
-        // also have distinct immutable version chains. Check the previously accepted version ID.
-        var version = current.Version;
+        // also have distinct immutable version chains. Check the accepted legacy version ID.
+        var version = publication.Version;
         long versionEdges = 0;
         while (version.Id != previous.Version.Id)
         {
@@ -65,7 +86,7 @@ public sealed partial class DocxVersionHistory
                     && version.Record.RestoredFrom is null, "A metadata-only version cannot change content or restore.");
             version = parent;
         }
-        Consistent(versionEdges == current.Head.Revision - after.Revision,
+        Consistent(versionEdges == publication.Head.Revision - after.Revision,
             "Publication revision does not match the accepted version ancestry.");
 
         var entries = new List<DocxHistoryLogEntry>();
@@ -96,5 +117,28 @@ public sealed partial class DocxVersionHistory
         }
         cancellationToken.ThrowIfCancellationRequested();
         return new DocxHistoryUpdate(after, current, entries.AsReadOnly(), current.State.Epoch != previous.State.Epoch);
+    }
+
+    private static void ValidatePublicationEdge(DocxHistoryView child, DocxHistoryView parent)
+    {
+        Consistent(child.State.InitialSnapshot == parent.State.InitialSnapshot
+            && child.State.Sequence >= parent.State.Sequence && child.State.Sequence - parent.State.Sequence <= 1
+            && child.State.Epoch >= parent.State.Epoch && child.State.Epoch - parent.State.Epoch <= 1,
+            "Publication ancestry is discontinuous.");
+        if (child.Version.Id == parent.Version.Id)
+        {
+            Consistent(child.State.Snapshot == parent.State.Snapshot && child.State.Sequence == parent.State.Sequence
+                && child.State.Commit == parent.State.Commit && child.State.Epoch == parent.State.Epoch
+                && child.State.Operation != parent.State.Operation && child.State.Requests?.Current is not null,
+                "A version-free publication must record a new identified decision without changing content.");
+        }
+        else
+        {
+            Consistent(child.Version.Record.Parent == parent.Version.Id, "Publication skipped its parent version.");
+            if (child.State.Sequence == parent.State.Sequence)
+                Consistent(child.State.Commit == parent.State.Commit && child.State.Epoch == parent.State.Epoch
+                    && child.State.Snapshot.ContentDigest == parent.State.Snapshot.ContentDigest
+                    && child.Version.Record.RestoredFrom is null, "A metadata-only publication cannot change content or restore.");
+        }
     }
 }

--- a/Docxodus/History/DocxVersionHistory.cs
+++ b/Docxodus/History/DocxVersionHistory.cs
@@ -7,7 +7,7 @@ using Docxodus.Verification;
 
 namespace Docxodus.History;
 
-public enum DocxHistoryError { StaleHead, ForeignDocument, InvalidHistory, HistoryUnavailable, TraversalLimit, RequestConflict }
+public enum DocxHistoryError { StaleHead, ForeignDocument, InvalidHistory, HistoryUnavailable, TraversalLimit, RequestConflict, Contention }
 
 /// <summary>A publication precondition or cross-record history invariant failed.</summary>
 public sealed class DocxHistoryException : Exception

--- a/Docxodus/History/DocxVersionHistory.cs
+++ b/Docxodus/History/DocxVersionHistory.cs
@@ -66,6 +66,8 @@ public sealed partial class DocxVersionHistory
         var state = await _records.LoadStateAsync(head.State, cancellationToken).ConfigureAwait(false);
         SameDocument(documentId, state.DocumentId);
         HistoryRequestJournalStore.ValidatePublication(documentId, head, state.Requests);
+        Consistent(state.ParentPublication is null || state.ParentPublication.Revision == head.Revision - 1,
+            "Publication parent must immediately precede this head.");
         Consistent(state.Sequence < head.Revision && state.Epoch <= state.Sequence, "Invalid head publication position.");
         var version = await GetVersionAsync(documentId, state.Version, cancellationToken).ConfigureAwait(false);
         Consistent(version.Record.Sequence == state.Sequence && version.Record.Snapshot == state.Snapshot,
@@ -116,11 +118,21 @@ public sealed partial class DocxVersionHistory
         var capturedMetadata = HistoryRecordStore.PrepareMetadata(metadata);
         var request = requestId is null ? null : VersionRequest("create", documentId, expected,
             capturedMetadata, requestId, captured, null);
-        var nonce = Guid.NewGuid();
         var current = await ReadAsync(documentId, cancellationToken).ConfigureAwait(false);
         var repeated = await FindRequestAsync(documentId, current, request, cancellationToken).ConfigureAwait(false);
         if (repeated is not null) return repeated;
         if (current?.Head != expected) throw Stale();
+        var prepared = await PrepareCandidateAsync(documentId, current, captured, capturedMetadata, cancellationToken).ConfigureAwait(false);
+        return await PublishAsync(documentId, expected, prepared.State, prepared.Version,
+            cancellationToken, request, current?.State.Requests).ConfigureAwait(false);
+    }
+
+    // Shared immutable preparation for version imports and accepted backend effects. Only the
+    // caller publishes; a losing backend writer may reconcile its original intent and try again.
+    private async ValueTask<(DocxHistoryStateRecord State, DocxStoredVersion Version)> PrepareCandidateAsync(
+        string documentId, DocxHistoryView? current, byte[] captured, DocxVersionMetadata capturedMetadata,
+        CancellationToken cancellationToken)
+    {
         var snapshot = await _snapshots.CaptureAsync(captured, cancellationToken).ConfigureAwait(false);
         var changed = current is not null && current.State.Snapshot.ContentDigest != snapshot.ContentDigest;
         var sequence = checked((current?.State.Sequence ?? 0) + (changed ? 1 : 0));
@@ -134,7 +146,7 @@ public sealed partial class DocxVersionHistory
         }
         var version = new DocxVersionRecord
         {
-            DocumentId = documentId, Metadata = capturedMetadata, Nonce = nonce,
+            DocumentId = documentId, Metadata = capturedMetadata, Nonce = Guid.NewGuid(),
             Parent = current?.State.Version, RestoredFrom = null, Sequence = sequence, Snapshot = snapshot,
         };
         var versionId = await _records.SaveVersionAsync(version, cancellationToken).ConfigureAwait(false);
@@ -150,12 +162,12 @@ public sealed partial class DocxVersionHistory
         }
         var state = new DocxHistoryStateRecord
         {
+            Operation = current?.State.Operation, ParentPublication = current?.State.ParentPublication,
             Commit = commitId, DocumentId = documentId, Epoch = current?.State.Epoch ?? 0,
             InitialSnapshot = current?.State.InitialSnapshot ?? snapshot, Sequence = sequence,
             Snapshot = snapshot, Version = versionId,
         };
-        return await PublishAsync(documentId, expected, state, new DocxStoredVersion(versionId, version),
-            cancellationToken, request, current?.State.Requests).ConfigureAwait(false);
+        return (state, new DocxStoredVersion(versionId, version));
     }
 
     /// <summary>
@@ -212,8 +224,12 @@ public sealed partial class DocxVersionHistory
         DocxHistoryStateRecord state, DocxStoredVersion version, CancellationToken cancellationToken,
         HistoryRequestIdentity? request = null, HistoryRequestJournal? previousRequests = null)
     {
-        state = state with { Requests = await _requests.AdvanceAsync(documentId, expected, previousRequests,
-            request, cancellationToken).ConfigureAwait(false) };
+        state = state with
+        {
+            ParentPublication = state.Operation is null ? null : expected,
+            Requests = await _requests.AdvanceAsync(documentId, expected, previousRequests,
+                request, cancellationToken).ConfigureAwait(false),
+        };
         var stateId = await _records.SaveStateAsync(state, cancellationToken).ConfigureAwait(false);
         var head = await _heads.TryAdvanceAsync(documentId, expected, stateId, cancellationToken).ConfigureAwait(false);
         // Do not throw cancellation after publication: the CAS is the definitive commit point.

--- a/Docxodus/History/HistoryRecordStore.cs
+++ b/Docxodus/History/HistoryRecordStore.cs
@@ -58,7 +58,8 @@ public sealed class HistoryRecordStore
     {
         cancellationToken.ThrowIfCancellationRequested();
         var normalized = Validate(record);
-        var schemaVersion = normalized is DocxHistoryStateRecord { Requests: not null } ? 2 : 1;
+        var schemaVersion = normalized is DocxHistoryStateRecord { Operation: not null } ? 3
+            : normalized is DocxHistoryStateRecord { Requests: not null } ? 2 : 1;
         var bytes = JsonSerializer.SerializeToUtf8Bytes(new HistoryRecordEnvelope<T>
         {
             Record = normalized, Schema = Schema(kind, schemaVersion), SchemaVersion = schemaVersion,
@@ -87,7 +88,7 @@ public sealed class HistoryRecordStore
             var fields = header.RootElement.EnumerateObject().Select(p => p.Name).ToHashSet(StringComparer.Ordinal);
             Require(fields.SetEquals(["record", "schema", "schemaVersion"]), "Malformed history envelope.");
             var schemaVersion = header.RootElement.GetProperty("schemaVersion").GetInt32();
-            if (schemaVersion != 1 && !(schemaVersion == 2 && kind == "package-state"))
+            if (schemaVersion != 1 && !(schemaVersion is 2 or 3 && kind == "package-state"))
                 throw new PackageChangeException(PackageChangeError.UnsupportedVersion, "Unsupported history record version.");
             Require(header.RootElement.GetProperty("schema").GetString() == Schema(kind, schemaVersion), "Unexpected history record schema.");
             var envelope = JsonSerializer.Deserialize(bytes, TypeInfo<T>());
@@ -95,9 +96,13 @@ public sealed class HistoryRecordStore
             var record = Validate(envelope!.Record);
             if (record is DocxHistoryStateRecord state)
             {
-                Require((state.Requests is not null) == (schemaVersion == 2), "Request journals require state schema V2.");
+                Require(schemaVersion != 2 || state.Requests is not null, "V2 states require request journals.");
                 Require(schemaVersion != 1 || !header.RootElement.GetProperty("record").TryGetProperty("requests", out _),
                     "V1 states cannot declare request journals, including null.");
+                Require((state.Operation is not null) == (schemaVersion == 3), "Backend tips require state schema V3.");
+                Require(schemaVersion == 3 || (!header.RootElement.GetProperty("record").TryGetProperty("operation", out _)
+                    && !header.RootElement.GetProperty("record").TryGetProperty("parentPublication", out _)),
+                    "Older states cannot declare V3 publication fields, including null.");
             }
             cancellationToken.ThrowIfCancellationRequested();
             return record;
@@ -138,6 +143,13 @@ public sealed class HistoryRecordStore
                 HistoryHeadCodec.Key(state.DocumentId);
                 HistoryRequestJournalStore.ValidateJournal(state.Requests);
                 Require(state.Requests is null || state.Requests.DocumentId == state.DocumentId, "Foreign request journal.");
+                Require((state.Operation is null) == (state.ParentPublication is null), "Backend tip and publication parent must occur together.");
+                Reference(state.Operation);
+                if (state.ParentPublication is not null)
+                {
+                    Require(state.ParentPublication.Revision > 0, "Invalid parent publication revision.");
+                    RequiredReference(state.ParentPublication.State);
+                }
                 Require(state.Sequence >= 0 && state.Epoch >= 0
                     && (state.Commit is null) == (state.Sequence == 0), "Invalid history state position.");
                 Reference(state.Commit); RequiredReference(state.Version);

--- a/Docxodus/History/HistoryRecords.cs
+++ b/Docxodus/History/HistoryRecords.cs
@@ -56,6 +56,12 @@ public sealed record PackageHistoryCommitRecord
 /// </summary>
 public sealed record DocxHistoryStateRecord
 {
+    /// <summary>V3 explicit publication ancestry, including decisions that create no version.</summary>
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    public HistoryHead? ParentPublication { get; init; }
+    /// <summary>V3 immutable backend decision-log tip, carried through later saves and restores.</summary>
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    public HistoryBlobReference? Operation { get; init; }
     /// <summary>V2 publication metadata. Absent in legacy V1 states; older records remain readable.</summary>
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
     public HistoryRequestJournal? Requests { get; init; }

--- a/docs/history-backend.md
+++ b/docs/history-backend.md
@@ -1,0 +1,120 @@
+# Backend operation reconciliation
+
+`DocxVersionHistory.SubmitOperationAsync` is a storage-neutral backend producer over the SAME
+blob/head adapters, exact versions, package effects, and durable request journal as named history.
+It does not create a GUI, network service, subscription, optimistic client, or real-time editor.
+Hosts authenticate actors, persist captured requests, supply storage, and decide when to submit.
+
+```csharp
+var history = new DocxVersionHistory(hostBlobs, hostHeads);
+var initial = await history.CreateVersionAsync("contract", "initial-request", null,
+    capturedDocx, capturedMetadata);
+var request = new DocxOperationRequest
+{
+    RequestId = "replica-uuid:42", Base = initial.Head, Kind = "text",
+    Metadata = capturedMetadata,
+    Text = new DocxTextSplice("/word/document.xml", TextNode: 0,
+        Offset: 8, DeleteCount: 0, Insert: " proposed"),
+};
+// Persist request once before submission. Retry exactly this input after an uncertain response.
+var outcome = await history.SubmitOperationAsync("contract", request);
+if (outcome.Operation.Record.Status == "conflict")
+{
+    byte[] contender = await history.ExportOperationProposalAsync("contract", outcome.Operation.Id);
+}
+```
+
+## Intent, effects, and publication
+
+The bounded, generated v1 input codec records document/request ID, original exact base head,
+operation kind, copied host metadata, sorted/unique read dependencies, optional resolution link,
+and the exact candidate-byte reference for package submissions. Its canonical manifest digest
+is the input fingerprint. Input capture finishes before awaiting storage. A request ID is shared
+with the version/restore namespace, not inferred from timestamp or content identity.
+
+The decision records original input, exact preceding publication, previous decision, assigned
+publication revision, preserved proposal snapshot, accepted snapshot/version, optional actual
+content commit, status/reason, and the mapped text splice when applicable. One CAS publishes
+state + decision tip + request receipt. Content-changing acceptances create an exact version and
+replayable import effects using the existing version producer. Conflicts, discards, and accepted
+no-ops publish an outcome but do NOT fabricate a version or content commit.
+
+The same ID/input returns its original outcome, not the current head, after later publications,
+restarts, competing identical calls, or a lost acknowledgement. Changed input under that ID
+raises `RequestConflict`. On a different writer's successful CAS, the loser re-reads and reconciles
+the ORIGINAL submitted intent against the new accepted tail; it never silently replaces its base.
+Unknown storage failures propagate. Retry the original request to resolve a possibly committed
+result. Cancellation after this call's own successful CAS cannot turn it into failure.
+
+## Supported reconciliation rules
+
+| Intent / concurrent change | Outcome |
+|---|---|
+| Text edits in disjoint ranges or different `w:t` nodes | Map UTF-16 positions through accepted text effects and retain both. |
+| Inserts at the same gap | Keep both in assigned acceptance order. |
+| Overlapping replacements/deletions, or an insertion inside a deleted range | Preserve the contender as `OverlappingText`; do not silently delete concurrent work. |
+| A concurrent insert inside an incoming deletion's observed range | Conflict; a stale deletion never expands to swallow inserted text. |
+| Unknown/package mutation of the addressed text part | `UnknownTextChange`, even if a convenient-looking ordinal still exists. |
+| Package writes to disjoint entries | Merge complete entry payloads atomically; untouched entries retain their uncompressed bytes. |
+| Package entry already equals the proposed value | Compatible no-op for that entry; intentional request still gets an outcome. |
+| Other overlapping package writes | Preserve the entire proposal as `ChangedPart`; no partial application. |
+| Changed declared read dependency or package topology | `ReadDependencyChanged`. |
+| A restore since the submitted base | `EpochChanged`; preserve the proposal instead of replaying it over the reset. |
+
+Text addressing is **relative to an immutable base**, not a persistent sidecar identity system.
+`TextNode` is a zero-based document-order ordinal of `w:t` in the named canonical OPC part URI.
+Recognized text operations preserve those elements and their order; they change only text and
+`xml:space`. Boundaries cannot split surrogate pairs. Inserted text must be valid XML characters.
+Tracked-change/comment topology and opaque parts are retained, but this primitive does not
+author new Word tracked revisions or merge arbitrary paragraph/table/review structures.
+
+`Kind = "package"` takes the original candidate DOCX in the separate `candidateDocx` argument.
+Declare any semantic whole-part dependencies in `ReadParts`; expected absence is meaningful too.
+All content-type and relationship entries are guarded automatically. The library cannot infer
+every application-specific semantic read from two snapshots. Package merging is NOT an arbitrary
+same-part XML merge, and passing an incomplete semantic read set is not a correctness guarantee.
+For text, the intervening contribution endpoints, actual applied footprint, and mapped text
+effects are verified before using a recorded position map. Unknown edits cannot masquerade as
+safe ordinal-preserving splices merely by matching the latest visible text.
+
+## Inspecting and resolving conflicts
+
+`ReadOperationsSinceAsync(documentId, acceptedHead)` returns ascending, validated durable outcomes
+and a captured current view. Null scans all retained decisions within the budget. Ordinary
+versions/labels may create gaps in decision revision numbers; publication ancestry proves those
+gaps rather than assuming every revision is an operation. Content-only consumers continue using
+`ReadChangesSinceAsync`; decision-only publications have empty content tails.
+
+`GetOperationAsync` reads a retained reference and validates its codec/input relationships; a
+reference alone is neither authorization nor proof it was published. The ordered reader correlates
+each decision with its exact original publication, inline receipt, preceding decision, and
+version/content commit. It walks publication ancestry once, without restarting the radix receipt
+lookup for every decision. Missing/corrupt records fail explicitly, not as an empty log.
+
+Resolve a conflict with a NEW request, using a base that has observed the conflict and setting
+`Resolves` to its decision reference. Submit an explicit text/package change or `Kind = "discard"`.
+A successful resolution is durable even without a content change. Only one accepted resolution
+can claim the original conflict; a competing later one records `AlreadyResolved`. A resolution
+that itself conflicts does not mark the original resolved. All attempts and proposals remain
+available. This API does not decide on behalf of the host which user's contested edit is preferred.
+
+## Limits, retention, and current cost
+
+`maxAttempts` defaults to 16 (1–1024), with typed `Contention` on exhaustion; retry the same request.
+`maxEntriesToScan` defaults to 10,000 and bounds each content/publication ancestry scan and each
+decision-publication walk independently, per attempt. Intervening labels count too. Resolution
+currently scans back through retained decisions to prove the target and detect prior resolutions.
+Raise limits explicitly, pass cancellation, and impose host request timeouts/aggregate quotas.
+Input/decision manifests are bounded to 512 KiB; inserts to 64 Ki UTF-16 characters; declared read
+sets to 256 canonical URIs. Existing snapshot, OPC expansion, and contribution limits still apply.
+
+This is a correctness-first backend/package path: it loads snapshots, verifies full contributions,
+and rewrites ZIP packages. It is NOT the planned incremental keystroke path. Performance scales
+with package size and intervening history. No claim of low-latency typing, automatic client
+outboxes, selective undo, or complete #671 collaboration is made.
+
+Retain the reachable state/publication, decision/input, proposal, version/snapshot, effect/payload,
+and receipt-index graph. Orphaned prepared blobs after failed CAS are host cleanup work; never
+delete reachable receipts merely because a response was acknowledged. The reference file adapter
+supports cooperating local processes, not distributed/network filesystem coordination. Process
+crash recovery and filesystem power-loss durability are distinct guarantees.

--- a/docs/history-validation.md
+++ b/docs/history-validation.md
@@ -1,0 +1,49 @@
+# Shared history infrastructure validation
+
+## Version model/fault fuzzing
+
+Run `bash scripts/history-fuzz.sh` for the extended corpus. Default ordinary test discovery runs
+16 seeds × 96 steps; the script runs 64 × 128. Override `DOCXODUS_HISTORY_FUZZ_SEEDS` (1–1024) and
+`DOCXODUS_HISTORY_FUZZ_STEPS` (1–10000) explicitly for larger campaigns. A failure reports seed,
+step count, storage kind, and command trace. TRX output is in `Docxodus.Tests/TestResults`.
+
+The recorded run below passed on 2026-09-06 (.NET 10.0.301 SDK / 10.0.9 runtime, Linux).
+Generated race cases rendezvous both contenders at the actual head CAS, release them in seeded
+order, and assert two attempts. Counts come from `history-model-fuzz-gated-64x128.trx`.
+
+| Observed coverage | Count |
+|---|---:|
+| Passing seeds | 64 |
+| Seeds using real filesystem adapters | 13 |
+| Scheduled steps | 8,192 |
+| Accepted versions, each checked by exact exported bytes | 5,409 |
+| Content sequences, each materialized and effect-replayed | 3,548 |
+| Restore operations | 640 |
+| Metadata/byte-preserving repacks | 667 |
+| Legacy saves carrying earlier receipts forward | 644 |
+| Old request retries during generated streams | 712 |
+| Same-ID/different-input refusals | 689 |
+| Stale writes refused, then intentionally corrected | 679 |
+| Corrupt/missing snapshot refusals | 690 |
+| Competing different-request races | 327 |
+| Concurrent identical-request races | 349 |
+| Recoveries from lost post-commit acknowledgements | 245 |
+
+All 64 cases passed in 3.57 minutes. Each seed also retries every accepted identified request at
+the end, checks immutable pagination against its independent version list, and resolves every
+content-boundary timestamp against its own recorded-time model. The oracle compares retained
+input bytes and uncompressed ZIP entry bytes; it does not use the production package digest or
+replay implementation to calculate expected content. Fixtures include Unicode and opaque binary
+custom parts. Timestamps move backwards and can tie; labels do not fabricate content sequences.
+
+Separate fault-matrix tests enumerate every immutable write before/after its durable store call,
+plus failures/cancellation before and after head CAS, for create AND restore on memory AND real
+filesystem adapters. Before-commit failures retain the old head; after-commit acknowledgement
+loss returns the original result on retry; cancellation after successful CAS cannot erase it.
+Producers are discarded before recovery. All four matrix cases passed. The receipt-index tests
+also insert/read 3,000 randomly ordered IDs, enforce the 257-node lookup bound, and check that
+lookup writes nothing and corruption is not treated as an absent request.
+
+These are deterministic model/fault campaigns, not a claim of exhaustive state-space coverage,
+power-loss certification, or a distributed-filesystem guarantee. Actual process-kill and backend
+reconciliation evidence are separate gates; in-process service recreation is not a process kill.

--- a/docs/history-validation.md
+++ b/docs/history-validation.md
@@ -47,3 +47,27 @@ lookup writes nothing and corruption is not treated as an absent request.
 These are deterministic model/fault campaigns, not a claim of exhaustive state-space coverage,
 power-loss certification, or a distributed-filesystem guarantee. Actual process-kill and backend
 reconciliation evidence are separate gates; in-process service recreation is not a process kill.
+
+## Backend reconciliation and fault tests
+
+On 2026-09-06, all 18 `DocxBackend*` tests passed (`history-backend-core.trx`, 20.43 seconds).
+These execute the real shared history backend over DOCX packages, not a standalone string model:
+same-gap/disjoint text, contested ranges with exported proposals, explicit one-winner resolutions,
+disjoint header/footnote package changes, read dependencies, no-ops/discards, restore epochs,
+unknown structural boundaries, delayed duplicate requests, and input identity conflicts.
+Four race cases (memory/filesystem × seeded left/right winner) force both head CAS attempts;
+different compatible intents require a third reconciled publication attempt, while identical
+requests require exactly two attempts and return one original outcome.
+
+Four additional matrix cases enumerate every immutable write before/after its durable call and
+both sides of CAS/cancellation for accepted AND conflicting operations on memory AND filesystem
+storage. Recovery validates exact original receipts, preserved contender text, visible text,
+version/decision counts, and recorded-effect replay. Record negatives reject malformed/future
+codecs, missing/corrupt metadata/proposals, altered fingerprints, and forged valid-range text maps.
+The decision audit is forbidden from reading even a single radix-index root and has exact budget
+boundary tests including intervening named versions. Untouched package parts (notes, headers,
+comment topology, relationships, and an opaque binary custom part) retain their entry bytes;
+saved/reopened packages introduce no OpenXML validation errors beyond the independent baseline.
+
+Actual process-kill recovery and a larger seeded backend stream campaign remain follow-up gates;
+these results do not claim either one or full real-time/editor collaboration.

--- a/docs/history.md
+++ b/docs/history.md
@@ -83,6 +83,19 @@ retirement/fencing, not a best-effort TTL. No retention deletion or transport is
 
 ## Reading and comparison
 
+Backend-enabled histories use state schema V3: `ParentPublication` binds the immediately prior
+head, while `Operation` references the latest immutable backend decision. This permits an
+identified conflict/no-op decision to advance publication revision without creating a version
+or content commit. Ordinary creates/restores carry the decision tip forward. V1/V2 history stays
+readable and retains its original wire format until enabled; older codecs reject V3 explicitly.
+The storage layer treats the decision reference as opaque; the backend owner must validate its
+record, outcome, and effects. A stored reference alone is not proof of acceptance.
+
+Ordered updates validate exact V3 publication parents, then legacy version ancestry if the tail
+crosses the schema boundary. The traversal budget includes publication edges as well as legacy
+version edges and content commits. Decision-only updates have an empty content tail, not a fake
+document edit; history consumers can still advance their accepted head.
+
 `ReadAsync` validates the current document and the state/version/commit tip relationships. `ListVersionsAsync` starts at that published head and returns newest-first pages (1–100 records); pass a non-null `Next` to continue the same immutable chain while newer versions publish. A null `Next` means the page reached the end.
 
 `GetVersionAsync`, `ExportVersionAsync`, and explicit list cursors also accept retained branch references belonging to the same document. A reference is neither authorization nor proof that a version is on the current published branch. The host must authorize access before invoking these APIs. Cross-document references are rejected.

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,9 @@
 # Named version history (.NET)
 
+The [backend operation producer](history-backend.md) now reconciles submitted text/package
+intents on this same history, preserving explicit conflicts and durable resolutions. It is
+separate from the live editor and installs no transport or GUI.
+
 `Docxodus.History.DocxVersionHistory` captures exact DOCX versions over host-owned storage. It supports create, read, paginated list, get, export, lazy semantic/native-redline comparison, non-destructive restore, sequence materialization, timestamp lookup, recorded-effect replay, and validated ordered log updates. Content-changing versions produce the same reversible package contributions used by the package fallback. [Browser/Python bindings and a host-driven live viewer](history-clients.md) share this core without a new transport layer. Fine-grained live session recording and concurrent-edit transforms remain in the [implementation plan](architecture/collaboration_and_version_history.md).
 
 ```csharp

--- a/docs/schemas/history-operation-decision-v1.schema.json
+++ b/docs/schemas/history-operation-decision-v1.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docxodus.dev/schemas/history/operation-decision/v1",
+  "title": "Durable backend acceptance or preserved conflict",
+  "$comment": "Register adjacent state-v2 and operation-input-v1 schemas. Runtime validates outcome relationships, exact publication/receipt ancestry, and actual accepted package effects before using text maps.",
+  "type": "object", "additionalProperties": false,
+  "required": ["schema", "schemaVersion", "record"],
+  "properties": {
+    "schema": { "const": "https://docxodus.dev/schemas/history/operation-decision/v1" },
+    "schemaVersion": { "const": 1 },
+    "record": {
+      "type": "object", "additionalProperties": false,
+      "required": ["documentId", "input", "parent", "revision", "before", "proposedSnapshot", "afterSnapshot", "version", "contentCommit", "status", "conflict", "appliedText"],
+      "properties": {
+        "documentId": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/id" },
+        "input": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/blob" },
+        "parent": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/optionalBlob" },
+        "revision": { "type": "integer", "minimum": 2, "maximum": 9223372036854775807 },
+        "before": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/head" },
+        "proposedSnapshot": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/snapshot" },
+        "afterSnapshot": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/snapshot" },
+        "version": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/blob" },
+        "contentCommit": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/optionalBlob" },
+        "status": { "enum": ["accepted", "conflict"] },
+        "conflict": { "enum": [null, "OverlappingText", "ChangedPart", "ReadDependencyChanged", "EpochChanged", "AlreadyResolved", "UnknownTextChange"] },
+        "appliedText": { "anyOf": [{ "$ref": "https://docxodus.dev/schemas/history/operation-input/v1#/$defs/text" }, { "type": "null" }] }
+      }
+    }
+  }
+}

--- a/docs/schemas/history-operation-input-v1.schema.json
+++ b/docs/schemas/history-operation-input-v1.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docxodus.dev/schemas/history/operation-input/v1",
+  "title": "Canonical backend operation input",
+  "$comment": "Register adjacent state-v2 and history-records-v1 schemas. Runtime also enforces 512 KiB envelope size, valid XML/Unicode, canonical part URIs, sorted unique reads, kind/payload relationships, and canonical manifest fingerprint.",
+  "type": "object", "additionalProperties": false,
+  "required": ["schema", "schemaVersion", "record"],
+  "properties": {
+    "schema": { "const": "https://docxodus.dev/schemas/history/operation-input/v1" },
+    "schemaVersion": { "const": 1 },
+    "record": {
+      "type": "object", "additionalProperties": false, "required": ["documentId", "request", "candidate"],
+      "properties": {
+        "documentId": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/id" },
+        "candidate": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/optionalBlob" },
+        "request": { "$ref": "#/$defs/request" }
+      }
+    }
+  },
+  "$defs": {
+    "text": {
+      "type": "object", "additionalProperties": false, "required": ["partUri", "textNode", "offset", "deleteCount", "insert"],
+      "properties": {
+        "partUri": { "type": "string", "minLength": 2, "maxLength": 4096, "pattern": "^/" },
+        "textNode": { "$ref": "#/$defs/index" }, "offset": { "$ref": "#/$defs/index" }, "deleteCount": { "$ref": "#/$defs/index" },
+        "insert": { "type": "string", "maxLength": 65536 }
+      }
+    },
+    "index": { "type": "integer", "minimum": 0, "maximum": 2147483647 },
+    "request": {
+      "type": "object", "additionalProperties": false,
+      "required": ["requestId", "base", "kind", "metadata", "text", "readParts", "resolves"],
+      "properties": {
+        "requestId": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/id" },
+        "base": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/head" },
+        "kind": { "enum": ["text", "package", "discard"] },
+        "metadata": { "$ref": "https://docxodus.dev/schemas/history/records/v1#/$defs/metadata" },
+        "text": { "anyOf": [{ "$ref": "#/$defs/text" }, { "type": "null" }] },
+        "readParts": { "type": "array", "maxItems": 256, "uniqueItems": true, "items": { "type": "string", "minLength": 2, "maxLength": 4096, "pattern": "^/" } },
+        "resolves": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/optionalBlob" }
+      }
+    }
+  }
+}

--- a/docs/schemas/history-state-v3.schema.json
+++ b/docs/schemas/history-state-v3.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docxodus.dev/schemas/history/package-state/v3",
+  "title": "Package-history state with explicit publication ancestry and backend decision tip",
+  "$comment": "Register adjacent state-v2 schema to resolve shared definitions. Runtime validation proves exact parent publication ancestry. Operation is an opaque immutable decision reference at this storage layer; its owner validates its record and graph.",
+  "type": "object", "additionalProperties": false,
+  "required": ["schema", "schemaVersion", "record"],
+  "properties": {
+    "schema": { "const": "https://docxodus.dev/schemas/history/package-state/v3" },
+    "schemaVersion": { "const": 3 },
+    "record": {
+      "type": "object", "additionalProperties": false,
+      "required": ["parentPublication", "operation", "commit", "documentId", "epoch", "initialSnapshot", "sequence", "snapshot", "version"],
+      "properties": {
+        "parentPublication": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/head" },
+        "operation": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/blob" },
+        "requests": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/journal" },
+        "commit": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/optionalBlob" },
+        "documentId": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/id" },
+        "epoch": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/position" },
+        "initialSnapshot": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/snapshot" },
+        "sequence": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/position" },
+        "snapshot": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/snapshot" },
+        "version": { "$ref": "https://docxodus.dev/schemas/history/package-state/v2#/$defs/blob" }
+      }
+    }
+  }
+}

--- a/scripts/history-fuzz.sh
+++ b/scripts/history-fuzz.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Deterministic extended version-history corpus. Every failing case prints its seed and trace.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export DOCXODUS_HISTORY_FUZZ_SEEDS="${DOCXODUS_HISTORY_FUZZ_SEEDS:-64}"
+export DOCXODUS_HISTORY_FUZZ_STEPS="${DOCXODUS_HISTORY_FUZZ_STEPS:-128}"
+dotnet test Docxodus.Tests/Docxodus.Tests.csproj -c Release -m:1 /p:UseSharedCompilation=false \
+  --filter 'FullyQualifiedName~DocxVersionModelFuzz|FullyQualifiedName~DocxVersionRequestFault|FullyQualifiedName~HistoryRequestJournal' \
+  --logger 'console;verbosity=normal' --logger 'trx;LogFileName=history-fuzz.trx' "$@"


### PR DESCRIPTION
Stacked on #724. Adds a backend-only operation producer on the same atomic head, request journal, exact version store and accepted package-effect log. It reconciles disjoint text/same-gap inserts and independent package-entry contributions, preserves contested proposals as durable conflicts, and supports explicit one-winner resolutions/discards. CAS losers reconcile original captured intent; identical retries recover original outcomes. No GUI, transport, subscriptions, optimistic clients or real-time editor.

Strict generated input/decision codecs and schemas; conservative read/topology/restore/unknown-structure boundaries. Decision audit follows bounded publication ancestry with inline receipt checks (zero repeated radix scans). Text maps must reproduce verified accepted effects before reuse.

Validation: 18 real DOCX backend tests passed, including forced memory/file CAS races, accepted/conflict fault matrices around every observed blob write and publication boundary, exact proposal recovery, notes/header/comment/opaque-part preservation, OpenXML validation-delta, malformed/corrupt/missing records, ID conflicts and forged position maps. GPT-5.6-sol reviewed/re-reviewed; its resource-amplification finding is fixed and no findings remain.

Actual process-kill recovery and a larger seeded backend campaign follow next; this does not claim full #671/editor collaboration or completion of the overall goal.