### PR TITLE
fix(arcade): confirm Doom menus with the mobile fire button

### DIFF
--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -137,7 +137,10 @@ is narrow.
 | **compact** | A slim HUD strip keeps the two controls you touch mid-game (play/pause and pacing); cartridges, restart, embed, telemetry and the hint move behind a `⋯` sheet. A thumb D-pad and an action cluster float over the bottom corners of the game. Nothing is dropped, only re-placed. |
 
 `FIRE` sends `Space` — jump in the platformer, the weapon in the raycasters and
-in Doom, and the coin drop on the attract screen. The old touch row had no
+in Doom, and the coin drop on the attract screen. Doom labels it **FIRE / OK**:
+it also confirms menu selections, so use **▲/▼** to choose and **FIRE / OK** to
+enter New Game, an episode, and a difficulty without opening the KEYS tray.
+The old touch row had no
 Space at all, so the shooters could be walked but never fought on a phone.
 
 **What the pad offers is the cartridge's call.** Each cartridge declares a touch

--- a/docs/demo/doom-cart.js
+++ b/docs/demo/doom-cart.js
@@ -107,9 +107,9 @@ export const DOOM_KEY_CODES = [...Object.keys(DOOM_KEY_MAP)];
  *  minus the aliases a keyboard has room for. Doom is the cartridge that
  *  needed this: a pad with movement and fire can walk E1M1 up to its first
  *  door and no further, because USE is a key and a phone had none. Its rarer
