### PR TITLE
Fix editor paper sizing when zooming document content

### DIFF
--- a/npm/src/ribbon-chrome.ts
+++ b/npm/src/ribbon-chrome.ts
@@ -487,9 +487,9 @@ export const RIBBON_CSS = `
    Word draws a header that is being edited — a dashed rule with a small tag in the margin. */
 .dxr-surface .docx-hf-band {
   /* Docked outside the zoomed sheet, so it takes the page's on-screen width from the
-     custom property the viewport publishes rather than stretching to the whole surface. */
+     custom property the viewport publishes, including when the page exceeds the surface. */
   position: relative;
-  width: min(100%, var(--docx-sheet-width, 100%));
+  width: var(--docx-sheet-width, 100%);
   margin: 0 auto;
   padding: 34px 72px 12px;
   background: var(--dxr-sheet);
@@ -548,7 +548,9 @@ export const RIBBON_CSS = `
    vertical breathing room is ours. Centering is left to margin:auto so a page the viewport
    has zoomed to fit stays centered at its scaled width. */
 .dxr[data-chrome] .dxr-surface[data-view="continuous"] .docx-body-flow {
-  max-width: 100%;
+  /* CSS zoom scales the authored page width. A percentage cap would shrink only the
+     paper to the host while its fixed-width section and content keep magnifying. */
+  max-width: none;
   margin: 0 auto;
   padding: 56px 0;
   border-radius: 3px;

--- a/npm/tests/editor-page-geometry.spec.ts
+++ b/npm/tests/editor-page-geometry.spec.ts
@@ -126,4 +126,87 @@ test.describe('Editor — page geometry on a wide window', () => {
     await setHeroFontSize(page, 66);
     expect(await overflowingBoxes(page)).toEqual([]);
   });
+
+  for (const bands of [false, true]) {
+    test(`zoom scales the paper with its contents (header/footer bands ${bands ? 'on' : 'off'})`, async ({ page }) => {
+      await openDemo(page);
+      if (bands) {
+        await page.locator('.dxr-tab[data-tab="layout"]').click();
+        await page.locator('[data-dxr="headerfooter"]').check();
+      }
+      await page.locator('.dxr-tab[data-tab="view"]').click();
+
+      const measure = () => page.evaluate(() => {
+        const surface = document.querySelector<HTMLElement>('[data-dxr-surface]')!;
+        const sheet = surface.querySelector<HTMLElement>('.docx-body-flow')!;
+        const section = sheet.querySelector<HTMLElement>('[data-section-index]')!;
+        const table = sheet.querySelector<HTMLElement>('table')!;
+        const scroll = surface.closest<HTMLElement>('.dxr-scroll')!;
+        const rect = (el: HTMLElement) => {
+          const { left, right, width } = el.getBoundingClientRect();
+          return { left, right, width };
+        };
+        return {
+          pageWidth: Number(section.dataset.pageWidth) * 96 / 72,
+          sheet: rect(sheet),
+          table: rect(table),
+          bands: Array.from(surface.querySelectorAll<HTMLElement>('.docx-hf-band'), rect),
+          scrollWidth: scroll.scrollWidth,
+          viewportWidth: scroll.clientWidth,
+          chromeWidth: surface.closest('.dxr')!.getBoundingClientRect().width,
+        };
+      });
+
+      const original = await measure();
+      // Require real page geometry and a substantial cover table: an empty document or
+      // a zoom control that does nothing must not satisfy this regression guard.
+      expect(original.pageWidth).toBeGreaterThan(700);
+      expect(original.table.width).toBeGreaterThan(500);
+      expect(original.bands).toHaveLength(bands ? 2 : 0);
+
+      for (const [control, scale] of [['zoom', 2], ['zoomlevel', 0.5], ['zoom', 1]] as const) {
+        await page.locator(`[data-dxr="${control}"]`).selectOption(String(scale));
+        await expect(page.locator('[data-dxr="zoom"]')).toHaveValue(String(scale));
+        await expect(page.locator('[data-dxr="zoomlevel"]')).toHaveValue(String(scale));
+        const current = await measure();
+        expect(Math.abs(current.sheet.width - original.pageWidth * scale)).toBeLessThan(1);
+        expect(Math.abs(current.table.width - original.table.width * scale)).toBeLessThan(1);
+        expect(current.table.left).toBeGreaterThanOrEqual(current.sheet.left);
+        expect(current.table.right).toBeLessThanOrEqual(current.sheet.right + 1);
+        expect(current.chromeWidth).toBe(original.chromeWidth);
+        expect(await overflowingBoxes(page)).toEqual([]);
+        for (const band of current.bands) {
+          expect(Math.abs(band.left - current.sheet.left)).toBeLessThan(1);
+          expect(Math.abs(band.right - current.sheet.right)).toBeLessThan(1);
+        }
+        if (scale === 2) {
+          expect(current.sheet.width).toBeGreaterThan(current.viewportWidth);
+          expect(current.scrollWidth).toBeGreaterThan(current.viewportWidth);
+          // The enlarged paper must be reachable by scrolling within the editor.
+          const reached = await page.evaluate(() => {
+            const scroll = document.querySelector<HTMLElement>('.dxr-scroll')!;
+            scroll.scrollLeft = scroll.scrollWidth;
+            const sheet = scroll.querySelector('.docx-body-flow')!.getBoundingClientRect();
+            const viewport = scroll.getBoundingClientRect();
+            const result = { offset: scroll.scrollLeft, right: sheet.right, limit: viewport.right };
+            scroll.scrollLeft = 0;
+            return result;
+          });
+          expect(reached.offset).toBeGreaterThan(0);
+          expect(reached.right).toBeLessThanOrEqual(reached.limit + 1);
+        }
+      }
+
+      // Remounting between views must preserve the same zoomed paper geometry.
+      await page.locator('[data-dxr="zoom"]').selectOption('2');
+      await page.locator('[data-dxr="viewpage"]').click();
+      const firstPage = await page.locator('.page-box').first().boundingBox();
+      expect(firstPage).not.toBeNull();
+      expect(Math.abs(firstPage!.width - original.pageWidth * 2)).toBeLessThan(1);
+      await page.locator('[data-dxr="viewweb"]').click();
+      expect(Math.abs((await measure()).sheet.width - original.pageWidth * 2)).toBeLessThan(1);
+      await page.locator('[data-dxr="zoomfit"]').click();
+      expect(Math.abs((await measure()).sheet.width - original.pageWidth)).toBeLessThan(1);
+    });
+  }
 });


### PR DESCRIPTION
At 200% zoom, document content grew beyond the white paper because the continuous sheet and header/footer bands were capped at the editor's width. Remove those caps so the paper follows the authored page geometry and zoom, with the enlarged page reachable by horizontal scrolling.

Add browser regressions using the real demo document, with header/footer bands on and off. They measure paper/table widths and content containment at 200%, 50%, and 100%, exercise both zoom selectors, check band alignment and horizontal scrolling, and verify page-view round trips and Fit width.

Validation:
- Both new cases failed against unchanged main: paper measured 1,248px instead of the required 1,632px at 200%.
- 27 Chromium checks passed across page geometry, header/footer editing, and ribbon behavior.
- TypeScript source/test checks and `git diff --check` passed.
- Visually checked both ends of the enlarged page; restoring either original CSS cap independently reproduced its width mismatch.
