### PR TITLE
docs(demo): pin consumer CDN snippets to docxodus@12.5.0

### DIFF
--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -447,7 +447,7 @@
     const moduleSnippet = `<div id="docx-editor" style="height:80vh"></div>
 <script type="module">
   import { createRibbonEditor } from
-    "https://cdn.jsdelivr.net/npm/docxodus@12.3.0/dist/embed.bundle.js";
+    "https://cdn.jsdelivr.net/npm/docxodus@12.5.0/dist/embed.bundle.js";
 
   await createRibbonEditor("#docx-editor", "/documents/example.docx");
 <\/script>`;

--- a/docs/demo/tools/engine-pin.test.mjs
+++ b/docs/demo/tools/engine-pin.test.mjs
@@ -24,7 +24,7 @@ const PINNED_FILES = [
   'npm/src/index.ts',
 ];
 
-// `docxodus@12.3.0`, `docxodus@12.3.0/dist/embed.bundle.js`, the bare npm URL —
+// `docxodus@12.5.0`, `docxodus@12.5.0/dist/embed.bundle.js`, the bare npm URL —
 // all of them, but never `docxodus@latest`, which the docs use deliberately in
 // one "unpinned" example.
 const PIN = /docxodus@(\d+\.\d+\.\d+)/g;

--- a/docs/npm-package.md
+++ b/docs/npm-package.md
@@ -1006,7 +1006,7 @@ editor, the `embed` bundle is the one-tag path — it packages the whole stack
 <div id="editor"></div>
 <script type="module">
   import { createViewer, createEditor }
-    from 'https://cdn.jsdelivr.net/npm/docxodus@12.3.0/dist/embed.bundle.js';
+    from 'https://cdn.jsdelivr.net/npm/docxodus@12.5.0/dist/embed.bundle.js';
 
   // Choose either factory, or render both into separate containers as shown.
   // Source: URL string, Uint8Array, ArrayBuffer, Blob, or File.

--- a/npm/README.md
+++ b/npm/README.md
@@ -99,7 +99,7 @@ runtime location auto-detected — no build step, no configuration:
 ```html
 <div id="doc" style="height: 100dvh"></div>
 <script type="module">
-  import { createRibbonEditor } from 'https://cdn.jsdelivr.net/npm/docxodus@12.3.0/dist/embed.bundle.js';
+  import { createRibbonEditor } from 'https://cdn.jsdelivr.net/npm/docxodus@12.5.0/dist/embed.bundle.js';
   const ribbon = await createRibbonEditor('#doc', './contract.docx'); // or bytes / Blob / File
   // ...later: const editedBytes = ribbon.save();
 </script>
@@ -681,7 +681,7 @@ so a page can embed a full viewer or editor without hosting anything itself.
 <div id="app" style="height: 100dvh"></div>
 <script type="module">
   import { createViewer, createEditor, createRibbonEditor }
-    from 'https://cdn.jsdelivr.net/npm/docxodus@12.3.0/dist/embed.bundle.js';
+    from 'https://cdn.jsdelivr.net/npm/docxodus@12.5.0/dist/embed.bundle.js';
 
   // Choose a factory, or render several into separate containers as shown.
   // Source may be a URL, Uint8Array, ArrayBuffer, Blob, or File.
@@ -711,7 +711,7 @@ For pages that can't use modules, `dist/embed.iife.js` exposes the same surface 
 
 ```html
 <div id="doc"></div>
-<script src="https://cdn.jsdelivr.net/npm/docxodus@12.3.0/dist/embed.iife.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/docxodus@12.5.0/dist/embed.iife.js"></script>
 <script>
   Docxodus.createRibbonEditor('#doc').then((ribbon) => { /* ... */ });
 </script>
@@ -727,7 +727,7 @@ first `<bundle dir>/wasm/`, then `<bundle dir>/` as a fallback. On a CDN that re
 
 ### CDN caveats
 
