### PR TITLE
Stage npm releases for separate 2FA approval

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -258,7 +258,7 @@ jobs:
           name: ${{ matrix.artifact }}
           path: ./publish/docx2oc*
 
-  # Build and publish npm package
+  # Build and stage npm packages; a maintainer approves each with 2FA on npm.
   build-npm:
     needs: build-test-publish
     runs-on: ubuntu-latest
@@ -289,12 +289,10 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      # Pin npm to 11.x — NOT @latest. npm >= 11.5.1 is required for OIDC trusted
-      # publishing (see the publish step below), and 11.x supports both Node 20 and
-      # Node 22 (engines.node ^20.17.0 || >=22.9.0). Using @latest is what broke this
-      # job: it silently rolled onto npm 12, which dropped Node 20 support.
-      - name: Pin npm (required for trusted publishers)
-        run: npm install -g npm@11
+      # Staging requires npm >= 11.15.0 and Node >= 22.14.0. Pin the tested CLI
+      # so a release keeps the same staging command and JSON output contract.
+      - name: Pin npm for staged publishing
+        run: npm install -g npm@11.19.1
 
       # @docxodus/export refuses to launch Chromium without its process sandbox (#595), and
       # that sandbox needs unprivileged user namespaces, which Ubuntu 24.04 restricts through
@@ -349,13 +347,42 @@ jobs:
       - name: Release preflight (package boundaries)
         run: RELEASE_PREFLIGHT_SKIP_INSTALL=1 ./scripts/release-preflight.sh
 
-      - name: Publish browser/WASM package
+      # The packages have already been built and checked above. Skipping lifecycle
+      # scripts avoids rebuilding and keeps the stage receipt valid JSON.
+      - name: Stage browser/WASM package
         run: |
           cd npm
-          npm publish --access public
+          npm stage publish --access public --ignore-scripts --json > "$RUNNER_TEMP/docxodus-stage.json"
 
-      - name: Publish Node export companion
+      - name: Stage Node export companion
         run: |
           cd npm-export
           npm pkg delete devDependencies.docxodus
-          npm publish --access public
+          npm stage publish --access public --ignore-scripts --json > "$RUNNER_TEMP/docxodus-export-stage.json"
+
+      - name: Report npm packages awaiting 2FA approval
+        if: always()
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const rows = [];
+          for (const [name, file] of [
+            ['docxodus', 'docxodus-stage.json'],
+            ['@docxodus/export', 'docxodus-export-stage.json'],
+          ]) {
+            const receipt = path.join(process.env.RUNNER_TEMP, file);
+            if (!fs.existsSync(receipt)) continue;
+            const contents = fs.readFileSync(receipt, 'utf8').trim();
+            if (!contents) continue;
+            const staged = JSON.parse(contents)[name];
+            if (staged?.stageId) rows.push(`| ${name}@${staged.version} | \`${staged.stageId}\` |`);
+          }
+          if (rows.length) fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, [
+            '## npm packages awaiting 2FA approval', '',
+            '| Package | Stage ID |', '| --- | --- |', ...rows, '',
+            'Review each package in npm\'s Staged Packages tab, or run `npm stage view <stage-id>`.', '',
+            'Approve `docxodus` first, then `@docxodus/export`, with `npm stage approve <stage-id>` and your own 2FA.', '',
+            'Update demo pins only after approval and a successful CDN check. See `docs/npm-releases.md`.', '',
+          ].join('\n'));
+          NODE

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -359,8 +359,10 @@ it with `python tools/generate-demo-guide.py` from the repository root.
 
 ## Publish
 
+The release workflow [stages both npm packages for separate 2FA approval](../npm-releases.md).
 The pages load the library from jsDelivr at an exact version, so the pin can
