### PR TITLE
feat(history): accessible version and collaboration controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ All notable changes to this project will be documented in this file.
   replacing it, which is what makes a competing draft fail loudly instead of overwriting a
   publication whose outcome is still unknown. Only a genuine `StaleHead` (the compare-and-swap
   provably did not apply) clears a pending request.
+- `mountHistoryControls(container, options)`: an accessible, responsive document-history panel an
+  app mounts beside its own editor. It pages through version metadata, previews or downloads a
+  selected DOCX, compares any two versions as tracked changes, finds a version by time, lists
+  recorded collaboration with its resolved conflicts, and — when given `checkpoints` and a
+  `capture` callback — saves, restores and retries checkpoints. The panel never owns, replaces or
+  closes the host's editor or reader: previews go to a host callback so browsing cannot discard a
+  draft, `destroy()` awaits the command still in flight, and controls that would conflict with a
+  running call are disabled while it runs. Read-only `.docxhistory` archives mount the same panel
+  by omitting `checkpoints`. `historyControlError(error, pending)` is exported separately so a host
+  can render the same plain-language explanations outside the panel.
 - `openIndexedDbHistoryStore(name)`: optional browser-local `HistoryStorage` plus a per-document
   `HistoryCheckpointJournal`, backed by IndexedDB. Head initialization and compare-and-swap share
   one read/write transaction on the same object store, so independent connections — separate tabs

--- a/docs/history-controls.md
+++ b/docs/history-controls.md
@@ -1,5 +1,42 @@
 # History controls (frontend)
 
+`mountHistoryControls` supplies an accessible, responsive panel for an app-owned reader.
+It pages through metadata, previews selected versions and comparisons, downloads DOCX or
+history files, finds versions by time, and shows recorded collaboration with resolved conflicts.
+Preview callbacks should render separately from the editor, so browsing never discards a draft.
+
+```ts
+import {
+  initialize, openDocxHistory, openIndexedDbHistoryStore,
+  HistoryCheckpoints, mountHistoryControls,
+} from 'docxodus';
+
+await initialize('/wasm/');
+const store = await openIndexedDbHistoryStore('my-app-history'); // Explicit, optional local persistence.
+const client = openDocxHistory(store.storage);
+const document = client.document(stableDocumentId);
+const checkpoints = await HistoryCheckpoints.open(document, store.journal(document.documentId));
+const panel = mountHistoryControls(container, {
+  reader: document, checkpoints, author: currentUserName,
+  capture: () => editor.save(),
+  preview: (bytes, title) => showSeparatePreview(bytes, title),
+});
+await panel.ready;
+// On teardown: await panel.destroy(); client.close(); store.close();
+```
+
+Omit `checkpoints` and `capture` when mounting a standalone archive reader. The panel never
+owns or closes its reader. It awaits preview/download callbacks and disables conflicting
+controls during calls. `ready` and `refresh()` reject on errors as well as showing feedback.
+The optional `download` callback lets your app choose its own download dialog.
+
+`HistoryCheckpoints` also works without the panel. Supply your own durable
+`HistoryCheckpointJournal`, or use the IndexedDB store's per-document journal. Complete
+requests survive reloads; Retry recovers the captured inputs, even if a later checkpoint
+exists. A stale draft stays open until the user refreshes history and decides what to save.
+IndexedDB data stays on this browser and can be removed by clearing site data; download a
+history file for a portable copy. No automatic checkpoint, network sync or retention is installed.
+
 Users handle documents, not storage directories. Your app owns persistence, request IDs,
 loading indicators, download dialogs and the editor; Docxodus supplies the history calls.
 

