### PR TITLE
feat(history): durable checkpoint commands and browser storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Durable browser checkpoint commands: `HistoryCheckpoints` persists a complete save/restore
+  request through a host-supplied `HistoryCheckpointJournal` *before* publishing it, so a lost
+  acknowledgement no longer leaves an app unsure whether a checkpoint exists. `retry()` replays
+  the stored request and returns the original result — the exact view the first attempt would
+  have produced — even when another editor has since published a newer version. The journal is
+  insert-only per document: a second tab's `put` returns the request already there rather than
+  replacing it, which is what makes a competing draft fail loudly instead of overwriting a
+  publication whose outcome is still unknown. Only a genuine `StaleHead` (the compare-and-swap
+  provably did not apply) clears a pending request.
+- `openIndexedDbHistoryStore(name)`: optional browser-local `HistoryStorage` plus a per-document
+  `HistoryCheckpointJournal`, backed by IndexedDB. Head initialization and compare-and-swap share
+  one read/write transaction on the same object store, so independent connections — separate tabs
+  included — serialize against each other; stored bytes are SHA-256 verified against their
+  reference before they are written. Nothing installs it: no storage, autosave or retention policy
+  is created by using the history API, and clearing browser site data removes the store.
+
 ## [12.2.0] - 2026-09-07
 
 ### Added

--- a/npm/src/history-checkpoints.ts
+++ b/npm/src/history-checkpoints.ts
@@ -1,0 +1,112 @@
+import { DocxHistoryError } from './history.js';
+import type { DocxHistoryDocument, DocxHistoryView, DocxVersionMetadata, HistoryBlobReference, HistoryHead } from './history.js';
+
+/** Persist the entire request before publication. Bytes are structured-cloneable, not JSON. */
+export type HistoryCheckpointRequest = {
+  id: string;
+  documentId: string;
+  metadata: DocxVersionMetadata;
+} & ({ kind: 'save'; head: HistoryHead | null; bytes: Uint8Array }
+  | { kind: 'restore'; head: HistoryHead; target: HistoryBlobReference });
+
+/** Host-owned durable outbox, scoped to one document. Methods resolve only after commit.
+ * put must atomically return the existing request or insert and return the supplied one.
+ * Existing inputs must never change, even for the same ID. remove must match the ID.
+ * Share exclusion between tabs/clients. Never clear an uncertain publication to start another. */
+export interface HistoryCheckpointJournal {
+  read(): Promise<HistoryCheckpointRequest | null>;
+  put(request: HistoryCheckpointRequest): Promise<HistoryCheckpointRequest>;
+  remove(requestId: string): Promise<void>;
+}
+
+/** Explicit checkpoint commands. No editor ownership, timers, automatic retries or subscriptions.
+ * Keep this instance for the document's editing session; refresh only when the user requests it. */
+export class HistoryCheckpoints {
+  private current: DocxHistoryView | null = null;
+  private request: HistoryCheckpointRequest | null = null;
+  private running = false;
+  private stale = false;
+
+  private constructor(readonly document: DocxHistoryDocument, private readonly journal: HistoryCheckpointJournal) {}
+
+  static async open(document: DocxHistoryDocument, journal: HistoryCheckpointJournal): Promise<HistoryCheckpoints> {
+    const controls = new HistoryCheckpoints(document, journal);
+    controls.request = structuredClone(await journal.read());
+    if (controls.request && controls.request.documentId !== document.documentId)
+      throw new DocxHistoryError('InvalidRequest', 'The pending checkpoint belongs to another document.');
+    controls.current = await document.read();
+    return controls;
+  }
+
+  get view(): DocxHistoryView | null { return structuredClone(this.current); }
+  get hasPending(): boolean { return this.request !== null; }
+  get needsRefresh(): boolean { return this.stale; }
+
+  async refresh(): Promise<DocxHistoryView | null> {
+    return this.exclusive(async () => {
+      this.current = await this.document.read();
+      this.stale = false;
+      return this.view;
+    });
+  }
+
+  async save(bytes: Uint8Array, metadata: DocxVersionMetadata): Promise<DocxHistoryView> {
+    return this.start({ kind: 'save', head: this.current?.head ?? null, bytes,
+      id: crypto.randomUUID(), documentId: this.document.documentId, metadata });
+  }
+
+  async restore(target: HistoryBlobReference, metadata: DocxVersionMetadata): Promise<DocxHistoryView> {
+    if (!this.current) throw new DocxHistoryError('NotFound', 'Save a checkpoint before restoring a version.');
+    return this.start({ kind: 'restore', head: this.current.head, target,
+      id: crypto.randomUUID(), documentId: this.document.documentId, metadata });
+  }
+
+  async retry(): Promise<DocxHistoryView> {
+    return this.exclusive(async () => {
+      if (!this.request) throw new DocxHistoryError('InvalidRequest', 'There is no pending checkpoint.');
+      return this.publish();
+    });
+  }
+
+  private async start(request: HistoryCheckpointRequest): Promise<DocxHistoryView> {
+    return this.exclusive(async () => {
+      if (this.request) throw new DocxHistoryError('PendingRequest', 'Retry the pending checkpoint first.');
+      if (this.stale) throw new DocxHistoryError('StaleHead', 'Refresh history before saving again.');
+      this.request = structuredClone(request);
+      return this.publish();
+    });
+  }
+
+  private async publish(): Promise<DocxHistoryView> {
+    const intended = this.request!;
+    // Retry persistence too: an outbox acknowledgement can be lost independently of publication.
+    const request = await this.journal.put(structuredClone(intended));
+    this.request = structuredClone(request);
+    if (request.id !== intended.id)
+      throw new DocxHistoryError('PendingRequest', 'Another tab has a pending checkpoint. Retry it before saving your draft.');
+    let view: DocxHistoryView;
+    try {
+      view = request.kind === 'save'
+        ? await this.document.createVersion(request.head, request.bytes, request.metadata, request.id)
+        : await this.document.restoreVersion(request.head, request.target, request.metadata, request.id);
+    } catch (error) {
+      if (error instanceof DocxHistoryError && error.code === 'StaleHead') {
+        this.stale = true;
+        await this.journal.remove(request.id);
+        this.request = null;
+      }
+      throw error;
+    }
+    // Idempotent retries may return an older version. Retain that exact view, never substitute latest.
+    this.current = view;
+    await this.journal.remove(request.id);
+    this.request = null;
+    return this.view!;
+  }
+
+  private async exclusive<T>(action: () => Promise<T>): Promise<T> {
+    if (this.running) throw new DocxHistoryError('Busy', 'A history command is still running.');
+    this.running = true;
+    try { return await action(); } finally { this.running = false; }
+  }
+}

