### PR TITLE
feat(history): safe portable-history editor example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,34 @@ All notable changes to this project will be documented in this file.
   running call are disabled while it runs. Read-only `.docxhistory` archives mount the same panel
   by omitting `checkpoints`. `historyControlError(error, pending)` is exported separately so a host
   can render the same plain-language explanations outside the panel.
+- `mountHistoryControls` gained `onCheckpoint(view, action)`, which reports an acknowledged save,
+  restore or retry before the version list reloads. A host uses it to decide whether its open draft
+  is now saved: because a retry can acknowledge a *request captured earlier* — possibly by another
+  tab — only a fresh save whose capture is still the current draft may clear an unsaved-work
+  warning. Recorded collaboration also pages instead of rendering every operation at once, and each
+  entry can expand into its decision detail. `HistoryCheckpoints.open` takes an optional third
+  argument, an already captured view, so an editor opened at an exact version keeps that head
+  paired with the bytes on screen instead of silently adopting the latest.
+- A runnable TypeScript editor example (`npm/examples/history.ts`, built with
+  `npm run build:history-example`) pairing the ribbon editor, IndexedDB checkpoints and the history
+  panel: portable `.docxhistory` files open read-only, importing their embedded identity resumes
+  editing, previews render separately from the draft, and a pending save reopens its captured draft
+  after a reload.
 - `openIndexedDbHistoryStore(name)`: optional browser-local `HistoryStorage` plus a per-document
   `HistoryCheckpointJournal`, backed by IndexedDB. Head initialization and compare-and-swap share
   one read/write transaction on the same object store, so independent connections — separate tabs
   included — serialize against each other; stored bytes are SHA-256 verified against their
   reference before they are written. Nothing installs it: no storage, autosave or retention policy
   is created by using the history API, and clearing browser site data removes the store.
+
+### Fixed
+
+- `mountRibbon({ fileActions: false })` threw `Docxodus ribbon: template is missing "save"` on the
+  first `open()`. That option removes the quick group holding New/Open/Save, but opening a document
+  re-enabled the Save button unconditionally, so every host that hides the file actions — precisely
+  the hosts that supply their own persistence — could mount the ribbon and never open anything in
+  it. The rest of the surface already looked its controls up optionally; this was the last
+  unconditional lookup.
 
 ## [12.2.0] - 2026-09-07
 

--- a/Docxodus.Tests/DocxHistoryArchiveArtifactTests.cs
+++ b/Docxodus.Tests/DocxHistoryArchiveArtifactTests.cs
@@ -55,6 +55,11 @@ public sealed class DocxHistoryArchiveArtifactTests
             Assert.Equal(committed, comparison.ToRedline().DocumentByteArray);
             using (var redline = new DocxSession(committed))
                 Assert.NotEmpty(redline.ListRevisions());