--- a/npm/src/history-controls.ts
+++ b/npm/src/history-controls.ts
@@ -1,0 +1,268 @@
+import { DocxHistoryError } from './history.js';
+import type { DocxHistoryReader, DocxHistoryView, DocxStoredVersion, HistoryBlobReference } from './history.js';
+import type { HistoryCheckpoints } from './history-checkpoints.js';
+
+export interface HistoryControlsOptions {
+  reader: DocxHistoryReader;
+  /** Omit for a read-only archive. Must belong to reader. */
+  checkpoints?: HistoryCheckpoints;
+  /** Capture the open draft on Save only. The panel never replaces editor content. */
+  capture?: () => Uint8Array | Promise<Uint8Array>;
+  author?: string;
+  documentName?: string;
+  /** Render in a separate preview; reject on failure, preserving the previous document. */
+  preview: (bytes: Uint8Array, title: string) => void | Promise<void>;
+  /** Defaults to a browser download. */
+  download?: (bytes: Uint8Array, filename: string) => void | Promise<void>;
+  pageSize?: number;
+}
+
+export interface HistoryControls {
+  readonly element: HTMLElement;
+  /** Initial metadata load. No document export or checkpoint is implicit. */
+  readonly ready: Promise<void>;
+  refresh(): Promise<void>;
+  /** Removes controls and awaits their active call. The host may then close its reader/client. */
+  destroy(): Promise<void>;
+}
+
+/** Mount explicit document-history controls. Persistence and preview/editor ownership stay with the host. */
+export function mountHistoryControls(container: HTMLElement, options: HistoryControlsOptions): HistoryControls {
+  const pageSize = options.pageSize ?? 25;
+  if (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > 100) throw new RangeError('History page size must be 1–100.');
+  if (options.checkpoints && options.checkpoints.document !== options.reader)
+    throw new Error('History controls and checkpoints must use the same document.');
+  return new HistoryPanel(container, options, pageSize);
+}
+
+class HistoryPanel implements HistoryControls {
+  readonly element: HTMLElement;
+  readonly ready: Promise<void>;
+  private readonly fieldset: HTMLFieldSetElement;
+  private readonly status: HTMLElement;
+  private readonly versions: HTMLSelectElement;
+  private readonly before: HTMLSelectElement;
+  private readonly detail: HTMLElement;
+  private readonly author: HTMLInputElement;
+  private readonly label: HTMLInputElement;
+  private readonly actions = new Map<string, HTMLButtonElement>();
+  private readonly events = new AbortController();
+  private records: DocxStoredVersion[] = [];
+  private next: HistoryBlobReference | null = null;
+  private view: DocxHistoryView | null = null;
+  private active: Promise<void> | null = null;
+  private destroyed = false;
+
+  constructor(container: HTMLElement, private readonly options: HistoryControlsOptions, private readonly pageSize: number) {
+    const doc = container.ownerDocument;
+    this.element = doc.createElement('section');
+    this.element.className = 'dx-history';
+    this.element.setAttribute('aria-label', 'Document history');
+    const style = doc.createElement('style'); style.textContent = HISTORY_CSS;
+    const title = doc.createElement('h2'); title.textContent = 'Document history';
+    this.status = doc.createElement('p'); this.status.setAttribute('role', 'status'); this.status.setAttribute('aria-live', 'polite');
+    this.fieldset = doc.createElement('fieldset');
+    const legend = doc.createElement('legend'); legend.textContent = 'Versions and checkpoints'; this.fieldset.append(legend);
+    this.element.append(style, title, this.status, this.fieldset); container.append(this.element);
+    const note = doc.createElement('p');
+    note.textContent = options.checkpoints ? 'Browse saved versions without changing your draft.' : 'Read-only history. Preview or download any saved version.';
+    this.fieldset.append(note);
+    this.button('refresh', 'Refresh history', () => this.load(true));
+    this.button('latest', 'Open latest', async () => this.preview(await options.reader.exportDocx(), 'Latest saved version'));
+    this.versions = this.select('Version'); this.versions.size = 6;
+    this.detail = doc.createElement('p'); this.fieldset.append(this.detail);
+    this.versions.addEventListener('change', () => this.update(), { signal: this.events.signal });
+    this.button('preview', 'Preview selected', async () => this.preview(await options.reader.exportDocx(this.selected().id), versionTitle(this.selected())));
+    this.button('download', 'Download selected', async () => this.download(await options.reader.exportDocx(this.selected().id), `version-${this.selected().record.sequence}.docx`));
+    this.before = this.select('Compare from');
+    this.before.addEventListener('change', () => this.update(), { signal: this.events.signal });
+    const compareNote = doc.createElement('p'); compareNote.textContent = 'Compare from this version to the selected version above.'; this.fieldset.append(compareNote);
+    this.button('compare', 'Compare versions', async () => {
+      const before = this.records[Number(this.before.value)];
+      await this.preview(await options.reader.compareVersions(before.id, this.selected().id), 'Comparison with tracked changes');
+    });
+    this.button('more', 'Load older versions', async () => { if (this.next) await this.page(this.next, false); });
+    this.author = this.input('Your name', 'text', options.author ?? 'You');
+    this.label = this.input('Checkpoint name (optional)', 'text');
+    this.author.parentElement!.hidden = this.label.parentElement!.hidden = !options.checkpoints;
+    this.button('save', 'Save checkpoint', async () => {
+      await options.checkpoints!.save(await options.capture!(), this.metadata());
+      await this.load(false); this.label.value = '';
+      this.status.textContent = 'Checkpoint saved. Your draft remains open.';
+    });
+    this.button('restore', 'Restore selected', async () => {
+      await options.checkpoints!.restore(this.selected().id, this.metadata());
+      await this.load(false);
+      this.status.textContent = 'Restored as a new checkpoint. Your draft and later versions are kept.';
+    });
+    const restoreNote = doc.createElement('p'); restoreNote.hidden = !options.checkpoints;
+    restoreNote.textContent = 'Restore creates a new checkpoint. Open latest to preview it; your draft stays open.'; this.fieldset.append(restoreNote);
+    this.button('retry', 'Retry checkpoint', async () => {
+      await options.checkpoints!.retry(); await this.load(false);
+      this.status.textContent = 'Checkpoint recovered. Your draft remains open. Refresh history to check for newer versions.';
+    });
+    const sharing = this.disclosure('Download with history');
+    const sharingNote = doc.createElement('p');
+    sharingNote.textContent = 'Includes retained drafts and collaboration proposals. Share this file only when you want to include that history. A DOCX download keeps existing Word comments and revisions, without external history.';
+    sharing.append(sharingNote);
+    this.button('archive', 'Download .docxhistory', async () => this.download(await options.reader.exportHistoryArchive(), 'docxhistory'), sharing);
+    const time = this.disclosure('Find a version by time');
+    const cutoff = this.input('Saved at or before (local time)', 'datetime-local', '', time);
+    this.button('time', 'Preview at time', async () => {
+      if (!cutoff.value) throw new DocxHistoryError('InvalidRequest', 'Choose a date and time first.');
+      const sequence = await options.reader.resolveSequenceAtTime(new Date(cutoff.value).toISOString());
+      await this.preview(await options.reader.materialize(sequence), 'Version at selected time');
+    }, time);
+    const activity = this.disclosure('Recorded collaboration');
+    const decisions = doc.createElement('ol');
+    this.button('activity', 'Load activity', async () => {
+      const { operations } = await options.reader.readOperationsSince(null);
+      const resolved = new Set(operations.filter(op => op.record.status === 'accepted').map(op => op.input.request.resolves?.digest.value));
+      const items = operations.map(op => {
+        const item = doc.createElement('li');
+        const state = op.record.status === 'accepted' ? 'Accepted' : resolved.has(op.id.digest.value) ? 'Conflict resolved' : 'Conflict needs review';
+        const label = doc.createElement('p');
+        label.textContent = `${op.input.request.metadata.author} · ${state} · ${formatTime(op.input.request.metadata.createdAt)}`;
+        item.append(label);
+        const button = doc.createElement('button'); button.type = 'button'; button.textContent = 'Download proposal';
+        button.addEventListener('click', () => {
+          void this.run('Downloading proposal', async () => {
+            const decision = await options.reader.getOperation(op.id);
+            await this.download(await options.reader.exportOperationProposal(decision.id), `proposal-${decision.record.revision}.docx`);
+          }).catch(() => {});
+        }, { signal: this.events.signal });
+        item.append(button); return item;
+      });
+      decisions.replaceChildren(...items);
+      this.status.textContent = operations.length ? 'Recorded activity loaded.' : 'No recorded collaboration.';
+    }, activity);
+    activity.append(decisions);
+    this.ready = this.refresh();
+  }
+
+  refresh(): Promise<void> { return this.run('Loading history', () => this.load(true)); }
+
+  async destroy(): Promise<void> {
+    this.destroyed = true; this.events.abort(); this.element.remove();
+    await this.active?.catch(() => {});
+  }
+
+  private async load(refresh: boolean): Promise<void> {
+    this.view = this.options.checkpoints
+      ? refresh ? await this.options.checkpoints.refresh() : this.options.checkpoints.view
+      : await this.options.reader.read();
+    if (this.view) await this.page(this.view.version.id, true);
+    else { this.records = []; this.next = null; this.versions.replaceChildren(); this.before.replaceChildren(); }
+    this.status.textContent = this.options.checkpoints?.hasPending
+      ? 'A checkpoint needs recovery. Retry it before saving more changes.'
+      : this.view ? 'History loaded. Select a version to preview, download or restore.' : 'No checkpoints yet. Save your first checkpoint when you are ready.';
+  }
+
+  private async page(cursor: HistoryBlobReference, reset: boolean): Promise<void> {
+    const page = await this.options.reader.listVersions(cursor, this.pageSize);
+    if (reset) { this.records = []; this.versions.replaceChildren(); this.before.replaceChildren(); }
+    const start = this.records.length;
+    this.records.push(...page.versions); this.next = page.next;
+    for (let index = start; index < this.records.length; index++) {
+      for (const select of [this.versions, this.before]) {
+        const option = select.ownerDocument.createElement('option'); option.value = String(index);
+        option.textContent = option.title = versionTitle(this.records[index]); select.append(option);
+      }
+    }
+    if (reset) { this.versions.value = '0'; this.before.value = this.records.length > 1 ? '1' : '0'; }
+  }
+
+  private update(): void {
+    const hasVersion = this.records.length > 0;
+    const pending = this.options.checkpoints?.hasPending ?? false;
+    const stale = this.options.checkpoints?.needsRefresh ?? false;
+    for (const key of ['latest', 'preview', 'download', 'archive', 'time', 'activity']) this.actions.get(key)!.disabled = !hasVersion;
+    this.actions.get('more')!.hidden = !this.next;
+    this.actions.get('compare')!.disabled = !hasVersion || this.before.value === this.versions.value;
+    this.actions.get('save')!.hidden = !this.options.checkpoints || !this.options.capture;
+    this.actions.get('save')!.disabled = pending || stale;
+    this.actions.get('restore')!.hidden = !this.options.checkpoints;
+    this.actions.get('restore')!.disabled = !hasVersion || pending || stale;
+    this.actions.get('retry')!.hidden = !pending;
+    this.detail.textContent = hasVersion ? [versionTitle(this.selected()), this.selected().record.metadata.message,
+      this.selected().record.restoredFrom ? 'Restored from an earlier version.' : ''].filter(Boolean).join(' — ') : '';
+  }
+
+  private selected(): DocxStoredVersion { return this.records[Number(this.versions.value)]; }
+  private metadata() { return { author: this.author.value.trim() || 'You', createdAt: new Date().toISOString(), label: this.label.value.trim() || undefined }; }
+  private async preview(bytes: Uint8Array, title: string): Promise<void> {
+    if (!this.destroyed) await this.options.preview(bytes, title);
+  }
+  private async download(bytes: Uint8Array, suffix: string): Promise<void> {
+    if (this.destroyed) return;
+    const stem = (this.options.documentName ?? 'document').replace(/\.(docx|docxhistory)$/i, '');
+    const name = suffix === 'docxhistory' ? `${stem}.docxhistory` : `${stem}-${suffix}`;
+    if (this.options.download) { await this.options.download(bytes, name); return; }
+    const url = URL.createObjectURL(new Blob([bytes.slice()], { type: suffix === 'docxhistory' ? 'application/octet-stream' : 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }));
+    const link = this.element.ownerDocument.createElement('a'); link.href = url; link.download = name;
+    link.click(); setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
+
+  private async run(label: string, action: () => Promise<void>): Promise<void> {
+    if (this.destroyed) throw new DocxHistoryError('Closed', 'History controls are closed.');
+    if (this.active) throw new DocxHistoryError('Busy', 'A history command is still running.');
+    this.fieldset.disabled = true; this.element.setAttribute('aria-busy', 'true'); this.status.textContent = `${label}…`;
+    const work = Promise.resolve().then(action); this.active = work;
+    try { await work; if (this.status.textContent === `${label}…`) this.status.textContent = 'Ready.'; }
+    catch (error) {
+      if (!this.destroyed) this.status.textContent = historyControlError(error, this.options.checkpoints?.hasPending);
+      throw error;
+    } finally {
+      this.active = null;
+      if (!this.destroyed) { this.fieldset.disabled = false; this.element.setAttribute('aria-busy', 'false'); this.update(); }
+    }
+  }
+
+  private button(key: string, title: string, action: () => Promise<void>, parent: HTMLElement = this.fieldset): void {
+    const button = parent.ownerDocument.createElement('button'); button.type = 'button'; button.textContent = title;
+    button.addEventListener('click', () => { void this.run(title, action).catch(() => {}); }, { signal: this.events.signal });
+    this.actions.set(key, button); parent.append(button);
+  }
+  private select(title: string): HTMLSelectElement {
+    const label = this.fieldset.ownerDocument.createElement('label'); label.textContent = title;
+    const select = label.ownerDocument.createElement('select'); select.setAttribute('aria-label', title);
+    label.append(select); this.fieldset.append(label); return select;
+  }
+  private input(title: string, type: string, value = '', parent: HTMLElement = this.fieldset): HTMLInputElement {
+    const label = parent.ownerDocument.createElement('label'); label.textContent = title;
+    const input = label.ownerDocument.createElement('input'); input.type = type; input.value = value;
+    label.append(input); parent.append(label); return input;
+  }
+  private disclosure(title: string): HTMLDetailsElement {
+    const details = this.fieldset.ownerDocument.createElement('details');
+    const summary = details.ownerDocument.createElement('summary'); summary.textContent = title;
+    details.append(summary); this.fieldset.append(details); return details;
+  }
+}
+
+export function historyControlError(error: unknown, pending = false): string {
+  const code = error instanceof DocxHistoryError ? error.code : '';
+  if (code === 'StaleHead') return 'A newer checkpoint exists. Your draft is safe. Refresh history, review the newer version, then save again.';
+  if (code === 'ImportConflict') return 'A different local history already exists. Open this file read-only to explore it.';
+  if (code === 'InitializationUnsupported') return 'This storage cannot import history. Open read-only or choose storage that supports importing.';
+  if (code === 'ResourceLimit') return 'This history file exceeds browser processing limits, which can apply even below 64 MiB. Your document is unchanged.';
+  if (pending) return 'The checkpoint could not be confirmed. Your draft is safe. Retry checkpoint to recover the original request.';
+  return `History could not be loaded. Your document is unchanged. ${error instanceof Error ? error.message : 'Please try again.'}`;
+}
+
+function versionTitle(version: DocxStoredVersion): string {
+  const { metadata, sequence } = version.record;
+  return `${metadata.label || `Version ${BigInt(sequence) + 1n}`} · ${metadata.author} · ${formatTime(metadata.createdAt)}`;
+}
+function formatTime(value: string): string { const time = new Date(value); return Number.isNaN(time.getTime()) ? value : time.toLocaleString(); }
+
+const HISTORY_CSS = `
+.dx-history{font:14px/1.5 system-ui,sans-serif;color:#203047;background:#fff;border:1px solid #cbd5e1;border-radius:12px;padding:18px;min-width:0}
+.dx-history *{box-sizing:border-box}.dx-history h2{font-size:20px;margin:0 0 8px}.dx-history p{margin:8px 0;overflow-wrap:anywhere}
+.dx-history fieldset{border:0;padding:0;margin:0;min-width:0}.dx-history legend{position:absolute;width:1px;height:1px;overflow:hidden;clip-path:inset(50%)}
+.dx-history label{display:block;font-weight:600;margin:12px 0 6px}.dx-history input,.dx-history select{display:block;width:100%;max-width:100%;margin-top:4px;font:inherit;color:inherit;border:1px solid #94a3b8;border-radius:6px;padding:8px;background:#fff}
+.dx-history button{min-height:40px;margin:4px 6px 4px 0;padding:7px 12px;border:1px solid #94a3b8;border-radius:6px;background:#f8fafc;color:inherit;font:inherit;cursor:pointer}
+.dx-history button:disabled{opacity:.5;cursor:wait}.dx-history :focus-visible{outline:3px solid #2563eb;outline-offset:2px}.dx-history [hidden]{display:none}
+.dx-history details{margin-top:16px;border-top:1px solid #e2e8f0;padding-top:12px}.dx-history summary{cursor:pointer;font-weight:600;padding:4px 0}
+.dx-history [role=status]{min-height:42px}.dx-history ol{padding-left:22px}.dx-history option{padding:6px}
+`;

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -73,6 +73,7 @@ import type { HistoryStorage } from './history.js';
 export * from './history.js';
 export * from './history-checkpoints.js';
 export * from './history-indexeddb.js';
+export * from './history-controls.js';
 
 /** Open history over host-owned storage after initialize(). No network layer is installed. */
 export function openDocxHistory(storage: HistoryStorage): DocxHistoryClient {

--- a/npm/tests/history-controls.spec.ts
+++ b/npm/tests/history-controls.spec.ts
@@ -1,0 +1,146 @@
+import { readFile } from 'node:fs/promises';
+import { test, expect } from './history-controls-harness.js';
+import type { HistoryControls } from '../src/history-controls.js';
+
+declare global {
+  interface Window {
+    historyPanel: HistoryControls;
+    historyPreview: { title: string; bytes: number[]; revisions: number; markdown: string } | null;
+    releaseHistory: () => void;
+    disposeHistory: () => Promise<void>;
+  }
+}
+
+test('browse, page, preview, compare and share a real agreement without changing its history', async ({ page }, testInfo) => {
+  const archive = (await readFile('../TestFiles/HistoryArchive/agreement.docxhistory')).toString('base64');
+  await page.evaluate(async encoded => {
+    const api = window.historyApi;
+    const reader = await api.openDocxHistoryArchive(Uint8Array.from(atob(encoded), c => c.charCodeAt(0)));
+    window.historyPreview = null;
+    window.historyPanel = api.mountHistoryControls(document.querySelector<HTMLElement>('#controls')!, {
+      reader, pageSize: 2, documentName: 'Agreement.docx',
+      preview(bytes, title) {
+        const session = api.openDocxSession(bytes);
+        window.historyPreview = { title, bytes: Array.from(bytes), revisions: session.listRevisions().length, markdown: session.project().markdown };
+        session.close();
+      },
+    });
+    await window.historyPanel.ready;
+    window.disposeHistory = async () => { await window.historyPanel.destroy(); reader.close(); };
+  }, archive);
+  const versions = page.getByLabel('Version', { exact: true });
+  await expect(page.getByRole('button', { name: 'Save checkpoint', exact: true })).toBeHidden();
+  await expect(versions.locator('option')).toHaveCount(2);
+  await page.getByRole('button', { name: 'Load older versions' }).click();
+  await expect(versions.locator('option')).toHaveCount(4);
+  await expect(page.getByRole('button', { name: 'Load older versions' })).toBeHidden();
+  await versions.selectOption('3');
+  await page.getByRole('button', { name: 'Preview selected' }).click();
+  await expect.poll(() => page.evaluate(() => window.historyPreview?.bytes.length)).toBeGreaterThan(100);
+  const preview = await page.evaluate(() => window.historyPreview!);
+  expect(Buffer.from(preview.bytes)).toEqual(await readFile('../TestFiles/HistoryArchive/agreement-v1.docx'));
+  expect(preview.markdown).toContain('Services');
+  await versions.selectOption('2');
+  await page.getByLabel('Compare from', { exact: true }).selectOption('3');
+  await page.getByRole('button', { name: 'Compare versions' }).click();
+  await expect.poll(() => page.evaluate(() => window.historyPreview?.revisions)).toBeGreaterThan(0);
+  expect((await page.evaluate(() => window.historyPreview!.title))).toBe('Comparison with tracked changes');
+  const downloadEvent = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Download selected' }).click();
+  const download = await downloadEvent;
+  await download.saveAs(testInfo.outputPath(download.suggestedFilename()));
+  expect(await readFile(testInfo.outputPath(download.suggestedFilename()))).toEqual(await readFile('../TestFiles/HistoryArchive/agreement-v2.docx'));
+  await page.getByText('Download with history', { exact: true }).click();
+  await expect(page.getByText(/Includes retained drafts and collaboration proposals/)).toBeVisible();
+  const historyDownload = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Download .docxhistory', exact: true }).click();
+  const portable = await historyDownload;
+  expect(portable.suggestedFilename()).toBe('Agreement.docxhistory');
+  await portable.saveAs(testInfo.outputPath('shared-agreement.docxhistory'));
+  const count = await page.evaluate(async encoded => {
+    const reader = await window.historyApi.openDocxHistoryArchive(Uint8Array.from(atob(encoded), c => c.charCodeAt(0)));
+    const count = (await reader.listVersions()).versions.length; reader.close(); return count;
+  }, (await readFile(testInfo.outputPath('shared-agreement.docxhistory'))).toString('base64'));
+  expect(count).toBe(4);
+  await page.setViewportSize({ width: 390, height: 844 });
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+  await page.screenshot({ path: testInfo.outputPath('history-phone.png'), fullPage: true });
+  await page.evaluate(() => window.disposeHistory());
+  await expect(page.getByRole('region', { name: 'Document history' })).toHaveCount(0);
+});
+
+test('saving disables conflicting controls and a lost restore acknowledgement retries its original target', async ({ page }) => {
+  const archive = (await readFile('../TestFiles/HistoryArchive/agreement.docxhistory')).toString('base64');
+  await page.evaluate(async encoded => {
+    const api = window.historyApi;
+    const store = await api.openIndexedDbHistoryStore('panel-restore');
+    let pause = false; let loseAck = false;
+    const history = api.openDocxHistory({ ...store.storage, async advanceHead(...args) {
+      if (pause) { pause = false; await new Promise<void>(resolve => { window.releaseHistory = resolve; }); }
+      const head = await store.storage.advanceHead(...args);
+      if (loseAck) { loseAck = false; throw new Error('Lost restore acknowledgement'); }
+      return head;
+    } });
+    const imported = await history.importHistoryArchive(Uint8Array.from(atob(encoded), c => c.charCodeAt(0)));
+    const doc = history.document(imported.archive.documentId);
+    const checkpoints = await api.HistoryCheckpoints.open(doc, store.journal(doc.documentId));
+    window.historyPanel = api.mountHistoryControls(document.querySelector<HTMLElement>('#controls')!, {
+      reader: doc, checkpoints, capture: () => api.createBlankDocx(), preview: () => { throw new Error('Unexpected draft replacement'); },
+    });
+    await window.historyPanel.ready; pause = true;
+    window.disposeHistory = async () => {
+      const versions = await doc.listVersions();
+      if (versions.versions.length !== 6) throw new Error(`Expected six checkpoints, found ${versions.versions.length}`);
+      const latest = await doc.read();
+      const bytes = await doc.exportDocx(latest!.version.id);
+      window.historyPreview = { title: latest!.version.record.metadata.label!, bytes: Array.from(bytes), markdown: '', revisions: 0 };
+      await window.historyPanel.destroy(); history.close(); store.close();
+    };
+    // The next call saves; the following restore loses its acknowledgement.
+    const save = checkpoints.save.bind(checkpoints);
+    checkpoints.save = async (...args) => { const view = await save(...args); loseAck = true; return view; };
+  }, archive);
+  await page.getByLabel('Checkpoint name (optional)').fill('Working draft');
+  await page.getByRole('button', { name: 'Save checkpoint', exact: true }).click();
+  await expect(page.getByRole('region', { name: 'Document history' })).toHaveAttribute('aria-busy', 'true');
+  await expect(page.getByRole('button', { name: 'Restore selected' })).toBeDisabled();
+  await expect(page.getByRole('button', { name: 'Refresh history' })).toBeDisabled();
+  await expect.poll(() => page.evaluate(() => typeof window.releaseHistory)).toBe('function');
+  await page.evaluate(() => window.releaseHistory());
+  await expect(page.getByRole('status')).toContainText('Checkpoint saved');
+  await page.getByLabel('Version', { exact: true }).selectOption('4');
+  await page.getByLabel('Checkpoint name (optional)').fill('Return to original');
+  await page.getByRole('button', { name: 'Restore selected' }).click();
+  await expect(page.getByRole('status')).toContainText('could not be confirmed');
+  await expect(page.getByRole('button', { name: 'Save checkpoint', exact: true })).toBeDisabled();
+  await page.getByLabel('Version', { exact: true }).selectOption('0');
+  await page.getByLabel('Checkpoint name (optional)').fill('Changed after failure');
+  await page.getByRole('button', { name: 'Retry checkpoint' }).click();
+  await expect(page.getByRole('status')).toContainText('Checkpoint recovered');
+  await page.evaluate(() => window.disposeHistory());
+  const recovered = await page.evaluate(() => window.historyPreview!);
+  expect(recovered.title).toBe('Return to original');
+  expect(Buffer.from(recovered.bytes)).toEqual(await readFile('../TestFiles/HistoryArchive/agreement-v1.docx'));
+});
+
+test('resolved collaboration conflicts remain distinguishable and retain the exact proposal download', async ({ page }, testInfo) => {
+  const archive = (await readFile('../TestFiles/HistoryArchive/charter-collaboration.docxhistory')).toString('base64');
+  await page.evaluate(async encoded => {
+    const api = window.historyApi;
+    const reader = await api.openDocxHistoryArchive(Uint8Array.from(atob(encoded), c => c.charCodeAt(0)));
+    window.historyPanel = api.mountHistoryControls(document.querySelector<HTMLElement>('#controls')!, { reader, preview() {} });
+    await window.historyPanel.ready;
+    window.disposeHistory = async () => { await window.historyPanel.destroy(); reader.close(); };
+  }, archive);
+  await page.getByText('Recorded collaboration', { exact: true }).click();
+  await page.getByRole('button', { name: 'Load activity' }).click();
+  const conflict = page.getByRole('listitem').filter({ hasText: 'Conflict resolved' });
+  await expect(conflict).toHaveCount(1);
+  await expect(page.getByText('Conflict needs review', { exact: false })).toHaveCount(0);
+  const downloadEvent = page.waitForEvent('download');
+  await conflict.getByRole('button', { name: 'Download proposal' }).click();
+  const download = await downloadEvent;
+  await download.saveAs(testInfo.outputPath('retained-proposal.docx'));
+  expect(await readFile(testInfo.outputPath('retained-proposal.docx'))).toEqual(await readFile('../TestFiles/HistoryArchive/charter-collaboration-conflicting-proposal.docx'));
+  await page.evaluate(() => window.disposeHistory());
+});

--- a/npm/tests/history-controls.spec.ts
+++ b/npm/tests/history-controls.spec.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { test, expect } from './history-controls-harness.js';
 import type { HistoryControls } from '../src/history-controls.js';
+import type { HistoryCheckpointRequest } from '../src/history-checkpoints.js';
 
 declare global {
   interface Window {
@@ -143,4 +144,61 @@ test('resolved collaboration conflicts remain distinguishable and retain the exa
   await download.saveAs(testInfo.outputPath('retained-proposal.docx'));
   expect(await readFile(testInfo.outputPath('retained-proposal.docx'))).toEqual(await readFile('../TestFiles/HistoryArchive/charter-collaboration-conflicting-proposal.docx'));
   await page.evaluate(() => window.disposeHistory());
+});
+
+test('mounting refuses an out-of-range page size and controls bound to another document', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const api = window.historyApi;
+    const client = api.openDocxHistory(api.createMemoryHistoryStorage());
+    const reader = client.document('agreement');
+    const elsewhere = client.document('a-different-agreement');
+    let stored: HistoryCheckpointRequest | null = null;
+    const checkpoints = await api.HistoryCheckpoints.open(elsewhere, {
+      read: async () => stored,
+      put: async (request: HistoryCheckpointRequest) => (stored ??= request),
+      remove: async (requestId: string) => { if (stored?.id === requestId) stored = null; },
+    });
+    const container = document.querySelector<HTMLElement>('#controls')!;
+    const sizes: string[] = [];
+    for (const pageSize of [0, 101, 2.5]) {
+      try { api.mountHistoryControls(container, { reader, preview() {}, pageSize }); sizes.push('mounted'); }
+      catch (error) { sizes.push((error as Error).name); }
+    }
+    let mismatch = '';
+    try { api.mountHistoryControls(container, { reader, checkpoints, preview() {} }); }
+    catch (error) { mismatch = (error as Error).message; }
+    client.close();
+    return { sizes, mismatch, mounted: container.childElementCount };
+  });
+  expect(result.sizes).toEqual(['RangeError', 'RangeError', 'RangeError']);
+  expect(result.mismatch).toContain('same document');
+  // A refused mount leaves the host's container exactly as it found it.
+  expect(result.mounted).toBe(0);
+});
+
+test('history control errors stay distinct and name the failure a host can act on', async ({ page }) => {
+  const messages = await page.evaluate(() => {
+    const api = window.historyApi;
+    const of = (code: string, pending = false) =>
+      api.historyControlError(new api.DocxHistoryError(code, `raw ${code} detail`), pending);
+    return {
+      stale: of('StaleHead'), conflict: of('ImportConflict'), unsupported: of('InitializationUnsupported'),
+      resource: of('ResourceLimit'),
+      // Codes with no dedicated explanation still reach the host: pending draws attention to the
+      // unconfirmed checkpoint, everything else surfaces the underlying message.
+      pending: of('Timeout', true), unrecognised: of('Timeout'),
+      plain: api.historyControlError(new Error('network unavailable')),
+      thrownValue: api.historyControlError('not an error object'),
+    };
+  });
+  expect(messages.stale).toContain('Your draft is safe');
+  expect(messages.conflict).toContain('read-only');
+  expect(messages.unsupported).toContain('import history');
+  expect(messages.resource).toContain('64 MiB');
+  expect(messages.pending).toContain('Retry checkpoint');
+  expect(messages.unrecognised).toContain('raw Timeout detail');
+  expect(messages.plain).toContain('network unavailable');
+  expect(messages.thrownValue).toContain('Please try again.');
+  // Nothing collapses into a single unhelpful sentence.
+  expect(new Set(Object.values(messages)).size).toBe(Object.values(messages).length);
 });


### PR DESCRIPTION
Apps can mount a document-history panel to browse saved versions, preview or download a selected DOCX, compare arbitrary versions, save checkpoints, restore, and explicitly share a portable history file. Read-only archive readers use the same panel. The editor remains host-owned, and conflicting controls are disabled during calls.

Stack 2/3: #738 → #739 → #740, based on #738 (452 added lines here). Includes time lookup, collaboration conflict status, retry feedback, and usage documentation.

Validation: TypeScript build/typecheck and three Chromium panel scenarios using the real agreement and charter archives. Tests verify paginated browsing, exact DOCX/proposal downloads, tracked-change comparison, standalone archive reopening, lost restore acknowledgement recovery, and phone-width layout. The checkpoint tests also pass.