--- a/npm/src/history-indexeddb.ts
+++ b/npm/src/history-indexeddb.ts
@@ -1,0 +1,141 @@
+import { DocxHistoryError } from './history.js';
+import type { HistoryBlobReference, HistoryHead, HistoryHeadInitializationResult, HistoryStorage } from './history.js';
+import type { HistoryCheckpointJournal, HistoryCheckpointRequest } from './history-checkpoints.js';
+
+export interface IndexedDbHistoryStore {
+  readonly storage: HistoryStorage;
+  journal(documentId: string): HistoryCheckpointJournal;
+  /** Await active history calls first. Stored documents and pending requests are retained. */
+  close(): void;
+}
+
+/** Optional browser-local persistence. Call explicitly; no storage, autosave or retention
+ * policy is installed by mounting controls. Browser site-data clearing removes this store. */
+export async function openIndexedDbHistoryStore(name: string): Promise<IndexedDbHistoryStore> {
+  const db = await new Promise<IDBDatabase>((resolve, reject) => {
+    let blocked = false;
+    const request = indexedDB.open(name, 1);
+    request.onupgradeneeded = () => {
+      for (const store of ['blobs', 'heads', 'requests']) request.result.createObjectStore(store);
+    };
+    request.onsuccess = () => { if (blocked) request.result.close(); else resolve(request.result); };
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => {
+      blocked = true;
+      reject(new Error('Close other tabs using this history store, then try again.'));
+    };
+  });
+  db.onversionchange = () => db.close();
+
+  function transaction<T>(name: string, mode: IDBTransactionMode,
+    action: (store: IDBObjectStore, result: (value: T) => void) => void): Promise<T> {
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(name, mode);
+      let value: T;
+      tx.oncomplete = () => resolve(value);
+      tx.onabort = () => reject(tx.error ?? new Error('History storage transaction was aborted.'));
+      try { action(tx.objectStore(name), result => { value = result; }); }
+      catch (error) { tx.abort(); reject(error); }
+    });
+  }
+
+  const storage: HistoryStorage = {
+    readBlob(reference) {
+      const key = referenceKey(reference);
+      return transaction<Uint8Array | null>('blobs', 'readonly', (store, result) => {
+        store.get(key).onsuccess = event => result((event.target as IDBRequest<Uint8Array>).result ?? null);
+      });
+    },
+    async putBlob(reference, bytes) {
+      const key = referenceKey(reference);
+      const captured = bytes.slice();
+      const hash = Array.from(new Uint8Array(await crypto.subtle.digest('SHA-256', captured)),
+        byte => byte.toString(16).padStart(2, '0')).join('');
+      if (captured.length !== reference.length || hash !== reference.digest.value)
+        throw new DocxHistoryError('PayloadMismatch', 'Stored document bytes do not match their reference.');
+      await transaction<void>('blobs', 'readwrite', (store, result) => {
+        store.put(captured, key); result();
+      });
+    },
+    readHead(documentId) {
+      return transaction<HistoryHead | null>('heads', 'readonly', (store, result) => {
+        store.get(documentId).onsuccess = event => result((event.target as IDBRequest<HistoryHead>).result ?? null);
+      });
+    },
+    advanceHead(documentId, expected, state) {
+      referenceKey(state);
+      const captured = structuredClone({ expected, state });
+      if (expected) validateHead(expected);
+      const revision = BigInt(expected?.revision ?? '0') + 1n;
+      if (revision > 9223372036854775807n) throw new RangeError('History revision exhausted.');
+      return transaction<HistoryHead | null>('heads', 'readwrite', (store, result) => {
+        store.get(documentId).onsuccess = event => {
+          const current = (event.target as IDBRequest<HistoryHead>).result ?? null;
+          if (!equalHead(current, captured.expected)) { result(null); return; }
+          const head = { revision: String(revision), state: captured.state };
+          store.put(head, documentId); result(head);
+        };
+      });
+    },
+    initializeHead(documentId, head) {
+      validateHead(head);
+      const captured = structuredClone(head);
+      // Both publication paths lock the same object store for the entire read/write transaction.
+      return transaction<HistoryHeadInitializationResult>('heads', 'readwrite', (store, result) => {
+        store.get(documentId).onsuccess = event => {
+          const existing = (event.target as IDBRequest<HistoryHead>).result;
+          if (existing) { result({ initialized: false, head: existing }); return; }
+          store.put(captured, documentId); result({ initialized: true, head: captured });
+        };
+      });
+    },
+  };
+
+  return {
+    storage,
+    journal(documentId) {
+      return {
+        read: () => transaction<HistoryCheckpointRequest | null>('requests', 'readonly', (store, result) => {
+          store.get(documentId).onsuccess = event => result((event.target as IDBRequest<HistoryCheckpointRequest>).result ?? null);
+        }),
+        put(request) {
+          if (request.documentId !== documentId) throw new Error('Checkpoint document identity does not match.');
+          const captured = structuredClone(request);
+          return transaction<HistoryCheckpointRequest>('requests', 'readwrite', (store, result) => {
+            store.get(documentId).onsuccess = event => {
+              const existing = (event.target as IDBRequest<HistoryCheckpointRequest>).result;
+              if (existing) { result(existing); return; }
+              store.put(captured, documentId); result(captured);
+            };
+          });
+        },
+        remove(requestId) {
+          return transaction<void>('requests', 'readwrite', (store, result) => {
+            store.get(documentId).onsuccess = event => {
+              if ((event.target as IDBRequest<HistoryCheckpointRequest>).result?.id === requestId) store.delete(documentId);
+              result();
+            };
+          });
+        },
+      };
+    },
+    close: () => db.close(),
+  };
+}
+
+function referenceKey(reference: HistoryBlobReference): string {
+  if (reference.digest.algorithm !== 'SHA-256' || !/^[a-f0-9]{64}$/.test(reference.digest.value)
+    || !Number.isSafeInteger(reference.length) || reference.length < 0)
+    throw new DocxHistoryError('InvalidRequest', 'Invalid history blob reference.');
+  return `${reference.digest.value}:${reference.length}`;
+}
+function validateHead(head: HistoryHead): void {
+  referenceKey(head.state);
+  if (!/^[1-9][0-9]*$/.test(head.revision) || BigInt(head.revision) > 9223372036854775807n)
+    throw new DocxHistoryError('InvalidRequest', 'Invalid history revision.');
+}
+function equalHead(a: HistoryHead | null, b: HistoryHead | null): boolean {
+  return a === null || b === null ? a === b
+    : a.revision === b.revision && a.state.length === b.state.length
+      && a.state.digest.algorithm === b.state.digest.algorithm && a.state.digest.value === b.state.digest.value;
+}

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -71,6 +71,8 @@ import { DocxSession, openDocxSession as openDocxSessionImpl } from "./session.j
 import { DocxHistoryArchive, DocxHistoryClient, installHistoryStorageImports } from './history.js';
 import type { HistoryStorage } from './history.js';
 export * from './history.js';