+            var compared = new WmlDocument(index.ComparisonFile, committed);
+            Assert.Empty(DocxDiff.GetRevisions(new WmlDocument("before.docx", await archive.ExportDocxAsync(before)),
+                RevisionProcessor.RejectRevisions(compared)));
+            Assert.Empty(DocxDiff.GetRevisions(new WmlDocument("after.docx", await archive.ExportDocxAsync(after)),
+                RevisionProcessor.AcceptRevisions(compared)));
             if (index.Conflict is { } conflict)
             {
                 Assert.Equal("conflict", (await archive.GetOperationAsync(conflict)).Record.Status);

--- a/docs/history-controls.md
+++ b/docs/history-controls.md
@@ -32,6 +32,9 @@ The optional `download` callback lets your app choose its own download dialog.
 `onCheckpoint(view, action)` reports an acknowledged save, restore or retry before refreshing
 the list. Hosts can use it to mark a captured draft as saved, provided no edits arrived while
 the save ran. A restore leaves the draft untouched; a retry can acknowledge an older request.
+**Restore selected** asks for confirmation, naming the selected version and explaining that
+the draft and later versions are preserved. Cancel leaves history and the retry journal
+unchanged. Confirmation applies to the panel; headless restore remains an explicit host call.
 
 `HistoryCheckpoints` also works without the panel. Supply your own durable
 `HistoryCheckpointJournal`, or use the IndexedDB store's per-document journal. Complete

--- a/docs/history-controls.md
+++ b/docs/history-controls.md
@@ -29,6 +29,9 @@ Omit `checkpoints` and `capture` when mounting a standalone archive reader. The 
 owns or closes its reader. It awaits preview/download callbacks and disables conflicting
 controls during calls. `ready` and `refresh()` reject on errors as well as showing feedback.
 The optional `download` callback lets your app choose its own download dialog.
+`onCheckpoint(view, action)` reports an acknowledged save, restore or retry before refreshing
+the list. Hosts can use it to mark a captured draft as saved, provided no edits arrived while
+the save ran. A restore leaves the draft untouched; a retry can acknowledge an older request.
 
 `HistoryCheckpoints` also works without the panel. Supply your own durable
 `HistoryCheckpointJournal`, or use the IndexedDB store's per-document journal. Complete
@@ -36,6 +39,35 @@ requests survive reloads; Retry recovers the captured inputs, even if a later ch
 exists. A stale draft stays open until the user refreshes history and decides what to save.
 IndexedDB data stays on this browser and can be removed by clearing site data; download a
 history file for a portable copy. No automatic checkpoint, network sync or retention is installed.
+
+The [runnable TypeScript example](../npm/examples/history.ts) pairs this panel with the ribbon
+editor and a separate preview. From `npm/`, with WASM already built:
+
+```sh
+npm run build:history-example
+python3 -m http.server 8088 --directory dist/wasm
+```
+
+Open `http://localhost:8088/history.html`. Open a DOCX, edit and save a checkpoint, or open one
+of the [sample history files](../TestFiles/HistoryArchive/README.md). History files open read-only
+first; **Resume editing this history** imports the embedded document identity. A conflicting
+local history leaves the archive open read-only. **Back to my draft** returns to the existing
+editor history. **Use as draft** in a saved-version preview asks before replacing unsaved work.
+Malformed or unsupported files leave the current editor intact; archive size is checked before
+reading upload bytes. Pending saves recover across reloads, and the example reopens their
+captured draft. Ordinary unsaved edits are not autosaved.
+
+When loading an already captured version, pass its view as the third argument to
+`HistoryCheckpoints.open(document, journal, view)`. This keeps the editor's expected head
+paired with its bytes, including when an import retry returns an older receipt.
+
+Run the artifact and browser-interaction checks with:
+
+```sh
+npm run build:ts
+npm run typecheck
+npx playwright test history-checkpoints.spec.ts history-controls.spec.ts history-example.spec.ts --project=chromium
+```
 
 Users handle documents, not storage directories. Your app owns persistence, request IDs,
 loading indicators, download dialogs and the editor; Docxodus supplies the history calls.

--- a/npm/README.md
+++ b/npm/README.md
@@ -723,6 +723,11 @@ Requires WebAssembly SIMD support.
 
 See the [concise history-controls API guide](../docs/history-controls.md) for latest/version
 loading, comparison, checkpoint/restore and `.docxhistory` import/export over host-owned storage.
+`mountHistoryControls` adds an accessible panel with separate previews, exact checkpoint retries
+and explicit history sharing. `openIndexedDbHistoryStore` provides optional browser persistence.
+These controls require `structuredClone` and `crypto.randomUUID`; the optional store also requires IndexedDB.
+The [TypeScript editor example](examples/history.ts) runs with `npm run build:history-example`
+and a local server serving `dist/wasm/history.html` after the WASM build.
 
 ## License
 

--- a/npm/examples/history.html
+++ b/npm/examples/history.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Docxodus — document history</title>
+<style>
+  *{box-sizing:border-box}body{margin:0!important;background:#f1f5f9;color:#203047;font:14px/1.5 system-ui,sans-serif}
+  header{padding:16px 24px;background:white;border-bottom:1px solid #cbd5e1}h1{font-size:24px;margin:0}header p{margin:6px 0}
+  fieldset{border:0;margin:0;padding:0}button,input{font:inherit}button{padding:8px 12px;margin:4px;border:1px solid #94a3b8;border-radius:6px;cursor:pointer;background:white;color:inherit}
+  button:focus-visible,input:focus-visible{outline:3px solid #2563eb}button:disabled{opacity:.5;cursor:default}[hidden]{display:none!important}
+  main{display:grid;grid-template-columns:minmax(0,1fr) 390px;gap:16px;padding:16px}#editor{height:calc(100dvh - 210px);min-height:520px;min-width:0}#editor>div{height:100%}
+  aside{min-width:0}#source{overflow-wrap:anywhere}dialog{width:min(1000px,95vw);max-height:94dvh;border:1px solid #94a3b8;border-radius:12px;padding:18px}dialog::backdrop{background:#0f172a99}
+  #preview{max-height:66dvh;overflow:auto;border:1px solid #cbd5e1;margin-top:12px}#preview-title{font-size:20px;margin:0}
+  @media(max-width:850px){main{grid-template-columns:minmax(0,1fr)}aside{grid-row:1}header{padding:12px}#editor{height:75dvh}}
+</style>
+<header>
+  <h1>Documents with history</h1>
+  <p>Keep checkpoints in this browser. Download a history file to take them with you.</p>
+  <fieldset id="files" disabled aria-label="Open documents">
+    <button id="new" type="button">New document</button>
+    <button id="download-draft" type="button">Download draft DOCX</button>
+    <label>Open a DOCX or history file <input id="file" type="file" accept=".docx,.docxhistory"></label>
+    <button id="resume" type="button" hidden>Resume editing this history</button>
+    <button id="back" type="button" hidden>Back to my draft</button>
+  </fieldset>
+  <p id="message" role="status">Loading document tools…</p>
+</header>
+<main><div id="editor" aria-label="Open draft"></div><aside><p id="source"></p><div id="history"></div></aside></main>
+<dialog id="preview-dialog" aria-labelledby="preview-title">
+  <h2 id="preview-title">Preview</h2>
+  <p>Your draft stays open while you browse.</p>
+  <button id="close-preview" type="button">Close preview</button>
+  <button id="use-preview" type="button">Use as draft</button>
+  <button id="download-preview" type="button">Download preview DOCX</button>
+  <div id="preview"></div>
+</dialog>
+<script type="module" src="./history-example.js"></script>
+</html>

--- a/npm/examples/history.ts
+++ b/npm/examples/history.ts
@@ -1,0 +1,183 @@
+import {
+  initialize, getWasmExports, createBlankDocx, mountRibbon, createViewer, openDocxHistory,
+  openDocxHistoryArchive, openIndexedDbHistoryStore, HistoryCheckpoints, mountHistoryControls,
+  MAX_HISTORY_ARCHIVE_BYTES, DocxHistoryError, historyControlError, TrackedChangeMode,
+} from '../src/embed.js';
+import type { DocxHistoryArchive, DocxHistoryDocument, DocxHistoryView, DocxViewer, HistoryControls, RibbonEditor, DocxEditorExports } from '../src/embed.js';
+
+interface Draft { document: DocxHistoryDocument; checkpoints: HistoryCheckpoints; name: string }
+const element = <T extends HTMLElement>(id: string): T => document.getElementById(id) as T;
+const files = element<HTMLFieldSetElement>('files');
+const input = element<HTMLInputElement>('file');
+const editorRoot = element<HTMLElement>('editor');
+const historyRoot = element<HTMLElement>('history');
+const message = element<HTMLElement>('message');
+const dialog = element<HTMLDialogElement>('preview-dialog');
+const resume = element<HTMLButtonElement>('resume');
+const back = element<HTMLButtonElement>('back');
+const usePreview = element<HTMLButtonElement>('use-preview');
+let ribbon: RibbonEditor | undefined;
+let panel: HistoryControls | undefined;
+let draft: Draft;
+let archive: { reader: DocxHistoryArchive; bytes: Uint8Array; name: string } | undefined;
+let preview: DocxViewer | undefined;
+let previewBytes: Uint8Array | undefined;
+let dirty = false;
+let editGeneration = 0;
+let capturedGeneration = -1;
+let busy = false;
+let activeHost: Promise<void> | undefined;
+
+async function start(): Promise<void> {
+  await initialize(new URL('./', location.href).href);
+  const store = await openIndexedDbHistoryStore('docxodus-history-example');
+  const client = openDocxHistory(store.storage);
+  const stored = localStorage.getItem('docxodus-history-draft');
+  const identity: { id: string; name: string } = stored ? JSON.parse(stored) : { id: crypto.randomUUID(), name: 'Untitled.docx' };
+
+  const makeDraft = async (id: string, name: string, view?: DocxHistoryView): Promise<Draft> => {
+    const document = client.document(id);
+    return { document, name, checkpoints: await HistoryCheckpoints.open(document, store.journal(id), view) };
+  };
+  const mountPanel = (holder: HTMLElement, current: Draft | DocxHistoryArchive, name: string): HistoryControls => {
+    const writable = 'checkpoints' in current;
+    return mountHistoryControls(holder, {
+      reader: writable ? current.document : current, documentName: name,
+      checkpoints: writable ? current.checkpoints : undefined,
+      capture: writable ? () => {
+        const bytes = ribbon?.save(); if (!bytes) throw new Error('Open a document first.');
+        capturedGeneration = editGeneration; return bytes;
+      } : undefined,
+      onCheckpoint: (_view, action) => {
+        // A retry can recover another tab's older request. Only a fresh save confirms this capture.
+        if (action === 'save' && capturedGeneration === editGeneration) dirty = false;
+        capturedGeneration = -1;
+      },
+      preview: showPreview,
+    });
+  };
+  const observer = new MutationObserver(() => { files.disabled = busy || panel?.element.getAttribute('aria-busy') === 'true'; });
+  function watchPanel(): void {
+    observer.disconnect();
+    if (panel) observer.observe(panel.element, { attributes: true, attributeFilter: ['aria-busy'] });
+  }
+  async function installDraft(next: Draft, bytes: Uint8Array): Promise<void> {
+    const editorHolder = document.createElement('div');
+    const controlsHolder = document.createElement('div');
+    const candidate = mountRibbon(editorHolder, {
+      exports: getWasmExports() as unknown as DocxEditorExports,
+      documentName: next.name, fileActions: false, loader: false, hint: false,
+      onEdit: () => { dirty = true; editGeneration++; }, onCommand: () => { dirty = true; editGeneration++; },
+      trackedChanges: TrackedChangeMode.RenderInline,
+    });
+    let controls: HistoryControls | undefined;
+    try {
+      candidate.open(bytes, next.name);
+      controls = mountPanel(controlsHolder, next, next.name); await controls.ready;
+      localStorage.setItem('docxodus-history-draft', JSON.stringify({ id: next.document.documentId, name: next.name }));
+    } catch (error) { candidate.destroy(); await controls?.destroy(); throw error; }
+    await panel?.destroy(); archive?.reader.close(); archive = undefined;
+    ribbon?.destroy(); ribbon = candidate; panel = controls; draft = next;
+    editorRoot.replaceChildren(editorHolder); historyRoot.replaceChildren(controlsHolder);
+    dirty = false; editGeneration = 0; capturedGeneration = -1; resume.hidden = back.hidden = true;
+    element('source').textContent = `${next.name} — checkpoints in this browser`;
+    watchPanel();
+  }
+  async function openFile(file: File): Promise<void> {
+    if (/\.docxhistory$/i.test(file.name)) {
+      if (file.size > MAX_HISTORY_ARCHIVE_BYTES) throw new DocxHistoryError('ResourceLimit', 'History archives are limited to 64 MiB.');
+      const bytes = new Uint8Array(await file.arrayBuffer());
+      const reader = await openDocxHistoryArchive(bytes);
+      const holder = document.createElement('div');
+      let controls: HistoryControls | undefined;
+      try { controls = mountPanel(holder, reader, file.name); await controls.ready; }
+      catch (error) { await controls?.destroy(); reader.close(); throw error; }
+      await panel?.destroy(); archive?.reader.close();
+      archive = { reader, bytes, name: file.name }; panel = controls;
+      historyRoot.replaceChildren(holder); resume.hidden = back.hidden = false;
+      element('source').textContent = `${file.name} — read-only; your draft is still open`;
+      watchPanel();
+    } else {
+      if (!/\.docx$/i.test(file.name)) throw new Error('Choose a .docx or .docxhistory file.');
+      if (!replaceDraft()) return;
+      await installDraft(await makeDraft(crypto.randomUUID(), file.name), new Uint8Array(await file.arrayBuffer()));
+      dirty = true;
+    }
+  }
+  async function act(action: () => Promise<void>): Promise<void> {
+    if (busy || panel?.element.getAttribute('aria-busy') === 'true') return;
+    busy = files.disabled = editorRoot.inert = true;
+    if (panel) panel.element.inert = true;
+    message.textContent = 'Opening document history…';
+    try { activeHost = action(); await activeHost; message.textContent = 'Ready. Save a checkpoint to keep your changes in this browser.'; }
+    catch (error) { message.textContent = historyControlError(error); }
+    finally {
+      activeHost = undefined;
+      busy = files.disabled = editorRoot.inert = false;
+      if (panel) panel.element.inert = false;
+    }
+  }
+  input.addEventListener('change', () => {
+    const file = input.files?.[0]; input.value = ''; if (file) void act(() => openFile(file));
+  });
+  element('new').addEventListener('click', () => void act(async () => {
+    if (replaceDraft()) await installDraft(await makeDraft(crypto.randomUUID(), 'Untitled.docx'), createBlankDocx());
+  }));
+  resume.addEventListener('click', () => void act(async () => {
+    if (!archive || !replaceDraft()) return;
+    const imported = await client.importHistoryArchive(archive.bytes);
+    const next = await makeDraft(imported.archive.documentId, archive.name.replace(/\.docxhistory$/i, '.docx'), imported.view);
+    // Exact-head retries can return an older receipt. Never replace its version with latest.
+    await installDraft(next, await next.document.exportDocx(imported.view.version.id));
+  }));
+  back.addEventListener('click', () => void act(async () => {
+    const holder = document.createElement('div');
+    const controls = mountPanel(holder, draft, draft.name);
+    try { await controls.ready; } catch (error) { await controls.destroy(); throw error; }
+    await panel?.destroy(); archive?.reader.close(); archive = undefined; panel = controls;
+    historyRoot.replaceChildren(holder); resume.hidden = back.hidden = true;
+    element('source').textContent = `${draft.name} — checkpoints in this browser`; watchPanel();
+  }));
+  usePreview.addEventListener('click', () => void act(async () => {
+    if (!previewBytes || archive || !replaceDraft()) return;
+    await installDraft(draft, previewBytes); dirty = true; dialog.close();
+  }));
+  element('close-preview').addEventListener('click', () => dialog.close());
+  element('download-preview').addEventListener('click', () => { if (previewBytes) download(previewBytes, 'preview.docx'); });
+  element('download-draft').addEventListener('click', () => { const bytes = ribbon?.save(); if (bytes) download(bytes, draft.name); });
+  window.addEventListener('beforeunload', event => { if (dirty || busy || panel?.element.getAttribute('aria-busy') === 'true') event.preventDefault(); });
+  // Teardown is explicit: stop accepting commands, await the panel, then release client/store handles.
+  window.addEventListener('pagehide', event => {
+    if (event.persisted) return;
+    observer.disconnect();
+    void (async () => {
+      await activeHost?.catch(() => {}); await panel?.destroy();
+      archive?.reader.close(); client.close(); store.close(); ribbon?.destroy(); preview?.destroy();
+    })();
+  });
+  const initial = await makeDraft(identity.id, identity.name);
+  const pending = await store.journal(identity.id).read();
+  const view = initial.checkpoints.view;
+  await installDraft(initial, pending?.kind === 'save' ? pending.bytes : view ? await initial.document.exportDocx(view.version.id) : createBlankDocx());
+  dirty = pending?.kind === 'save';
+  files.disabled = false; message.textContent = 'Ready. Save a checkpoint to keep your changes in this browser.';
+}
+
+function replaceDraft(): boolean { return !dirty || confirm('Replace your open draft? Download it or save a checkpoint first if you want to keep your changes.'); }
+async function showPreview(bytes: Uint8Array, title: string): Promise<void> {
+  const holder = document.createElement('div');
+  const candidate = await createViewer(holder, bytes, {
+    wasmBasePath: new URL('./', location.href).href, renderTrackedChanges: true,
+  });
+  preview?.destroy(); preview = candidate; previewBytes = bytes;
+  element('preview').replaceChildren(holder); element('preview-title').textContent = title;
+  usePreview.hidden = !!archive;
+  if (!dialog.open) dialog.showModal();
+  element('close-preview').focus();
+}
+function download(bytes: Uint8Array, name: string): void {
+  const url = URL.createObjectURL(new Blob([bytes.slice()], { type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }));
+  const link = document.createElement('a'); link.href = url; link.download = name; link.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+void start().catch(error => { message.textContent = historyControlError(error); });

--- a/npm/package.json
+++ b/npm/package.json
@@ -57,6 +57,7 @@
   "scripts": {
     "build:wasm": "../scripts/build-wasm.sh",
     "build:ts": "tsc",
+    "build:history-example": "esbuild examples/history.ts --bundle --format=esm --outfile=dist/wasm/history-example.js && cp examples/history.html dist/wasm/history.html",
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.tests.json",
     "build:pagination-bundle": "esbuild src/pagination.ts --bundle --format=iife --global-name=DocxodusPagination --outfile=dist/pagination.bundle.js",
     "build:session-bundle": "esbuild src/session.ts --bundle --format=iife --global-name=DocxodusSession --outfile=dist/session.bundle.js",

--- a/npm/src/history-checkpoints.ts
+++ b/npm/src/history-checkpoints.ts
@@ -29,12 +29,16 @@ export class HistoryCheckpoints {
 
   private constructor(readonly document: DocxHistoryDocument, private readonly journal: HistoryCheckpointJournal) {}
 
-  static async open(document: DocxHistoryDocument, journal: HistoryCheckpointJournal): Promise<HistoryCheckpoints> {
+  /** Pass an already captured view when opening its exact version in an editor (for example, after import). */
+  static async open(document: DocxHistoryDocument, journal: HistoryCheckpointJournal,
+    view?: DocxHistoryView | null): Promise<HistoryCheckpoints> {
     const controls = new HistoryCheckpoints(document, journal);
     controls.request = structuredClone(await journal.read());
     if (controls.request && controls.request.documentId !== document.documentId)
       throw new DocxHistoryError('InvalidRequest', 'The pending checkpoint belongs to another document.');
-    controls.current = await document.read();
+    controls.current = view === undefined ? await document.read() : structuredClone(view);
+    if (controls.current && controls.current.state.documentId !== document.documentId)
+      throw new DocxHistoryError('InvalidRequest', 'The captured view belongs to another document.');
     return controls;
   }
 

--- a/npm/src/history-controls.ts
+++ b/npm/src/history-controls.ts
@@ -94,7 +94,12 @@ class HistoryPanel implements HistoryControls {
       this.status.textContent = 'Checkpoint saved. Your draft remains open.';
     });
     this.button('restore', 'Restore selected', async () => {
-      const view = await options.checkpoints!.restore(this.selected().id, this.metadata());
+      const version = this.selected();
+      if (!doc.defaultView?.confirm(`Restore ${versionTitle(version)} as a new checkpoint?\n\nYour current draft and all later versions will be kept.`)) {
+        this.status.textContent = 'Restore canceled. Your draft and history are unchanged.';
+        return;
+      }
+      const view = await options.checkpoints!.restore(version.id, this.metadata());
       await options.onCheckpoint?.(view, 'restore');
       await this.load(false);
       this.status.textContent = 'Restored as a new checkpoint. Your draft and later versions are kept.';

--- a/npm/src/history-controls.ts
+++ b/npm/src/history-controls.ts
@@ -1,5 +1,5 @@
 import { DocxHistoryError } from './history.js';
-import type { DocxHistoryReader, DocxHistoryView, DocxStoredVersion, HistoryBlobReference } from './history.js';
+import type { DocxHistoryReader, DocxHistoryView, DocxStoredOperation, DocxStoredVersion, HistoryBlobReference } from './history.js';
 import type { HistoryCheckpoints } from './history-checkpoints.js';
 
 export interface HistoryControlsOptions {
@@ -14,6 +14,8 @@ export interface HistoryControlsOptions {
   preview: (bytes: Uint8Array, title: string) => void | Promise<void>;
   /** Defaults to a browser download. */
   download?: (bytes: Uint8Array, filename: string) => void | Promise<void>;
+  /** Called after an acknowledged checkpoint, before the list refreshes. Retries may return an older view. */
+  onCheckpoint?: (view: DocxHistoryView, action: 'save' | 'restore' | 'retry') => void | Promise<void>;
   pageSize?: number;
 }
 
@@ -86,19 +88,22 @@ class HistoryPanel implements HistoryControls {
     this.label = this.input('Checkpoint name (optional)', 'text');
     this.author.parentElement!.hidden = this.label.parentElement!.hidden = !options.checkpoints;
     this.button('save', 'Save checkpoint', async () => {
-      await options.checkpoints!.save(await options.capture!(), this.metadata());
+      const view = await options.checkpoints!.save(await options.capture!(), this.metadata());
+      await options.onCheckpoint?.(view, 'save');
       await this.load(false); this.label.value = '';
       this.status.textContent = 'Checkpoint saved. Your draft remains open.';
     });
     this.button('restore', 'Restore selected', async () => {
-      await options.checkpoints!.restore(this.selected().id, this.metadata());
+      const view = await options.checkpoints!.restore(this.selected().id, this.metadata());
+      await options.onCheckpoint?.(view, 'restore');
       await this.load(false);
       this.status.textContent = 'Restored as a new checkpoint. Your draft and later versions are kept.';
     });
     const restoreNote = doc.createElement('p'); restoreNote.hidden = !options.checkpoints;
     restoreNote.textContent = 'Restore creates a new checkpoint. Open latest to preview it; your draft stays open.'; this.fieldset.append(restoreNote);
     this.button('retry', 'Retry checkpoint', async () => {
-      await options.checkpoints!.retry(); await this.load(false);
+      const view = await options.checkpoints!.retry();
+      await options.onCheckpoint?.(view, 'retry'); await this.load(false);
       this.status.textContent = 'Checkpoint recovered. Your draft remains open. Refresh history to check for newer versions.';
     });
     const sharing = this.disclosure('Download with history');
@@ -115,29 +120,23 @@ class HistoryPanel implements HistoryControls {
     }, time);
     const activity = this.disclosure('Recorded collaboration');
     const decisions = doc.createElement('ol');
+    let showOlderActivity = () => {};
     this.button('activity', 'Load activity', async () => {
       const { operations } = await options.reader.readOperationsSince(null);
       const resolved = new Set(operations.filter(op => op.record.status === 'accepted').map(op => op.input.request.resolves?.digest.value));
-      const items = operations.map(op => {
-        const item = doc.createElement('li');
-        const state = op.record.status === 'accepted' ? 'Accepted' : resolved.has(op.id.digest.value) ? 'Conflict resolved' : 'Conflict needs review';
-        const label = doc.createElement('p');
-        label.textContent = `${op.input.request.metadata.author} · ${state} · ${formatTime(op.input.request.metadata.createdAt)}`;
-        item.append(label);
-        const button = doc.createElement('button'); button.type = 'button'; button.textContent = 'Download proposal';
-        button.addEventListener('click', () => {
-          void this.run('Downloading proposal', async () => {
-            const decision = await options.reader.getOperation(op.id);
-            await this.download(await options.reader.exportOperationProposal(decision.id), `proposal-${decision.record.revision}.docx`);
-          }).catch(() => {});
-        }, { signal: this.events.signal });
-        item.append(button); return item;
-      });
-      decisions.replaceChildren(...items);
+      let shown = 0;
+      showOlderActivity = () => {
+        const page = operations.slice(Math.max(0, operations.length - shown - this.pageSize), operations.length - shown).reverse();
+        decisions.append(...page.map(op => this.activityItem(op, resolved.has(op.id.digest.value)))); shown += page.length;
+        this.actions.get('activity-more')!.hidden = shown >= operations.length;
+      };
+      decisions.replaceChildren(); showOlderActivity();
       this.status.textContent = operations.length ? 'Recorded activity loaded.' : 'No recorded collaboration.';
     }, activity);
     activity.append(decisions);
-    this.ready = this.refresh();
+    this.button('activity-more', 'Load older activity', async () => showOlderActivity(), activity);
+    this.actions.get('activity-more')!.hidden = true;
+    this.ready = this.run('Loading history', () => this.load(false));
   }
 
   refresh(): Promise<void> { return this.run('Loading history', () => this.load(true)); }
@@ -189,6 +188,26 @@ class HistoryPanel implements HistoryControls {
   }
 
   private selected(): DocxStoredVersion { return this.records[Number(this.versions.value)]; }
+  private activityItem(op: DocxStoredOperation, resolved: boolean): HTMLLIElement {
+    const doc = this.element.ownerDocument;
+    const item = doc.createElement('li');
+    const state = op.record.status === 'accepted' ? 'Accepted' : resolved ? 'Conflict resolved' : 'Conflict needs review';
+    const label = doc.createElement('p');
+    label.textContent = `${op.input.request.metadata.author} · ${state} · ${formatTime(op.input.request.metadata.createdAt)}`;
+    item.append(label);
+    const description = doc.createElement('p');
+    this.commandButton('View decision', async () => {
+      const decision = await this.options.reader.getOperation(op.id);
+      const { kind, metadata } = decision.input.request;
+      description.textContent = [{ text: 'Text edit', package: 'Document edit', discard: 'Discarded proposal' }[kind],
+        metadata.label, metadata.message, decision.record.conflict].filter(Boolean).join(' — ');
+    }, item);
+    item.append(description);
+    this.commandButton('Download proposal', async () => {
+      await this.download(await this.options.reader.exportOperationProposal(op.id), `proposal-${op.record.revision}.docx`);
+    }, item);
+    return item;
+  }
   private metadata() { return { author: this.author.value.trim() || 'You', createdAt: new Date().toISOString(), label: this.label.value.trim() || undefined }; }
   private async preview(bytes: Uint8Array, title: string): Promise<void> {
     if (!this.destroyed) await this.options.preview(bytes, title);
@@ -219,9 +238,12 @@ class HistoryPanel implements HistoryControls {
   }
 
   private button(key: string, title: string, action: () => Promise<void>, parent: HTMLElement = this.fieldset): void {
+    this.actions.set(key, this.commandButton(title, action, parent));
+  }
+  private commandButton(title: string, action: () => Promise<void>, parent: HTMLElement): HTMLButtonElement {
     const button = parent.ownerDocument.createElement('button'); button.type = 'button'; button.textContent = title;
     button.addEventListener('click', () => { void this.run(title, action).catch(() => {}); }, { signal: this.events.signal });
-    this.actions.set(key, button); parent.append(button);
+    parent.append(button); return button;
   }
   private select(title: string): HTMLSelectElement {
     const label = this.fieldset.ownerDocument.createElement('label'); label.textContent = title;
@@ -245,8 +267,10 @@ export function historyControlError(error: unknown, pending = false): string {
   if (code === 'StaleHead') return 'A newer checkpoint exists. Your draft is safe. Refresh history, review the newer version, then save again.';
   if (code === 'ImportConflict') return 'A different local history already exists. Open this file read-only to explore it.';
   if (code === 'InitializationUnsupported') return 'This storage cannot import history. Open read-only or choose storage that supports importing.';
-  if (code === 'ResourceLimit') return 'This history file exceeds browser processing limits, which can apply even below 64 MiB. Your document is unchanged.';
   if (pending) return 'The checkpoint could not be confirmed. Your draft is safe. Retry checkpoint to recover the original request.';
+  if (code === 'ResourceLimit') return 'This history file exceeds browser processing limits, which can apply even below 64 MiB. Your document is unchanged.';
+  if (code === 'UnsupportedVersion') return 'This history file uses an unsupported version. Open it with a newer app. Your document is unchanged.';
+  if (code === 'InvalidManifest') return 'This history file is damaged or incomplete. Choose another copy. Your document is unchanged.';
   return `History could not be loaded. Your document is unchanged. ${error instanceof Error ? error.message : 'Please try again.'}`;
 }
 

--- a/npm/src/history-indexeddb.ts
+++ b/npm/src/history-indexeddb.ts
@@ -49,9 +49,10 @@ export async function openIndexedDbHistoryStore(name: string): Promise<IndexedDb
     async putBlob(reference, bytes) {
       const key = referenceKey(reference);
       const captured = bytes.slice();
+      if (captured.length !== reference.length) throw new DocxHistoryError('PayloadMismatch', 'Stored document length does not match its reference.');
       const hash = Array.from(new Uint8Array(await crypto.subtle.digest('SHA-256', captured)),
         byte => byte.toString(16).padStart(2, '0')).join('');
-      if (captured.length !== reference.length || hash !== reference.digest.value)
+      if (hash !== key.split(':')[0])
         throw new DocxHistoryError('PayloadMismatch', 'Stored document bytes do not match their reference.');
       await transaction<void>('blobs', 'readwrite', (store, result) => {
         store.put(captured, key); result();
@@ -131,7 +132,7 @@ function referenceKey(reference: HistoryBlobReference): string {
 }
 function validateHead(head: HistoryHead): void {
   referenceKey(head.state);
-  if (!/^[1-9][0-9]*$/.test(head.revision) || BigInt(head.revision) > 9223372036854775807n)
+  if (typeof head.revision !== 'string' || !/^[1-9][0-9]*$/.test(head.revision) || BigInt(head.revision) > 9223372036854775807n)
     throw new DocxHistoryError('InvalidRequest', 'Invalid history revision.');
 }
 function equalHead(a: HistoryHead | null, b: HistoryHead | null): boolean {

--- a/npm/src/ribbon.ts
+++ b/npm/src/ribbon.ts
@@ -681,7 +681,8 @@ class RibbonSurface implements RibbonEditor {
       comments: this.options.comments,
       commentAuthor: this.author,
     });
-    this.require<HTMLButtonElement>("save").disabled = false;
+    const saveButton = this.control<HTMLButtonElement>("save");
+    if (saveButton) saveButton.disabled = false;
     this.require("ribbon").setAttribute("aria-disabled", "false");
     this.setState("ready");
     this.setStatus(`Rendered in ${Math.round(performance.now() - started)} ms`);

--- a/npm/tests/history-controls.spec.ts
+++ b/npm/tests/history-controls.spec.ts
@@ -274,10 +274,13 @@ test('history control errors stay distinct and name the failure a host can act o
       api.historyControlError(new api.DocxHistoryError(code, `raw ${code} detail`), pending);
     return {
       stale: of('StaleHead'), conflict: of('ImportConflict'), unsupported: of('InitializationUnsupported'),
-      resource: of('ResourceLimit'),
+      resource: of('ResourceLimit'), unsupportedVersion: of('UnsupportedVersion'), damaged: of('InvalidManifest'),
       // Codes with no dedicated explanation still reach the host: pending draws attention to the
       // unconfirmed checkpoint, everything else surfaces the underlying message.
       pending: of('Timeout', true), unrecognised: of('Timeout'),
+      // An unconfirmed checkpoint outranks a file-shaped failure, because the draft is the thing
+      // at risk. Codes that already say what to do next keep their own instruction.
+      pendingFile: of('ResourceLimit', true), pendingStale: of('StaleHead', true),
       plain: api.historyControlError(new Error('network unavailable')),
       thrownValue: api.historyControlError('not an error object'),
     };
@@ -286,10 +289,15 @@ test('history control errors stay distinct and name the failure a host can act o
   expect(messages.conflict).toContain('read-only');
   expect(messages.unsupported).toContain('import history');
   expect(messages.resource).toContain('64 MiB');
+  expect(messages.unsupportedVersion).toContain('unsupported version');
+  expect(messages.damaged).toContain('damaged or incomplete');
+  expect(messages.pendingFile).toBe(messages.pending);
+  expect(messages.pendingStale).toBe(messages.stale);
   expect(messages.pending).toContain('Retry checkpoint');
   expect(messages.unrecognised).toContain('raw Timeout detail');
   expect(messages.plain).toContain('network unavailable');
   expect(messages.thrownValue).toContain('Please try again.');
-  // Nothing collapses into a single unhelpful sentence.
-  expect(new Set(Object.values(messages)).size).toBe(Object.values(messages).length);
+  // Nothing else collapses into a single unhelpful sentence.
+  const distinct = Object.entries(messages).filter(([key]) => !key.startsWith('pending') || key === 'pending');
+  expect(new Set(distinct.map(([, text]) => text)).size).toBe(distinct.length);
 });

--- a/npm/tests/history-controls.spec.ts
+++ b/npm/tests/history-controls.spec.ts
@@ -8,6 +8,7 @@ declare global {
     historyPreview: { title: string; bytes: number[]; revisions: number; markdown: string } | null;
     releaseHistory: () => void;
     disposeHistory: () => Promise<void>;
+    historyAcknowledgements: Array<{ action: string; label: string | null | undefined; revision: string }>;
   }
 }
 
@@ -84,8 +85,12 @@ test('saving disables conflicting controls and a lost restore acknowledgement re
     const imported = await history.importHistoryArchive(Uint8Array.from(atob(encoded), c => c.charCodeAt(0)));
     const doc = history.document(imported.archive.documentId);
     const checkpoints = await api.HistoryCheckpoints.open(doc, store.journal(doc.documentId));
+    window.historyAcknowledgements = [];
     window.historyPanel = api.mountHistoryControls(document.querySelector<HTMLElement>('#controls')!, {
       reader: doc, checkpoints, capture: () => api.createBlankDocx(), preview: () => { throw new Error('Unexpected draft replacement'); },
+      onCheckpoint: (view, action) => {
+        window.historyAcknowledgements.push({ action, label: view.version.record.metadata.label, revision: view.head.revision });
+      },
     });
     await window.historyPanel.ready; pause = true;
     window.disposeHistory = async () => {
@@ -120,6 +125,10 @@ test('saving disables conflicting controls and a lost restore acknowledgement re
   await page.evaluate(() => window.disposeHistory());
   const recovered = await page.evaluate(() => window.historyPreview!);
   expect(recovered.title).toBe('Return to original');
+  expect(await page.evaluate(() => window.historyAcknowledgements)).toEqual([
+    { action: 'save', label: 'Working draft', revision: '5' },
+    { action: 'retry', label: 'Return to original', revision: '6' },
+  ]);
   expect(Buffer.from(recovered.bytes)).toEqual(await readFile('../TestFiles/HistoryArchive/agreement-v1.docx'));
 });
 
@@ -128,19 +137,101 @@ test('resolved collaboration conflicts remain distinguishable and retain the exa
   await page.evaluate(async encoded => {
     const api = window.historyApi;
     const reader = await api.openDocxHistoryArchive(Uint8Array.from(atob(encoded), c => c.charCodeAt(0)));
-    window.historyPanel = api.mountHistoryControls(document.querySelector<HTMLElement>('#controls')!, { reader, preview() {} });
+    window.historyPanel = api.mountHistoryControls(document.querySelector<HTMLElement>('#controls')!, { reader, pageSize: 1, preview() {} });
     await window.historyPanel.ready;
     window.disposeHistory = async () => { await window.historyPanel.destroy(); reader.close(); };
   }, archive);
   await page.getByText('Recorded collaboration', { exact: true }).click();
   await page.getByRole('button', { name: 'Load activity' }).click();
+  await expect(page.getByRole('listitem')).toHaveCount(1);
+  await page.getByRole('button', { name: 'Load older activity' }).click();
+  await page.getByRole('button', { name: 'Load older activity' }).click();
+  await expect(page.getByRole('listitem')).toHaveCount(3);
+  await expect(page.getByRole('button', { name: 'Load older activity' })).toBeHidden();
   const conflict = page.getByRole('listitem').filter({ hasText: 'Conflict resolved' });
   await expect(conflict).toHaveCount(1);
   await expect(page.getByText('Conflict needs review', { exact: false })).toHaveCount(0);
+  await conflict.getByRole('button', { name: 'View decision' }).click();
+  await expect(conflict).toContainText('Document edit');
   const downloadEvent = page.waitForEvent('download');
   await conflict.getByRole('button', { name: 'Download proposal' }).click();
   const download = await downloadEvent;
   await download.saveAs(testInfo.outputPath('retained-proposal.docx'));
   expect(await readFile(testInfo.outputPath('retained-proposal.docx'))).toEqual(await readFile('../TestFiles/HistoryArchive/charter-collaboration-conflicting-proposal.docx'));
+  await page.evaluate(() => window.disposeHistory());
+});
+
+test('a captured editor view stays pinned when mounting, and closing a slow preview waits without repainting', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const api = window.historyApi;
+    const store = await api.openIndexedDbHistoryStore('captured-editor');
+    let entered!: () => void; let release!: () => void;
+    const started = new Promise<void>(resolve => { entered = resolve; });
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    let slow = false;
+    const client = api.openDocxHistory({ ...store.storage, async readBlob(reference) {
+      if (slow) { entered(); await gate; } return store.storage.readBlob(reference);
+    } });
+    const doc = client.document('agreement');
+    const bytes = api.createBlankDocx();
+    const metadata = { author: 'Taylor', createdAt: '2026-09-01T12:00:00Z' };
+    const first = await doc.createVersion(null, bytes, metadata, 'original');
+    await doc.createVersion(first.head, bytes, { ...metadata, label: 'A newer version' }, 'newer');
+    const checkpoints = await api.HistoryCheckpoints.open(doc, store.journal(doc.documentId), first);
+    let previews = 0;
+    const panel = api.mountHistoryControls(document.querySelector<HTMLElement>('#controls')!, {
+      reader: doc, checkpoints, capture: () => bytes, preview: () => { previews++; },
+    });
+    await panel.ready;
+    const captured = checkpoints.view!.head;
+    let stale = '';
+    try { await checkpoints.save(bytes, metadata); } catch (error) { stale = (error as InstanceType<typeof api.DocxHistoryError>).code; }
+    slow = true;
+    Array.from(panel.element.querySelectorAll('button')).find(button => button.textContent === 'Preview selected')!.click();
+    await started;
+    let closed = false;
+    const disposal = panel.destroy().then(() => { closed = true; });
+    await Promise.resolve();
+    const waits = !closed; release(); await disposal;
+    const retained = (await doc.listVersions()).versions.length;
+    client.close(); store.close();
+    return { captured, first: first.head, stale, waits, previews, retained, empty: document.querySelector('#controls')!.childElementCount === 0 };
+  });
+  expect(result.captured).toEqual(result.first);
+  expect(result.stale).toBe('StaleHead');
+  expect(result.waits).toBe(true);
+  expect(result.previews).toBe(0);
+  expect(result.retained).toBe(2);
+  expect(result.empty).toBe(true);
+});
+
+test('keyboard version selection and a local-time lookup export the intended agreement', async ({ page }) => {
+  const original = (await readFile('../TestFiles/HistoryArchive/agreement-v1.docx')).toString('base64');
+  const time = await page.evaluate(async encoded => {
+    const api = window.historyApi;
+    const client = api.openDocxHistory(api.createMemoryHistoryStorage());
+    const doc = client.document('time-lookup');
+    const first = await doc.createVersion(null, Uint8Array.from(atob(encoded), c => c.charCodeAt(0)),
+      { author: 'Taylor', createdAt: '2026-09-01T12:00:00Z', label: '<img src=x onerror=alert(1)>' }, 'first');
+    await doc.createVersion(first.head, api.createBlankDocx(), { author: 'Taylor', createdAt: '2026-09-01T14:00:00Z', label: 'Later draft' }, 'second');
+    window.historyPreview = null;
+    window.historyPanel = api.mountHistoryControls(document.querySelector<HTMLElement>('#controls')!, {
+      reader: doc, preview(bytes, title) { window.historyPreview = { bytes: Array.from(bytes), title, markdown: '', revisions: 0 }; },
+    });
+    await window.historyPanel.ready;
+    window.disposeHistory = async () => { await window.historyPanel.destroy(); client.close(); };
+    const local = new Date('2026-09-01T13:00:00Z');
+    return new Date(local.getTime() - local.getTimezoneOffset() * 60_000).toISOString().slice(0, 16);
+  }, original);
+  const versions = page.getByLabel('Version', { exact: true });
+  await versions.focus(); await page.keyboard.press('ArrowDown');
+  await expect(versions).toHaveValue('1');
+  await expect(page.locator('#controls img')).toHaveCount(0);
+  await expect(versions.locator('option').last()).toContainText('<img src=x onerror=alert(1)>');
+  await page.getByText('Find a version by time', { exact: true }).click();
+  await page.getByLabel('Saved at or before (local time)').fill(time);
+  await page.getByRole('button', { name: 'Preview at time' }).click();
+  await expect.poll(() => page.evaluate(() => window.historyPreview?.title)).toBe('Version at selected time');
+  expect(Buffer.from(await page.evaluate(() => window.historyPreview!.bytes))).toEqual(Buffer.from(original, 'base64'));
   await page.evaluate(() => window.disposeHistory());
 });

--- a/npm/tests/history-controls.spec.ts
+++ b/npm/tests/history-controls.spec.ts
@@ -1,6 +1,8 @@
 import { readFile } from 'node:fs/promises';
 import { test, expect } from './history-controls-harness.js';
 import type { HistoryControls } from '../src/history-controls.js';
+import type { DocxHistoryView, DocxStoredVersion } from '../src/history.js';
+import type { HistoryCheckpointRequest } from '../src/history-checkpoints.js';
 
 declare global {
   interface Window {
@@ -9,6 +11,7 @@ declare global {
     releaseHistory: () => void;
     disposeHistory: () => Promise<void>;
     historyAcknowledgements: Array<{ action: string; label: string | null | undefined; revision: string }>;
+    readRestoreState: () => Promise<{ view: DocxHistoryView | null; versions: DocxStoredVersion[]; pending: HistoryCheckpointRequest | null }>;
   }
 }
 
@@ -70,7 +73,7 @@ test('browse, page, preview, compare and share a real agreement without changing
   await expect(page.getByRole('region', { name: 'Document history' })).toHaveCount(0);
 });
 
-test('saving disables conflicting controls and a lost restore acknowledgement retries its original target', async ({ page }) => {
+test('canceling restore preserves history; a confirmed restore recovers its original target after a lost acknowledgement', async ({ page }) => {
   const archive = (await readFile('../TestFiles/HistoryArchive/agreement.docxhistory')).toString('base64');
   await page.evaluate(async encoded => {
     const api = window.historyApi;
@@ -85,6 +88,8 @@ test('saving disables conflicting controls and a lost restore acknowledgement re
     const imported = await history.importHistoryArchive(Uint8Array.from(atob(encoded), c => c.charCodeAt(0)));
     const doc = history.document(imported.archive.documentId);
     const checkpoints = await api.HistoryCheckpoints.open(doc, store.journal(doc.documentId));
+    window.readRestoreState = async () => ({ view: await doc.read(), versions: (await doc.listVersions()).versions,
+      pending: await store.journal(doc.documentId).read() });
     window.historyAcknowledgements = [];
     window.historyPanel = api.mountHistoryControls(document.querySelector<HTMLElement>('#controls')!, {
       reader: doc, checkpoints, capture: () => api.createBlankDocx(), preview: () => { throw new Error('Unexpected draft replacement'); },
@@ -115,6 +120,22 @@ test('saving disables conflicting controls and a lost restore acknowledgement re
   await expect(page.getByRole('status')).toContainText('Checkpoint saved');
   await page.getByLabel('Version', { exact: true }).selectOption('4');
   await page.getByLabel('Checkpoint name (optional)').fill('Return to original');
+  const beforeRestore = await page.evaluate(() => window.readRestoreState());
+  expect(beforeRestore.pending).toBeNull();
+  const selectedTitle = await page.getByLabel('Version', { exact: true }).locator('option:checked').textContent();
+  const canceledDialog = page.waitForEvent('dialog');
+  const cancelPress = page.getByRole('button', { name: 'Restore selected' }).press('Enter');
+  const dialog = await canceledDialog;
+  const message = dialog.message();
+  await dialog.dismiss(); await cancelPress;
+  expect(dialog.type()).toBe('confirm');
+  expect(message).toContain(`Restore ${selectedTitle} as a new checkpoint?`);
+  expect(message).toContain('Your current draft and all later versions will be kept.');
+  await expect(page.getByRole('status')).toContainText('Restore canceled');
+  expect(await page.evaluate(() => window.readRestoreState())).toEqual(beforeRestore);
+  await expect(page.getByLabel('Checkpoint name (optional)')).toHaveValue('Return to original');
+  await expect(page.getByRole('button', { name: 'Retry checkpoint' })).toBeHidden();
+  page.once('dialog', dialog => dialog.accept());
   await page.getByRole('button', { name: 'Restore selected' }).click();
   await expect(page.getByRole('status')).toContainText('could not be confirmed');
   await expect(page.getByRole('button', { name: 'Save checkpoint', exact: true })).toBeDisabled();
@@ -122,6 +143,11 @@ test('saving disables conflicting controls and a lost restore acknowledgement re
   await page.getByLabel('Checkpoint name (optional)').fill('Changed after failure');
   await page.getByRole('button', { name: 'Retry checkpoint' }).click();
   await expect(page.getByRole('status')).toContainText('Checkpoint recovered');
+  const restored = await page.evaluate(() => window.readRestoreState());
+  expect(restored.pending).toBeNull();
+  expect(restored.versions.slice(1)).toEqual(beforeRestore.versions);
+  expect(restored.view!.version.record.parent).toEqual(beforeRestore.view!.version.id);
+  expect(restored.view!.version.record.restoredFrom).toEqual(beforeRestore.versions.at(-1)!.id);
   await page.evaluate(() => window.disposeHistory());
   const recovered = await page.evaluate(() => window.historyPreview!);
   expect(recovered.title).toBe('Return to original');

--- a/npm/tests/history-example.spec.ts
+++ b/npm/tests/history-example.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+import { build } from 'esbuild';
+
+let script: string;
+let html: string;
+test.beforeAll(async () => {
+  script = (await build({ entryPoints: ['examples/history.ts'], bundle: true, format: 'esm', write: false })).outputFiles[0].text;
+  html = await readFile('examples/history.html', 'utf8');
+});
+test.beforeEach(async ({ context, page }) => {
+  await context.route('**/history.html', route => route.fulfill({ contentType: 'text/html', body: html }));
+  await context.route('**/history-example.js', route => route.fulfill({ contentType: 'text/javascript', body: script }));
+  page.on('dialog', dialog => void dialog.accept());
+  await page.goto('/history.html');
+  await expect(page.getByRole('button', { name: 'New document', exact: true })).toBeEnabled();
+});
+
+test('resume a portable agreement, save a checkpoint, reopen after reload, and keep conflicting imports read-only', async ({ page }, testInfo) => {
+  const file = page.getByLabel('Open a DOCX or history file');
+  const versions = page.getByLabel('Version', { exact: true });
+  await file.setInputFiles('../TestFiles/HistoryArchive/agreement.docxhistory');
+  await expect(versions.locator('option')).toHaveCount(4);
+  await expect(page.getByRole('button', { name: 'Save checkpoint', exact: true })).toBeHidden();
+  await expect(page.locator('#editor')).not.toContainText('Services');
+  await versions.selectOption('3');
+  await page.getByRole('button', { name: 'Preview selected' }).click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await expect(page.locator('#preview')).toContainText('Services');
+  await expect(page.getByRole('button', { name: 'Use as draft' })).toBeHidden();
+  await page.keyboard.press('Escape');
+  await page.getByRole('button', { name: 'Resume editing this history' }).click();
+  await expect(page.locator('#editor')).toContainText('Services');
+  await expect(page.getByRole('button', { name: 'Save checkpoint', exact: true })).toBeEnabled();
+  await page.getByLabel('Checkpoint name (optional)').fill('Browser review');
+  await page.getByRole('button', { name: 'Save checkpoint', exact: true }).click();
+  await expect(versions.locator('option')).toHaveCount(5);
+  await page.reload();
+  await expect(versions.locator('option')).toHaveCount(5);
+  await expect(versions).toHaveValue('0');
+  await expect(versions.locator('option').first()).toContainText('Browser review');
+  await expect(page.locator('#editor')).toContainText('Services');
+  await page.getByText('Download with history', { exact: true }).click();
+  const downloaded = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Download .docxhistory', exact: true }).click();
+  await (await downloaded).saveAs(testInfo.outputPath('reviewed-agreement.docxhistory'));
+  await file.setInputFiles('../TestFiles/HistoryArchive/agreement.docxhistory');
+  await page.getByRole('button', { name: 'Resume editing this history' }).click();
+  await expect(page.locator('#message')).toContainText('different local history');
+  await expect(versions.locator('option')).toHaveCount(4);
+  await expect(page.getByRole('button', { name: 'Preview selected' })).toBeEnabled();
+  await expect(page.locator('#editor')).toContainText('Services');
+  await page.getByRole('button', { name: 'Back to my draft' }).click();
+  await expect(versions.locator('option')).toHaveCount(5);
+  await page.screenshot({ path: testInfo.outputPath('history-editor.png'), fullPage: true });
+});
+
+test('a stale save and malformed or oversized uploads preserve the open draft and its local history', async ({ context, page }) => {
+  const file = page.getByLabel('Open a DOCX or history file');
+  await file.setInputFiles('../TestFiles/HistoryArchive/agreement-v1.docx');
+  await expect(page.locator('#editor')).toContainText('Services');
+  await page.getByRole('button', { name: 'Save checkpoint', exact: true }).click();
+  await expect(page.getByLabel('Version', { exact: true }).locator('option')).toHaveCount(1);
+  const other = await context.newPage(); other.on('dialog', dialog => void dialog.accept());
+  await other.goto('/history.html');
+  await expect(other.getByLabel('Version', { exact: true }).locator('option')).toHaveCount(1);
+  await page.getByLabel('Checkpoint name (optional)').fill('Another editor saved');
+  await page.getByRole('button', { name: 'Save checkpoint', exact: true }).click();
+  await expect(page.getByLabel('Version', { exact: true }).locator('option')).toHaveCount(2);
+  const draft = other.locator('#editor [data-anchor][contenteditable="true"]').first();
+  await draft.click(); await other.keyboard.press('End');
+  await draft.pressSequentially(' — My unsaved agreement changes');
+  await other.getByRole('button', { name: 'Save checkpoint', exact: true }).click();
+  await expect(other.locator('#history [role="status"]')).toContainText('A newer checkpoint exists');
+  await expect(draft).toContainText('My unsaved agreement changes');
+  await expect(other.getByRole('button', { name: 'Save checkpoint', exact: true })).toBeDisabled();
+  for (const name of ['broken.docxhistory', 'broken.docx']) {
+    await other.getByLabel('Open a DOCX or history file').setInputFiles({ name, mimeType: 'application/octet-stream', buffer: Buffer.from('This is not a document archive') });
+    await expect(other.locator('#message')).toContainText('Your document is unchanged');
+    await expect(draft).toContainText('My unsaved agreement changes');
+  }
+  await other.evaluate(() => {
+    const file = new File([new Uint8Array(64 * 1024 * 1024 + 1)], 'too-large.docxhistory');
+    file.arrayBuffer = async () => { throw new Error('Oversized uploads must be rejected before reading bytes'); };
+    const transfer = new DataTransfer(); transfer.items.add(file);
+    const input = document.querySelector<HTMLInputElement>('#file')!; input.files = transfer.files;
+    input.dispatchEvent(new Event('change'));
+  });
+  await expect(other.locator('#message')).toContainText('browser processing limits');
+  await expect(draft).toContainText('My unsaved agreement changes');
+  await other.getByRole('button', { name: 'Refresh history' }).click();
+  await expect(other.getByLabel('Version', { exact: true }).locator('option')).toHaveCount(2);
+  await other.getByRole('button', { name: 'Save checkpoint', exact: true }).click();
+  await expect(other.getByLabel('Version', { exact: true }).locator('option')).toHaveCount(3);
+  await other.getByRole('button', { name: 'Open latest' }).click();
+  await expect(other.locator('#preview')).toContainText('My unsaved agreement changes');
+  await other.getByRole('button', { name: 'Close preview' }).click();
+  await other.close();
+});
+
+test('saved agreements need no discard warning, while newer edits remain protected', async ({ page }) => {
+  const confirmations: string[] = [];
+  page.on('dialog', dialog => { if (dialog.type() === 'confirm') confirmations.push(dialog.message()); });
+  await page.getByLabel('Open a DOCX or history file').setInputFiles('../TestFiles/HistoryArchive/agreement-v1.docx');
+  await expect(page.locator('#editor')).toContainText('Services');
+  await page.getByRole('button', { name: 'Save checkpoint', exact: true }).click();
+  await expect(page.locator('#history [role="status"]')).toContainText('Checkpoint saved');
+  await page.getByRole('button', { name: 'New document', exact: true }).click();
+  await expect(page.getByLabel('Version', { exact: true }).locator('option')).toHaveCount(0);
+  expect(confirmations).toEqual([]);
+
+  const draft = page.locator('#editor [data-anchor][contenteditable="true"]').first();
+  await draft.click(); await draft.pressSequentially('Terms to retain in a checkpoint');
+  await page.getByRole('button', { name: 'Save checkpoint', exact: true }).click();
+  await expect(page.locator('#history [role="status"]')).toContainText('Checkpoint saved');
+  await draft.click(); await page.keyboard.press('End');
+  await draft.pressSequentially(' and newer unsaved changes');
+  await page.getByRole('button', { name: 'New document', exact: true }).click();
+  await expect(page.getByLabel('Version', { exact: true }).locator('option')).toHaveCount(0);
+  expect(confirmations).toHaveLength(1);
+  expect(confirmations[0]).toContain('Replace your open draft?');
+});

--- a/npm/tests/ribbon-surface.spec.ts
+++ b/npm/tests/ribbon-surface.spec.ts
@@ -303,6 +303,7 @@ test('a host that hides the file actions can still open a document', async ({ pa
     const { mountRibbon } = (window as any).DocxodusEditor;
     const demo = (window as any).__demo;
     const host = document.createElement('div');
+    host.style.cssText = 'height:400px';
     document.body.appendChild(host);
     const ribbon = mountRibbon(host, {
       exports: demo.exports, fileActions: false, loader: false, hint: false, documentName: 'hosted.docx',

--- a/npm/tests/ribbon-surface.spec.ts
+++ b/npm/tests/ribbon-surface.spec.ts
@@ -292,3 +292,43 @@ test.describe('ribbon surface', () => {
     expect(persisted[0].text).toContain('Please reconsider this clause.');
   });
 });
+
+test('a host that hides the file actions can still open a document', async ({ page }) => {
+  // `fileActions: false` removes the quick group holding New/Open/Save. Opening a document used
+  // to require the Save button unconditionally, so every host that hides the file actions — the
+  // ones that supply their own persistence — crashed on the first open() with
+  // `Docxodus ribbon: template is missing "save"`.
+  await openEditorHost(page);
+  const hosted = await page.evaluate(() => {
+    const { mountRibbon } = (window as any).DocxodusEditor;
+    const demo = (window as any).__demo;
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const ribbon = mountRibbon(host, {
+      exports: demo.exports, fileActions: false, loader: false, hint: false, documentName: 'hosted.docx',
+    });
+    let failure = '';
+    try { ribbon.open(demo.getEditor().save(), 'hosted.docx'); }
+    catch (error) { failure = (error as Error).message; }
+    const result = {
+      failure,
+      files: host.querySelector('[data-dxr-files]') !== null,
+      save: ribbon.control('save') !== null,
+      // Only the file group goes: the rest of the surface still mounts and wires up.
+      undo: ribbon.control('undo') !== null,
+      state: ribbon.element.getAttribute('data-state'),
+      // The document really opened rather than open() merely not throwing.
+      blocks: ribbon.surface.querySelectorAll('[data-anchor][contenteditable="true"]').length,
+      session: ribbon.editor ? ribbon.editor.sessionHandle !== demo.getEditor().sessionHandle : false,
+    };
+    ribbon.destroy(); host.remove();
+    return result;
+  });
+  expect(hosted.failure).toBe('');
+  expect(hosted.files).toBe(false);
+  expect(hosted.save).toBe(false);
+  expect(hosted.undo).toBe(true);
+  expect(hosted.state).toBe('ready');
+  expect(hosted.blocks).toBeGreaterThan(0);
+  expect(hosted.session).toBe(true);
+});

--- a/npm/tsconfig.tests.json
+++ b/npm/tsconfig.tests.json
@@ -13,7 +13,7 @@
     "noEmit": true,
     "rootDir": "."
   },
-  "include": ["src/**/*", "tests/**/*"],
+  "include": ["src/**/*", "tests/**/*", "examples/**/*.ts"],
   "exclude": [
     "node_modules",
     "dist",


### PR DESCRIPTION
Add a runnable TypeScript editor example with opt-in IndexedDB checkpoints, read-only portable history, import/resume with embedded document identity, and version previews separate from the draft. Conflicting imports, stale saves, and invalid uploads preserve the open editor. Durable retries retain the original captured inputs and receipt.

Restore now asks for confirmation naming the selected version and explaining that the draft and later versions are kept. Cancel leaves the published head, versions, and durable retry journal unchanged. Confirmed restores append an auditable checkpoint. Acknowledged checkpoint callbacks clear discard warnings only for the confirmed capture; newer edits stay protected.

Also preserve captured heads when mounting or resuming imports, add paginated collaboration decisions/proposal downloads, and fix ribbon opening when the host hides file actions.

Stack 3/3: #738 → #739 → #740, based on #739. This PR has 572 additions and 31 deletions (603 changed lines). Merge the stack in order; this final PR closes the issue when merged into `main`.

Validation:
- TypeScript build/typecheck, including the example; example bundle and package boundary audit.
- 29 Chromium history/editor/ribbon tests, including keyboard restore cancellation, exact retry recovery, preserved later versions, stale drafts, uploads, and portable-file reopening.
- 38 native history/storage/client/MCP tests. Real agreement and charter redlines now explicitly verify that reject reproduces the earlier version and accept reproduces the later version.
- 8 Python headless history tests, including process restart and exact exports.

Closes #672
