### PR TITLE
fix(wasm): warm the preview clone-and-snapshot path before the first shadow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,12 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Browser mutation previews no longer stall on a module instance's first preview. The first
+  `previewBatch` after opening a document could hang in the browser (never natively): the
+  shadow session's first transaction serializes a package snapshot on an interpreted cold path
+  with the live package and the clone already on the heap, the same conservative-GC collapse
+  fixed for comparisons in #697. `OpenPreviewSession` now warms that path once on a
+  one-paragraph seed session (`PreviewEngine.EnsureWarm`), mirroring the comparison invariant.
 - Tracked `DeleteRange`/`DeleteSection` stamped each paragraph, row and wrapper marker with
   its own clock reading, so an operation straddling a second boundary produced payload marks
   the registry could not fold into their wrapper's envelope; resolving the pieces separately

--- a/docs/architecture/wasm-packaging.md
+++ b/docs/architecture/wasm-packaging.md
@@ -190,6 +190,15 @@ the tier did not change behaviour; both ran green on the AOT bundle before it sh
 
 ### The cold path can collapse, so every comparison warms first (issues #695, #696)
 
+The same collapse has a second home: the mutation preview. `OpenPreviewSession` clones the
+live package into a shadow session, and the shadow's first transaction serializes every part
+into a package snapshot — an allocation-heavy cold path that, run interpreted with the live
+package, the clone and the caller's listings already on the heap, stopped finishing in the
+browser (`previewBatch` never returned; the same preview is ~400 ms natively).
+`PreviewEngine.EnsureWarm()` is the invariant `DocxSessionBridge.OpenPreviewSession` holds
+before the first shadow: clone, begin, mutate and roll back a one-paragraph seed session once
+per module instance. A new preview entry point must hold it too.
+
 A stale profile costs speed, never correctness — but the *cold path* costs more than speed.
 The first comparison a module instance runs executes the engine's whole cold path (assembly
 resolution, type loads, static constructors, first-time entry into every method the diff and

--- a/wasm/DocxodusWasm/ComparisonEngine.cs
+++ b/wasm/DocxodusWasm/ComparisonEngine.cs
@@ -94,7 +94,7 @@ internal static class ComparisonEngine
     /// Build a minimal but valid DOCX package (one paragraph) in memory.
     /// Includes the parts comparison expects (styles, settings).
     /// </summary>