+export * from './history-checkpoints.js';
+export * from './history-indexeddb.js';
 
 /** Open history over host-owned storage after initialize(). No network layer is installed. */
 export function openDocxHistory(storage: HistoryStorage): DocxHistoryClient {

--- a/npm/tests/history-checkpoints.spec.ts
+++ b/npm/tests/history-checkpoints.spec.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { test, expect } from './history-controls-harness.js';
+import type { HistoryCheckpointRequest } from '../src/history-checkpoints.js';
 
 test('a lost save acknowledgement survives reload and recovers the original agreement, even after a later save', async ({ page }) => {
   const agreement = (await readFile('../TestFiles/HistoryArchive/agreement-v1.docx')).toString('base64');
@@ -136,4 +137,102 @@ test('independent database connections serialize head initialization, compare-an
   expect(result.remaining).toEqual(result.first);
   expect(result.mismatch).toBe('PayloadMismatch');
   expect(result.retained).toEqual([1, 2, 3]);
+});
+
+test('checkpoint guards refuse a foreign document, an empty retry and a re-entrant command', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const api = window.historyApi;
+    // Only the contract HistoryCheckpoints relies on: insert-or-return-existing per document, and a
+    // remove that ignores an ID it does not hold. Durability is IndexedDB's job, tested separately.
+    const journal = (seed: HistoryCheckpointRequest | null = null) => {
+      let stored = seed;
+      return {
+        read: async () => stored,
+        put: async (request: HistoryCheckpointRequest) => (stored ??= request),
+        remove: async (requestId: string) => { if (stored?.id === requestId) stored = null; },
+      };
+    };
+    const client = api.openDocxHistory(api.createMemoryHistoryStorage());
+    const doc = client.document('agreement');
+    const metadata = { author: 'Taylor', createdAt: '2026-09-01T12:00:00Z' };
+    const code = (error: unknown) => (error as InstanceType<typeof api.DocxHistoryError>).code;
+
+    let foreignDocument = '';
+    try {
+      await api.HistoryCheckpoints.open(doc, journal({ id: crypto.randomUUID(), documentId: 'a-different-agreement',
+        kind: 'save', head: null, bytes: api.createBlankDocx(), metadata }));
+    } catch (error) { foreignDocument = code(error); }
+
+    const commands = await api.HistoryCheckpoints.open(doc, journal());
+    let emptyRetry = '';
+    try { await commands.retry(); } catch (error) { emptyRetry = code(error); }
+    const pendingAfterEmptyRetry = commands.hasPending;
+
+    // save() reaches its exclusion guard synchronously, so the second command sees the first running.
+    const running = commands.save(api.createBlankDocx(), metadata);
+    let reentrant = '';
+    try { await commands.save(api.createBlankDocx(), metadata); } catch (error) { reentrant = code(error); }
+    await running;
+    const afterRunning = await commands.refresh();
+    client.close();
+    return { foreignDocument, emptyRetry, pendingAfterEmptyRetry, reentrant, published: afterRunning?.head.revision };
+  });
+  expect(result.foreignDocument).toBe('InvalidRequest');
+  expect(result.emptyRetry).toBe('InvalidRequest');
+  expect(result.pendingAfterEmptyRetry).toBe(false);
+  expect(result.reentrant).toBe('Busy');
+  // The rejected re-entrant command neither published a second version nor blocked the first.
+  expect(result.published).toBe('1');
+});
+
+test('a competing tab pending checkpoint is adopted: the local draft is refused and the original publishes', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const api = window.historyApi;
+    let stored: HistoryCheckpointRequest | null = null;
+    const journal = {
+      read: async () => stored,
+      put: async (request: HistoryCheckpointRequest) => (stored ??= request),
+      remove: async (requestId: string) => { if (stored?.id === requestId) stored = null; },
+    };
+    const client = api.openDocxHistory(api.createMemoryHistoryStorage());
+    const doc = client.document('agreement');
+    const metadata = { author: 'Taylor', createdAt: '2026-09-01T12:00:00Z' };
+
+    const distinct = (text: string) => {
+      const session = api.openDocxSession(api.createBlankDocx());
+      const paragraph = Object.keys(session.project().anchorIndex).find(id => id.startsWith('p:'))!;
+      const edit = session.replaceText(paragraph, text);
+      if (!edit.success) throw new Error(JSON.stringify(edit));
+      const bytes = session.save(); session.close(); return bytes;
+    };
+    const otherBytes = distinct('The other tab agreement');
+    const myBytes = distinct('My own agreement draft');
+
+    // This tab opens with an empty journal; the competing tab records its request afterwards.
+    const commands = await api.HistoryCheckpoints.open(doc, journal);
+    const otherRequest: HistoryCheckpointRequest = { id: crypto.randomUUID(), documentId: 'agreement',
+      kind: 'save', head: null, bytes: otherBytes, metadata: { ...metadata, label: 'Other tab draft' } };
+    await journal.put(otherRequest);
+
+    let refused = '';
+    try { await commands.save(myBytes, { ...metadata, label: 'My draft' }); }
+    catch (error) { refused = (error as InstanceType<typeof api.DocxHistoryError>).code; }
+    const adopted = commands.hasPending;
+
+    const recovered = await commands.retry();
+    const published = await doc.exportDocx(recovered.version.id);
+    const listed = await doc.listVersions();
+    client.close();
+    return { refused, adopted, remaining: stored, label: recovered.version.record.metadata.label,
+      labels: listed.versions.map(version => version.record.metadata.label),
+      published: Array.from(published), other: Array.from(otherBytes), mine: Array.from(myBytes) };
+  });
+  expect(result.refused).toBe('PendingRequest');
+  expect(result.adopted).toBe(true);
+  expect(result.label).toBe('Other tab draft');
+  // The local draft never reached storage: exactly one version exists, and it is the other tab's.
+  expect(result.labels).toEqual(['Other tab draft']);
+  expect(result.published).toEqual(result.other);
+  expect(result.published).not.toEqual(result.mine);
+  expect(result.remaining).toBeNull();
 });