- *  keys — seven weapons, the automap, Doom's own menu and the Enter that
- *  works it — go in the pad's tray rather than under a thumb, since they are
- *  what you reach for between fights, not during one. */
+ *  keys — seven weapons, the automap, Doom's own menu and a separate Enter —
+ *  go in the pad's tray. FIRE also confirms menus, so starting a game never
+ *  requires discovering the tray. */
 export const DOOM_TOUCH = {
   up: { code: 'KeyW', glyph: '▲', label: 'Forward' },
   down: { code: 'KeyS', glyph: '▼', label: 'Back' },
@@ -117,7 +117,7 @@ export const DOOM_TOUCH = {
   right: { code: 'ArrowRight', glyph: '↻', label: 'Turn right' },
   strafeLeft: { code: 'KeyA', glyph: '◀', label: 'Strafe left' },
   strafeRight: { code: 'KeyD', glyph: '▶', label: 'Strafe right' },
-  fire: { code: 'Space', glyph: 'FIRE', label: 'Fire' },
+  fire: { code: 'Space', glyph: 'FIRE / OK', label: 'Fire / confirm menu selection' },
   use: { code: 'KeyE', glyph: 'USE', label: 'Open doors and switches' },
   run: { code: 'ShiftLeft', glyph: 'RUN', label: 'Run (stays on until tapped again)', toggle: true },
   extras: [
@@ -833,6 +833,13 @@ export function doomCart(options = {}) {
     // cartridge wants the log rather than the held/pressed sets the other two
     // cartridges use.
     for (const { code, down } of input.drain?.() ?? []) {
+      // Doom's menu accepts Enter, not its attack key. Pair Space/FIRE with
+      // Enter on both edges so even a tap released between rendered frames
+      // confirms once, while holding it still fires normally in a level.
+      // Enter goes FIRST: on the title screen either key opens the menu, so
+      // attack followed by Enter would also select New Game in the same tap.
+      // In gameplay Enter has no action; the attack binding stays unchanged.
+      if (code === 'Space') handle.keys.push([KEY.ENTER, down ? 1 : 0]);
       const key = DOOM_KEY_MAP[code];
       if (key !== undefined) handle.keys.push([key, down ? 1 : 0]);
     }
@@ -911,9 +918,9 @@ export function doomCart(options = {}) {
       'Word runs, including the original HUD. Switch modes on the same frame, even while paused. ' +
       'Move **W/S** · strafe ' +
       '**A/D** · turn **←/→** · **Space** ' +
-      'fires · **E** opens · **Q** is Doom’s own menu. **Esc** pauses — and then it is only a ' +
+      'fires / confirms menus · **E** opens · **Q** is Doom’s own menu. **Esc** pauses — and then it is only a ' +
       'document again: copy and paste the frame, Undo rewinds it, Save downloads it as .docx.',
-    hint: '<b>WASD</b> move · <b>←/→</b> turn · <b>Space</b> fire · <b>E</b> open · <b>Q</b> Doom’s menu · <b>Original / ASCII</b> switches the same frame, even while paused.',
+    hint: '<b>WASD</b> move · <b>←/→</b> turn · <b>Space</b> fire / confirm menu · <b>E</b> open · <b>Q</b> Doom’s menu · <b>Original / ASCII</b> switches the same frame, even while paused.',
     reset() {
       // Doom's own state lives inside the WebAssembly heap and the engine is
       // a page singleton, so a cartridge reset cannot restart the game. Q

--- a/npm/tests/demo-arcade-mobile.spec.ts
+++ b/npm/tests/demo-arcade-mobile.spec.ts
@@ -1,4 +1,16 @@
 import { test, expect, Page } from '@playwright/test';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+
+// Match the capture script's optional offline mirror, including its pin check.
+test.beforeEach(async ({ page }) => {
+  if (!process.env.DOOM_ENGINE_PATH) return;
+  const bytes = readFileSync(process.env.DOOM_ENGINE_PATH);
+  expect(createHash('sha256').update(bytes).digest('hex')).toBe(
+    'efd7c34714e3753a84cf6873f2c2ae0e1a41bde1f10aaa2b0a95cb6935e8cce9');
+  await page.route('https://cdn.jsdelivr.net/gh/grubbyplaya/**', route =>
+    route.fulfill({ body: bytes, contentType: 'text/javascript' }));
+});
 
 // THE DOCX ARCADE on a phone — the mobile-Chrome regression that garbled the
 // GitHub Pages demo. On Android the canvas rows render WIDER than authored:
@@ -504,6 +516,75 @@ test.describe('The pad takes its controls from the cartridge', () => {
     const use = page.locator('.dxa-use');
     await expect(use).toBeHidden();
     expect(await use.getAttribute('data-code')).toBeNull();
+  });
+
+  test('FIRE touch taps confirm Doom menus and holding it still fires in a level', async ({ page }) => {
+    test.setTimeout(240000);
+    await page.goto(`/demo-arcade.html?${OVERRIDE}&intro=0&cart=doom`);
+    await waitForBoot(page);
+    await page.waitForFunction(() => {
+      const state = (window as any).__arcade.game();
+      if (state.status === 'error') throw new Error(state.error);
+      return state.doomFrames >= 4;
+    }, null, { timeout: 180000 });
+
+    const fire = page.locator('#pad .dxa-fire');
+    await expect(fire).toBeVisible();
+    await expect(page.locator('#padextras')).toBeHidden();
+
+    // Actual Chromium touch events, including pointer capture and release.
+    // A synthetic pointerdown or an input.held() check cannot prove that a
+    // quick tap survives until Doom processes its menu input on the next frame.
+    for (let i = 0; i < 4; i++) {
+      await fire.tap(); // title → New Game → episode → skill → level
+      await page.waitForTimeout(700);
+    }
+    await page.waitForTimeout(1500); // level wipe and weapon raise
+
+    const sample = (x0: number, y0: number, x1: number, y1: number) =>
+      page.evaluate(({ x0, y0, x1, y1 }) => {
+        const state = (window as any).__arcade.game();
+        const pixels: number[] = [];
+        for (let y = y0; y < y1; y += 2) {
+          for (let x = x0; x < x1; x += 2) pixels.push(...state.pixel(x, y));
+        }
+        return pixels;
+      }, { x0, y0, x1, y1 });
+    const motion = (a: number[], b: number[]) =>
+      a.reduce((sum, value, i) => sum + Math.abs(value - b[i]), 0) / a.length;
+    const view = await sample(0, 35, 320, 135);
+    const hud = await sample(0, 175, 320, 198);
+    await page.waitForTimeout(600);
+    expect(motion(view, await sample(0, 35, 320, 135)), 'an idle level holds still').toBeLessThan(1);
+
+    // The view must actually turn while the HUD stays fixed. An opening menu
+    // or attract demo cannot satisfy both the idle and controlled-motion checks.
+    const cdp = await page.context().newCDPSession(page);
+    const hold = async (selector: string) => {
+      const box = await page.locator(selector).boundingBox();
+      expect(box).not.toBeNull();
+      await cdp.send('Input.dispatchTouchEvent', {
+        type: 'touchStart', touchPoints: [{ x: box!.x + box!.width / 2, y: box!.y + box!.height / 2 }],
+      });
+    };
+    const release = () => cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+    await hold('#pad .dxa-right');
+    await page.waitForTimeout(900);
+    await release();
+    expect(motion(view, await sample(0, 35, 320, 135)), 'FIRE must get past the opening menus')
+      .toBeGreaterThan(6);
+    expect(motion(hud, await sample(0, 175, 320, 198))).toBeLessThan(1);
+
+    const ammo = await sample(2, 171, 42, 194);
+    await hold('#pad .dxa-fire');
+    await page.waitForTimeout(1400);
+    await release();
+    await page.waitForTimeout(700);
+    expect(motion(ammo, await sample(2, 171, 42, 194)), 'holding FIRE spends ammunition')
+      .toBeGreaterThan(1);
+    expect(await page.evaluate(() => (window as any).__arcade.input.held('Space'))).toBe(false);
+    expect(await page.evaluate(() => (window as any).__arcade.playing())).toBe(true);
+    await cdp.detach();
   });
 
   test('the rarer Doom keys ride in a tray instead of under a thumb', async ({ page }) => {


### PR DESCRIPTION
Tapping FIRE on Doom’s opening menu could not select an item: it sent only the attack key, while Enter was hidden in the KEYS tray. FIRE now also sends Enter and is labeled **FIRE / OK**, allowing phone users to start a game from the visible controls and continue shooting normally in a level.

Send Enter before the attack transition so the first tap opens the main menu without also selecting New Game. Preserve both press and release events so brief taps survive between rendered frames. Update the control hints and demo documentation.

Validation:

- The new regression fails before the fix and passes afterward. It uses Chromium touch events against the real Doom engine to enter a level, turn, fire, and release the button.
- All 12 `chromium-pixel5` mobile arcade tests pass, using the SHA-256-verified offline engine mirror.
- `npm run typecheck`, the 12 arcade logic tests, and `git diff --check` pass.

Browser validation uses Pixel 5 emulation; physical Android Chrome was not tested.