-only move *after* npm publishes and the CDN serves it. Move every pin in one
+only move *after* the staged browser package is approved, published, and served by the CDN.
+Move every pin in one
 change — the pages, this README, `docs/npm-package.md`, `npm/README.md`,
 `npm/examples/embed.html`, and `RELEASE_ENGINE` in
 `npm/tests/social-demo.spec.ts` — and `tools/engine-pin.test.mjs` (run by
@@ -370,7 +372,7 @@ is left behind, if the version drops below the arcade's
 serve it yet. That guard exists because a stale pin is invisible to the browser
 specs: every one of them overrides `?engine=` to the locally built bundle.
 
-1. Publish `docxodus@12.3.0` and confirm
+1. Approve the staged `docxodus@12.3.0` release with 2FA and confirm
    `https://cdn.jsdelivr.net/npm/docxodus@12.3.0/dist/embed.bundle.js` returns JavaScript.
 2. In GitHub **Settings → Pages**, choose **GitHub Actions** as the publishing source.
    The `Deploy static demo to GitHub Pages` workflow uploads `/docs` without

--- a/docs/npm-releases.md
+++ b/docs/npm-releases.md
@@ -1,0 +1,50 @@
+# npm releases
+
+The `v*` release workflow builds and tests `docxodus` and `@docxodus/export`, then
+submits both with `npm stage publish`. A successful workflow means the npm
+packages are staged for review; a maintainer separately approves each package
+with their own two-factor authentication before it becomes public. NuGet and
+the independent `docx-scalpel` PyPI workflow retain their existing publishing flow.
+
+The workflow pins npm 11.19.1. Local staging and approval commands require npm
+11.15.0 or newer and Node 22.14.0 or newer. Both npm packages need a trusted
+publisher matching `JSv4/Docxodus`, workflow `publish.yml`, environment `Publisher`,
+with staging allowed. Direct-publishing permission is unnecessary for this flow.
+
+## Review and approve
+
+1. Find each stage ID in the workflow's **npm packages awaiting 2FA approval**
+   summary. A partial failure still reports any package that was successfully staged.
+2. Review the packages in npm's **Staged Packages** tab, or use the CLI:
+
+   ```sh
+   npm stage list docxodus
+   npm stage list @docxodus/export
+   npm stage view <stage-id>
+   ```
+
+3. Approve `docxodus` first, then the matching `@docxodus/export` stage, since the
+   companion requires that exact browser-package version:
+
+   ```sh
+   npm stage approve <stage-id>
+   ```
+
+   Complete the 2FA prompt yourself. Approval is an explicit maintainer action;
+   the workflow does not perform it. A local npm older than 11.15.0 can run these
+   commands through `npx npm@11.19.1 stage ...`.
+
+4. Confirm both packages are publicly available at the intended version. Then
+   confirm the browser bundle is served by jsDelivr before updating demo pins;
+   follow [the demo publishing instructions](demo/README.md#publish).
+
+## Partial releases
+
+Staged and published versions share the same version namespace. If one package
+stages successfully and the other fails, keep the successful stage for review
+and retry only the missing package from the release tag. Re-running the entire
+npm job will encounter the existing version. An already validated tarball can
+be submitted with `npm stage publish ./package.tgz --access public --tag latest`.
+
+See npm's [staged publishing guide](https://docs.npmjs.com/staged-publishing/)
+and [trusted publisher configuration](https://docs.npmjs.com/trusted-publishers/).

--- a/python/RELEASING.md
+++ b/python/RELEASING.md
@@ -42,7 +42,7 @@ After the first successful publish, the "pending" publisher becomes a regular tr
 
 | Tag pattern | Workflow | Publishes |
 |---|---|---|
-| `v*` (e.g. `v1.2.3`) | `publish.yml` | NuGet (Docxodus + redline + docx2html + docx2oc) + npm (`docxodus`) + GitHub Release binaries |
+| `v*` (e.g. `v1.2.3`) | `publish.yml` | NuGet (Docxodus + redline + docx2html + docx2oc) + staged npm (`docxodus`, `@docxodus/export`; [separate 2FA approval](../docs/npm-releases.md)) + GitHub Release binaries |
 | `docx-scalpel-v*` (e.g. `docx-scalpel-v0.1.0a1`) | `python-publish.yml` | PyPI (`docx-scalpel`) |
 
 The two tag namespaces are independent. A docx-scalpel point-release doesn't drag Docxodus core through a version bump, and a Docxodus core release doesn't force unrelated PyPI churn. Each docx-scalpel wheel bundles a `docxodus-pyhost` built from the same commit the tag points to, so there's no runtime version-pinning between the two distributions.


### PR DESCRIPTION
The npm release job directly published both packages, so a trusted publisher limited to staging failed with `OIDC permission denied for this action`. Stage both packages and leave publication to a maintainer's separate 2FA approval.

Pin npm 11.19.1, retain the existing builds/tests/package checks, and show each successful stage ID in the job summary even when the other package fails. Document approval order and keep demo pins gated on actual public/CDN availability.

Validation: staged the validated `@docxodus/export` 12.3.0 tarball and verified its pending status and matching release-build checksum; parsed the workflow YAML, checked all shell steps, exercised the summary with a partial failure, and passed the demo pin checks.