--- a/npm/tests/history-checkpoints.spec.ts
+++ b/npm/tests/history-checkpoints.spec.ts
@@ -1,0 +1,139 @@
+import { readFile } from 'node:fs/promises';
+import { test, expect } from './history-controls-harness.js';
+
+test('a lost save acknowledgement survives reload and recovers the original agreement, even after a later save', async ({ page }) => {
+  const agreement = (await readFile('../TestFiles/HistoryArchive/agreement-v1.docx')).toString('base64');
+  const first = await page.evaluate(async encoded => {
+    const api = window.historyApi;
+    const store = await api.openIndexedDbHistoryStore('checkpoint-reload');
+    const journal = store.journal('agreement');
+    const history = api.openDocxHistory({ ...store.storage, async advanceHead(...args) {
+      const pending = await journal.read();
+      if (!pending) throw new Error('A request must be durable before publication.');
+      const head = await store.storage.advanceHead(...args);
+      if (head) throw new Error('Connection dropped after commit');
+      return head;
+    } });
+    const doc = history.document('agreement');
+    const commands = await api.HistoryCheckpoints.open(doc, journal);
+    const empty = await doc.listVersions();
+    const bytes = Uint8Array.from(atob(encoded), c => c.charCodeAt(0));
+    const metadata = { author: 'Taylor', createdAt: '2026-09-01T12:00:00Z', label: 'Signed agreement' };
+    const pending = commands.save(bytes, metadata).then(() => '', (error: Error) => error.message);
+    bytes.fill(0); metadata.label = 'Mutated';
+    const failure = await pending;
+    const captured = await journal.read();
+    const first = await doc.read();
+    history.close();
+    const other = api.openDocxHistory(store.storage);
+    await other.document('agreement').createVersion(first!.head, api.createBlankDocx(),
+      { author: 'Other editor', createdAt: '2026-09-01T13:00:00Z' }, 'later');
+    other.close(); store.close();
+    return { empty: empty.versions.length, failure, requestId: captured?.id, head: first!.head, pending: commands.hasPending };
+  }, agreement);
+  expect(first.empty).toBe(0);
+  expect(first.failure).toBeTruthy();
+  expect(first.pending).toBe(true);
+  await page.reload();
+  await page.evaluate(async () => {
+    const url = '/history-controls-api.js'; window.historyApi = await import(url);
+    await window.historyApi.initialize('http://localhost:8083/wasm/');
+  });
+  const recovered = await page.evaluate(async () => {
+    const api = window.historyApi;
+    const store = await api.openIndexedDbHistoryStore('checkpoint-reload');
+    const history = api.openDocxHistory(store.storage);
+    const doc = history.document('agreement');
+    const commands = await api.HistoryCheckpoints.open(doc, store.journal('agreement'));
+    const result = await commands.retry();
+    const bytes = await doc.exportDocx(result.version.id);
+    const output = { head: result.head, label: result.version.record.metadata.label,
+      current: commands.view!.head, latest: (await doc.read())!.head, requestId: result.state.requests?.current?.id,
+      remaining: await store.journal('agreement').read(), count: (await doc.listVersions()).versions.length,
+      bytes: Array.from(bytes) };
+    history.close(); store.close(); return output;
+  });
+  expect(recovered.head).toEqual(first.head);
+  expect(recovered.current).toEqual(first.head);
+  expect(recovered.latest.revision).toBe('2');
+  expect(recovered.label).toBe('Signed agreement');
+  expect(recovered.requestId).toBe(first.requestId);
+  expect(recovered.remaining).toBeNull();
+  expect(recovered.count).toBe(2);
+  expect(Buffer.from(recovered.bytes)).toEqual(Buffer.from(agreement, 'base64'));
+});
+
+test('stale drafts require refresh; restoring appends a checkpoint and keeps every later version', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const api = window.historyApi;
+    const store = await api.openIndexedDbHistoryStore('stale-draft');
+    const history = api.openDocxHistory(store.storage);
+    const doc = history.document('agreement');
+    const metadata = { author: 'Taylor', createdAt: '2026-09-01T12:00:00Z' };
+    const original = api.createBlankDocx();
+    const commands = await api.HistoryCheckpoints.open(doc, store.journal('agreement'));
+    const first = await commands.save(original, metadata);
+    const session = api.openDocxSession(original);
+    const paragraph = Object.keys(session.project().anchorIndex).find(id => id.startsWith('p:'))!;
+    const edit = session.replaceText(paragraph, 'My unsaved agreement draft');
+    if (!edit.success) throw new Error(JSON.stringify(edit));
+    const draft = session.save(); session.close();
+    await doc.createVersion(first.head, original, metadata, 'other-tab');
+    let stale = '';
+    try { await commands.save(draft, metadata); } catch (error) { stale = (error as Error).message; }
+    const needsRefresh = commands.needsRefresh;
+    const pending = commands.hasPending;
+    await commands.refresh();
+    const saved = await commands.save(draft, metadata);
+    const restored = await commands.restore(first.version.id, { ...metadata, label: 'Restore original' });
+    const retained = await doc.exportDocx(saved.version.id);
+    const latest = await doc.exportDocx(restored.version.id);
+    const count = (await doc.listVersions()).versions.length;
+    history.close(); store.close();
+    return { stale, needsRefresh, pending, count, source: restored.version.record.restoredFrom,
+      first: first.version.id, retained: Array.from(retained), draft: Array.from(draft), latest: Array.from(latest), original: Array.from(original) };
+  });
+  expect(result.stale).toBeTruthy();
+  expect(result.needsRefresh).toBe(true);
+  expect(result.pending).toBe(false);
+  expect(result.count).toBe(4);
+  expect(result.source).toEqual(result.first);
+  expect(result.retained).toEqual(result.draft);
+  expect(result.latest).toEqual(result.original);
+});
+
+test('independent database connections serialize head initialization, compare-and-swap, and pending requests', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const api = window.historyApi;
+    const a = await api.openIndexedDbHistoryStore('two-tabs');
+    const b = await api.openIndexedDbHistoryStore('two-tabs');
+    const bytes = new Uint8Array([1, 2, 3]);
+    const value = Array.from(new Uint8Array(await crypto.subtle.digest('SHA-256', bytes)), n => n.toString(16).padStart(2, '0')).join('');
+    const state = { digest: { algorithm: 'SHA-256' as const, value }, length: bytes.length };
+    await a.storage.putBlob(state, bytes); bytes.fill(0);
+    const head = { revision: '9007199254740993', state };
+    const [initialized, advanced] = await Promise.all([
+      a.storage.initializeHead!('agreement', head), b.storage.advanceHead('agreement', null, state),
+    ]);
+    const initialHead = await b.storage.readHead('agreement');
+    const winners = await Promise.all([a.storage.advanceHead('agreement', initialHead, state), b.storage.advanceHead('agreement', initialHead, state)]);
+    const metadata = { author: 'Taylor', createdAt: '2026-09-01T12:00:00Z' };
+    const first = await a.journal('agreement').put({ id: 'one', documentId: 'agreement', kind: 'save', head: null, bytes, metadata });
+    const second = await b.journal('agreement').put({ ...first, id: 'two', metadata: { ...metadata, author: 'Someone else' } });
+    await b.journal('agreement').remove('two');
+    const remaining = await a.journal('agreement').read();
+    let mismatch = '';
+    try { await b.storage.putBlob(state, bytes); } catch (error) { mismatch = (error as InstanceType<typeof api.DocxHistoryError>).code; }
+    const retained = await b.storage.readBlob(state);
+    a.close(); b.close();
+    return { initialized, advanced, initialHead, winners: winners.filter(Boolean).length,
+      first, second, remaining, mismatch, retained: Array.from(retained!) };
+  });
+  expect(Number(result.initialized.initialized) + Number(result.advanced !== null)).toBe(1);
+  expect(result.initialHead).toEqual(result.initialized.initialized ? result.initialized.head : result.advanced);
+  expect(result.winners).toBe(1);
+  expect(result.first).toEqual(result.second);
+  expect(result.remaining).toEqual(result.first);
+  expect(result.mismatch).toBe('PayloadMismatch');
+  expect(result.retained).toEqual([1, 2, 3]);
+});

