### PR TITLE
test: enforce the copyright and nullable rules #728 documented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ tools/mcp-server/smoke/__pycache__/
 /.playwright-mcp/
 /observatory-960-live.png
 /python/uv.lock
+/.claude/scheduled_tasks.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,12 @@ All notable changes to this project will be documented in this file.
   derivatives of an original file (`DocumentBuilder.cs`, `PtOpenXmlUtil.cs`, `WmlToHtmlConverter.cs`,
   and the like, plus their like-named tests) keep the Microsoft notice, matching the repository
   `LICENSE`, which has always credited both; everything else now reads
-  `// Copyright (c) John Scrudato IV. All rights reserved.` CLAUDE.md documents the rule and the
-  keep-list so it isn't reintroduced.
+  `// Copyright (c) John Scrudato IV. All rights reserved.` `SourceFileCopyrightTests` asserts the
+  keep-list in both directions, so neither reintroducing the Microsoft header on new source nor
+  stripping it off inherited source can pass CI. StyleCop's `SA1636` — which compared every header
+  against a single configured company name, and so could only ever be right about one of this
+  repository's two copyright holders — is switched off in its favour, taking the build's warning
+  baseline from 187/804 down to 175/671.
 
 - The editor's find bar no longer loses the keyboard the moment a query matches. It re-scanned on
   every keystroke and then *selected* the first hit, and selecting inside a contenteditable block

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,31 +18,25 @@ duplicated description is one that will go stale.
   jargon a reader outside the change wouldn't recognize — a reviewer who hasn't read the
   code should be able to follow the description on its own.
 - **Never put a Microsoft copyright header on a new file.** `// Copyright (c) Microsoft. All
-  rights reserved.` belongs only on the ~40 files that are genuine derivatives of the original
-  Microsoft `OpenXmlPowerTools` source: `ColorParser.cs`, `DocumentBuilder.cs`,
-  `FieldRetriever.cs`, `FormattingAssembler.cs`, the six `GetListItemText_*.cs` locale files,
-  `HtmlToWmlConverter.cs`, `HtmlToWmlConverterCore.cs`, `HtmlToWmlCssApplier.cs`,
-  `HtmlToWmlCssParser.cs`, `ListItemRetriever.cs`, `MarkupSimplifier.cs`, `MetricsGetter.cs`,
-  `OpenXmlRegex.cs`, `PtOpenXmlDocument.cs`, `PtOpenXmlUtil.cs`, `PtUtil.cs`,
-  `RevisionAccepter.cs`, `RevisionProcessor.cs`, `ScalarTypes.cs`, `TestUtil.cs`,
-  `UnicodeMapper.cs`, `WmlDocument.cs`, `WmlToHtmlConverter.cs`, `Properties/AssemblyInfo.cs`,
-  and their like-named test counterparts (`DocumentBuilderTests.cs`, `HtmlConverterTests.cs`,
-  `HtmlToWmlConverterTests.cs`, `HtmlToWmlReadAsXElement.cs`, `MarkupSimplifierTests.cs`,
-  `MetricsGetterTests.cs`, `OpenXmlRegexTests.cs`, `PtUtilTests.cs`, `RevisionAccepterTests.cs`,
-  `RevisionProcessorTests.cs`, `TestsBase.cs`, `UnicodeMapperTests.cs`). Everything else in this
-  repo — `DocxSession`, `History/`, `Verification/`, `Delivery/`, `Internal/`, `Ir/`, the editor,
-  the MCP server, the npm/Python/WASM layers, and every other file with no line-for-line ancestor
-  in [OfficeDev/Open-Xml-PowerTools](https://github.com/OfficeDev/Open-Xml-PowerTools) — is
-  original work and must not claim Microsoft's copyright. Give a new file no header at all, or
+  rights reserved.` belongs only on the 41 files that are genuine derivatives of the original
+  Microsoft `OpenXmlPowerTools` source — `DocumentBuilder.cs`, `PtOpenXmlUtil.cs`,
+  `WmlToHtmlConverter.cs`, the `GetListItemText_*.cs` locale files and their like-named tests
+  among them. Everything else in this repo — `DocxSession`, `History/`, `Verification/`,
+  `Delivery/`, `Internal/`, `Ir/`, the editor, the MCP server, the npm/Python/WASM layers, and
+  every other file with no ancestor in
+  [OfficeDev/Open-Xml-PowerTools](https://github.com/OfficeDev/Open-Xml-PowerTools) — is original
+  work and must not claim Microsoft's copyright. Give a new file no header at all, or
   `// Copyright (c) John Scrudato IV. All rights reserved.` if you want the same two-line
-  `SA1633`-satisfying form the rest of the library uses. This was a real bug, not a hypothetical:
-  ~195 files had the Microsoft line copy-pasted onto wholly new post-fork source before a
-  dedicated pass corrected them — don't reintroduce it on the next one.
+  `SA1633`-satisfying form the rest of the library uses. This was a real bug, not a
+  hypothetical: ~195 files had the Microsoft line copy-pasted onto wholly new post-fork source
+  before a dedicated pass corrected them. **The enforced keep-list lives in
+  `Docxodus.Tests/SourceFileCopyrightTests.cs`**, which asserts set equality in both directions
+  — edit that list, not a copy of it here, when a file's lineage genuinely changes.
 - **Never add a `#nullable enable` or `#nullable disable` directive to a file.**
   `Docxodus.csproj` already sets `<Nullable>enable</Nullable>` project-wide (see
   [Nullable Reference Types](#nullable-reference-types) below), so a per-file directive is never
   correct: `#nullable enable` is a redundant no-op and `#nullable disable` is a regression. New
-  and refactored files get neither.
+  and refactored files get neither. `SourceFileCopyrightTests` asserts the `disable` half.
 
 ## Coding Standards
 
@@ -64,8 +58,8 @@ file that could fire them.
 **`Docxodus.csproj` and `Docxodus.Tests.csproj` both override it to `false`**, so the core
 library and the test project do *not* fail on warnings. The CLI tools, MCP server,
 python-host and WASM project do inherit it. Current baseline: the library builds with
-**204 warnings**, the test project with **829** (mostly StyleCop `SA1633`/`SA1636` file
-headers and `SA1206` modifier/using order). Don't add to either baseline. Measure with
+**175 warnings**, the test project with **671** (mostly StyleCop `SA1633` missing file headers
+and `SA1206` modifier/using order). Don't add to either baseline. Measure with
 `--no-incremental` — a warm incremental build reports zero because nothing recompiles.
 
 What a new file costs depends on whether it carries a StyleCop file header. Most of the
@@ -80,8 +74,11 @@ actually add rather than assuming one apiece.
 
 Update the two numbers here in the same commit rather than leaving them stale. They had
 drifted before (113/707 described a tree ~30 warnings behind, then 175/788, then briefly
-177/791 and 184/800 while `stylecop.json` still expected Microsoft's name for files that had
-moved to John Scrudato IV's); re-measure, don't extrapolate.
+177/791 and 184/800); re-measure, don't extrapolate. The drop from 187/804 came from switching
+`SA1636` off in `rules.ruleset`: it compares every header against `stylecop.json`'s single
+`companyName`, which a repository with two legitimate copyright holders can never satisfy.
+`SourceFileCopyrightTests` enforces attribution per file instead, which is what that rule was
+failing to do.
 
 ## Repository Layout
 

--- a/Docxodus.Tests/SourceFileCopyrightTests.cs
+++ b/Docxodus.Tests/SourceFileCopyrightTests.cs
@@ -1,0 +1,142 @@
+// Copyright (c) John Scrudato IV. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+namespace Docxodus.Tests;
+
+/// <summary>
+/// Enforces the two source-hygiene rules stated in CLAUDE.md. Both were prose-only rules that a
+/// single copy-paste had already broken across ~195 files before anyone noticed, so they are
+/// asserted here rather than left to review: StyleCop cannot express either one. Its
+/// <c>SA1636</c> compares every header against a single configured company name, which a
+/// repository with two legitimate copyright holders can never satisfy — that rule is switched
+/// off in <c>rules.ruleset</c> and this class is what replaced it.
+/// </summary>
+public class SourceFileCopyrightTests
+{
+    /// <summary>
+    /// Files whose content descends from Microsoft's original OpenXmlPowerTools source and must
+    /// keep its copyright notice. Every name here exists in
+    /// <see href="https://github.com/OfficeDev/Open-Xml-PowerTools">OfficeDev/Open-Xml-PowerTools</see>;
+    /// nothing written after the fork belongs in this list.
+    /// </summary>
+    private static readonly HashSet<string> InheritedFromMicrosoft = new(StringComparer.Ordinal)
+    {
+        "Docxodus/ColorParser.cs",
+        "Docxodus/DocumentBuilder.cs",
+        "Docxodus/FieldRetriever.cs",
+        "Docxodus/FormattingAssembler.cs",
+        "Docxodus/GetListItemText_Default.cs",
+        "Docxodus/GetListItemText_fr_FR.cs",
+        "Docxodus/GetListItemText_ru_RU.cs",
+        "Docxodus/GetListItemText_sv_SE.cs",
+        "Docxodus/GetListItemText_tr_TR.cs",
+        "Docxodus/GetListItemText_zh_CN.cs",
+        "Docxodus/HtmlToWmlConverter.cs",
+        "Docxodus/HtmlToWmlConverterCore.cs",
+        "Docxodus/HtmlToWmlCssApplier.cs",
+        "Docxodus/HtmlToWmlCssParser.cs",
+        "Docxodus/ListItemRetriever.cs",
+        "Docxodus/MarkupSimplifier.cs",
+        "Docxodus/MetricsGetter.cs",
+        "Docxodus/OpenXmlRegex.cs",
+        "Docxodus/Properties/AssemblyInfo.cs",
+        "Docxodus/PtOpenXmlDocument.cs",
+        "Docxodus/PtOpenXmlUtil.cs",
+        "Docxodus/PtUtil.cs",
+        "Docxodus/RevisionAccepter.cs",
+        "Docxodus/RevisionProcessor.cs",
+        "Docxodus/ScalarTypes.cs",
+        "Docxodus/TestUtil.cs",
+        "Docxodus/UnicodeMapper.cs",
+        "Docxodus/WmlDocument.cs",
+        "Docxodus/WmlToHtmlConverter.cs",
+        "Docxodus.Tests/DocumentBuilderTests.cs",
+        "Docxodus.Tests/HtmlConverterTests.cs",
+        "Docxodus.Tests/HtmlToWmlConverterTests.cs",
+        "Docxodus.Tests/HtmlToWmlReadAsXElement.cs",
+        "Docxodus.Tests/MarkupSimplifierTests.cs",
+        "Docxodus.Tests/MetricsGetterTests.cs",
+        "Docxodus.Tests/OpenXmlRegexTests.cs",
+        "Docxodus.Tests/PtUtilTests.cs",
+        "Docxodus.Tests/RevisionAccepterTests.cs",
+        "Docxodus.Tests/RevisionProcessorTests.cs",
+        "Docxodus.Tests/TestsBase.cs",
+        "Docxodus.Tests/UnicodeMapperTests.cs",
+    };
+
+    private const string MicrosoftNotice = "// Copyright (c) Microsoft. All rights reserved.";
+    private const string ProjectNotice = "// Copyright (c) John Scrudato IV. All rights reserved.";
+    private const string LicenseNotice =
+        "// Licensed under the MIT license. See LICENSE file in the project root for full license information.";
+
+    [Fact]
+    public void OnlyFilesInheritedFromOpenXmlPowerToolsClaimMicrosoftsCopyright()
+    {
+        var claiming = SourceFiles()
+            .Where(file => Header(file.Path).Any(line => line.StartsWith("// Copyright (c) Microsoft", StringComparison.Ordinal)))
+            .Select(file => file.Relative)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+
+        // Set equality in both directions: a new post-fork file that copy-pasted the Microsoft
+        // header fails, and so does stripping the notice off genuinely inherited source.
+        Assert.Equal(InheritedFromMicrosoft.OrderBy(path => path, StringComparer.Ordinal).ToArray(), claiming);
+    }
+
+    [Fact]
+    public void EveryFileHeaderUsesOneOfTheTwoApprovedNotices()
+    {
+        foreach (var file in SourceFiles())
+        {
+            var header = Header(file.Path);
+            var copyright = header.FirstOrDefault(line => line.StartsWith("// Copyright", StringComparison.Ordinal));
+            if (copyright is null) continue; // Most of the library carries no header at all; SA1633 covers that.
+
+            var expected = InheritedFromMicrosoft.Contains(file.Relative) ? MicrosoftNotice : ProjectNotice;
+            Assert.True(copyright == expected,
+                $"{file.Relative} header reads \"{copyright}\" but must read \"{expected}\".");
+            Assert.Contains(LicenseNotice, header);
+        }
+    }
+
+    /// <summary>
+    /// CLAUDE.md forbids per-file nullable directives because Docxodus.csproj already sets
+    /// <c>&lt;Nullable&gt;enable&lt;/Nullable&gt;</c> project-wide. <c>#nullable disable</c> is the
+    /// half that is an outright regression, and issue #645 finished removing the last one.
+    /// </summary>
+    [Fact]
+    public void NoSourceFileOptsOutOfNullableReferenceTypes()
+    {
+        var disabled = SourceFiles()
+            .Where(file => File.ReadLines(file.Path)
+                .Any(line => line.TrimStart().StartsWith("#nullable disable", StringComparison.Ordinal)))
+            .Select(file => file.Relative)
+            .ToArray();
+
+        Assert.Empty(disabled);
+    }
+
+    private static string[] Header(string path) => File.ReadLines(path).Take(5).ToArray();
+
+    /// <summary>Every tracked C# file, excluding build output and the upstream clone-free tree.</summary>
+    private static IEnumerable<(string Path, string Relative)> SourceFiles()
+    {
+        var root = RepositoryRoot();
+        return Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories)
+            .Select(path => (Path: path, Relative: Path.GetRelativePath(root, path).Replace('\\', '/')))
+            .Where(file => !file.Relative.Contains("/bin/", StringComparison.Ordinal)
+                && !file.Relative.Contains("/obj/", StringComparison.Ordinal))
+            .OrderBy(file => file.Relative, StringComparer.Ordinal);
+    }
+
+    private static string RepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Docxodus.sln")))
+            directory = directory.Parent;
+        Assert.True(directory is not null, "Could not locate the repository root from " + AppContext.BaseDirectory);
+        return directory!.FullName;
+    }
+}

--- a/rules.ruleset
+++ b/rules.ruleset
@@ -92,7 +92,13 @@
     <Rule Id="SA1633" Action="Warning" />
     <Rule Id="SA1634" Action="Warning" />
     <Rule Id="SA1635" Action="Warning" />
-    <Rule Id="SA1636" Action="Warning" />
+    <!-- SA1636 compares every file header against stylecop.json's single companyName. This
+         repository has two legitimate copyright holders - Microsoft for the ~41 files inherited
+         from OpenXmlPowerTools, John Scrudato IV for everything written after the fork - so the
+         rule flags one group or the other no matter which name is configured. Attribution is
+         enforced per file by Docxodus.Tests/SourceFileCopyrightTests.cs instead, which can tell
+         the two groups apart. SA1633/SA1634/SA1635/SA1637 still require a well-formed header. -->
+    <Rule Id="SA1636" Action="None" />
     <Rule Id="SA1637" Action="Warning" />
     <Rule Id="SA1649" Action="None" />
   </Rules>


### PR DESCRIPTION
## Why

#728 corrected roughly 195 misattributed file headers, and wrote down two rules in `CLAUDE.md` so
it would not happen again: post-fork files must not claim Microsoft's copyright, and no file gets a
`#nullable disable` directive. Both rules landed as prose only.

That is the same footing the codebase was on before #728. The Microsoft header spread across
`DocxSession`, `History/`, `Verification/`, `Delivery/`, `Internal/`, `Ir/`, the editor, the MCP
server and the npm/Python/WASM layers precisely because nothing checked it — someone copied a file,
the header came along, and no build step or test noticed for however many files it took to reach
195. A rule that only a careful reader can apply will decay the same way. This PR makes both rules
executable.

## What changed

**`Docxodus.Tests/SourceFileCopyrightTests.cs`** — three assertions over every tracked `.cs` file in
the repository (build output excluded):

1. **Set equality, in both directions**, between the files whose header says
   `Copyright (c) Microsoft` and a 41-entry list of files that genuinely descend from
   OpenXmlPowerTools. A new post-fork file that copy-pastes the Microsoft header fails, and so does
   stripping the notice off a file that legitimately carries it — the second direction matters
   because the licence obligation runs that way too.
2. **Every header that exists uses one of the two approved notices verbatim**, paired with the MIT
   licence line. This catches a near-miss like a dropped `IV`, which a substring check would let
   through.
3. **No file reintroduces `#nullable disable`**, the other rule #728 added. (`#nullable enable` is
   redundant rather than wrong, and ~150 files still have one, so that half stays documentation-only
   until someone does the cleanup.)