-    private static byte[] BuildSeedDocx(string text)
+    internal static byte[] BuildSeedDocx(string text)
     {
         using var ms = new MemoryStream();
         using (var doc = WordprocessingDocument.Create(ms, WordprocessingDocumentType.Document))

--- a/wasm/DocxodusWasm/DocxSessionBridge.cs
+++ b/wasm/DocxodusWasm/DocxSessionBridge.cs
@@ -36,8 +36,13 @@ public static partial class DocxSessionBridge
     /// undo/redo history; callers must close it. Abandonment cannot affect the live handle.
     /// </summary>
     [JSExport]
-    public static int OpenPreviewSession(int liveHandle) =>
-        SessionRegistry.CloneSessionForPreview(liveHandle);
+    public static int OpenPreviewSession(int liveHandle)
+    {
+        // The first preview of a module instance must not be the one that walks the cold
+        // clone-and-snapshot path — see PreviewEngine for why that can stop finishing.
+        PreviewEngine.EnsureWarm();
+        return SessionRegistry.CloneSessionForPreview(liveHandle);
+    }
 
     [JSExport]
     public static void CloseSession(int handle)

--- a/wasm/DocxodusWasm/PreviewEngine.cs
+++ b/wasm/DocxodusWasm/PreviewEngine.cs
@@ -1,0 +1,54 @@
+// Copyright (c) John Scrudato IV. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Runtime.Versioning;
+using Docxodus;
+
+namespace DocxodusWasm;
+
+/// <summary>
+/// The preview path's one-time warm-up, and the invariant <see cref="DocxSessionBridge.OpenPreviewSession"/>
+/// holds before handing out the first shadow of a module instance. Same mechanism as
+/// <see cref="ComparisonEngine.EnsureWarm"/> (issues #695, #696), on a different allocation-heavy
+/// cold path: a preview clones the live package into a second session and then, on its first
+/// transaction, serializes every part into a package snapshot. Run cold — interpreted, with the
+/// live package, the clone and the caller's listings already on the heap — that snapshot can
+/// stop making progress under Mono's conservative root scans, and <c>previewBatch</c> never
+/// returns. The seed below walks the identical path on a one-paragraph document that allocates
+/// almost nothing, so the caller's real preview runs warm whatever its size.
+/// </summary>
+[SupportedOSPlatform("browser")]
+internal static class PreviewEngine
+{
+    private static bool warmed;
+
+    /// <summary>Clone, begin, mutate and roll back a seed session once per module instance.</summary>
+    /// <returns><c>"ok"</c> on success, or a JSON error object.</returns>
+    /// <remarks>Latched even on failure, for the same reason as the comparison warm-up: a
+    /// warm-up that throws has still forced the cold path to run, and a caller must not pay a
+    /// failing warm-up on every preview.</remarks>
+    internal static string EnsureWarm()
+    {
+        if (warmed)
+            return "ok";
+        warmed = true;
+
+        try
+        {
+            using var seed = new DocxSession(ComparisonEngine.BuildSeedDocx("warmup preview"));
+            using var shadow = seed.CreateShadowSession();
+            using var transaction = shadow.BeginTransaction();
+            var anchor = shadow.Project().AnchorIndex.Values
+                .First(target => target.Anchor.Kind == "p").Anchor.Id;
+            _ = shadow.InsertParagraph(anchor, Position.After, "warmup");
+            transaction.Rollback();
+            return "ok";
+        }
+        catch (Exception ex)
+        {
+            return DocumentConverter.SerializeError(ex.Message, ex.GetType().Name);
+        }
+    }
+}


### PR DESCRIPTION
## Why

`npm/tests/preview-commit.spec.ts` started timing out on PR #771 even though that PR does not touch previews, and the same spec hangs locally on every bundle built from current `main`. The hang is browser-only: the identical preview takes about 400 ms in .NET.

## What is happening

Tracing the npm wrapper's WASM calls one by one shows the stall in the shadow session's first `BeginTransaction`. A preview clones the live package into a second session, and the shadow's first transaction serializes every part into a package snapshot. Run cold, that path executes interpreted, with the live package, the clone and the caller's listings already on the heap. That is exactly the shape #697 diagnosed for comparisons (#695/#696): Mono's collector pins conservatively from the interpreter stack, so a nursery collection taken while a large cold path is live pays a root scan proportional to it, and an allocation-heavy operation stops making meaningful progress. Replaying the same export sequence by hand does not reproduce it, which matches the earlier finding that the collapse depends on heap state rather than on call order, and rules out chasing it as a logic bug.

## The fix

`OpenPreviewSession` now holds the same invariant the comparison exports hold: `PreviewEngine.EnsureWarm()` clones, begins, mutates and rolls back a one-paragraph seed session once per module instance before the first real shadow is handed out. The seed walks the identical cold path while allocating almost nothing, so the caller's real preview runs warm whatever its size. It is latched even on failure, for the same reason as the comparison warm-up. `ComparisonEngine.BuildSeedDocx` is reused (made internal) so there is one seed document.

## Validation

- Locally, `preview-commit.spec.ts` hung deterministically on bundles built from `main` and from #771; with this change both of its tests pass (18 s together with the delivery-evidence spec).
- The WASM project builds cleanly under its warnings-as-errors setting; the library is untouched.
- `docs/architecture/wasm-packaging.md` documents the second home of the collapse next to the first, and the changelog carries a `### Fixed` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TZazZwuvFkCcNadd6wxV2