-- **Pin an exact version in production** (`docxodus@12.3.0`, not `@latest`) — CDN responses are
+- **Pin an exact version in production** (`docxodus@12.5.0`, not `@latest`) — CDN responses are
   cached as immutable, and the wire shapes between the JS wrappers and the WASM assemblies must
   come from the same release.
 - The build patches the .NET loader to fetch with `credentials: "omit"` — required because the

--- a/npm/examples/embed.html
+++ b/npm/examples/embed.html
@@ -45,7 +45,7 @@
     bundle relatively. From a CDN the ONLY line that changes is the import:
 
       import { createViewer, createEditor, createRibbonEditor }
-        from "https://cdn.jsdelivr.net/npm/docxodus@12.3.0/dist/embed.bundle.js";
+        from "https://cdn.jsdelivr.net/npm/docxodus@12.5.0/dist/embed.bundle.js";
 
     WASM assets auto-resolve from the wasm/ directory next to the bundle —
     no other configuration needed. Pin an exact version in production so the

--- a/npm/src/core.ts
+++ b/npm/src/core.ts
@@ -532,7 +532,7 @@ async function yieldToMain(): Promise<void> {
 function getDefaultWasmBasePath(): string {
   try {
     // import.meta.url gives us the URL of this module
-    // e.g., "https://cdn.jsdelivr.net/npm/docxodus@12.3.0/dist/core.js"
+    // e.g., "https://cdn.jsdelivr.net/npm/docxodus@12.5.0/dist/core.js"
     // or "file:///path/to/node_modules/docxodus/dist/core.js"
     const moduleUrl = import.meta.url;
 

--- a/npm/src/embed.ts
+++ b/npm/src/embed.ts
@@ -7,7 +7,7 @@
  * ```html
  * <div id="doc"></div>
  * <script type="module">
- *   import { createViewer } from "https://cdn.jsdelivr.net/npm/docxodus@12.3.0/dist/embed.bundle.js";
+ *   import { createViewer } from "https://cdn.jsdelivr.net/npm/docxodus@12.5.0/dist/embed.bundle.js";
  *   await createViewer("#doc", "./contract.docx");
  * </script>
  * ```

--- a/npm/tests/social-demo.spec.ts
+++ b/npm/tests/social-demo.spec.ts
@@ -21,7 +21,7 @@ import { test, expect, type Page } from '@playwright/test';
  */
 
 const OVERRIDES = 'engine=./embed.bundle.js&doc=./docxodus-demo-guide.docx';
-const RELEASE_ENGINE = 'docxodus@12.3.0/dist/embed.bundle.js';
+const RELEASE_ENGINE = 'docxodus@12.5.0/dist/embed.bundle.js';
 
 async function formattingState(page: Page, anchor: string, text: string) {
   return page.evaluate(({ anchor, text }) => {


### PR DESCRIPTION
## Why

Every copy-pasteable CDN snippet in the docs (demo index page, npm README, package docs, the embed example, and the doc comments on the `docxodus` and `docxodus/core` entries) still named `docxodus@12.3.0`. The 12.4.0 and 12.4.1 re-pins never happened. This moves all of them, plus the `RELEASE_ENGINE` constant in `social-demo.spec.ts`, to `12.5.0`.

## What it does not change

The demo site itself no longer loads the engine from the CDN. It builds its own runtime alongside the pages (`npm run build` in `pages.yml`), so the live demo is already on the current engine regardless of this pin. Only reader-facing snippets move.

## Merge condition

`docxodus@12.5.0` is staged on npm by the release workflow but needs the maintainer's 2FA approval before it is publicly installable, and jsDelivr lags npm by a few minutes after that. Merge once

```sh
curl -I https://cdn.jsdelivr.net/npm/docxodus@12.5.0/dist/embed.bundle.js
```

returns `200` with a JavaScript content type, so a reader who pastes a snippet gets a working engine.

## Validation

- `node --test docs/demo/tools/engine-pin.test.mjs` passes: every pinned page and doc agrees on one version, and it clears the image-cartridge minimum.
- 12 occurrences replaced byte-wise across 8 files; the only other `docxodus@` pin left in the tree is the deliberately grandfathered `9.6.0` sentence in `docs/demo/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TZazZwuvFkCcNadd6wxV2