--- a/npm/tests/history-controls-harness.ts
+++ b/npm/tests/history-controls-harness.ts
@@ -1,0 +1,22 @@
+import { test as base, expect } from '@playwright/test';
+import { build } from 'esbuild';
+import type * as HistoryApi from '../src/index.js';
+
+declare global { interface Window { historyApi: typeof HistoryApi } }
+
+export const test = base.extend<{ historyPage: void }>({
+  historyPage: [async ({ page }, use) => {
+    const bundle = await build({ entryPoints: ['dist/index.js'], bundle: true, format: 'esm', write: false });
+    await page.route('**/history-controls.html', route => route.fulfill({ contentType: 'text/html',
+      body: '<!doctype html><html lang="en"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Document history</title><main id="controls"></main></html>' }));
+    await page.route('**/history-controls-api.js', route => route.fulfill({ contentType: 'text/javascript', body: bundle.outputFiles[0].text }));
+    await page.goto('http://localhost:8083/history-controls.html');
+    await page.evaluate(async () => {
+      const url = '/history-controls-api.js';
+      window.historyApi = await import(url);
+      await window.historyApi.initialize('http://localhost:8083/wasm/');
+    });
+    await use();
+  }, { auto: true }],
+});
+export { expect };


### PR DESCRIPTION
A lost save acknowledgement can leave an app unsure whether a checkpoint was published. Add explicit checkpoint commands that persist complete requests before publication and recover the original result across reloads. The optional IndexedDB adapter serializes head initialization/publication and keeps one durable pending request per document.

Stack 1/3: #738 → #739 → #740 (416 added lines here). The following PRs add the panel and runnable editor example.

Validation: TypeScript build and source/test typecheck; three Chromium scenarios cover a real agreement recovered after reload and a later save, stale drafts and append-only restore, and independent database connections competing for heads and requests.