### PR TITLE
feat(history): validate a portable document history graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Portable-history foundation: bounded, document-scoped graph validation retains exact
+  snapshots, package effects, restore targets, retry receipts, and operation proposals
+  without enumerating shared storage. Includes real legal-document and hostile-graph tests.
+
 ### Fixed
 
 - The editor's find bar no longer loses the keyboard the moment a query matches. It re-scanned on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ file that could fire them.
 **`Docxodus.csproj` and `Docxodus.Tests.csproj` both override it to `false`**, so the core
 library and the test project do *not* fail on warnings. The CLI tools, MCP server,
 python-host and WASM project do inherit it. Current baseline: the library builds with
-**175 warnings**, the test project with **788** (mostly StyleCop `SA1633`/`SA1636` file
+**177 warnings**, the test project with **791** (mostly StyleCop `SA1633`/`SA1636` file
 headers and `SA1206` modifier/using order). Don't add to either baseline. Measure with
 `--no-incremental` — a warm incremental build reports zero because nothing recompiles.
 
@@ -52,6 +52,8 @@ rather than assuming one apiece.
 
 Update the two numbers here in the same commit rather than leaving them stale. They had
 drifted before (113/707 described a tree ~30 warnings behind); re-measure, don't extrapolate.
+The three portable-history foundation files use John Scrudato IV's copyright; the
+still-Microsoft-only StyleCop configuration reports `SA1636` for those correct headers.
 
 ## Repository Layout
 

--- a/Docxodus.Tests/HistoryArchiveGraphTests.cs
+++ b/Docxodus.Tests/HistoryArchiveGraphTests.cs
@@ -1,0 +1,333 @@
+// Copyright (c) John Scrudato IV. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO.Compression;
+using System.Text;
+using System.Xml.Linq;
+using Docxodus.History;
+using Docxodus.Verification;
+using Xunit;
+
+namespace Docxodus.Tests;
+
+public sealed class HistoryArchiveGraphTests
+{
+    [Fact]
+    public async Task RealLegalDocumentClosureAloneReopensSnapshotsEffectsRestoresAndConflictingProposals()
+    {
+        var fixture = await HistoryArchiveFixture.CreateAsync();
+        var source = new CountingBlobs(fixture.Blobs);
+        var graph = await HistoryArchiveGraph.LoadAsync(HistoryArchiveFixture.Id, fixture.Latest.Head, source);
+        Assert.Equal(fixture.Latest.Head, graph.View.Head);
+        Assert.DoesNotContain(graph.Inventory, r => r == fixture.Unrelated.Version.Id || r == fixture.Sentinel);
+        Assert.DoesNotContain(fixture.Unrelated.Version.Id, source.Reads.Keys);
+        Assert.DoesNotContain(fixture.Sentinel, source.Reads.Keys);
+        Assert.Equal(graph.Inventory.Count, graph.Inventory.Select(r => r.Digest).Distinct().Count());
+        var isolated = new MemoryHistoryBlobStore();
+        foreach (var reference in graph.Inventory)
+        {
+            using var stream = await fixture.Blobs.OpenReadAsync(reference);
+            await isolated.PutAsync(reference, stream!);
+        }
+        var reopened = new DocxVersionHistory(isolated, new PinnedHead(fixture.Latest.Head));
+        Assert.Equal(fixture.Latest.Head, (await reopened.ReadAsync(HistoryArchiveFixture.Id))!.Head);
+        var originalPage = await fixture.History.ListVersionsAsync(HistoryArchiveFixture.Id);
+        var importedPage = await reopened.ListVersionsAsync(HistoryArchiveFixture.Id);
+        Assert.Equal(originalPage.Versions.Select(v => v.Id), importedPage.Versions.Select(v => v.Id));
+        foreach (var version in importedPage.Versions)
+        {
+            Assert.Equal(await fixture.History.ExportVersionAsync(HistoryArchiveFixture.Id, version.Id),
+                await reopened.ExportVersionAsync(HistoryArchiveFixture.Id, version.Id));
+            Assert.Equal(version.Record.Snapshot.ContentDigest, PackageManifestGenerator.Generate(
+                await reopened.ReplayAsync(HistoryArchiveFixture.Id, version.Record.Sequence)).OrderedOpcContentDigest);
+        }
+        var operations = await reopened.ReadOperationsSinceAsync(HistoryArchiveFixture.Id, null);
+        Assert.Equal(new[] { "accepted", "conflict", "accepted" }, operations.Operations.Select(o => o.Record.Status));
+        Assert.Equal(fixture.Conflict.Operation.Id, operations.Operations[1].Id);
+        Assert.Equal(fixture.Proposal, await reopened.ExportOperationProposalAsync(HistoryArchiveFixture.Id, fixture.Conflict.Operation.Id));
+        var firstRequest = fixture.Initial.State.Requests!.Current!;
+        Assert.Equal(fixture.Initial.Head, await new HistoryRequestJournalStore(isolated).FindAsync(
+            HistoryArchiveFixture.Id, fixture.Latest.Head, fixture.Latest.State.Requests, firstRequest));
+        Assert.Equal(fixture.Original, await reopened.ExportVersionAsync(HistoryArchiveFixture.Id, fixture.Initial.Version.Id));
+    }
+
+    [Fact]
+    public async Task TraversalUsesPinnedHeadEvenWhenSourceHasNewerPublications()
+    {
+        var fixture = await HistoryArchiveFixture.CreateAsync();
+        var captured = fixture.Latest;
+        var newer = await fixture.History.CreateVersionAsync(HistoryArchiveFixture.Id, "after-capture", captured.Head,
+            fixture.Original, HistoryArchiveFixture.Metadata("later"));
+        var graph = await HistoryArchiveGraph.LoadAsync(HistoryArchiveFixture.Id, captured.Head, fixture.Blobs);
+        Assert.Equal(captured.Head, graph.View.Head);
+        Assert.DoesNotContain(newer.Head.State, graph.Inventory);
+        Assert.DoesNotContain(newer.Version.Id, graph.Inventory);
+    }
+
+    [Fact]
+    public async Task AllExplicitGraphBudgetsAreEnforced()
+    {
+        var fixture = await HistoryArchiveFixture.CreateAsync();
+        foreach (var limits in new[]
+        {
+            new DocxHistoryArchiveLimits { MaxBlobs = 1 },
+            new DocxHistoryArchiveLimits { MaxTotalBlobBytes = 1 },
+            new DocxHistoryArchiveLimits { MaxMetadataBytes = 1 },
+            new DocxHistoryArchiveLimits { MaxValidationBytes = 1 },
+            new DocxHistoryArchiveLimits { MaxExpandedBytes = 1 },
+            new DocxHistoryArchiveLimits { MaxBlobBytes = 1 },
+            new DocxHistoryArchiveLimits { MaxRecordBytes = 1 },
+            new DocxHistoryArchiveLimits { MaxManifestBytes = 1 },
+        })
+            Assert.Equal(PackageChangeError.ResourceLimit, (await Assert.ThrowsAsync<PackageChangeException>(async () =>
+                await HistoryArchiveGraph.LoadAsync(HistoryArchiveFixture.Id, fixture.Latest.Head, fixture.Blobs, limits))).Code);
+        Assert.Equal(DocxHistoryError.TraversalLimit, (await Assert.ThrowsAsync<DocxHistoryException>(async () =>
+            await HistoryArchiveGraph.LoadAsync(HistoryArchiveFixture.Id, fixture.Latest.Head, fixture.Blobs,
+                new DocxHistoryArchiveLimits { MaxEdges = 1 }))).Code);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await HistoryArchiveGraph.LoadAsync(
+            HistoryArchiveFixture.Id, fixture.Latest.Head, fixture.Blobs, cancellationToken: new CancellationToken(true)));
+    }
+
+    [Fact]
+    public async Task MissingCorruptAndForeignReachableDataFailEvenAwayFromTheLatestSnapshot()
+    {
+        var fixture = await HistoryArchiveFixture.CreateAsync();
+        var graph = await HistoryArchiveGraph.LoadAsync(HistoryArchiveFixture.Id, fixture.Latest.Head, fixture.Blobs);
+        // Includes old snapshots, both branches of the receipt index, original request heads,
+        // proposed work, package effects and payloads. Every retained byte is actually inspected.
+        foreach (var reference in graph.Inventory)
+        {
+            var missing = new ReplacedBlob(fixture.Blobs, reference, null);
+            Assert.Equal(PackageChangeError.PayloadMissing, (await Assert.ThrowsAsync<PackageChangeException>(async () =>
+                await HistoryArchiveGraph.LoadAsync(HistoryArchiveFixture.Id, fixture.Latest.Head, missing))).Code);
+        }
+        var corrupt = new ReplacedBlob(fixture.Blobs, fixture.Initial.State.Snapshot.Blob, new byte[] { 0 });
+        Assert.Equal(PackageChangeError.PayloadMismatch, (await Assert.ThrowsAsync<PackageChangeException>(async () =>
+            await HistoryArchiveGraph.LoadAsync(HistoryArchiveFixture.Id, fixture.Latest.Head, corrupt))).Code);
+        Assert.Equal(DocxHistoryError.ForeignDocument, (await Assert.ThrowsAsync<DocxHistoryException>(async () =>
+            await HistoryArchiveGraph.LoadAsync("another-document", fixture.Latest.Head, fixture.Blobs))).Code);
+    }
+
+    [Fact]
+    public async Task StateReferenceCannotHideASecondInvalidHeadRevision()
+    {
+        var fixture = await HistoryArchiveFixture.CreateAsync();
+        var falseHead = fixture.Latest.Head with { Revision = fixture.Latest.Head.Revision + 1 };
+        Assert.Equal(DocxHistoryError.InvalidHistory, (await Assert.ThrowsAsync<DocxHistoryException>(async () =>
+            await HistoryArchiveGraph.LoadAsync(HistoryArchiveFixture.Id, falseHead, fixture.Blobs))).Code);
+    }
+
+    [Fact]
+    public async Task SameContentForkCommitCannotSubstituteForThePublishedVersion()
+    {
+        var fixture = await HistoryArchiveFixture.CreateAsync(); var records = new HistoryRecordStore(fixture.Blobs);
+        var commit = await records.LoadCommitAsync(fixture.Latest.State.Commit!);
+        var version = await records.LoadVersionAsync(commit.Version);
+        var fork = await records.SaveVersionAsync(version with { Nonce = Guid.NewGuid() });
+        var forkCommit = await records.SaveCommitAsync(commit with { Version = fork });
+        var falseState = await records.SaveStateAsync(fixture.Latest.State with { Commit = forkCommit });
+        Assert.Equal(DocxHistoryError.InvalidHistory, (await Assert.ThrowsAsync<DocxHistoryException>(async () =>
+            await HistoryArchiveGraph.LoadAsync(HistoryArchiveFixture.Id,
+                fixture.Latest.Head with { State = falseState }, fixture.Blobs))).Code);
+    }
+
+    [Fact]
+    public async Task FutureReceiptCannotBeHiddenInAnOlderJournal()
+    {
+        var fixture = await HistoryArchiveFixture.CreateAsync();
+        var later = await fixture.History.CreateVersionAsync(HistoryArchiveFixture.Id, "later", fixture.Latest.Head,
+            fixture.Original, HistoryArchiveFixture.Metadata("later"));
+        var falseState = await new HistoryRecordStore(fixture.Blobs).SaveStateAsync(fixture.Latest.State with
+        {
+            Requests = fixture.Latest.State.Requests! with { Index = later.State.Requests!.Index },
+        });
+        Assert.Equal(DocxHistoryError.InvalidHistory, (await Assert.ThrowsAsync<DocxHistoryException>(async () =>
+            await HistoryArchiveGraph.LoadAsync(HistoryArchiveFixture.Id,
+                fixture.Latest.Head with { State = falseState }, fixture.Blobs))).Code);
+    }
+
+    [Fact]
+    public async Task OneBlobMayBeBothAnExactSnapshotAndAnOpaqueContributionPayload()
+    {
+        var original = DocxSession.CreateBlankDocxBytes();
+        using var buffer = new MemoryStream(); buffer.Write(original);
+        using (var zip = new ZipArchive(buffer, ZipArchiveMode.Update, leaveOpen: true))
+        {
+            var typesEntry = zip.GetEntry("[Content_Types].xml")!; XDocument types;
+            using (var input = typesEntry.Open()) types = XDocument.Load(input);
+            types.Root!.Add(new XElement(types.Root.Name.Namespace + "Default", new XAttribute("Extension", "docx"),
+                new XAttribute("ContentType", "application/octet-stream")));
+            typesEntry.Delete();
+            using (var output = zip.CreateEntry("[Content_Types].xml").Open()) types.Save(output);
+            using var entry = zip.CreateEntry("custom/attached.docx").Open(); entry.Write(original);
+        }
+        var blobs = new MemoryHistoryBlobStore(); var history = new DocxVersionHistory(blobs, new MemoryHistoryHeadStore());
+        var first = await history.CreateVersionAsync("doc", null, original, HistoryArchiveFixture.Metadata("original"));
+        var next = await history.CreateVersionAsync("doc", first.Head, buffer.ToArray(), HistoryArchiveFixture.Metadata("attachment"));
+        var graph = await HistoryArchiveGraph.LoadAsync("doc", next.Head, blobs);
+        Assert.Single(graph.Inventory, r => r == first.State.Snapshot.Blob);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task TextProposalAndAcceptedMapMustRepresentTheOriginalIntent(bool missingMap)
+    {
+        var blobs = new MemoryHistoryBlobStore(); var history = new DocxVersionHistory(blobs, new MemoryHistoryHeadStore());
+        var bytes = File.ReadAllBytes("../../../../TestFiles/NVCA-Model-COI.docx");
+        using var zip = new ZipArchive(new MemoryStream(bytes), ZipArchiveMode.Read);
+        using var input = zip.GetEntry("word/document.xml")!.Open();
+        var texts = XDocument.Load(input).Descendants(W.t).ToArray();
+        var ordinal = Array.FindIndex(texts, t => t.Value.Length >= 4);
+        Assert.True(ordinal >= 0);
+        var first = await history.CreateVersionAsync("doc", "initial", null, bytes, HistoryArchiveFixture.Metadata("initial"));
+        var request = new DocxOperationRequest
+        {
+            RequestId = "text-a", Base = first.Head, Kind = "text", Metadata = HistoryArchiveFixture.Metadata("a"),
+            Text = new DocxTextSplice("/word/document.xml", ordinal, 0, 1, "X"),
+        };
+        var accepted = await history.SubmitOperationAsync("doc", request);
+        var conflict = await history.SubmitOperationAsync("doc", request with
+        { RequestId = "text-b", Text = request.Text with { Insert = "Y" } });
+        Assert.Equal("conflict", conflict.Operation.Record.Status);
+        await HistoryArchiveGraph.LoadAsync("doc", conflict.View.Head, blobs);
+        var selected = missingMap ? accepted : conflict;
+        var wrong = await new DocxOperationStore(blobs).SaveDecisionAsync(missingMap
+            ? selected.Operation.Record with { AppliedText = null }
+            : selected.Operation.Record with { ProposedSnapshot = first.State.Snapshot }, default);
+        var state = await new HistoryRecordStore(blobs).SaveStateAsync(selected.View.State with { Operation = wrong });
+        Assert.Equal(DocxHistoryError.InvalidHistory, (await Assert.ThrowsAsync<DocxHistoryException>(async () =>
+            await HistoryArchiveGraph.LoadAsync("doc", selected.View.Head with { State = state }, blobs))).Code);
+    }
+
+    [Fact]
+    public async Task ANewPublicationCannotForgetRetryReceiptsRetainedByItsParent()
+    {
+        var fixture = await HistoryArchiveFixture.CreateAsync();
+        var state = await new HistoryRecordStore(fixture.Blobs).SaveStateAsync(fixture.Latest.State with
+        { Requests = fixture.Latest.State.Requests! with { Index = null } });
+        Assert.Equal(DocxHistoryError.InvalidHistory, (await Assert.ThrowsAsync<DocxHistoryException>(async () =>
+            await HistoryArchiveGraph.LoadAsync(HistoryArchiveFixture.Id, fixture.Latest.Head with { State = state }, fixture.Blobs))).Code);
+    }
+
+    [Fact]
+    public async Task AConflictCannotBeAcceptedAsResolvedTwice()
+    {
+        var fixture = await HistoryArchiveFixture.CreateAsync();
+        var again = await fixture.History.SubmitOperationAsync(HistoryArchiveFixture.Id, new DocxOperationRequest
+        {
+            RequestId = "resolve-again", Base = fixture.Latest.Head, Kind = "discard",
+            Resolves = fixture.Conflict.Operation.Id, Metadata = HistoryArchiveFixture.Metadata("Already resolved"),
+        });
+        Assert.Equal("AlreadyResolved", again.Operation.Record.Conflict);
+        var wrong = await new DocxOperationStore(fixture.Blobs).SaveDecisionAsync(again.Operation.Record with
+        { Status = "accepted", Conflict = null }, default);
+        var state = await new HistoryRecordStore(fixture.Blobs).SaveStateAsync(again.View.State with { Operation = wrong });
+        Assert.Equal(DocxHistoryError.InvalidHistory, (await Assert.ThrowsAsync<DocxHistoryException>(async () =>
+            await HistoryArchiveGraph.LoadAsync(HistoryArchiveFixture.Id, again.View.Head with { State = state }, fixture.Blobs))).Code);
+    }
+
+    [Fact]
+    public async Task PersistentReceiptDAGIsReadOncePerNodeNotOncePerHistoricalRoot()
+    {
+        var blobs = new MemoryHistoryBlobStore(); var history = new DocxVersionHistory(blobs, new MemoryHistoryHeadStore());
+        var bytes = DocxSession.CreateBlankDocxBytes(); DocxHistoryView? current = null;
+        for (var i = 0; i < 96; i++) current = await history.CreateVersionAsync("doc", $"request-{i}", current?.Head,
+            bytes, HistoryArchiveFixture.Metadata($"version-{i}"));
+        var counting = new CountingBlobs(blobs);
+        var graph = await HistoryArchiveGraph.LoadAsync("doc", current!.Head, counting);
+        Assert.Equal(graph.Inventory.Count, counting.Reads.Count);
+        Assert.All(counting.Reads.Values, count => Assert.Equal(1, count));
+    }
+
+    [Fact]
+    public async Task RestoreMayRetainASameDocumentVersionFromADifferentInitialBranch()
+    {
+        var blobs = new MemoryHistoryBlobStore();
+        var left = new DocxVersionHistory(blobs, new MemoryHistoryHeadStore());
+        var right = new DocxVersionHistory(blobs, new MemoryHistoryHeadStore());
+        var bytes = DocxSession.CreateBlankDocxBytes();
+        var a = await left.CreateVersionAsync("doc", null, bytes, HistoryArchiveFixture.Metadata("a"));
+        var source = File.ReadAllBytes("../../../../TestFiles/VP/VP004-Legal-Contract.docx");
+        var b = await right.CreateVersionAsync("doc", null, source, HistoryArchiveFixture.Metadata("b"));
+        var restored = await left.RestoreVersionAsync("doc", a.Head, b.Version.Id, HistoryArchiveFixture.Metadata("restore b"));
+        var graph = await HistoryArchiveGraph.LoadAsync("doc", restored.Head, blobs);
+        Assert.Contains(b.Version.Id, graph.Inventory);
+        Assert.Contains(b.State.Snapshot.Blob, graph.Inventory);
+        Assert.DoesNotContain(b.Head.State, graph.Inventory);
+        Assert.Equal(a.State.InitialSnapshot, graph.View.State.InitialSnapshot);
+        Assert.Equal(b.Version.Id, graph.View.Version.Record.RestoredFrom);
+    }
+
+    internal sealed class PinnedHead(HistoryHead head) : IHistoryHeadStore
+    {
+        public ValueTask<HistoryHead?> ReadAsync(string documentId, CancellationToken cancellationToken = default) => ValueTask.FromResult<HistoryHead?>(head);
+        public ValueTask<HistoryHead?> TryAdvanceAsync(string documentId, HistoryHead? expected, HistoryBlobReference state,
+            CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+    private sealed class CountingBlobs(IHistoryBlobStore inner) : IHistoryBlobStore
+    {
+        internal Dictionary<HistoryBlobReference, int> Reads { get; } = new();
+        public ValueTask PutAsync(HistoryBlobReference reference, Stream content, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public ValueTask<Stream?> OpenReadAsync(HistoryBlobReference reference, CancellationToken cancellationToken = default)
+        { Reads[reference] = Reads.GetValueOrDefault(reference) + 1; return inner.OpenReadAsync(reference, cancellationToken); }
+    }
+    private sealed class ReplacedBlob(IHistoryBlobStore inner, HistoryBlobReference target, byte[]? replacement) : IHistoryBlobStore
+    {
+        public ValueTask PutAsync(HistoryBlobReference reference, Stream content, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public ValueTask<Stream?> OpenReadAsync(HistoryBlobReference reference, CancellationToken cancellationToken = default) => reference == target
+            ? ValueTask.FromResult<Stream?>(replacement is null ? null : new MemoryStream(replacement, false))
+            : inner.OpenReadAsync(reference, cancellationToken);
+    }
+}
+
+internal sealed record HistoryArchiveFixture(MemoryHistoryBlobStore Blobs, DocxVersionHistory History,
+    byte[] Original, byte[] Proposal, DocxHistoryView Initial, DocxHistoryView Latest,
+    DocxOperationResult Conflict, DocxHistoryView Unrelated, HistoryBlobReference Sentinel)
+{
+    internal const string Id = "matter-nvca-charter";
+    internal static DocxVersionMetadata Metadata(string label) => new()
+    {
+        Author = "Archive test counsel", CreatedAt = new DateTimeOffset(2026, 8, 15, 10, 0, 0, TimeSpan.FromHours(-5)),
+        Label = label, ApplicationMetadata = new Dictionary<string, string> { ["matter"] = "NVCA charter" },
+    };
+    internal static async Task<HistoryArchiveFixture> CreateAsync()
+    {
+        var original = File.ReadAllBytes("../../../../TestFiles/NVCA-Model-COI.docx");
+        var blobs = new MemoryHistoryBlobStore(); var history = new DocxVersionHistory(blobs, new MemoryHistoryHeadStore());
+        var initial = await history.CreateVersionAsync(Id, "initial", null, original, Metadata("Original charter"));
+        var named = await history.CreateVersionAsync(Id, "named", initial.Head, original, Metadata("Partner review"));
+        var edited = await history.CreateVersionAsync(Id, "edited", named.Head, Edit(original, " Counsel revision"), Metadata("Revised charter"));
+        var restored = await history.RestoreVersionAsync(Id, "restore", edited.Head, initial.Version.Id, Metadata("Restore original"));
+        var request = new DocxOperationRequest { RequestId = "counsel-a", Base = restored.Head, Kind = "package", Metadata = Metadata("Counsel A") };
+        await history.SubmitOperationAsync(Id, request, Edit(original, " Counsel A"));
+        var proposal = Edit(original, " Counsel B");
+        var conflict = await history.SubmitOperationAsync(Id, request with { RequestId = "counsel-b", Metadata = Metadata("Counsel B") }, proposal);
+        Assert.Equal("conflict", conflict.Operation.Record.Status);
+        var discarded = await history.SubmitOperationAsync(Id, new DocxOperationRequest
+        {
+            RequestId = "discard-b", Base = conflict.View.Head, Kind = "discard", Resolves = conflict.Operation.Id,
+            Metadata = Metadata("Keep counsel A"),
+        });
+        var latest = await history.CreateVersionAsync(Id, "final-label", discarded.View.Head,
+            await history.ExportVersionAsync(Id, discarded.View.Version.Id), Metadata("Approved"));
+        var unrelated = await history.CreateVersionAsync("unrelated-client", null, Edit(original, " Confidential unrelated client"), Metadata("PRIVATE"));
+        var sentinel = await HistoryBlobIO.PutBytesAsync(blobs, Encoding.UTF8.GetBytes("Unreferenced private data"), default);
+        return new(blobs, history, original, proposal, initial, latest, conflict, unrelated, sentinel);
+    }
+    internal static byte[] Edit(byte[] original, string suffix)
+    {
+        using var output = new MemoryStream(); output.Write(original);
+        using (var zip = new ZipArchive(output, ZipArchiveMode.Update, leaveOpen: true))
+        {
+            var entry = zip.GetEntry("word/document.xml")!;
+            XDocument document;
+            using (var source = entry.Open()) document = XDocument.Load(source, LoadOptions.PreserveWhitespace);
+            var text = document.Descendants(W.t).First(t => !string.IsNullOrWhiteSpace(t.Value));
+            text.Value += suffix;
+            entry.Delete();
+            using var destination = zip.CreateEntry("word/document.xml").Open(); document.Save(destination, SaveOptions.DisableFormatting);
+        }
+        return output.ToArray();
+    }
+}

--- a/Docxodus/History/DocxHistoryArchiveLimits.cs
+++ b/Docxodus/History/DocxHistoryArchiveLimits.cs
@@ -1,0 +1,28 @@
+// Copyright (c) John Scrudato IV. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Docxodus.History;
+
+/// <summary>Explicit archive resource budgets; hosts may choose smaller limits for untrusted uploads.</summary>
+public sealed record DocxHistoryArchiveLimits
+{
+    public long MaxArchiveBytes { get; init; } = 1024L * 1024 * 1024;
+    public long MaxTotalBlobBytes { get; init; } = 1024L * 1024 * 1024;
+    public long MaxMetadataBytes { get; init; } = 64L * 1024 * 1024;
+    /// <summary>Total raw bytes visited during validation, including repeated reads for effect verification.</summary>
+    public long MaxValidationBytes { get; init; } = 4L * 1024 * 1024 * 1024;
+    /// <summary>Conservative aggregate package-expansion work allowance, reserved before repeated package processing.</summary>
+    public long MaxExpandedBytes { get; init; } = 32L * 1024 * 1024 * 1024;
+    public int MaxBlobs { get; init; } = 100_000;
+    public int MaxEdges { get; init; } = 1_000_000;
+    public int MaxManifestBytes { get; init; } = 16 * 1024 * 1024;
+    public int MaxBlobBytes { get; init; } = HistoryBlobIO.DefaultMaxBlobBytes;
+    public int MaxRecordBytes { get; init; } = HistoryRecordStore.DefaultMaxRecordBytes;
+
+    internal void Validate()
+    {
+        if (MaxArchiveBytes <= 0 || MaxTotalBlobBytes <= 0 || MaxMetadataBytes <= 0 || MaxValidationBytes <= 0 || MaxExpandedBytes <= 0
+            || MaxBlobs <= 0 || MaxEdges <= 0 || MaxManifestBytes <= 0 || MaxBlobBytes <= 0 || MaxRecordBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(DocxHistoryArchiveLimits), "Archive limits must be positive.");
+    }
+}

--- a/Docxodus/History/DocxSnapshotStore.cs
+++ b/Docxodus/History/DocxSnapshotStore.cs
@@ -80,7 +80,7 @@ public sealed class DocxSnapshotStore
         return DocxDiff.CreateComparison(new WmlDocument("before.docx", left), new WmlDocument("after.docx", right), settings);
     }
 
-    private PackageManifest Inspect(byte[] bytes)
+    internal PackageManifest Inspect(byte[] bytes)
     {
         var manifest = PackageManifestGenerator.Generate(bytes, _packageOptions);
         if (!manifest.IsValid || manifest.PackageKind != "opc" || manifest.Facts.MainDocumentUri is null

--- a/Docxodus/History/DocxVersionHistory.Updates.cs
+++ b/Docxodus/History/DocxVersionHistory.Updates.cs
@@ -119,7 +119,7 @@ public sealed partial class DocxVersionHistory
         return new DocxHistoryUpdate(after, current, entries.AsReadOnly(), current.State.Epoch != previous.State.Epoch);
     }
 
-    private static void ValidatePublicationEdge(DocxHistoryView child, DocxHistoryView parent)
+    internal static void ValidatePublicationEdge(DocxHistoryView child, DocxHistoryView parent)
     {
         Consistent(child.State.InitialSnapshot == parent.State.InitialSnapshot
             && child.State.Sequence >= parent.State.Sequence && child.State.Sequence - parent.State.Sequence <= 1

--- a/Docxodus/History/HistoryArchiveGraph.cs
+++ b/Docxodus/History/HistoryArchiveGraph.cs
@@ -1,0 +1,532 @@
+// Copyright (c) John Scrudato IV. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO.Compression;
+using Docxodus.Verification;
+
+namespace Docxodus.History;
+
+/// <summary>
+/// Typed closure of ONE captured head. Never enumerates a store and never treats arbitrary
+/// metadata/digest strings as references. Caches records, not snapshot/payload byte arrays.
+/// </summary>
+internal sealed class HistoryArchiveGraph
+{
+    private enum Role { State, Version, Commit, Index, Decision, Input, Contribution, Snapshot, Payload }
+    private readonly string _documentId;
+    private readonly HistoryHead _head;
+    private readonly IHistoryBlobStore _blobs;
+    private readonly DocxHistoryArchiveLimits _limits;
+    private readonly PackageManifestOptions? _packageOptions;
+    private readonly HistoryRecordStore _records;
+    private readonly HistoryRequestJournalStore _requests;
+    private readonly DocxOperationStore _operations;
+    private readonly Dictionary<string, HistoryBlobReference> _inventory = new(StringComparer.Ordinal);
+    private readonly HashSet<(HistoryBlobReference, Role)> _visited = new();
+    private readonly Queue<(HistoryBlobReference Reference, Role Role)> _pending = new();
+    private readonly HashSet<HistoryHead> _heads = new();
+    private readonly Dictionary<HistoryBlobReference, DocxHistoryStateRecord> _states = new();
+    private readonly Dictionary<HistoryBlobReference, DocxVersionRecord> _versions = new();
+    private readonly Dictionary<HistoryBlobReference, PackageHistoryCommitRecord> _commits = new();
+    private readonly Dictionary<HistoryBlobReference, HistoryRequestIndexNode> _indexes = new();
+    private readonly Dictionary<HistoryBlobReference, DocxOperationRecord> _decisions = new();
+    private readonly Dictionary<HistoryBlobReference, DocxOperationInput> _inputs = new();
+    private readonly Dictionary<HistoryBlobReference, PackageChangeSetCodec.Manifest> _contributions = new();
+    private readonly Dictionary<HistoryBlobReference, VerificationDigest?> _snapshotDigests = new();
+    private readonly Dictionary<HistoryBlobReference, long> _snapshotSizes = new();
+    private long _totalBytes, _metadataBytes, _validationBytes, _expandedBytes;
+    private int _edges;
+
+    private HistoryArchiveGraph(string documentId, HistoryHead head, IHistoryBlobStore blobs,
+        DocxHistoryArchiveLimits limits, PackageManifestOptions? packageOptions)
+    {
+        HistoryHeadCodec.Key(documentId); limits.Validate();
+        _documentId = documentId; _head = head; _blobs = blobs; _limits = limits; _packageOptions = packageOptions;
+        _records = new HistoryRecordStore(blobs, limits.MaxRecordBytes);
+        _requests = new HistoryRequestJournalStore(blobs); _operations = new DocxOperationStore(blobs);
+    }
+
+    internal DocxHistoryView View => ViewAt(_head);
+    internal IReadOnlyList<HistoryBlobReference> Inventory => Array.AsReadOnly(_inventory.Values
+        .OrderBy(r => r.Digest.Value, StringComparer.Ordinal).ToArray());
+
+    internal static async ValueTask<HistoryArchiveGraph> LoadAsync(string documentId, HistoryHead head,
+        IHistoryBlobStore blobs, DocxHistoryArchiveLimits? limits = null,
+        PackageManifestOptions? packageOptions = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(blobs); ArgumentNullException.ThrowIfNull(head);
+        var graph = new HistoryArchiveGraph(documentId, head, blobs, limits ?? new(), packageOptions);
+        graph.Head(head);
+        await graph.VisitAsync(cancellationToken).ConfigureAwait(false);
+        graph.Validate(cancellationToken);
+        await graph.ValidateEffectsAsync(cancellationToken).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+        return graph;
+    }
+
+    private void Spend()
+    {
+        if (_edges++ >= _limits.MaxEdges) throw new DocxHistoryException(DocxHistoryError.TraversalLimit,
+            "Archive graph edge budget reached.");
+    }
+
+    private void Add(HistoryBlobReference? reference, Role role)
+    {
+        if (reference is null) return;
+        Spend();
+        HistoryBlobIO.Validate(reference, _limits.MaxBlobBytes);
+        if (_inventory.TryGetValue(reference.Digest.Value, out var known))
+            Require(known == reference, "One digest has conflicting lengths.");
+        else
+        {
+            Budget(_inventory.Count < _limits.MaxBlobs && reference.Length <= _limits.MaxTotalBlobBytes - _totalBytes,
+                "Archive blob inventory exceeds its budget.");
+            _totalBytes += reference.Length; _inventory.Add(reference.Digest.Value, reference);
+        }
+        if (!_visited.Add((reference, role))) return;
+        if (role is not (Role.Payload or Role.Snapshot))
+        {
+            Budget(reference.Length <= _limits.MaxMetadataBytes - _metadataBytes, "Archive metadata exceeds its budget.");
+            _metadataBytes += reference.Length;
+        }
+        _pending.Enqueue((reference, role));
+    }
+
+    private void Head(HistoryHead? head)
+    {
+        if (head is null) return;
+        Require(head.Revision > 0 && head.Revision <= _head.Revision, "Invalid referenced publication revision.");
+        Add(head.State, Role.State); _heads.Add(head);
+    }
+
+    private void Snapshot(DocxSnapshotReference snapshot)
+    {
+        HistoryBlobIO.Validate(new HistoryBlobReference(snapshot.ContentDigest, 0), 0);
+        if (_snapshotDigests.TryGetValue(snapshot.Blob, out var known) && known is not null)
+            Require(known == snapshot.ContentDigest, "One snapshot has conflicting OPC content digests.");
+        _snapshotDigests[snapshot.Blob] = snapshot.ContentDigest;
+        Add(snapshot.Blob, Role.Snapshot);
+    }
+
+    private void SameDocument(string actual)
+    {
+        if (_documentId != actual) throw new DocxHistoryException(DocxHistoryError.ForeignDocument,
+            "Archive graph crosses document identity.");
+    }
+
+    private async ValueTask VisitAsync(CancellationToken ct)
+    {
+        while (_pending.TryDequeue(out var item))
+        {
+            ct.ThrowIfCancellationRequested();
+            var r = item.Reference;
+            ChargeRead(r.Length);
+            switch (item.Role)
+            {
+                case Role.State:
+                    var s = await _records.LoadStateAsync(r, ct).ConfigureAwait(false);
+                    SameDocument(s.DocumentId); _states.Add(r, s);
+                    Head(s.ParentPublication); Add(s.Version, Role.Version); Add(s.Commit, Role.Commit);
+                    Add(s.Operation, Role.Decision); Add(s.Requests?.Index, Role.Index);
+                    Snapshot(s.InitialSnapshot); Snapshot(s.Snapshot);
+                    break;
+                case Role.Version:
+                    var v = await _records.LoadVersionAsync(r, ct).ConfigureAwait(false);
+                    SameDocument(v.DocumentId); _versions.Add(r, v);
+                    Add(v.Parent, Role.Version); Add(v.RestoredFrom, Role.Version); Snapshot(v.Snapshot);
+                    break;
+                case Role.Commit:
+                    var c = await _records.LoadCommitAsync(r, ct).ConfigureAwait(false);
+                    SameDocument(c.DocumentId); _commits.Add(r, c);
+                    Add(c.Parent, Role.Commit); Add(c.Version, Role.Version); Add(c.Contribution, Role.Contribution);
+                    Snapshot(c.Before); Snapshot(c.After);
+                    break;
+                case Role.Index:
+                    var n = await _requests.LoadAsync(_documentId, r, ct).ConfigureAwait(false);
+                    _indexes.Add(r, n); Add(n.Zero, Role.Index); Add(n.One, Role.Index); Head(n.Receipt?.Head);
+                    break;
+                case Role.Decision:
+                    var d = await _operations.LoadDecisionAsync(r, ct).ConfigureAwait(false);
+                    SameDocument(d.DocumentId); _decisions.Add(r, d);
+                    Add(d.Input, Role.Input); Add(d.Parent, Role.Decision); Head(d.Before);
+                    Add(d.Version, Role.Version); Add(d.ContentCommit, Role.Commit);
+                    Snapshot(d.ProposedSnapshot); Snapshot(d.AfterSnapshot);
+                    break;
+                case Role.Input:
+                    var input = await _operations.LoadInputAsync(r, ct).ConfigureAwait(false);
+                    SameDocument(input.DocumentId); _inputs.Add(r, input);
+                    Head(input.Request.Base); Add(input.Request.Resolves, Role.Decision);
+                    if (input.Candidate is { } candidate)
+                    {
+                        _snapshotDigests.TryAdd(candidate, null); Add(candidate, Role.Snapshot);
+                    }
+                    break;
+                case Role.Contribution:
+                    var manifest = PackageChangeSetCodec.ReadInventory(await HistoryBlobIO.ReadBytesAsync(_blobs, r,
+                        _limits.MaxManifestBytes, ct).ConfigureAwait(false), ChangeLimits());
+                    _contributions.Add(r, manifest);
+                    foreach (var payload in manifest.Payloads) Add(payload, Role.Payload);
+                    break;
+                case Role.Snapshot:
+                    var bytes = await HistoryBlobIO.ReadBytesAsync(_blobs, r, _limits.MaxBlobBytes, ct).ConfigureAwait(false);
+                    var inspected = InspectSnapshot(bytes);
+                    var digest = inspected.OrderedOpcContentDigest!;
+                    Require(_snapshotDigests[r] is null || _snapshotDigests[r] == digest, "Snapshot OPC content digest disagrees.");
+                    // Retain the inspected identity, not the potentially large package.
+                    _snapshotDigests[r] = digest;
+                    _snapshotSizes[r] = inspected.Entries.Sum(e => e.Size);
+                    break;
+                case Role.Payload:
+                    using (var content = await _blobs.OpenReadAsync(r, ct).ConfigureAwait(false))
+                    {
+                        if (content is null) throw new PackageChangeException(PackageChangeError.PayloadMissing, "Archive payload is missing.");
+                        await HistoryBlobIO.CopyVerifiedAsync(r, content, Stream.Null, ct).ConfigureAwait(false);
+                    }
+                    break;
+            }
+        }
+    }
+
+    private void Validate(CancellationToken ct)
+    {
+        // Iterative ancestry numbering detects cycles without recursion/stack exhaustion.
+        var depths = new Dictionary<HistoryBlobReference, long>();
+        foreach (var id in _versions.Keys)
+        {
+            ct.ThrowIfCancellationRequested();
+            var path = new List<HistoryBlobReference>(); var seen = new HashSet<HistoryBlobReference>();
+            HistoryBlobReference? cursor = id;
+            while (cursor is not null && !depths.ContainsKey(cursor))
+            {
+                Spend(); Require(seen.Add(cursor), "Cyclic version ancestry.");
+                path.Add(cursor); cursor = _versions[cursor].Parent;
+            }
+            var depth = cursor is null ? 0 : depths[cursor];
+            for (var i = path.Count - 1; i >= 0; i--) depths.Add(path[i], ++depth);
+        }
+        var contentVersions = new Dictionary<HistoryBlobReference, HistoryBlobReference>();
+        foreach (var (id, _) in depths.OrderBy(pair => pair.Value))
+        {
+            var v = _versions[id];
+            contentVersions.Add(id, v.Parent is not null && _versions[v.Parent].Sequence == v.Sequence
+                ? contentVersions[v.Parent] : id);
+        }
+        foreach (var v in _versions.Values)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (v.Parent is null) Require(v.Sequence == 0 && v.RestoredFrom is null, "Invalid initial version.");
+            else
+            {
+                var p = _versions[v.Parent];
+                Require(v.Sequence >= p.Sequence && v.Sequence - p.Sequence <= 1, "Discontinuous version ancestry.");
+                if (v.Sequence == p.Sequence) Require(v.RestoredFrom is null
+                    && v.Snapshot.ContentDigest == p.Snapshot.ContentDigest, "Metadata version changed content.");
+            }
+            if (v.RestoredFrom is not null) Require(_versions[v.RestoredFrom].Snapshot == v.Snapshot, "Restore target disagrees.");
+        }
+        foreach (var c in _commits.Values)
+        {
+            ct.ThrowIfCancellationRequested();
+            var v = _versions[c.Version];
+            Require(v.Sequence == c.Sequence && v.Snapshot == c.After && v.Parent is not null
+                && (v.RestoredFrom is not null) == (c.Kind == "restore"), "Commit version disagrees.");
+            var previousVersion = _versions[v.Parent!];
+            Require(previousVersion.Sequence == c.Sequence - 1 && previousVersion.Snapshot == c.Before, "Commit before-version disagrees.");
+            var previous = c.Parent is null ? null : _commits[c.Parent];
+            Require((previous?.Sequence ?? 0) == c.Sequence - 1
+                && (previous?.Epoch ?? 0) == c.Epoch - (c.Kind == "restore" ? 1 : 0)
+                && (previous is null || previous.After.ContentDigest == c.Before.ContentDigest), "Discontinuous commit ancestry.");
+            Require(previous is null || previous.Version == contentVersions[v.Parent!], "Commit ancestry follows a different version branch.");
+            if (c.Contribution is not null)
+            {
+                var effects = _contributions[c.Contribution];
+                Require(effects.Before == c.Before.ContentDigest && effects.After == c.After.ContentDigest, "Contribution endpoints disagree.");
+            }
+        }
+        // Memoized max receipt revision validates every root context without repeatedly expanding
+        // the persistent radix DAG. Every incoming branch edge is still checked individually.
+        var indexMax = new Dictionary<HistoryBlobReference, long>();
+        var indexCount = new Dictionary<HistoryBlobReference, long>();
+        foreach (var (id, node) in _indexes.OrderByDescending(pair => pair.Value.Bit))
+        {
+            ct.ThrowIfCancellationRequested();
+            if (node.Receipt is { } receipt)
+            {
+                Require(_states[receipt.Head.State].Requests?.Current == receipt.Request, "Receipt does not bind its original publication.");
+                indexMax.Add(id, receipt.Head.Revision);
+                indexCount.Add(id, 1);
+            }
+            else
+            {
+                HistoryRequestJournalStore.ValidateArchiveChild(node, _indexes[node.Zero!], false);
+                HistoryRequestJournalStore.ValidateArchiveChild(node, _indexes[node.One!], true);
+                indexMax.Add(id, Math.Max(indexMax[node.Zero!], indexMax[node.One!]));
+                indexCount.Add(id, indexCount[node.Zero!] + indexCount[node.One!]);
+            }
+        }
+        // Every leaf is unique by the validated radix prefix, points at one earlier inline
+        // identity, and is revision-bounded. Cardinality then proves each journal retains ALL
+        // known earlier identities without expanding the shared tree once per publication.
+        var expectedReceipts = new Dictionary<HistoryHead, long>();
+        var requestIds = new HashSet<string>(StringComparer.Ordinal);
+        long receiptCount = 0;
+        foreach (var head in _heads.OrderBy(h => h.Revision))
+        {
+            ct.ThrowIfCancellationRequested(); expectedReceipts.Add(head, receiptCount);
+            if (_states[head.State].Requests?.Current is { } identity)
+            {
+                Require(requestIds.Add(identity.Id), "A request identity was published more than once.");
+                receiptCount++;
+            }
+        }
+        foreach (var head in _heads)
+        {
+            ct.ThrowIfCancellationRequested();
+            var s = _states[head.State]; var v = _versions[s.Version];
+            HistoryRequestJournalStore.ValidatePublication(_documentId, head, s.Requests);
+            Require(s.Sequence < head.Revision && s.Epoch <= s.Sequence
+                && v.Snapshot == s.Snapshot && v.Sequence == s.Sequence, "Head/version position disagrees.");
+            if (s.Requests?.Index is { } index) Require(indexMax[index] < head.Revision, "Journal indexes a future receipt.");
+            Require((s.Requests?.Index is { } root ? indexCount[root] : 0) == expectedReceipts[head],
+                "Journal dropped earlier retained retry identities.");
+            if (s.Commit is { } commit)
+            {
+                var c = _commits[commit];
+                Require(c.Sequence == s.Sequence && c.Epoch == s.Epoch && c.After.ContentDigest == s.Snapshot.ContentDigest,
+                    "Head/commit position disagrees.");
+                Require(c.Version == contentVersions[s.Version], "Head commit follows a different version branch.");
+            }
+            else Require(s.Sequence == 0 && s.Epoch == 0 && s.InitialSnapshot.ContentDigest == s.Snapshot.ContentDigest,
+                "Empty content history disagrees with initial snapshot.");
+            if (s.ParentPublication is { } parent)
+            {
+                Require(parent.Revision == head.Revision - 1, "Publication parent revision disagrees.");
+                DocxVersionHistory.ValidatePublicationEdge(ViewAt(head), ViewAt(parent));
+                var before = _states[parent.State];
+                if (s.Sequence != before.Sequence)
+                {
+                    var c = _commits[s.Commit!];
+                    Require(c.Parent == before.Commit && c.Before == before.Snapshot,
+                        "Content publication does not extend its parent's commit.");
+                }
+                if (s.Operation != _states[parent.State].Operation) ValidateDecisionPublication(head, s.Operation!);
+            }
+            else Require(s.Operation is null && depths[s.Version] == head.Revision, "Legacy publication/version depth disagrees.");
+        }
+        ValidatePublishedHeads(depths, ct);
+        // Every referenced head must share the root checkpoint, including retained branches.
+        Require(_states.Values.All(s => s.InitialSnapshot == _states[_head.State].InitialSnapshot), "History has multiple initial checkpoints.");
+        foreach (var c in _commits.Values.Where(c => c.Parent is null))
+            Require(c.Before.ContentDigest == _states[_head.State].InitialSnapshot.ContentDigest, "Commit root is not the initial checkpoint.");
+        var resolved = new HashSet<HistoryBlobReference>();
+        foreach (var (id, d) in _decisions)
+        {
+            ct.ThrowIfCancellationRequested();
+            var input = _inputs[d.Input];
+            Require(DocxOperationStore.Reference(DocxOperationStore.EncodeInput(input)) == d.Input, "Noncanonical operation input.");
+            Require(input.Request.Base.Revision <= d.Before.Revision && (input.Candidate is null || input.Candidate == d.ProposedSnapshot.Blob),
+                "Operation base or preserved candidate disagrees.");
+            Require(d.Parent == _states[d.Before.State].Operation, "Decision parent disagrees with its before publication.");
+            if (d.Parent is not null) Require(_decisions[d.Parent].Revision < d.Revision, "Decision ancestry is not decreasing.");
+            if (input.Request.Resolves is { } resolves) Require(_decisions[resolves].Status == "conflict"
+                && _decisions[resolves].Revision <= input.Request.Base.Revision, "Resolution target is not an earlier conflict.");
+            if (input.Request.Resolves is { } acceptedResolution && d.Status == "accepted")
+                Require(resolved.Add(acceptedResolution), "A conflict was resolved more than once.");
+            Require(input.Request.Kind != "discard" || d.ContentCommit is null, "Discard cannot have content effects.");
+            Require(input.Request.Kind != "text" || d.ContentCommit is null || d.AppliedText is not null,
+                "Accepted text effects require their recorded text map.");
+            if (d.AppliedText is { } applied) Require(input.Request.Kind == "text" && input.Request.Text is { } original
+                && applied == original with { Offset = applied.Offset }, "Mapped text changed the original intent.");
+        }
+    }
+
+    private void ValidatePublishedHeads(Dictionary<HistoryBlobReference, long> depths, CancellationToken ct)
+    {
+        // V3 has exact publication links; V1/V2 proves ancestry through one version per
+        // publication. Receipt and operation-base heads must belong to this pinned chain,
+        // while a restored-from *version* may deliberately retain a separate branch.
+        var published = new HashSet<HistoryHead>();
+        var decisions = new HashSet<HistoryBlobReference>();
+        var anchor = _head;
+        while (_states[anchor.State].ParentPublication is { } parent)
+        {
+            ct.ThrowIfCancellationRequested(); Spend();
+            Require(published.Add(anchor), "Cyclic publication ancestry.");
+            if (_states[anchor.State].Operation != _states[parent.State].Operation)
+                decisions.Add(_states[anchor.State].Operation!);
+            anchor = parent;
+        }
+        published.Add(anchor);
+        var legacyVersions = new HashSet<HistoryBlobReference>();
+        HistoryBlobReference? cursor = _states[anchor.State].Version;
+        while (cursor is not null)
+        {
+            ct.ThrowIfCancellationRequested(); Spend();
+            legacyVersions.Add(cursor);
+            var version = _versions[cursor];
+            if (version.Parent is null) Require(version.Snapshot == _states[_head.State].InitialSnapshot,
+                "Published version root is not the initial checkpoint.");
+            cursor = version.Parent;
+        }
+        var revisions = new Dictionary<long, HistoryHead>();
+        foreach (var head in _heads)
+        {
+            ct.ThrowIfCancellationRequested();
+            Require(!revisions.TryGetValue(head.Revision, out var samePosition) || samePosition == head,
+                "Referenced publications fork at the same revision.");
+            revisions[head.Revision] = head;
+            if (published.Contains(head)) continue;
+            var state = _states[head.State];
+            Require(state.Operation is null && head.Revision < anchor.Revision && legacyVersions.Contains(state.Version)
+                && anchor.Revision - head.Revision == depths[_states[anchor.State].Version] - depths[state.Version],
+                "Referenced publication is not on the captured history chain.");
+        }
+        Require(_decisions.Keys.All(decisions.Contains), "Referenced decision was not published on the captured history chain.");
+    }
+
+    private void ValidateDecisionPublication(HistoryHead head, HistoryBlobReference id)
+    {
+        var s = _states[head.State]; var d = _decisions[id]; var input = _inputs[d.Input];
+        var before = _states[d.Before.State];
+        Require(d.Revision == head.Revision && s.ParentPublication == d.Before && s.Snapshot == d.AfterSnapshot
+            && s.Version == d.Version && s.Requests?.Current == new HistoryRequestIdentity(input.Request.RequestId, d.Input.Digest),
+            "Decision disagrees with its publication or receipt.");
+        if (d.ContentCommit is null) Require(s.Version == before.Version && s.Snapshot == before.Snapshot,
+            "Decision without effects changed the document.");
+        else
+        {
+            var c = _commits[d.ContentCommit];
+            Require(d.Status == "accepted" && s.Commit == d.ContentCommit && s.Sequence == before.Sequence + 1
+                && s.Epoch == before.Epoch && c.Kind == "import" && c.Parent == before.Commit && c.Before == before.Snapshot
+                && c.After == s.Snapshot && c.Version == s.Version, "Decision content effects disagree.");
+        }
+    }
+
+    private async ValueTask ValidateEffectsAsync(CancellationToken ct)
+    {
+        // Derive the actual entry delta from the exact endpoints and compare the complete
+        // recorded footprint. Payload bytes were independently hash-verified during traversal.
+        // This proves forward/inverse replay without allocating a reconstructed ZIP from
+        // untrusted effects. Only one pair of snapshots is held at a time.
+        foreach (var c in _commits.Values.Where(c => c.Contribution is not null))
+        {
+            ct.ThrowIfCancellationRequested(); Spend();
+            var inventory = _contributions[c.Contribution!];
+            var before = await ReadInspectedSnapshotAsync(c.Before, ct).ConfigureAwait(false);
+            var after = await ReadInspectedSnapshotAsync(c.After, ct).ConfigureAwait(false);
+            Require(EntryDelta(before, after).SequenceEqual(inventory.Changes.OrderBy(c => c.Uri, StringComparer.Ordinal)),
+                "Recorded contribution is not the exact endpoint entry delta.");
+        }
+        foreach (var d in _decisions.Values.Where(d => d.AppliedText is not null))
+        {
+            ct.ThrowIfCancellationRequested(); Spend();
+            var beforeRef = _states[d.Before.State].Snapshot;
+            var before = await ReadSnapshotAsync(beforeRef, ct).ConfigureAwait(false);
+            ReserveTextWork(beforeRef, d.AppliedText!);
+            var after = DocxOperationPackage.ApplyText(before, d.AppliedText!, _packageOptions);
+            Require(InspectSnapshot(after).OrderedOpcContentDigest == d.AfterSnapshot.ContentDigest,
+                "Recorded text map does not describe the accepted effects.");
+        }
+        foreach (var d in _decisions.Values)
+        {
+            ct.ThrowIfCancellationRequested(); Spend();
+            var request = _inputs[d.Input].Request; var baseline = _states[request.Base.State].Snapshot;
+            if (request.Kind == "discard") Require(d.ProposedSnapshot == baseline, "Discard proposal is not its base snapshot.");
+            if (request.Kind != "text") continue;
+            var before = await ReadSnapshotAsync(baseline, ct).ConfigureAwait(false);
+            ReserveTextWork(baseline, request.Text!);
+            var proposed = DocxOperationPackage.ApplyText(before, request.Text!, _packageOptions);
+            Require(InspectSnapshot(proposed).OrderedOpcContentDigest == d.ProposedSnapshot.ContentDigest,
+                "Preserved proposal does not represent the original text intent.");
+        }
+    }
+
+    private async ValueTask<byte[]> ReadSnapshotAsync(DocxSnapshotReference snapshot, CancellationToken ct)
+        => (await ReadInspectedSnapshotAsync(snapshot, ct).ConfigureAwait(false)).Bytes;
+
+    private async ValueTask<(byte[] Bytes, PackageManifest Manifest)> ReadInspectedSnapshotAsync(
+        DocxSnapshotReference snapshot, CancellationToken ct)
+    {
+        ChargeRead(snapshot.Blob.Length);
+        var bytes = await HistoryBlobIO.ReadBytesAsync(_blobs, snapshot.Blob, _limits.MaxBlobBytes, ct).ConfigureAwait(false);
+        var manifest = InspectSnapshot(bytes);
+        Require(manifest.OrderedOpcContentDigest == snapshot.ContentDigest, "Snapshot OPC identity changed.");
+        return (bytes, manifest);
+    }
+
+    private static IEnumerable<PackageEntryChange> EntryDelta((byte[] Bytes, PackageManifest Manifest) before,
+        (byte[] Bytes, PackageManifest Manifest) after)
+    {
+        // Entry names are ZIP metadata. Do not use PackageChangeSet.Create: it would retain
+        // all changed uncompressed payloads before checking the hostile contribution inventory.
+        var leftNames = EntryNames(before.Bytes); var rightNames = EntryNames(after.Bytes);
+        var left = before.Manifest.Entries.ToDictionary(e => e.Uri, StringComparer.Ordinal);
+        var right = after.Manifest.Entries.ToDictionary(e => e.Uri, StringComparer.Ordinal);
+        foreach (var uri in left.Keys.Union(right.Keys, StringComparer.Ordinal).OrderBy(uri => uri, StringComparer.Ordinal))
+        {
+            left.TryGetValue(uri, out var a); right.TryGetValue(uri, out var b);
+            if (a?.RawBytesDigest == b?.RawBytesDigest) continue;
+            yield return new PackageEntryChange(uri, a is null ? null : leftNames[uri], a?.RawBytesDigest,
+                b is null ? null : rightNames[uri], b?.RawBytesDigest);
+        }
+    }
+
+    private static Dictionary<string, string> EntryNames(byte[] bytes)
+    {
+        using var zip = new ZipArchive(new MemoryStream(bytes, writable: false), ZipArchiveMode.Read);
+        return zip.Entries.ToDictionary(e =>
+        {
+            Require(PackageManifestGenerator.TryCanonicalizeEntryName(e.FullName, out var uri), "Invalid OPC entry name.");
+            return uri;
+        }, e => e.FullName, StringComparer.Ordinal);
+    }
+
+    private PackageManifest InspectSnapshot(byte[] bytes)
+    {
+        // The inspector enforces this remaining allowance BEFORE inflating package entries.
+        // Eight passes conservatively covers inspection's XML/facts reads and hashing.
+        var remaining = (_limits.MaxExpandedBytes - _expandedBytes) / 8;
+        Budget(remaining > 0, "Archive package-expansion budget reached.");
+        var options = _packageOptions ?? new PackageManifestOptions();
+        var manifest = new DocxSnapshotStore(_blobs, _limits.MaxBlobBytes, options with
+        {
+            MaxTotalUncompressedBytes = Math.Min(options.MaxTotalUncompressedBytes, remaining),
+            MaxEntryUncompressedBytes = Math.Min(options.MaxEntryUncompressedBytes, remaining),
+        }).Inspect(bytes);
+        ChargeExpanded(8 * manifest.Entries.Sum(e => e.Size));
+        return manifest;
+    }
+
+    private void ReserveTextWork(DocxSnapshotReference before, DocxTextSplice text) =>
+        // Includes input inspection, entry copies, XML escaping/serialization and output
+        // construction. Output inspection separately reserves its own remaining allowance.
+        ChargeExpanded(8 * (6 * _snapshotSizes[before.Blob] + 6L * text.Insert.Length + 1024));
+
+    private void ChargeExpanded(long bytes)
+    {
+        Budget(bytes <= _limits.MaxExpandedBytes - _expandedBytes, "Archive package-expansion budget reached.");
+        _expandedBytes += bytes;
+    }
+
+    private PackageChangeLimits ChangeLimits() => new()
+    {
+        MaxManifestBytes = _limits.MaxManifestBytes, MaxPayloadBytes = _limits.MaxBlobBytes,
+        MaxTotalPayloadBytes = Math.Min(_limits.MaxTotalBlobBytes, 512L * 1024 * 1024),
+    };
+
+    private void ChargeRead(long bytes)
+    {
+        Budget(bytes <= _limits.MaxValidationBytes - _validationBytes, "Archive validation work exceeds its byte budget.");
+        _validationBytes += bytes;
+    }
+
+    private DocxHistoryView ViewAt(HistoryHead head)
+    {
+        var state = _states[head.State];
+        return new(head, state, new(state.Version, _versions[state.Version]));
+    }
+    private static void Require(bool condition, string message)
+    { if (!condition) throw new DocxHistoryException(DocxHistoryError.InvalidHistory, message); }
+    private static void Budget(bool condition, string message)
+    { if (!condition) throw new PackageChangeException(PackageChangeError.ResourceLimit, message); }
+}

--- a/Docxodus/History/HistoryRequestJournal.cs
+++ b/Docxodus/History/HistoryRequestJournal.cs
@@ -167,7 +167,7 @@ public sealed class HistoryRequestJournalStore
         }
     }
 
-    private async ValueTask<HistoryRequestIndexNode> LoadAsync(string documentId, HistoryBlobReference reference,
+    internal async ValueTask<HistoryRequestIndexNode> LoadAsync(string documentId, HistoryBlobReference reference,
         CancellationToken cancellationToken)
     {
         HistoryBlobIO.Validate(reference, MaxNodeBytes);
@@ -257,6 +257,13 @@ public sealed class HistoryRequestJournalStore
         if (parent is null) return;
         Require(child.Bit > parent.Bit && PrefixMatches(child.Key, parent.Key, parent.Bit)
             && Bit(child.Key, parent.Bit) == Bit(key, parent.Bit), "Request-index path is inconsistent or cyclic.");
+    }
+
+    // Archive validation visits BOTH sides, not merely one request's lookup path.
+    internal static void ValidateArchiveChild(HistoryRequestIndexNode parent, HistoryRequestIndexNode child, bool one)
+    {
+        Require(child.Bit > parent.Bit && PrefixMatches(child.Key, parent.Key, parent.Bit)
+            && Bit(child.Key, parent.Bit) == one, "Request-index branch is inconsistent or cyclic.");
     }
 
     private static void Match(HistoryRequestIdentity stored, HistoryRequestIdentity requested)

--- a/Docxodus/History/PackageChangeSetCodec.cs
+++ b/Docxodus/History/PackageChangeSetCodec.cs
@@ -130,8 +130,16 @@ public static class PackageChangeSetCodec
         return bytes;
     }
 
-    private sealed record Manifest(VerificationDigest Before, VerificationDigest After,
+    internal sealed record Manifest(VerificationDigest Before, VerificationDigest After,
         IReadOnlyList<PackageEntryChange> Changes, IReadOnlyList<HistoryBlobReference> Payloads);
+
+    // Typed inventory without buffering all payloads. Uses the same strict codec as replay.
+    internal static Manifest ReadInventory(byte[] bytes, PackageChangeLimits limits)
+    {
+        limits.Validate();
+        Budget(bytes.Length <= limits.MaxManifestBytes, "Manifest exceeds the byte limit.");
+        return Parse(bytes, limits);
+    }
 
     private static Manifest Parse(byte[] bytes, PackageChangeLimits limits)
     {

--- a/docs/architecture/portable_history.md
+++ b/docs/architecture/portable_history.md
@@ -1,0 +1,56 @@
+# Portable document history
+
+The host owns everyday persistence. Users open a document, save checkpoints, browse
+versions, compare any pair, restore, and download files without managing store directories.
+
+Two explicit exports prevent accidental draft disclosure:
+
+- `.docx`: one exact selected snapshot; no external history is embedded.
+- `.docxhistory`: one captured document head and its complete referenced history.
+
+The archive is a versioned ZIP, not a dump of the host's storage directory. Typed
+references select snapshots, versions, package effects, retry receipts, original
+publication states, and backend decisions/proposals. Unrelated documents and
+unreferenced blobs are excluded. IDs and snapshot bytes survive unchanged.
+
+Opening an archive is read-only and validates the bounded graph. Import validates
+before publication, writes immutable blobs, then atomically initializes an absent
+head with its **original revision**. Existing different histories are never
+overwritten. Identical imports are idempotent. Import requires an additive
+absent-only initialization capability; ordinary head CAS semantics do not change.
+
+Implementation/review groups:
+
+1. Bounded typed graph traversal and validation.
+2. Stream archive export and read-only opening; strict format and hostile-file tests.
+3. Safe writable import and document-scoped native API.
+4. Client bindings and a concise frontend controls guide.
+5. Real DOCX/file lifecycle and failure/recovery verification.
+
+Each group gets a separate stacked PR and adversarial 5.6-sol review/revision.
+Tests must exercise real legal documents, actual archive and snapshot files,
+reopening with fresh stores, arbitrary comparison, restore, continued saves,
+receipt retries, unrelated-data exclusion, malformed input, concurrent changes,
+and failures before/after publication. Test artifacts and reproduction commands
+will be documented; transient unit-test files alone are not the completion gate.
+
+No GUI, transport, background recorder, implicit checkpoint, distributed filesystem
+guarantee, or automatic retention policy is added. Archive integrity is not
+authentication: the host still owns access control and trust/provenance policy.
+
+## Graph validation
+
+The internal graph reader accepts a pinned head, not a mutable head store. It verifies
+every typed record once, checks each incoming edge, and streams payload hash checks.
+Radix subtree receipt counts and maximum revisions prove receipt retention without
+re-expanding shared trees per publication. Referenced publication heads must be on the
+captured chain; a restore target may retain another same-document version branch.
+
+Effects are checked against exact endpoint entry names/digests, without materializing
+changed payloads or constructing a ZIP from untrusted effects. Original text proposals
+and accepted maps are checked separately. Snapshot buffers are transient; graph metadata,
+blobs, edges, raw validation reads, and conservative package-expansion work have distinct
+limits. Expansion work is charged with conservative multipliers, so the allowance is
+not a promise that an archive of that size will open. Package-level ZIP/XML limits also
+apply. This proves bounded structural/content consistency, not authorship or trust in
+host timestamps and metadata.

--- a/docs/architecture/portable_history.md
+++ b/docs/architecture/portable_history.md
@@ -54,3 +54,10 @@ limits. Expansion work is charged with conservative multipliers, so the allowanc
 not a promise that an archive of that size will open. Package-level ZIP/XML limits also
 apply. This proves bounded structural/content consistency, not authorship or trust in
 host timestamps and metadata.
+
+Archive validation is **not a backend decision-policy audit**. It retains acceptance
+statuses, conflict reasons, and chosen text-map offsets; it does not re-adjudicate
+those choices by rerunning reconciliation. A verified contribution proves its recorded
+before/after content, not that accepting that contribution was the right response to
+an operation proposal. The authoritative backend owns that decision. Opening a history
+file must not reinterpret recorded outcomes using a newer conflict policy.


### PR DESCRIPTION
## Why

A portable history file must contain one document's complete referenced history, not a dump of a shared store. Its reader must reject broken history before import can publish anything.

## Change

- Add an internal, bounded graph reader rooted at one captured head. Preserve exact snapshot/record identities, retry receipts, effects, restore branches, and operation proposals; never enumerate storage.
- Validate ancestry, receipt retention, both radix branches, actual endpoint deltas, and original/mapped text intent. Keep large payloads out of the metadata cache.
- Exercise real NVCA and legal-contract documents, isolated reopening/replay, missing/corrupt data, forged edges, resource limits, and shared-graph scaling.

This is the first foundation PR. ZIP files, safe writable import, document-scoped APIs, client bindings, concise frontend docs, and committed archive artifacts follow in the stack. No GUI or transport.

Validation establishes referential and recorded-content integrity, not authentication or an independent audit of the backend's acceptance/conflict policy. Recorded outcomes are preserved, not re-adjudicated.

## Validation

Focused graph and affected snapshot/codec/journal/update regressions: 50 tests passed. Adversarial 5.6-sol review drove revisions for proposal integrity, retained-branch compatibility, receipt loss, forked commit tips, duplicate resolutions, and peak-memory bounds.