I verified each assertion **fails** on a deliberately broken tree — a Microsoft header pasted onto
`Docxodus/PageMap.cs` and a `#nullable disable` inserted into `Docxodus/DocxSession.cs` — before
committing, so these are not three tests that pass because they check nothing.

**`rules.ruleset`: `SA1636` switched off.** #728 also flipped `stylecop.json`'s `companyName` to
`John Scrudato IV`, which moved the warning baseline from 187/804 to 204/829 — against `CLAUDE.md`'s
own "don't add to either baseline". The cause is structural, not an oversight: `SA1636` compares
every file header against the single configured company name, and this repository has two legitimate
copyright holders. Whichever name is configured, the other group's 41 files are flagged. The rule
cannot be satisfied here, and it cannot distinguish the two groups, which is exactly the distinction
that needed enforcing. It is switched off with that reasoning recorded inline, and the new test does
the job properly. `SA1633`/`SA1634`/`SA1635`/`SA1637` still require a well-formed header.

Re-measured non-incrementally against this branch: **library 175, tests 671** — below the 187/804
this started from. `CLAUDE.md` and the `CHANGELOG.md` entry are updated to match.

**Smaller items.** `.claude/scheduled_tasks.lock`, a runtime lock file #728 deleted, is now
gitignored so it does not come back. `CLAUDE.md`'s inline copy of the 41-file keep-list is trimmed to
a pointer at the enforced list in the test — two copies of the same list is precisely the "duplicated
description that will go stale" that file warns against, and only one of them can fail a build.

## Validation

- `SourceFileCopyrightTests`: 3 passed on a clean tree; all 3 fail with specific, actionable messages
  on the deliberately broken tree described above.
- `dotnet build Docxodus.Tests/Docxodus.Tests.csproj`: 0 errors.
- Warning baselines re-measured with `--no-incremental` on both projects, not extrapolated.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017H3myrxq9faz9LoKvGcgwm

---
_Generated by [Claude Code](https://claude.ai/code/session_017H3myrxq9faz9LoKvGcgwm)_